### PR TITLE
parser: avoid cascades for invalid select selector

### DIFF
--- a/test/fixtures/parser_select_invalid_selector.zax
+++ b/test/fixtures/parser_select_invalid_selector.zax
@@ -1,0 +1,8 @@
+export func main(): void
+  asm
+    select A,
+      case 0
+        nop
+    end
+  end
+

--- a/test/pr15_structured_control.test.ts
+++ b/test/pr15_structured_control.test.ts
@@ -267,6 +267,14 @@ describe('PR15 structured asm control flow', () => {
     expect(res.diagnostics[0]?.message).toBe('"select" expects a selector');
   });
 
+  it('diagnoses invalid select selector (no cascades)', async () => {
+    const entry = join(__dirname, 'fixtures', 'parser_select_invalid_selector.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe('Invalid select selector');
+  });
+
   it('diagnoses case without a value', async () => {
     const entry = join(__dirname, 'fixtures', 'parser_case_missing_value.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });


### PR DESCRIPTION
When `select <selector>` has a selector that fails to parse, emit a single "Invalid select selector" diagnostic and still treat it as a `select` block so subsequent `case` lines do not cascade into additional errors.

This is implemented by parsing the selector with diagnostics disabled and falling back to a dummy selector operand. Includes a negative fixture + test.

Run locally: yarn -s format:check && yarn -s typecheck && yarn -s test