### PR TITLE
PR39: listing output (.lst)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,7 +30,7 @@ The codebase has meaningful progress, but it is **not near complete** for a prod
 
 2. Parser/AST behavior is not fully settled.
 
-- `src/frontend/parser.ts` is large (~1,618 lines) with known edge-case TODOs.
+- `src/frontend/parser.ts` is large (~1,618 lines); behavior is still subset-constrained and needs broader negative coverage.
 - Several grammar/behavior areas are subset-constrained or intentionally unsupported today.
 - Parser robustness/error recovery strategy is still shallow.
 
@@ -42,7 +42,7 @@ The codebase has meaningful progress, but it is **not near complete** for a prod
 
 4. Output/tooling completeness is partial.
 
-- `.bin`, `.hex`, and D8M exist, but `.lst` is still not complete.
+- `.bin`, `.hex`, D8M, and a minimal `.lst` exist, but `.lst` is not yet a full source listing (currently a byte dump + symbols).
 - CLI parity with `docs/zax-cli.md` is not fully proven as a stable contract.
 
 5. Hardening and acceptance are incomplete.
@@ -180,21 +180,28 @@ Use only real GitHub PR numbers:
 - For work not opened yet, refer to it as "next PR".
 - As soon as a PR is opened, update this section with its actual `#<number>`.
 
-Completed (anchored):
+Completed (anchored, most recent first):
 
-1. #28: Shared-case `select` semantics (stacked `case` labels share one body) + tests + spec update.
-2. #29: Deduplicate `select` join stack-mismatch diagnostics + regression test.
-3. #30: Parser hardening: diagnose `case` (and `else`) outside valid control context + negative fixtures.
+1. #38: Document examples as compiled contract (`examples/README.md`).
+2. #37: Fixups and forward references (spec + tests).
+3. #36: Expand char literal escape coverage (tests).
+4. #35: Char literals in `imm` expressions (parser + tests).
+5. #34: Examples compile gate (CI contract test + example updates).
+6. #33: Parser `select` arm ordering hardening.
+7. #32: Harden asm control keyword parsing (prevent cascaded diagnostics).
+8. #31: Roadmap anchors updated to real PR numbers (remove placeholders).
+9. #30: Diagnose `case` outside `select` during parsing (negative fixtures).
+10. #29: Deduplicate `select` join mismatch diagnostics (regression test).
+11. #28: Stacked `select case` labels share one body (spec + tests).
 
-Next:
+Next (assembler-first):
 
-1. Next PR (#31): Parser/AST closure pass (edge cases + diagnostic consistency + negative fixtures).
+1. Next PR: Parser/AST closure pass (tighten remaining edge cases, eliminate core TODOs, expand negative fixtures).
 2. Following PR: Lowering/frame/op safety pass (SP/control/cleanup invariants + tests).
-3. Following PR: ISA expansion tranche 1 (high-frequency instructions + diagnostics + fixtures).
-4. Following PR: ISA expansion tranche 2 (remaining control/bit/system instructions).
-5. Following PR: CLI parity + `.lst` implementation.
-6. Following PR: Hardening sweep (examples CI gate + negative coverage + determinism).
-7. Following PR: Debug80 integration (only if all gates pass).
+3. Following PR: ISA coverage tranche (prioritize v0.1 workflows + fixtures).
+4. Following PR: CLI parity + `.lst` completion (contract tests).
+5. Following PR: Hardening sweep (determinism + negative coverage + cross-platform gates).
+6. Following PR: Debug80 integration (only after all gates pass).
 
 ---
 

--- a/docs/zax-cli.md
+++ b/docs/zax-cli.md
@@ -28,6 +28,11 @@ ZAX uses a single “primary output path” to derive sibling artifacts.
     - Listing: `artifactBase + ".lst"`
     - Debug map (D8M v1): `artifactBase + ".d8dbg.json"`
 
+Listing note:
+
+- In v0.1, `.lst` is a deterministic byte dump plus a symbol table (not a full source listing).
+- Use `.d8dbg.json` (D8M) for debugger-grade source mapping.
+
 Directory creation:
 
 - If `--output` points into a directory that does not exist, the assembler creates it.

--- a/src/formats/index.ts
+++ b/src/formats/index.ts
@@ -2,6 +2,7 @@ import type { FormatWriters } from './types.js';
 import { writeBin } from './writeBin.js';
 import { writeD8m } from './writeD8m.js';
 import { writeHex } from './writeHex.js';
+import { writeListing } from './writeListing.js';
 
 /**
  * Default in-memory artifact writers for PR1.
@@ -12,4 +13,5 @@ export const defaultFormatWriters: FormatWriters = {
   writeHex,
   writeBin,
   writeD8m,
+  writeListing,
 };

--- a/src/formats/types.ts
+++ b/src/formats/types.ts
@@ -73,6 +73,22 @@ export interface WriteBinOptions {}
 export interface WriteD8mOptions {}
 
 /**
+ * Options for listing writing.
+ *
+ * Note: the listing format is currently a deterministic byte dump plus a symbol table.
+ */
+export interface WriteListingOptions {
+  /**
+   * Line ending to use when emitting text formats.
+   */
+  lineEnding?: '\n' | '\r\n';
+  /**
+   * Number of bytes shown per listing line.
+   */
+  bytesPerLine?: number;
+}
+
+/**
  * In-memory Intel HEX artifact.
  */
 export interface HexArtifact {
@@ -135,6 +151,6 @@ export interface FormatWriters {
   writeListing?(
     map: EmittedByteMap,
     symbols: SymbolEntry[],
-    opts?: Record<string, unknown>,
+    opts?: WriteListingOptions,
   ): ListingArtifact;
 }

--- a/src/formats/writeListing.ts
+++ b/src/formats/writeListing.ts
@@ -1,0 +1,68 @@
+import type { EmittedByteMap, ListingArtifact, SymbolEntry, WriteListingOptions } from './types.js';
+import { getWrittenRange } from './range.js';
+
+function toHexByte(n: number): string {
+  return (n & 0xff).toString(16).toUpperCase().padStart(2, '0');
+}
+
+function toHexWord(n: number): string {
+  return (n & 0xffff).toString(16).toUpperCase().padStart(4, '0');
+}
+
+function formatSymbol(s: SymbolEntry): string {
+  if (s.kind === 'constant') {
+    const value = s.value & 0xffff;
+    return `${s.kind} ${s.name} = $${toHexWord(value)} (${s.value})`;
+  }
+  return `${s.kind} ${s.name} = $${toHexWord(s.address)}`;
+}
+
+function sortSymbols(a: SymbolEntry, b: SymbolEntry): number {
+  const aKey =
+    a.kind === 'constant'
+      ? `1\n${toHexWord(a.value & 0xffff)}\n${a.name.toLowerCase()}`
+      : `0\n${toHexWord(a.address)}\n${a.name.toLowerCase()}`;
+  const bKey =
+    b.kind === 'constant'
+      ? `1\n${toHexWord(b.value & 0xffff)}\n${b.name.toLowerCase()}`
+      : `0\n${toHexWord(b.address)}\n${b.name.toLowerCase()}`;
+  return aKey.localeCompare(bKey);
+}
+
+/**
+ * Create a deterministic `.lst` listing artifact.
+ *
+ * Current implementation is a stable byte dump + symbol table. It does not yet include per-instruction
+ * source mapping; D8M should be used for debuggers.
+ */
+export function writeListing(
+  map: EmittedByteMap,
+  symbols: SymbolEntry[],
+  opts?: WriteListingOptions,
+): ListingArtifact {
+  const lineEnding = opts?.lineEnding ?? '\n';
+  const bytesPerLine = opts?.bytesPerLine ?? 16;
+  const { start, end } = getWrittenRange(map);
+
+  const lines: string[] = [];
+  lines.push('; ZAX listing');
+  lines.push(`; range: $${toHexWord(start)}..$${toHexWord(end)} (end exclusive)`);
+  lines.push('');
+
+  for (let addr = start; addr < end; addr += bytesPerLine) {
+    const count = Math.min(bytesPerLine, end - addr);
+    const bytes: string[] = [];
+    for (let i = 0; i < count; i++) {
+      bytes.push(toHexByte(map.bytes.get(addr + i) ?? 0));
+    }
+    lines.push(`${toHexWord(addr)}: ${bytes.join(' ')}`);
+  }
+
+  lines.push('');
+  lines.push('; symbols:');
+  for (const s of [...symbols].sort(sortSymbols)) {
+    lines.push(`; ${formatSymbol(s)}`);
+  }
+
+  return { kind: 'lst', text: lines.join(lineEnding) + lineEnding };
+}

--- a/test/pr39_listing.test.ts
+++ b/test/pr39_listing.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { ListingArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR39 listing (.lst) artifact', () => {
+  it('emits a deterministic byte-dump listing by default', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr2_const_data.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const lst = res.artifacts.find((a): a is ListingArtifact => a.kind === 'lst');
+    expect(lst).toBeDefined();
+
+    expect(lst!.text).toContain('; ZAX listing');
+    expect(lst!.text).toContain('0000: 3E 05 C9 00 48 45 4C 4C 4F');
+    expect(lst!.text).toMatch(/;\s+data\s+msg\s+=\s+\$0004/);
+    expect(lst!.text).toMatch(/;\s+constant\s+MsgLen\s+=\s+\$0005\s+\(5\)/);
+  });
+
+  it('allows suppressing listing without changing other defaults', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr1_minimal.zax');
+    const res = await compile(entry, { emitListing: false }, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const lst = res.artifacts.find((a): a is ListingArtifact => a.kind === 'lst');
+    expect(lst).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add deterministic .lst listing writer (byte dump + symbols)
- emit listing by default and support emitListing suppression (sidecar semantics)
- add listing contract test and CLI note
- update roadmap section 5 to remove placeholder PR numbers

## Validation
- yarn format:check
- yarn typecheck
- yarn test