### PR TITLE
PR56: ISA misc ops

### DIFF
--- a/test/fixtures/pr56_isa_misc.zax
+++ b/test/fixtures/pr56_isa_misc.zax
@@ -1,0 +1,13 @@
+export func main(): void
+  asm
+    di
+    ei
+    scf
+    ccf
+    cpl
+    ex de, hl
+    ex (sp), hl
+    exx
+    halt
+end
+

--- a/test/pr56_isa_misc.test.ts
+++ b/test/pr56_isa_misc.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR56: ISA misc single-byte ops', () => {
+  it('encodes common misc ops', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr56_isa_misc.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    // di, ei, scf, ccf, cpl, ex de,hl, ex (sp),hl, exx, halt, implicit ret
+    expect(bin!.bytes).toEqual(
+      Uint8Array.of(0xf3, 0xfb, 0x37, 0x3f, 0x2f, 0xeb, 0xe3, 0xd9, 0x76, 0xc9),
+    );
+  });
+});


### PR DESCRIPTION
Expands ISA coverage with common “misc” instructions.

- Encoder: adds `halt`, `di`, `ei`, `scf`, `ccf`, `cpl`, `ex de,hl`, `ex (sp),hl`, and `exx`.
- Tests: adds an e2e fixture asserting exact emitted bytes.

This is a small, low-risk ISA tranche that unblocks real-world asm without touching lowering/SP tracking.
