### PR TITLE
docs: clarify shared-case select syntax

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+content/

--- a/docs/zax-spec.md
+++ b/docs/zax-spec.md
@@ -1037,6 +1037,10 @@ Rules:
   - `case 0`
   - `case 1`
   - `<body>`
+- Shared-case example (no fallthrough, shared body):
+  - `case 0`
+  - `case 1`
+  - `nop`
 - `case` and `else` are only valid inside `select` (and `else` is also valid inside `if`). Encountering them outside their enclosing construct is a compile error.
 - A `select` must contain at least one arm (`case` or `else`). A `select` with no arms is a compile error.
 


### PR DESCRIPTION
Adds a concrete example showing how to share one clause body across multiple `case` labels (stacked-case syntax). Also adds `.prettierignore` to ignore untracked local `content/` drafts so `yarn format:check` stays clean.

Run locally: yarn -s format:check && yarn -s typecheck && yarn -s test