### PR TITLE
PR57: ISA im/rst/reti/retn

### DIFF
--- a/src/z80/encode.ts
+++ b/src/z80/encode.ts
@@ -220,6 +220,27 @@ export function encodeInstruction(
     return Uint8Array.of(opcode, n & 0xff, (n >> 8) & 0xff);
   }
 
+  if (head === 'rst' && ops.length === 1) {
+    const n = immValue(ops[0]!, env);
+    if (n === undefined || n < 0 || n > 0x38 || (n & 0x07) !== 0) {
+      diag(diagnostics, node, `rst expects an imm8 multiple of 8 (0..56)`);
+      return undefined;
+    }
+    return Uint8Array.of(0xc7 + n);
+  }
+
+  if (head === 'im' && ops.length === 1) {
+    const n = immValue(ops[0]!, env);
+    if (n === 0) return Uint8Array.of(0xed, 0x46);
+    if (n === 1) return Uint8Array.of(0xed, 0x56);
+    if (n === 2) return Uint8Array.of(0xed, 0x5e);
+    diag(diagnostics, node, `im expects 0, 1, or 2`);
+    return undefined;
+  }
+
+  if (head === 'reti' && ops.length === 0) return Uint8Array.of(0xed, 0x4d);
+  if (head === 'retn' && ops.length === 0) return Uint8Array.of(0xed, 0x45);
+
   if (head === 'jp' && ops.length === 1) {
     const n = immValue(ops[0]!, env);
     if (n === undefined || n < 0 || n > 0xffff) {

--- a/test/fixtures/pr57_isa_im_rst.zax
+++ b/test/fixtures/pr57_isa_im_rst.zax
@@ -1,0 +1,10 @@
+export func main(): void
+  asm
+    im 1
+    rst 0
+    rst 8
+    rst 56
+    reti
+    retn
+end
+

--- a/test/pr57_isa_im_rst.test.ts
+++ b/test/pr57_isa_im_rst.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR57: ISA im/rst/reti/retn', () => {
+  it('encodes im, rst, reti, and retn', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr57_isa_im_rst.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    expect(bin!.bytes).toEqual(
+      // im 1, rst 0, rst 8, rst 56, reti, retn
+      Uint8Array.of(0xed, 0x56, 0xc7, 0xcf, 0xff, 0xed, 0x4d, 0xed, 0x45),
+    );
+  });
+});


### PR DESCRIPTION
Adds `im`, `rst`, `reti`, and `retn` encoding.

- Encoder: `im 0|1|2` (ED 46/56/5E), `rst <imm8>` for multiples of 8 (0..56), plus `reti`/`retn`.
- Tests: adds an e2e fixture asserting exact emitted bytes.

Notes:
- `retn`/`reti` are treated as terminators by lowering (so no implicit trailing `ret`).
