### PR TITLE
ISA: encode block instructions

### DIFF
--- a/src/z80/encode.ts
+++ b/src/z80/encode.ts
@@ -254,6 +254,16 @@ export function encodeInstruction(
   if (head === 'rrd' && ops.length === 0) return Uint8Array.of(0xed, 0x67);
   if (head === 'rld' && ops.length === 0) return Uint8Array.of(0xed, 0x6f);
 
+  if (head === 'ldi' && ops.length === 0) return Uint8Array.of(0xed, 0xa0);
+  if (head === 'ldir' && ops.length === 0) return Uint8Array.of(0xed, 0xb0);
+  if (head === 'ldd' && ops.length === 0) return Uint8Array.of(0xed, 0xa8);
+  if (head === 'lddr' && ops.length === 0) return Uint8Array.of(0xed, 0xb8);
+
+  if (head === 'cpi' && ops.length === 0) return Uint8Array.of(0xed, 0xa1);
+  if (head === 'cpir' && ops.length === 0) return Uint8Array.of(0xed, 0xb1);
+  if (head === 'cpd' && ops.length === 0) return Uint8Array.of(0xed, 0xa9);
+  if (head === 'cpdr' && ops.length === 0) return Uint8Array.of(0xed, 0xb9);
+
   if (head === 'ld' && ops.length === 2) {
     const dst = regName(ops[0]!);
     const src = regName(ops[1]!);

--- a/test/fixtures/isa_block_instructions.zax
+++ b/test/fixtures/isa_block_instructions.zax
@@ -1,0 +1,12 @@
+export func main(): void
+  asm
+    ldi
+    ldir
+    ldd
+    lddr
+    cpi
+    cpir
+    cpd
+    cpdr
+    ; fallthrough: implicit ret
+end

--- a/test/isa_block_instructions.test.ts
+++ b/test/isa_block_instructions.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('ISA: block instructions (LDI/LDIR/LDD/LDDR/CPI/CPIR/CPD/CPDR)', () => {
+  it('encodes ED block instructions', async () => {
+    const entry = join(__dirname, 'fixtures', 'isa_block_instructions.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    // ldi; ldir; ldd; lddr; cpi; cpir; cpd; cpdr; implicit ret
+    expect(bin!.bytes).toEqual(
+      Uint8Array.of(
+        0xed,
+        0xa0,
+        0xed,
+        0xb0,
+        0xed,
+        0xa8,
+        0xed,
+        0xb8,
+        0xed,
+        0xa1,
+        0xed,
+        0xb1,
+        0xed,
+        0xa9,
+        0xed,
+        0xb9,
+        0xc9,
+      ),
+    );
+  });
+});


### PR DESCRIPTION
Adds ED block instructions with exact-byte tests:\n- `ldi`, `ldir`, `ldd`, `lddr`\n- `cpi`, `cpir`, `cpd`, `cpdr`\n\nFixture asserts bytes + implicit fallthrough `ret`.\n\nChecks:\n- `yarn format:check`, `yarn typecheck`, `yarn test` all green locally.