### PR TITLE
ISA: indexed IX/IY disp8 addressing for ld

### DIFF
--- a/test/fixtures/isa_indexed_ld.zax
+++ b/test/fixtures/isa_indexed_ld.zax
@@ -1,0 +1,8 @@
+export func main(): void
+  asm
+    ld a, (ix[5])
+    ld (ix[5]), a
+    ld c, (iy[-2])
+    ld (iy[-2]), b
+    ; fallthrough: implicit ret
+end

--- a/test/isa_indexed_ld.test.ts
+++ b/test/isa_indexed_ld.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('ISA: indexed addressing (IX/IY + disp8)', () => {
+  it('encodes ld r,(ix/iy+disp) and ld (ix/iy+disp),r', async () => {
+    const entry = join(__dirname, 'fixtures', 'isa_indexed_ld.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    // ld a,(ix+5); ld (ix+5),a; ld c,(iy-2); ld (iy-2),b; implicit ret
+    expect(bin!.bytes).toEqual(
+      Uint8Array.of(0xdd, 0x7e, 0x05, 0xdd, 0x77, 0x05, 0xfd, 0x4e, 0xfe, 0xfd, 0x70, 0xfe, 0xc9),
+    );
+  });
+});


### PR DESCRIPTION
Adds Z80 indexed addressing for `ld` with `(ix/iy + disp8)` expressed as `(ix[disp])` / `(iy[disp])` in ZAX:\n- Encoder: `ld r,(ix/iy+disp)` and `ld (ix/iy+disp),r`\n- Lowering: bypasses EA materialization for these operands so the encoder sees them directly\n- Tests: exact-byte fixture covering positive and negative displacements\n\nChecks:\n- `yarn format:check`, `yarn typecheck`, `yarn test` all green locally.