### PR TITLE
parser: diagnose duplicate else in if

### DIFF
--- a/test/fixtures/parser_if_duplicate_else.zax
+++ b/test/fixtures/parser_if_duplicate_else.zax
@@ -1,0 +1,11 @@
+export func main(): void
+  asm
+    if z
+      nop
+    else
+      nop
+    else
+      nop
+    end
+  end
+

--- a/test/pr15_structured_control.test.ts
+++ b/test/pr15_structured_control.test.ts
@@ -203,6 +203,14 @@ describe('PR15 structured asm control flow', () => {
     expect(res.diagnostics[0]?.message).toBe('"else" without matching "if" or "select"');
   });
 
+  it('diagnoses duplicate else in if', async () => {
+    const entry = join(__dirname, 'fixtures', 'parser_if_duplicate_else.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe('"else" duplicated in if');
+  });
+
   it('diagnoses repeat closed by end (until required)', async () => {
     const entry = join(__dirname, 'fixtures', 'pr32_repeat_closed_by_end.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });


### PR DESCRIPTION
Disallows multiple `else` arms in a single `if` block inside `asm` (previously the parser would accept repeated `else` lines). Adds a negative fixture + test asserting the diagnostic.

Run locally: yarn -s format:check && yarn -s typecheck && yarn -s test