### PR TITLE
ISA: indexed rotates/shifts (IX/IY + disp8)

### DIFF
--- a/src/z80/encode.ts
+++ b/src/z80/encode.ts
@@ -732,6 +732,16 @@ export function encodeInstruction(
   const encodeCbRotateShift = (base: number, mnemonic: string): Uint8Array | undefined => {
     if (ops.length !== 1) return undefined;
     const operand = ops[0]!;
+    const idx = memIndexed(operand, env);
+    if (idx) {
+      const disp = idx.disp;
+      if (disp < -128 || disp > 127) {
+        diag(diagnostics, node, `${mnemonic} (ix/iy+disp) expects disp8`);
+        return undefined;
+      }
+      // DD/FD CB disp <op> (where <op> matches the (HL) encoding)
+      return Uint8Array.of(idx.prefix, 0xcb, disp & 0xff, base + 0x06);
+    }
     if (isMemHL(operand)) return Uint8Array.of(0xcb, base + 0x06);
     const reg = regName(operand);
     const code = reg ? reg8Code(reg) : undefined;

--- a/test/fixtures/isa_indexed_rotates.zax
+++ b/test/fixtures/isa_indexed_rotates.zax
@@ -1,0 +1,11 @@
+export func main(): void
+  asm
+    rl (ix[1])
+    rr (iy[-1])
+    rlc (ix[0])
+    rrc (iy[2])
+    sla (ix[-2])
+    sra (iy[0])
+    srl (ix[127])
+    ; fallthrough: implicit ret
+end

--- a/test/isa_indexed_rotates.test.ts
+++ b/test/isa_indexed_rotates.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('ISA: indexed rotates/shifts (IX/IY + disp8)', () => {
+  it('encodes CB rotates/shifts on (ix/iy+disp)', async () => {
+    const entry = join(__dirname, 'fixtures', 'isa_indexed_rotates.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    // rl (ix+1); rr (iy-1); rlc (ix+0); rrc (iy+2); sla (ix-2); sra (iy+0); srl (ix+127); implicit ret
+    expect(bin!.bytes).toEqual(
+      Uint8Array.of(
+        0xdd,
+        0xcb,
+        0x01,
+        0x16,
+        0xfd,
+        0xcb,
+        0xff,
+        0x1e,
+        0xdd,
+        0xcb,
+        0x00,
+        0x06,
+        0xfd,
+        0xcb,
+        0x02,
+        0x0e,
+        0xdd,
+        0xcb,
+        0xfe,
+        0x26,
+        0xfd,
+        0xcb,
+        0x00,
+        0x2e,
+        0xdd,
+        0xcb,
+        0x7f,
+        0x3e,
+        0xc9,
+      ),
+    );
+  });
+});


### PR DESCRIPTION
Adds indexed CB rotate/shift ops for `(ix/iy + disp8)` (written as `(ix[disp])` / `(iy[disp])`).\n\nImplements DD/FD CB disp <op> forms for: rl/rr/rlc/rrc/sla/sra/srl and adds exact-byte tests.\n\nChecks:\n- `yarn format:check`, `yarn typecheck`, `yarn test` all green locally.