### PR TITLE
parser: avoid cascades for invalid case values

### DIFF
--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -805,7 +805,7 @@ function parseAsmStatement(
     }
     top.armSeen = true;
     const exprText = caseMatch[1]!.trim();
-    const value = parseImmExprFromText(filePath, exprText, stmtSpan, diagnostics);
+    const value = parseImmExprFromText(filePath, exprText, stmtSpan, diagnostics, false);
     if (!value) {
       diag(diagnostics, filePath, `Invalid case value`, {
         line: stmtSpan.start.line,

--- a/test/fixtures/parser_case_invalid_value_comma.zax
+++ b/test/fixtures/parser_case_invalid_value_comma.zax
@@ -1,0 +1,8 @@
+export func main(): void
+  asm
+    select A
+      case 0,
+        nop
+    end
+  end
+

--- a/test/fixtures/parser_case_invalid_value_list.zax
+++ b/test/fixtures/parser_case_invalid_value_list.zax
@@ -1,0 +1,8 @@
+export func main(): void
+  asm
+    select A
+      case 0, 1
+        nop
+    end
+  end
+

--- a/test/pr15_structured_control.test.ts
+++ b/test/pr15_structured_control.test.ts
@@ -283,6 +283,22 @@ describe('PR15 structured asm control flow', () => {
     expect(res.diagnostics[0]?.message).toBe('"case" expects a value');
   });
 
+  it('diagnoses invalid case value with one diagnostic (comma)', async () => {
+    const entry = join(__dirname, 'fixtures', 'parser_case_invalid_value_comma.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe('Invalid case value');
+  });
+
+  it('diagnoses invalid case value with one diagnostic (list)', async () => {
+    const entry = join(__dirname, 'fixtures', 'parser_case_invalid_value_list.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toBe('Invalid case value');
+  });
+
   it('diagnoses unterminated control at EOF', async () => {
     const entry = join(__dirname, 'fixtures', 'parser_unterminated_if_eof.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });


### PR DESCRIPTION
Avoids duplicate diagnostics for invalid `case` values inside `select` by parsing the imm expression with diagnostics disabled and emitting a single "Invalid case value". Adds fixtures + tests for `case 0,` and `case 0, 1`.

Run locally: yarn -s format:check && yarn -s typecheck && yarn -s test