### PR TITLE
Diagnostics: stable IDs

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -52,7 +52,7 @@ export const compile: CompileFn = async (
     sourceText = await readFile(entryFile, 'utf8');
   } catch (err) {
     diagnostics.push({
-      id: DiagnosticIds.Unknown,
+      id: DiagnosticIds.IoReadFailed,
       severity: 'error',
       message: `Failed to read entry file: ${String(err)}`,
       file: entryFile,
@@ -65,7 +65,7 @@ export const compile: CompileFn = async (
     program = parseProgram(entryFile, sourceText, diagnostics);
   } catch (err) {
     diagnostics.push({
-      id: DiagnosticIds.Unknown,
+      id: DiagnosticIds.InternalParseError,
       severity: 'error',
       message: `Internal error during parse: ${String(err)}`,
       file: entryFile,

--- a/src/diagnostics/types.ts
+++ b/src/diagnostics/types.ts
@@ -26,7 +26,39 @@ export interface Diagnostic {
  * PR0 started with a minimal set; later PRs should extend this via contract changes.
  */
 export const DiagnosticIds = {
+  /**
+   * Unknown/unclassified diagnostic.
+   *
+   * Use a more specific ID when possible; this remains for forward compatibility.
+   */
   Unknown: 'ZAX000',
+
+  /** Failed to read a source file from disk. */
+  IoReadFailed: 'ZAX001',
+
+  /** Internal error during parsing (unexpected exception). */
+  InternalParseError: 'ZAX002',
+
+  /** Generic parse error (syntax / unsupported in current PR subset). */
+  ParseError: 'ZAX100',
+
+  /** Generic instruction encoding error (unsupported mnemonic/operands, out-of-range imm, etc.). */
+  EncodeError: 'ZAX200',
+
+  /** Generic emission/lowering error (layout/packing/symbol collisions, etc.). */
+  EmitError: 'ZAX300',
+
+  /** Generic semantic evaluation error (env building, imm evaluation, etc.). */
+  SemanticsError: 'ZAX400',
+
+  /** Divide by zero in an imm expression. */
+  ImmDivideByZero: 'ZAX401',
+
+  /** Modulo by zero in an imm expression. */
+  ImmModuloByZero: 'ZAX402',
+
+  /** Type/layout error (unknown type, recursion, missing array length, etc.). */
+  TypeError: 'ZAX403',
 } as const;
 
 /**

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -33,7 +33,7 @@ function diag(
   where?: { line: number; column: number },
 ): void {
   diagnostics.push({
-    id: DiagnosticIds.Unknown,
+    id: DiagnosticIds.ParseError,
     severity: 'error',
     message,
     file,

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -8,7 +8,7 @@ import { sizeOfTypeExpr } from '../semantics/layout.js';
 import { encodeInstruction } from '../z80/encode.js';
 
 function diag(diagnostics: Diagnostic[], file: string, message: string): void {
-  diagnostics.push({ id: DiagnosticIds.Unknown, severity: 'error', message, file });
+  diagnostics.push({ id: DiagnosticIds.EmitError, severity: 'error', message, file });
 }
 
 /**

--- a/src/semantics/env.ts
+++ b/src/semantics/env.ts
@@ -36,7 +36,7 @@ export interface CompileEnv {
 }
 
 function diag(diagnostics: Diagnostic[], file: string, message: string): void {
-  diagnostics.push({ id: DiagnosticIds.Unknown, severity: 'error', message, file });
+  diagnostics.push({ id: DiagnosticIds.SemanticsError, severity: 'error', message, file });
 }
 
 /**
@@ -85,7 +85,7 @@ export function evalImmExpr(
         case '/':
           if (r === 0) {
             diagnostics?.push({
-              id: DiagnosticIds.Unknown,
+              id: DiagnosticIds.ImmDivideByZero,
               severity: 'error',
               message: 'Divide by zero in imm expression.',
               file: expr.span.file,
@@ -98,7 +98,7 @@ export function evalImmExpr(
         case '%':
           if (r === 0) {
             diagnostics?.push({
-              id: DiagnosticIds.Unknown,
+              id: DiagnosticIds.ImmModuloByZero,
               severity: 'error',
               message: 'Modulo by zero in imm expression.',
               file: expr.span.file,

--- a/src/semantics/layout.ts
+++ b/src/semantics/layout.ts
@@ -19,7 +19,7 @@ export function sizeOfTypeExpr(
   const memo = new Map<string, number>();
 
   const diag = (file: string, message: string) => {
-    diagnostics?.push({ id: DiagnosticIds.Unknown, severity: 'error', message, file });
+    diagnostics?.push({ id: DiagnosticIds.TypeError, severity: 'error', message, file });
   };
 
   const scalarSize = (name: string): number | undefined => {

--- a/src/z80/encode.ts
+++ b/src/z80/encode.ts
@@ -10,7 +10,7 @@ function diag(
   message: string,
 ): void {
   diagnostics.push({
-    id: DiagnosticIds.Unknown,
+    id: DiagnosticIds.EncodeError,
     severity: 'error',
     message,
     file: node.span.file,

--- a/test/pr2_div_zero.test.ts
+++ b/test/pr2_div_zero.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { DiagnosticIds } from '../src/diagnostics/types.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,8 +14,14 @@ describe('PR2 divide by zero', () => {
     const entry = join(__dirname, 'fixtures', 'pr2_div_zero.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics.map((d) => d.id)).toEqual(
+      expect.arrayContaining([DiagnosticIds.ImmDivideByZero, DiagnosticIds.SemanticsError]),
+    );
     expect(res.diagnostics.map((d) => d.message)).toEqual(
-      expect.arrayContaining(['Divide by zero in imm expression.']),
+      expect.arrayContaining([
+        'Divide by zero in imm expression.',
+        'Failed to evaluate const "Bad".',
+      ]),
     );
   });
 });

--- a/test/semantics_layout.test.ts
+++ b/test/semantics_layout.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Diagnostic } from '../src/diagnostics/types.js';
+import { DiagnosticIds } from '../src/diagnostics/types.js';
 import type { CompileEnv } from '../src/semantics/env.js';
 import { sizeOfTypeExpr } from '../src/semantics/layout.js';
 import type {
@@ -42,6 +43,7 @@ describe('sizeOfTypeExpr', () => {
     const env = emptyEnv();
     const res = sizeOfTypeExpr({ kind: 'TypeName', span: s(), name: 'Nope' }, env, diagnostics);
     expect(res).toBeUndefined();
+    expect(diagnostics[0]?.id).toBe(DiagnosticIds.TypeError);
     expect(diagnostics.map((d) => d.message)).toContain('Unknown type "Nope".');
   });
 
@@ -68,6 +70,7 @@ describe('sizeOfTypeExpr', () => {
 
     const res = sizeOfTypeExpr({ kind: 'TypeName', span: s(), name: 'A' }, env, diagnostics);
     expect(res).toBeUndefined();
+    expect(diagnostics[0]?.id).toBe(DiagnosticIds.TypeError);
     expect(diagnostics.map((d) => d.message)).toContain(
       'Recursive type definition detected for "A".',
     );
@@ -86,6 +89,7 @@ describe('sizeOfTypeExpr', () => {
       diagnostics,
     );
     expect(res).toBeUndefined();
+    expect(diagnostics[0]?.id).toBe(DiagnosticIds.TypeError);
     expect(diagnostics.map((d) => d.message)).toContain('Array length is required in PR3 subset.');
   });
 });


### PR DESCRIPTION
Add stable diagnostic IDs

- Expand DiagnosticIds beyond ZAX000 (IO, parse, encode, emit, semantics, imm div/mod by zero, type/layout).
- Route existing diagnostics to the most appropriate IDs.
- Update a couple tests to assert IDs for key cases.
