### PR TITLE
PR29: Deduplicate select join mismatch diagnostics

### DIFF
--- a/test/fixtures/pr29_select_stack_mismatch_dedup.zax
+++ b/test/fixtures/pr29_select_stack_mismatch_dedup.zax
@@ -1,0 +1,12 @@
+export func main(): void
+  asm
+    ld a, 1
+    select A
+      case 0
+        nop
+      case 1
+        push BC
+      else
+        push DE
+    end
+  end

--- a/test/pr15_structured_control.test.ts
+++ b/test/pr15_structured_control.test.ts
@@ -84,6 +84,16 @@ describe('PR15 structured asm control flow', () => {
     ).toBe(true);
   });
 
+  it('reports select join stack mismatch once', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr29_select_stack_mismatch_dedup.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    const joinMismatch = res.diagnostics.filter((d) =>
+      d.message.includes('Stack depth mismatch at select join'),
+    );
+    expect(joinMismatch).toHaveLength(1);
+  });
+
   it('supports nested structured control flow', async () => {
     const entry = join(__dirname, 'fixtures', 'pr15_nested_while_if.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });


### PR DESCRIPTION
## Summary
- tighten select-join flow merging to emit at most one stack-depth mismatch diagnostic per join site
- keep resulting flow state behavior unchanged while reducing duplicate diagnostic noise
- add regression fixture and test that asserts exactly one select-join mismatch diagnostic

## Validation
- yarn format:check
- yarn typecheck
- yarn test test/pr15_structured_control.test.ts
- yarn test