### PR TITLE
PR38: Document examples as compiled contract

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,8 @@
+# ZAX Examples
+
+These examples are part of the assembler contract: they are compiled by the test suite (`test/examples_compile.test.ts`).
+
+Notes:
+
+- Files prefixed with `legacy_` are kept for reference and are not compiled as part of the current ZAX subset.
+- Examples may use features that are supported by the compiler even if they are not directly encodable in a single Z80 instruction; such cases are lowered by the compiler.


### PR DESCRIPTION
## Summary
- add examples/README.md clarifying that examples are compiled by the test suite and that legacy_* files are excluded

## Validation
- yarn format:check
- yarn typecheck
- yarn test