### PR TITLE
PR47: encode ld a,(bc|de) and ld (bc|de),a

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -819,10 +819,13 @@ export function emitProgram(
     const src = inst.operands[1]!;
     const isEaNameHL = (ea: EaExprNode): boolean =>
       ea.kind === 'EaName' && ea.name.toUpperCase() === 'HL';
+    const isEaNameBCorDE = (ea: EaExprNode): boolean =>
+      ea.kind === 'EaName' && (ea.name.toUpperCase() === 'BC' || ea.name.toUpperCase() === 'DE');
 
     // LD r8, (ea)
     if (dst.kind === 'Reg' && src.kind === 'Mem') {
       if (isEaNameHL(src.expr)) return false; // let the encoder handle (hl)
+      if (dst.name.toUpperCase() === 'A' && isEaNameBCorDE(src.expr)) return false; // ld a,(bc|de)
       if (dst.name.toUpperCase() === 'A') {
         const r = resolveEa(src.expr, inst.span);
         if (r?.kind === 'abs') {
@@ -881,6 +884,7 @@ export function emitProgram(
     // LD (ea), r8/r16
     if (dst.kind === 'Mem' && src.kind === 'Reg') {
       if (isEaNameHL(dst.expr)) return false; // let the encoder handle (hl)
+      if (src.name.toUpperCase() === 'A' && isEaNameBCorDE(dst.expr)) return false; // ld (bc|de),a
       if (src.name.toUpperCase() === 'A') {
         const r = resolveEa(dst.expr, inst.span);
         if (r?.kind === 'abs') {

--- a/src/z80/encode.ts
+++ b/src/z80/encode.ts
@@ -277,6 +277,11 @@ export function encodeInstruction(
         if (mem.expr.kind === 'EaName' && mem.expr.name.toUpperCase() === 'HL') {
           return Uint8Array.of(0x46 + (d << 3));
         }
+        if (dst.toUpperCase() === 'A' && mem.expr.kind === 'EaName') {
+          const ea = mem.expr.name.toUpperCase();
+          if (ea === 'BC') return Uint8Array.of(0x0a); // ld a,(bc)
+          if (ea === 'DE') return Uint8Array.of(0x1a); // ld a,(de)
+        }
       }
     }
 
@@ -288,6 +293,11 @@ export function encodeInstruction(
         if (s !== undefined) {
           return Uint8Array.of(0x70 + s);
         }
+      }
+      if (mem.expr.kind === 'EaName' && src?.toUpperCase() === 'A') {
+        const ea = mem.expr.name.toUpperCase();
+        if (ea === 'BC') return Uint8Array.of(0x02); // ld (bc),a
+        if (ea === 'DE') return Uint8Array.of(0x12); // ld (de),a
       }
     }
 

--- a/test/fixtures/pr47_ld_a_bcde_mem.zax
+++ b/test/fixtures/pr47_ld_a_bcde_mem.zax
@@ -1,0 +1,8 @@
+export func main(): void
+  asm
+    ld a, (bc)
+    ld a, (de)
+    ld (bc), a
+    ld (de), a
+  end
+

--- a/test/pr47_ld_a_bcde_mem.test.ts
+++ b/test/pr47_ld_a_bcde_mem.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR47: encode ld a,(bc|de) and ld (bc|de),a', () => {
+  it('encodes direct BC/DE memory forms without being captured by EA lowering', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr47_ld_a_bcde_mem.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    expect(bin!.bytes).toEqual(Uint8Array.of(0x0a, 0x1a, 0x02, 0x12, 0xc9));
+  });
+});


### PR DESCRIPTION
## Summary
- Encode Z80 direct forms:
  - `ld a,(bc)` (0x0A)
  - `ld a,(de)` (0x1A)
  - `ld (bc),a` (0x02)
  - `ld (de),a` (0x12)
- Prevent EA lowering from misinterpreting `(bc)`/`(de)` as absolute EAs (bail out so encoder handles it).
- Add focused fixture + byte-exact test.

## Validation
- `yarn format`
- `yarn typecheck`
- `yarn test`
