### PR TITLE
test: expand fixup coverage for call/jr/djnz

### DIFF
--- a/test/fixtures/pr37_forward_label_call.zax
+++ b/test/fixtures/pr37_forward_label_call.zax
@@ -1,0 +1,7 @@
+export func main(): void
+  asm
+    call target
+    nop
+target:
+    nop
+end

--- a/test/fixtures/pr37_forward_label_djnz.zax
+++ b/test/fixtures/pr37_forward_label_djnz.zax
@@ -1,0 +1,7 @@
+export func main(): void
+  asm
+    djnz target
+    nop
+target:
+    nop
+end

--- a/test/fixtures/pr37_forward_label_jr_cond.zax
+++ b/test/fixtures/pr37_forward_label_jr_cond.zax
@@ -1,0 +1,7 @@
+export func main(): void
+  asm
+    jr nz, target
+    nop
+target:
+    nop
+end

--- a/test/fixtures/pr37_unresolved_symbol_rel8.zax
+++ b/test/fixtures/pr37_unresolved_symbol_rel8.zax
@@ -1,0 +1,4 @@
+export func main(): void
+  asm
+    jr missing_label
+end

--- a/test/pr37_fixup_negative.test.ts
+++ b/test/pr37_fixup_negative.test.ts
@@ -18,6 +18,16 @@ describe('PR37 fixup negatives', () => {
     ).toBe(true);
   });
 
+  it('diagnoses unresolved rel8 fixup symbols', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr37_unresolved_symbol_rel8.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(
+      res.diagnostics.some((d) => d.message.includes('Unresolved symbol "missing_label"')),
+    ).toBe(true);
+    expect(res.diagnostics.some((d) => d.message.includes('rel8 jr fixup'))).toBe(true);
+  });
+
   it('diagnoses rel8 out-of-range fixups', async () => {
     const entry = join(__dirname, 'fixtures', 'pr37_rel8_out_of_range.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });

--- a/test/pr37_forward_label_fixups.test.ts
+++ b/test/pr37_forward_label_fixups.test.ts
@@ -19,6 +19,15 @@ describe('PR37 forward label fixups', () => {
     expect(bin!.bytes).toEqual(Uint8Array.of(0xc3, 0x04, 0x00, 0x00, 0x00, 0xc9));
   });
 
+  it('resolves forward label for call abs16 fixup', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr37_forward_label_call.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    expect(bin!.bytes).toEqual(Uint8Array.of(0xcd, 0x04, 0x00, 0x00, 0x00, 0xc9));
+  });
+
   it('resolves forward label for rel8 branches', async () => {
     const entry = join(__dirname, 'fixtures', 'pr37_forward_label_rel8.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
@@ -26,5 +35,23 @@ describe('PR37 forward label fixups', () => {
     const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
     expect(bin).toBeDefined();
     expect(bin!.bytes).toEqual(Uint8Array.of(0x18, 0x01, 0x00, 0x00, 0xc9));
+  });
+
+  it('resolves forward label for conditional jr rel8 fixup', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr37_forward_label_jr_cond.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    expect(bin!.bytes).toEqual(Uint8Array.of(0x20, 0x01, 0x00, 0x00, 0xc9));
+  });
+
+  it('resolves forward label for djnz rel8 fixup', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr37_forward_label_djnz.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    expect(bin!.bytes).toEqual(Uint8Array.of(0x10, 0x01, 0x00, 0x00, 0xc9));
   });
 });


### PR DESCRIPTION
 - Add forward-reference fixtures/tests covering abs16 fixups via `call` and rel8 fixups via conditional `jr` and `djnz`.
- Add a negative fixture/test for unresolved rel8 symbols (`jr missing_label`) to lock in the diagnostic class.

Local checks: yarn -s format:check && yarn -s typecheck && yarn -s test.