### PR TITLE
parser: diagnose case without a value

### DIFF
--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -777,6 +777,29 @@ function parseAsmStatement(
     }
     return { kind: 'Case', span: stmtSpan, value };
   }
+  if (lower === 'case') {
+    const top = controlStack[controlStack.length - 1];
+    if (top?.kind !== 'Select') {
+      diag(diagnostics, filePath, `"case" without matching "select"`, {
+        line: stmtSpan.start.line,
+        column: stmtSpan.start.column,
+      });
+      return undefined;
+    }
+    if (top.elseSeen) {
+      diag(diagnostics, filePath, `"case" after "else" in select`, {
+        line: stmtSpan.start.line,
+        column: stmtSpan.start.column,
+      });
+      return undefined;
+    }
+    top.armSeen = true;
+    diag(diagnostics, filePath, `"case" expects a value`, {
+      line: stmtSpan.start.line,
+      column: stmtSpan.start.column,
+    });
+    return undefined;
+  }
 
   return parseAsmInstruction(filePath, trimmed, stmtSpan, diagnostics);
 }

--- a/test/fixtures/parser_case_missing_value.zax
+++ b/test/fixtures/parser_case_missing_value.zax
@@ -1,0 +1,7 @@
+export func main(): void
+  asm
+    select A
+      case
+    end
+  end
+

--- a/test/pr15_structured_control.test.ts
+++ b/test/pr15_structured_control.test.ts
@@ -243,6 +243,14 @@ describe('PR15 structured asm control flow', () => {
     expect(res.diagnostics[0]?.message).toBe('"select" expects a selector');
   });
 
+  it('diagnoses case without a value', async () => {
+    const entry = join(__dirname, 'fixtures', 'parser_case_missing_value.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe('"case" expects a value');
+  });
+
   it('diagnoses repeat closed by end (until required)', async () => {
     const entry = join(__dirname, 'fixtures', 'pr32_repeat_closed_by_end.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });


### PR DESCRIPTION
Handles bare `case` in `asm` as structured control (instead of a bogus instruction), emitting a single diagnostic and avoiding cascades inside `select`.

Run locally: yarn -s format:check && yarn -s typecheck && yarn -s test