### PR TITLE
test: use implicit ret in PR14 no-locals fixture

### DIFF
--- a/test/fixtures/pr14_no_locals_direct_ret.zax
+++ b/test/fixtures/pr14_no_locals_direct_ret.zax
@@ -1,4 +1,4 @@
 export func main(): void
   asm
-    ret
+    ; fallthrough: implicit ret
 end

--- a/test/pr14_frame_epilogue.test.ts
+++ b/test/pr14_frame_epilogue.test.ts
@@ -32,7 +32,7 @@ describe('PR14 frame slots and epilogue rewriting', () => {
     expect(bin!.bytes).toEqual(Uint8Array.of(0xc2, 0x07, 0x00, 0x00, 0xc3, 0x07, 0x00, 0xc9));
   });
 
-  it('keeps direct ret when there are no locals and no ret cc', async () => {
+  it('emits an implicit ret on fallthrough when there are no locals and no ret cc', async () => {
     const entry = join(__dirname, 'fixtures', 'pr14_no_locals_direct_ret.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics).toEqual([]);


### PR DESCRIPTION
Removes the explicit `ret` from `pr14_no_locals_direct_ret.zax` and relies on the documented fallthrough behavior (implicit ret at end of `asm`).\n\nChecks:\n- `yarn format:check`, `yarn typecheck`, `yarn test` all green locally.