### PR TITLE
ISA: indexed bit ops (IX/IY + disp8)

### DIFF
--- a/src/z80/encode.ts
+++ b/src/z80/encode.ts
@@ -694,6 +694,16 @@ export function encodeInstruction(
       return undefined;
     }
     const src = ops[1]!;
+    const idx = memIndexed(src, env);
+    if (idx) {
+      const disp = idx.disp;
+      if (disp < -128 || disp > 127) {
+        diag(diagnostics, node, `${mnemonic} (ix/iy+disp) expects disp8`);
+        return undefined;
+      }
+      // DD/FD CB disp <op> (where <op> matches the (HL) encoding)
+      return Uint8Array.of(idx.prefix, 0xcb, disp & 0xff, base + (bit << 3) + 0x06);
+    }
     if (isMemHL(src)) {
       return Uint8Array.of(0xcb, base + (bit << 3) + 0x06);
     }

--- a/test/fixtures/isa_indexed_bitops.zax
+++ b/test/fixtures/isa_indexed_bitops.zax
@@ -1,0 +1,7 @@
+export func main(): void
+  asm
+    bit 3, (ix[5])
+    res 2, (iy[-1])
+    set 7, (ix[0])
+    ; fallthrough: implicit ret
+end

--- a/test/isa_indexed_bitops.test.ts
+++ b/test/isa_indexed_bitops.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('ISA: indexed bit ops (IX/IY + disp8)', () => {
+  it('encodes bit/res/set on (ix/iy+disp)', async () => {
+    const entry = join(__dirname, 'fixtures', 'isa_indexed_bitops.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    // bit 3,(ix+5); res 2,(iy-1); set 7,(ix+0); implicit ret
+    expect(bin!.bytes).toEqual(
+      Uint8Array.of(0xdd, 0xcb, 0x05, 0x5e, 0xfd, 0xcb, 0xff, 0x96, 0xdd, 0xcb, 0x00, 0xfe, 0xc9),
+    );
+  });
+});


### PR DESCRIPTION
Adds indexed bit operations for `bit`/`res`/`set` on `(ix/iy + disp8)` (written as `(ix[disp])` / `(iy[disp])`).\n\nEncodes `DD/FD CB disp op` forms and adds exact-byte tests.\n\nChecks:\n- `yarn format:check`, `yarn typecheck`, `yarn test` all green locally.