### PR TITLE
D8M: explicit constant values

### DIFF
--- a/src/formats/types.ts
+++ b/src/formats/types.ts
@@ -22,15 +22,35 @@ export interface EmittedByteMap {
 /**
  * A symbol entry for debug maps and listings.
  */
-export interface SymbolEntry {
-  kind: 'label' | 'constant' | 'data' | 'var' | 'unknown';
-  name: string;
-  address: number;
-  file?: string;
-  line?: number;
-  scope?: 'global' | 'local';
-  size?: number;
-}
+export type SymbolEntry =
+  | {
+      kind: 'constant';
+      name: string;
+      /**
+       * Constant value (not an address).
+       *
+       * D8M serialization includes this as `value`.
+       */
+      value: number;
+      /**
+       * Back-compat: legacy constant representation stored the value in `address`.
+       *
+       * Writers may include this field for compatibility with older tooling.
+       */
+      address?: number;
+      file?: string;
+      line?: number;
+      scope?: 'global' | 'local';
+    }
+  | {
+      kind: 'label' | 'data' | 'var' | 'unknown';
+      name: string;
+      address: number;
+      file?: string;
+      line?: number;
+      scope?: 'global' | 'local';
+      size?: number;
+    };
 
 /**
  * Options for Intel HEX writing.

--- a/src/formats/writeD8m.ts
+++ b/src/formats/writeD8m.ts
@@ -29,11 +29,12 @@ export function writeD8m(
     symbols: symbols.map((s) => ({
       name: s.name,
       kind: s.kind,
-      address: s.address,
+      ...(s.kind === 'constant' ? { value: s.value } : { address: s.address }),
+      ...(s.kind === 'constant' && s.address !== undefined ? { address: s.address } : {}),
       ...(s.file !== undefined ? { file: s.file } : {}),
       ...(s.line !== undefined ? { line: s.line } : {}),
       ...(s.scope !== undefined ? { scope: s.scope } : {}),
-      ...(s.size !== undefined ? { size: s.size } : {}),
+      ...(s.kind !== 'constant' && s.size !== undefined ? { size: s.size } : {}),
     })),
   };
 

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -53,6 +53,7 @@ export function emitProgram(
         symbols.push({
           kind: 'constant',
           name: item.name,
+          value: v,
           address: v,
           file: item.span.file,
           line: item.span.start.line,
@@ -100,6 +101,7 @@ export function emitProgram(
       symbols.push({
         kind: 'constant',
         name,
+        value: idx,
         address: idx,
         file: e.span.file,
         line: e.span.start.line,

--- a/test/pr2_const_data.test.ts
+++ b/test/pr2_const_data.test.ts
@@ -26,11 +26,12 @@ describe('PR2 const + data', () => {
       name: string;
       kind: string;
       address: number;
+      value?: number;
       [k: string]: unknown;
     }>;
     expect(symbols).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ name: 'MsgLen', kind: 'constant', address: 5 }),
+        expect.objectContaining({ name: 'MsgLen', kind: 'constant', value: 5 }),
         expect.objectContaining({ name: 'msg', kind: 'data', address: 4 }),
       ]),
     );

--- a/test/pr4_enum.test.ts
+++ b/test/pr4_enum.test.ts
@@ -26,13 +26,14 @@ describe('PR4 enum parsing', () => {
       name: string;
       kind: string;
       address: number;
+      value?: number;
       [k: string]: unknown;
     }>;
     expect(symbols).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ name: 'Read', kind: 'constant', address: 0 }),
-        expect.objectContaining({ name: 'Write', kind: 'constant', address: 1 }),
-        expect.objectContaining({ name: 'Append', kind: 'constant', address: 2 }),
+        expect.objectContaining({ name: 'Read', kind: 'constant', value: 0 }),
+        expect.objectContaining({ name: 'Write', kind: 'constant', value: 1 }),
+        expect.objectContaining({ name: 'Append', kind: 'constant', value: 2 }),
       ]),
     );
   });


### PR DESCRIPTION
D8M: explicit constant values

- Add a dedicated value field for constant symbols in D8M output (stops overloading address).
- Keep legacy address for constant symbols for backward compatibility (same numeric value).
- Update tests to assert value for consts/enums.
