### PR TITLE
PR54: disallow inferred arrays outside data

### DIFF
--- a/test/fixtures/pr54_inferred_array_len_invalid_var.zax
+++ b/test/fixtures/pr54_inferred_array_len_invalid_var.zax
@@ -1,0 +1,8 @@
+var
+  xs: byte[]
+
+export func main(): void
+  asm
+    nop
+end
+

--- a/test/pr54_inferred_array_len_invalid.test.ts
+++ b/test/pr54_inferred_array_len_invalid.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR54: restrict inferred-length arrays to data declarations', () => {
+  it('rejects byte[] in var declarations', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr54_inferred_array_len_invalid_var.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics.some((d) => d.message.includes('Inferred-length arrays (T[])'))).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
Restricts inferred-length array syntax `T[]` to `data` declarations (per spec) and makes the error immediate and explicit elsewhere.

- Parser: `parseTypeExprFromText` takes an option to allow/disallow `[]` and emits a targeted diagnostic when disallowed.
- Updates all non-`data` type parsing call sites to disallow inferred-length arrays.
- Tests: adds a negative fixture asserting `var xs: byte[]` is rejected with the new diagnostic.
