### PR TITLE
PR32: Harden asm control keyword parsing

### DIFF
--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -507,6 +507,7 @@ function parseAsmStatement(
         line: stmtSpan.start.line,
         column: stmtSpan.start.column,
       });
+      return undefined;
     }
     return { kind: 'Else', span: stmtSpan };
   }
@@ -525,6 +526,7 @@ function parseAsmStatement(
         line: stmtSpan.start.line,
         column: stmtSpan.start.column,
       });
+      return undefined;
     }
     return { kind: 'End', span: stmtSpan };
   }
@@ -546,13 +548,15 @@ function parseAsmStatement(
   const untilMatch = /^until\s+([A-Za-z][A-Za-z0-9]*)$/i.exec(trimmed);
   if (untilMatch) {
     const cc = untilMatch[1]!;
-    const top = controlStack.pop();
+    const top = controlStack[controlStack.length - 1];
     if (top !== 'Repeat') {
       diag(diagnostics, filePath, `"until" without matching "repeat"`, {
         line: stmtSpan.start.line,
         column: stmtSpan.start.column,
       });
+      return undefined;
     }
+    controlStack.pop();
     return { kind: 'Until', span: stmtSpan, cc };
   }
 

--- a/test/fixtures/pr32_repeat_closed_by_end.zax
+++ b/test/fixtures/pr32_repeat_closed_by_end.zax
@@ -1,0 +1,6 @@
+export func main(): void
+  asm
+    repeat
+      nop
+    end
+  end

--- a/test/pr15_structured_control.test.ts
+++ b/test/pr15_structured_control.test.ts
@@ -173,22 +173,31 @@ describe('PR15 structured asm control flow', () => {
     const entry = join(__dirname, 'fixtures', 'pr15_until_without_repeat.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(res.diagnostics.some((d) => d.message.includes('without matching "repeat"'))).toBe(true);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe('"until" without matching "repeat"');
   });
 
   it('diagnoses case without matching select', async () => {
     const entry = join(__dirname, 'fixtures', 'pr30_case_without_select.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(res.diagnostics.some((d) => d.message.includes('without matching "select"'))).toBe(true);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe('"case" without matching "select"');
   });
 
   it('diagnoses else without matching if or select', async () => {
     const entry = join(__dirname, 'fixtures', 'pr30_else_without_if_or_select.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(
-      res.diagnostics.some((d) => d.message.includes('without matching "if" or "select"')),
-    ).toBe(true);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe('"else" without matching "if" or "select"');
+  });
+
+  it('diagnoses repeat closed by end (until required)', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr32_repeat_closed_by_end.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe('"repeat" blocks must close with "until <cc>"');
   });
 });


### PR DESCRIPTION
## Summary
- treat invalid asm control keywords as hard parse errors to avoid downstream duplicate diagnostics:
  - else outside if/select returns no AST node
  - until outside repeat returns no AST node (and does not pop unrelated frames)
  - end closing repeat emits error and returns no AST node
- tighten tests to assert exactly 1 diagnostic for these parse errors
- add fixture for repeat closed by end

## Validation
- yarn format:check
- yarn typecheck
- yarn test