### PR TITLE
parser: diagnose missing control operands

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -1593,6 +1593,7 @@ export function emitProgram(
           emitAbs16Fixup(op, label.toLowerCase(), 0, span);
         };
         const emitJumpIfFalse = (cc: string, label: string, span: SourceSpan): boolean => {
+          if (cc === '__missing__') return false;
           const inv = inverseConditionName(cc);
           if (!inv) {
             diagAt(diagnostics, span, `Unsupported condition code "${cc}".`);

--- a/test/fixtures/parser_if_missing_cc.zax
+++ b/test/fixtures/parser_if_missing_cc.zax
@@ -1,0 +1,6 @@
+export func main(): void
+  asm
+    if
+      nop
+    end
+  end

--- a/test/fixtures/parser_select_missing_selector.zax
+++ b/test/fixtures/parser_select_missing_selector.zax
@@ -1,0 +1,7 @@
+export func main(): void
+  asm
+    select
+      case 0
+        nop
+    end
+  end

--- a/test/fixtures/parser_until_missing_cc.zax
+++ b/test/fixtures/parser_until_missing_cc.zax
@@ -1,0 +1,6 @@
+export func main(): void
+  asm
+    repeat
+      nop
+    until
+  end

--- a/test/fixtures/parser_while_missing_cc.zax
+++ b/test/fixtures/parser_while_missing_cc.zax
@@ -1,0 +1,6 @@
+export func main(): void
+  asm
+    while
+      nop
+    end
+  end

--- a/test/pr15_structured_control.test.ts
+++ b/test/pr15_structured_control.test.ts
@@ -211,6 +211,38 @@ describe('PR15 structured asm control flow', () => {
     expect(res.diagnostics[0]?.message).toBe('"else" duplicated in if');
   });
 
+  it('diagnoses if without a condition code', async () => {
+    const entry = join(__dirname, 'fixtures', 'parser_if_missing_cc.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe('"if" expects a condition code');
+  });
+
+  it('diagnoses while without a condition code', async () => {
+    const entry = join(__dirname, 'fixtures', 'parser_while_missing_cc.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe('"while" expects a condition code');
+  });
+
+  it('diagnoses until without a condition code', async () => {
+    const entry = join(__dirname, 'fixtures', 'parser_until_missing_cc.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe('"until" expects a condition code');
+  });
+
+  it('diagnoses select without a selector', async () => {
+    const entry = join(__dirname, 'fixtures', 'parser_select_missing_selector.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe('"select" expects a selector');
+  });
+
   it('diagnoses repeat closed by end (until required)', async () => {
     const entry = join(__dirname, 'fixtures', 'pr32_repeat_closed_by_end.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });


### PR DESCRIPTION
Treats bare control keywords inside `asm` as structured-control statements with a single, non-cascading diagnostic:
- `if`/`while`/`until` without a condition code
- `select` without a selector

Also avoids duplicate lowering diagnostics for these missing-cc sentinels.

Run locally: yarn -s format:check && yarn -s typecheck && yarn -s test