### PR TITLE
PR33: Parser select arm ordering

### DIFF
--- a/docs/zax-spec.md
+++ b/docs/zax-spec.md
@@ -1017,6 +1017,7 @@ Rules:
   - Comparisons are by 16-bit equality.
   - For `reg8` selectors, the selector value is in the range `0..255` (zero-extended). `case` values outside `0..255` can never match; the compiler may warn.
 - `else` is optional and is taken if no `case` matches. If no `else` is present and no `case` matches, control transfers to after the enclosing `end`.
+- If present, `else` must be the final arm in the `select`. A `case` after `else` is a compile error.
 - There is no fallthrough: after a `case` body finishes, control transfers to after the enclosing `end` (unless the case body terminates, e.g., `ret`).
 - Duplicate `case` values within the same `select` are a compile error.
 - Nested `select` is allowed.

--- a/test/fixtures/pr33_select_case_after_else.zax
+++ b/test/fixtures/pr33_select_case_after_else.zax
@@ -1,0 +1,9 @@
+export func main(): void
+  asm
+    select A
+      else
+        nop
+      case 1
+        nop
+    end
+  end

--- a/test/fixtures/pr33_select_duplicate_else.zax
+++ b/test/fixtures/pr33_select_duplicate_else.zax
@@ -1,0 +1,9 @@
+export func main(): void
+  asm
+    select A
+      else
+        nop
+      else
+        nop
+    end
+  end

--- a/test/pr15_structured_control.test.ts
+++ b/test/pr15_structured_control.test.ts
@@ -200,4 +200,20 @@ describe('PR15 structured asm control flow', () => {
     expect(res.diagnostics).toHaveLength(1);
     expect(res.diagnostics[0]?.message).toBe('"repeat" blocks must close with "until <cc>"');
   });
+
+  it('diagnoses case after else in select', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr33_select_case_after_else.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe('"case" after "else" in select');
+  });
+
+  it('diagnoses duplicate else in select', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr33_select_duplicate_else.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe('"else" duplicated in select');
+  });
 });


### PR DESCRIPTION
## Summary
- track select arm state in parser (elseSeen)
- diagnose duplicate else in select at parse time (single error)
- diagnose case after else in select at parse time (single error)
- update spec to state else must be final arm
- add fixtures + tests for new parser errors

## Validation
- yarn format:check
- yarn typecheck
- yarn test