### PR TITLE
PR58: encode jp (hl|ix|iy)

### DIFF
--- a/src/z80/encode.ts
+++ b/src/z80/encode.ts
@@ -59,6 +59,10 @@ function isMemHL(op: AsmOperandNode): boolean {
   return op.kind === 'Mem' && op.expr.kind === 'EaName' && op.expr.name.toUpperCase() === 'HL';
 }
 
+function isMemRegName(op: AsmOperandNode, reg: string): boolean {
+  return op.kind === 'Mem' && op.expr.kind === 'EaName' && op.expr.name.toUpperCase() === reg;
+}
+
 function conditionName(op: AsmOperandNode): string | undefined {
   if (op.kind === 'Reg') return op.name.toUpperCase();
   if (op.kind === 'Imm' && op.expr.kind === 'ImmName') return op.expr.name.toUpperCase();
@@ -242,6 +246,11 @@ export function encodeInstruction(
   if (head === 'retn' && ops.length === 0) return Uint8Array.of(0xed, 0x45);
 
   if (head === 'jp' && ops.length === 1) {
+    // jp (hl) / jp (ix) / jp (iy)
+    if (isMemRegName(ops[0]!, 'HL')) return Uint8Array.of(0xe9);
+    if (isMemRegName(ops[0]!, 'IX')) return Uint8Array.of(0xdd, 0xe9);
+    if (isMemRegName(ops[0]!, 'IY')) return Uint8Array.of(0xfd, 0xe9);
+
     const n = immValue(ops[0]!, env);
     if (n === undefined || n < 0 || n > 0xffff) {
       diag(diagnostics, node, `jp expects imm16`);

--- a/test/fixtures/pr58_jp_indirect.zax
+++ b/test/fixtures/pr58_jp_indirect.zax
@@ -1,0 +1,7 @@
+export func main(): void
+  asm
+    jp (hl)
+    jp (ix)
+    jp (iy)
+end
+

--- a/test/pr58_jp_indirect.test.ts
+++ b/test/pr58_jp_indirect.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR58: ISA jp (rr) indirect', () => {
+  it('encodes jp (hl)/(ix)/(iy)', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr58_jp_indirect.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    // jp (hl), jp (ix), jp (iy)
+    expect(bin!.bytes).toEqual(Uint8Array.of(0xe9, 0xdd, 0xe9, 0xfd, 0xe9));
+  });
+});


### PR DESCRIPTION
Adds encoding for indirect jumps:

- `jp (hl)`
- `jp (ix)`
- `jp (iy)`

Includes an e2e fixture asserting exact emitted bytes.
