### PR TITLE
parser: avoid cascades for invalid control syntax

### DIFF
--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -666,6 +666,13 @@ function parseAsmStatement(
     controlStack.push({ kind: 'If', elseSeen: false, openSpan: stmtSpan });
     return { kind: 'If', span: stmtSpan, cc };
   }
+  if (lower.startsWith('if ')) {
+    diag(diagnostics, filePath, `"if" expects a condition code`, {
+      line: stmtSpan.start.line,
+      column: stmtSpan.start.column,
+    });
+    return undefined;
+  }
   if (lower === 'if') {
     diag(diagnostics, filePath, `"if" expects a condition code`, {
       line: stmtSpan.start.line,
@@ -680,6 +687,13 @@ function parseAsmStatement(
     const cc = whileMatch[1]!;
     controlStack.push({ kind: 'While', openSpan: stmtSpan });
     return { kind: 'While', span: stmtSpan, cc };
+  }
+  if (lower.startsWith('while ')) {
+    diag(diagnostics, filePath, `"while" expects a condition code`, {
+      line: stmtSpan.start.line,
+      column: stmtSpan.start.column,
+    });
+    return undefined;
   }
   if (lower === 'while') {
     diag(diagnostics, filePath, `"while" expects a condition code`, {
@@ -719,6 +733,22 @@ function parseAsmStatement(
     }
     controlStack.pop();
     return { kind: 'Until', span: stmtSpan, cc };
+  }
+  if (lower.startsWith('until ')) {
+    const top = controlStack[controlStack.length - 1];
+    if (top?.kind !== 'Repeat') {
+      diag(diagnostics, filePath, `"until" without matching "repeat"`, {
+        line: stmtSpan.start.line,
+        column: stmtSpan.start.column,
+      });
+      return undefined;
+    }
+    diag(diagnostics, filePath, `"until" expects a condition code`, {
+      line: stmtSpan.start.line,
+      column: stmtSpan.start.column,
+    });
+    controlStack.pop();
+    return { kind: 'Until', span: stmtSpan, cc: missingCc };
   }
 
   if (lower === 'select') {

--- a/test/fixtures/parser_if_invalid_cc.zax
+++ b/test/fixtures/parser_if_invalid_cc.zax
@@ -1,0 +1,6 @@
+export func main(): void
+  asm
+    if z,
+      nop
+  end
+

--- a/test/fixtures/parser_until_invalid_cc.zax
+++ b/test/fixtures/parser_until_invalid_cc.zax
@@ -1,0 +1,7 @@
+export func main(): void
+  asm
+    repeat
+      nop
+    until z,
+  end
+

--- a/test/fixtures/parser_while_invalid_cc.zax
+++ b/test/fixtures/parser_while_invalid_cc.zax
@@ -1,0 +1,6 @@
+export func main(): void
+  asm
+    while nz,
+      nop
+  end
+

--- a/test/pr15_structured_control.test.ts
+++ b/test/pr15_structured_control.test.ts
@@ -219,6 +219,14 @@ describe('PR15 structured asm control flow', () => {
     expect(res.diagnostics[0]?.message).toBe('"if" expects a condition code');
   });
 
+  it('diagnoses invalid if syntax (no cascades)', async () => {
+    const entry = join(__dirname, 'fixtures', 'parser_if_invalid_cc.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe('"if" expects a condition code');
+  });
+
   it('diagnoses while without a condition code', async () => {
     const entry = join(__dirname, 'fixtures', 'parser_while_missing_cc.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
@@ -227,8 +235,24 @@ describe('PR15 structured asm control flow', () => {
     expect(res.diagnostics[0]?.message).toBe('"while" expects a condition code');
   });
 
+  it('diagnoses invalid while syntax (no cascades)', async () => {
+    const entry = join(__dirname, 'fixtures', 'parser_while_invalid_cc.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe('"while" expects a condition code');
+  });
+
   it('diagnoses until without a condition code', async () => {
     const entry = join(__dirname, 'fixtures', 'parser_until_missing_cc.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe('"until" expects a condition code');
+  });
+
+  it('diagnoses invalid until syntax (no cascades)', async () => {
+    const entry = join(__dirname, 'fixtures', 'parser_until_invalid_cc.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics).toHaveLength(1);


### PR DESCRIPTION
Treats `if ...`, `while ...`, and `until ...` lines that start like structured control but have invalid syntax as control keywords (not instructions), emitting a single diagnostic and avoiding cascaded lowering/encoding noise. Adds negative fixtures + tests.

Run locally: yarn -s format:check && yarn -s typecheck && yarn -s test