### PR TITLE
ISA: encode ED misc ops

### DIFF
--- a/src/z80/encode.ts
+++ b/src/z80/encode.ts
@@ -250,6 +250,19 @@ export function encodeInstruction(
   if (head === 'reti' && ops.length === 0) return Uint8Array.of(0xed, 0x4d);
   if (head === 'retn' && ops.length === 0) return Uint8Array.of(0xed, 0x45);
 
+  if (head === 'neg' && ops.length === 0) return Uint8Array.of(0xed, 0x44);
+  if (head === 'rrd' && ops.length === 0) return Uint8Array.of(0xed, 0x67);
+  if (head === 'rld' && ops.length === 0) return Uint8Array.of(0xed, 0x6f);
+
+  if (head === 'ld' && ops.length === 2) {
+    const dst = regName(ops[0]!);
+    const src = regName(ops[1]!);
+    if (dst === 'I' && src === 'A') return Uint8Array.of(0xed, 0x47);
+    if (dst === 'A' && src === 'I') return Uint8Array.of(0xed, 0x57);
+    if (dst === 'R' && src === 'A') return Uint8Array.of(0xed, 0x4f);
+    if (dst === 'A' && src === 'R') return Uint8Array.of(0xed, 0x5f);
+  }
+
   if (head === 'in' && ops.length === 2) {
     const dst = regName(ops[0]!);
     const dst8 = dst ? reg8Code(dst) : undefined;

--- a/test/fixtures/isa_ed_misc.zax
+++ b/test/fixtures/isa_ed_misc.zax
@@ -1,0 +1,11 @@
+export func main(): void
+  asm
+    neg
+    rrd
+    rld
+    ld i, a
+    ld a, i
+    ld r, a
+    ld a, r
+    ; fallthrough: implicit ret
+end

--- a/test/isa_ed_misc.test.ts
+++ b/test/isa_ed_misc.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('ISA: ED misc ops', () => {
+  it('encodes neg/rrd/rld and ld {i,r}<->a', async () => {
+    const entry = join(__dirname, 'fixtures', 'isa_ed_misc.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    // neg; rrd; rld; ld i,a; ld a,i; ld r,a; ld a,r; implicit ret
+    expect(bin!.bytes).toEqual(
+      Uint8Array.of(
+        0xed,
+        0x44,
+        0xed,
+        0x67,
+        0xed,
+        0x6f,
+        0xed,
+        0x47,
+        0xed,
+        0x57,
+        0xed,
+        0x4f,
+        0xed,
+        0x5f,
+        0xc9,
+      ),
+    );
+  });
+});


### PR DESCRIPTION
Adds ED-prefixed misc Z80 ops with exact-byte tests:\n- `neg` (ED 44)\n- `rrd` (ED 67)\n- `rld` (ED 6F)\n- `ld i,a` / `ld a,i` / `ld r,a` / `ld a,r`\n\nIncludes a fixture and asserts the emitted bytes + implicit fallthrough `ret`.\n\nChecks:\n- `yarn format:check`, `yarn typecheck`, `yarn test` all green locally.