### PR TITLE
parser: diagnose select with no arms

### DIFF
--- a/test/fixtures/parser_select_no_arms.zax
+++ b/test/fixtures/parser_select_no_arms.zax
@@ -1,0 +1,6 @@
+export func main(): void
+  asm
+    select A
+    end
+  end
+

--- a/test/pr15_structured_control.test.ts
+++ b/test/pr15_structured_control.test.ts
@@ -128,6 +128,16 @@ describe('PR15 structured asm control flow', () => {
     expect(bin!.bytes[bin!.bytes.length - 1]).toBe(0xc9);
   });
 
+  it('diagnoses select with no arms', async () => {
+    const entry = join(__dirname, 'fixtures', 'parser_select_no_arms.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe(
+      '"select" must contain at least one arm ("case" or "else")',
+    );
+  });
+
   it('supports stacked case labels sharing a single clause body', async () => {
     const entry = join(__dirname, 'fixtures', 'pr28_select_stacked_case_shared_body.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });


### PR DESCRIPTION
Implements the spec rule that `select` must contain at least one arm (`case` or `else`). Adds a negative fixture + test asserting the diagnostic.

Run locally: yarn -s format:check && yarn -s typecheck && yarn -s test