### PR TITLE
ISA: indexed inc/dec (IX/IY + disp8)

### DIFF
--- a/src/z80/encode.ts
+++ b/src/z80/encode.ts
@@ -505,6 +505,16 @@ export function encodeInstruction(
     }
     // inc (hl)
     if (isMemHL(ops[0]!)) return Uint8Array.of(0x34);
+    // inc (ix/iy+disp)
+    const idx = memIndexed(ops[0]!, env);
+    if (idx) {
+      const disp = idx.disp;
+      if (disp < -128 || disp > 127) {
+        diag(diagnostics, node, `inc (ix/iy+disp) expects disp8`);
+        return undefined;
+      }
+      return Uint8Array.of(idx.prefix, 0x34, disp & 0xff);
+    }
     diag(diagnostics, node, `inc expects r8/rr/(hl) operand`);
     return undefined;
   }
@@ -531,6 +541,16 @@ export function encodeInstruction(
     }
     // dec (hl)
     if (isMemHL(ops[0]!)) return Uint8Array.of(0x35);
+    // dec (ix/iy+disp)
+    const idx = memIndexed(ops[0]!, env);
+    if (idx) {
+      const disp = idx.disp;
+      if (disp < -128 || disp > 127) {
+        diag(diagnostics, node, `dec (ix/iy+disp) expects disp8`);
+        return undefined;
+      }
+      return Uint8Array.of(idx.prefix, 0x35, disp & 0xff);
+    }
     diag(diagnostics, node, `dec expects r8/rr/(hl) operand`);
     return undefined;
   }

--- a/test/fixtures/isa_indexed_incdec.zax
+++ b/test/fixtures/isa_indexed_incdec.zax
@@ -1,0 +1,6 @@
+export func main(): void
+  asm
+    inc (ix[1])
+    dec (iy[-1])
+    ; fallthrough: implicit ret
+end

--- a/test/isa_indexed_incdec.test.ts
+++ b/test/isa_indexed_incdec.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('ISA: indexed inc/dec (IX/IY + disp8)', () => {
+  it('encodes inc/dec (ix/iy+disp)', async () => {
+    const entry = join(__dirname, 'fixtures', 'isa_indexed_incdec.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    // inc (ix+1); dec (iy-1); implicit ret
+    expect(bin!.bytes).toEqual(Uint8Array.of(0xdd, 0x34, 0x01, 0xfd, 0x35, 0xff, 0xc9));
+  });
+});


### PR DESCRIPTION
Extends indexed addressing support to `inc`/`dec` on `(ix/iy + disp8)`, expressed as `(ix[disp])` / `(iy[disp])` in ZAX.\n\nAdds fixture + exact-byte test for positive and negative displacements.\n\nChecks:\n- `yarn format:check`, `yarn typecheck`, `yarn test` all green locally.