### PR TITLE
parser: report unclosed asm control at EOF

### DIFF
--- a/test/fixtures/parser_unterminated_if_eof.zax
+++ b/test/fixtures/parser_unterminated_if_eof.zax
@@ -1,0 +1,4 @@
+export func main(): void
+  asm
+    if z
+      nop

--- a/test/pr15_structured_control.test.ts
+++ b/test/pr15_structured_control.test.ts
@@ -251,6 +251,14 @@ describe('PR15 structured asm control flow', () => {
     expect(res.diagnostics[0]?.message).toBe('"case" expects a value');
   });
 
+  it('diagnoses unterminated control at EOF', async () => {
+    const entry = join(__dirname, 'fixtures', 'parser_unterminated_if_eof.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics.some((d) => d.message === '"if" without matching "end"')).toBe(true);
+    expect(res.diagnostics.some((d) => d.message.includes('Unterminated func "main"'))).toBe(true);
+  });
+
   it('diagnoses repeat closed by end (until required)', async () => {
     const entry = join(__dirname, 'fixtures', 'pr32_repeat_closed_by_end.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });


### PR DESCRIPTION
Improves parser diagnostics when a `func`/`op` ends unexpectedly at EOF while structured asm control blocks are still open. The parser now emits a specific "<kind> without matching end" (or repeat/until) diagnostic anchored at the opening keyword, in addition to the existing unterminated func/op message. Includes a fixture + test.

Run locally: yarn -s format:check && yarn -s typecheck && yarn -s test