### PR TITLE
PR45: ld abs16 ED forms (BC/DE/SP)

### DIFF
--- a/test/fixtures/pr45_ld_abs16_ed_forms.zax
+++ b/test/fixtures/pr45_ld_abs16_ed_forms.zax
@@ -1,0 +1,18 @@
+section code at $0000
+section var at $1000
+
+var
+  w0: word
+  w1: word
+  w2: word
+
+export func main(): void
+  asm
+    ld bc, (w0)
+    ld (w0), bc
+    ld de, (w1)
+    ld (w1), de
+    ld sp, (w2)
+    ld (w2), sp
+  end
+

--- a/test/pr45_ld_abs16_ed_forms.test.ts
+++ b/test/pr45_ld_abs16_ed_forms.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR45: ld abs16 ED forms (BC/DE/SP)', () => {
+  it('encodes ld rr,(nn) and ld (nn),rr for BC/DE/SP when EA is absolute', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr45_ld_abs16_ed_forms.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+
+    // var section at $1000: w0=$1000, w1=$1002, w2=$1004
+    expect(bin!.bytes).toEqual(
+      Uint8Array.of(
+        0xed,
+        0x4b,
+        0x00,
+        0x10, // ld bc, ($1000)
+        0xed,
+        0x43,
+        0x00,
+        0x10, // ld ($1000), bc
+        0xed,
+        0x5b,
+        0x02,
+        0x10, // ld de, ($1002)
+        0xed,
+        0x53,
+        0x02,
+        0x10, // ld ($1002), de
+        0xed,
+        0x7b,
+        0x04,
+        0x10, // ld sp, ($1004)
+        0xed,
+        0x73,
+        0x04,
+        0x10, // ld ($1004), sp
+        0xc9, // implicit ret
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add ED-prefixed abs16 load/store fast paths in lowering when EA is absolute:
  - `ld bc,(nn)` (ED 4B) / `ld (nn),bc` (ED 43)
  - `ld de,(nn)` (ED 5B) / `ld (nn),de` (ED 53)
  - `ld sp,(nn)` (ED 7B) / `ld (nn),sp` (ED 73)
- Ensures SP tracking is invalidated after `ld sp,(nn)`.
- Add focused fixture + byte-exact test.

## Validation
- `yarn format`
- `yarn typecheck`
- `yarn test`
