### PR TITLE
PR34: Examples compile gate

### DIFF
--- a/examples/control_flow_and_labels.zax
+++ b/examples/control_flow_and_labels.zax
@@ -16,9 +16,9 @@ func print_mode(mode: byte): void
     ld a, (mode)
     or a
     if Z
-      ld a, 'R'
+      ld a, $52 ; 'R'
     else
-      ld a, 'W'
+      ld a, $57 ; 'W'
     end
     bios_putc A
 end

--- a/examples/hello.zax
+++ b/examples/hello.zax
@@ -3,7 +3,7 @@
 ; Minimal example showing:
 ; - extern absolute binding
 ; - calling convention via function-call syntax inside `asm`
-; - simple control flow (repeat/until)
+; - simple control flow (loop + conditional jump)
 
 ; BIOS entry point example (address is illustrative)
 extern func bios_putc(ch: byte): void at $F003
@@ -14,26 +14,18 @@ data
   msg: byte[10] = "HELLO, ZAX"
 
 export func main(): void
-  var
-    p: addr
   asm
-    ; p = &msg
     ld hl, msg
-    ld (p), hl
-
-    ld b, MsgLen
-    repeat
-      ; load byte at *p into A
-      ld hl, (p)
-      ld a, (hl)
-      inc hl
-      ld (p), hl
-      push bc
+    ld bc, MsgLen
+  loop:
+    ld a, (hl)
+    push bc
       bios_putc A
       pop bc
-
-      ; repeat until B reaches 0
-      dec b
-    until Z
+    inc hl
+    dec bc
+    ld a, b
+    or c
+    jp nz, loop
 
 end

--- a/examples/stack_and_structs.zax
+++ b/examples/stack_and_structs.zax
@@ -28,20 +28,37 @@ end
 ; Bump sprites[i].x by dx (dx is zero-extended in v0.1).
 export func bump_sprite_x(i: byte, dx: byte): void
   asm
-    ; Convert i to an index register
+    ; In v0.1, non-constant array indexing is limited to element sizes 1 and 2.
+    ; Sprite is larger, so we dispatch on i and use constant indices.
     ld a, (i)
-    ld c, a
-
-    ; HL = sprites[i].x
-    ; (Non-encodable ea operands are lowered by the compiler.)
-    ld hl, (sprites[C].x)
-
-    ; HL += dx
-    ld a, (dx)
-    ld e, a
-    ld d, 0
-    add hl, de
-
-    ; sprites[i].x = HL
-    ld (sprites[C].x), hl
+    select A
+      case 0
+        ld hl, (sprites[0].x)
+        ld a, (dx)
+        ld e, a
+        ld d, 0
+        add hl, de
+        ld (sprites[0].x), hl
+      case 1
+        ld hl, (sprites[1].x)
+        ld a, (dx)
+        ld e, a
+        ld d, 0
+        add hl, de
+        ld (sprites[1].x), hl
+      case 2
+        ld hl, (sprites[2].x)
+        ld a, (dx)
+        ld e, a
+        ld d, 0
+        add hl, de
+        ld (sprites[2].x), hl
+      case 3
+        ld hl, (sprites[3].x)
+        ld a, (dx)
+        ld e, a
+        ld d, 0
+        add hl, de
+        ld (sprites[3].x), hl
+    end
 end

--- a/test/examples_compile.test.ts
+++ b/test/examples_compile.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { readdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('examples', () => {
+  it('compile cleanly', async () => {
+    const examplesDir = join(__dirname, '..', 'examples');
+    const entries = (await readdir(examplesDir, { withFileTypes: true }))
+      .filter((e) => e.isFile() && e.name.endsWith('.zax'))
+      // Keep legacy asm80 examples around for reference, but they are not part of the current ZAX subset.
+      .filter((e) => !e.name.startsWith('legacy_'))
+      .map((e) => join(examplesDir, e.name))
+      .sort((a, b) => a.localeCompare(b));
+
+    expect(entries.length).toBeGreaterThan(0);
+
+    for (const entry of entries) {
+      const res = await compile(entry, {}, { formats: defaultFormatWriters });
+      expect(res.diagnostics).toEqual([]);
+      expect(res.artifacts.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add CI-style test that compiles non-legacy examples/*.zax
- update examples to current supported subset (replace unsupported char literals; simplify hello loop; adjust stack_and_structs to avoid unsupported runtime indexing)
- fix lowering for ld rr, <symbol> via abs16 fixups
- avoid treating (hl) as generic (ea) in ld lowering

## Validation
- yarn format:check
- yarn typecheck
- yarn test