### PR TITLE
PR52: treat ptr as 16-bit scalar

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -119,6 +119,7 @@ export function emitProgram(
     if (typeExpr.kind !== 'TypeName') return undefined;
     const lower = typeExpr.name.toLowerCase();
     if (lower === 'byte' || lower === 'word' || lower === 'addr') return lower;
+    if (lower === 'ptr') return 'addr';
     if (seen.has(lower)) return undefined;
     seen.add(lower);
     const decl = env.types.get(typeExpr.name);
@@ -2528,7 +2529,7 @@ export function emitProgram(
                 ? type.name
                 : undefined;
           const elementSize =
-            elementType === 'word' || elementType === 'addr'
+            elementType === 'word' || elementType === 'addr' || elementType === 'ptr'
               ? 2
               : elementType === 'byte'
                 ? 1

--- a/test/fixtures/pr52_ptr_scalar_slots.zax
+++ b/test/fixtures/pr52_ptr_scalar_slots.zax
@@ -1,0 +1,8 @@
+export func main(): void
+  var
+    p: ptr
+  asm
+    ; Store an imm16 into a ptr-typed slot (treated as addr/word for codegen).
+    ld (p), $1234
+end
+

--- a/test/pr52_ptr_scalar_slots.test.ts
+++ b/test/pr52_ptr_scalar_slots.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR52: treat ptr as 16-bit scalar in codegen', () => {
+  it('allows ptr locals/args as 16-bit slots', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr52_ptr_scalar_slots.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    // stack-local word store sequence: ld (hl),lo; inc hl; ld (hl),hi
+    expect([...bin!.bytes]).toContain(0x36);
+    expect([...bin!.bytes]).toContain(0x23);
+    expect(bin!.bytes[bin!.bytes.length - 1]).toBe(0xc9);
+  });
+});


### PR DESCRIPTION
Treats `ptr` as a first-class 16-bit scalar for codegen.

- Lowering: `resolveScalarKind` maps `ptr` to the existing 16-bit scalar path (same behavior as `addr`).
- Data emission: allows `ptr` elements in `data` blocks (2-byte words), consistent with `sizeof(ptr)=2`.
- Tests: adds an e2e fixture storing an imm16 into a function-local `ptr` slot.
