### PR TITLE
test: conditional abs16 fixups (jp/call) + roadmap sync

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,7 +11,7 @@ Core policy:
 
 Progress snapshot (rough, assembler-first):
 
-- Completed PR anchors listed below: 56
+- Completed PR anchors listed below: 57
 - Assembler completion gates fully green: 0/6
 - Integration readiness with Debug80: not yet (gates not satisfied)
 
@@ -192,62 +192,63 @@ Open / in review (anchored):
 
 Completed (anchored, most recent first):
 
-1. #84: Test: expand fixup coverage for `call`/`jr`/`djnz` (fixtures + tests).
-2. #83: Docs: assembler pipeline mapping + roadmap anchor sync.
-3. #82: Lowering: avoid dead epilogue jump; docs: terminal `ret` optional (tests).
-4. #81: Parser: avoid cascades for invalid `case` values (fixtures + tests).
-5. #80: Parser: avoid cascades for invalid `select` selector (fixtures + tests).
-6. #79: Parser: avoid cascades for invalid control syntax (fixtures + tests).
-7. #78: Parser: report unclosed asm control at EOF (fixtures + tests).
-8. #77: Parser: diagnose `case` without a value (fixtures + tests).
-9. #76: Parser: diagnose missing control operands (fixtures + tests).
-10. #75: Docs: clarify shared-case `select` syntax.
-11. #74: Parser: diagnose duplicate `else` in `if` (fixtures + tests).
-12. #73: Parser: diagnose `select` with no arms (fixtures + tests).
-13. #72: Docs: sync roadmap through PR #71.
-14. #71: ISA: ED block I/O instructions (INI/INIR/IND/INDR/OUTI/OTIR/OUTD/OTDR) (fixture + test).
-15. #70: ISA: indexed rotates/shifts (IX/IY + disp8) (fixture + test).
-16. #68: ISA: indexed bit ops (IX/IY + disp8) (fixture + test).
-17. #67: ISA: indexed inc/dec (IX/IY + disp8) (fixture + test).
-18. #66: ISA: indexed IX/IY disp8 addressing for `ld` (fixture + test).
-19. #65: ISA: ED block instructions (LDI/LDIR/LDD/LDDR/CPI/CPIR/CPD/CPDR) (fixture + test).
-20. #64: ISA: ED misc ops (`neg/rrd/rld`, `ld i,a / ld a,i / ld r,a / ld a,r`) (fixture + test).
-21. #63: ISA: `in/out` port operands end-to-end (parser + encoder + fixture + test).
-22. #62: Test: use implicit return in PR14 no-locals fixture.
-23. #61: Docs: sync roadmap completed PR anchors.
-24. #60: Revert: undo PR #59 merge (self-approval policy).
-25. #59: Docs: sync roadmap completed PR anchors (reverted by #60).
-26. #58: ISA: encode `jp (hl)`, `jp (ix)`, `jp (iy)` (fixture + test).
-27. #57: ISA: encode `im 0|1|2`, `rst <imm8>`, `reti`, `retn` (fixture + test).
-28. #56: ISA: encode misc system ops (`halt/di/ei/scf/ccf/cpl/ex*/exx`) (fixture + test).
-29. #55: Parser UX: avoid duplicate diagnostics for illegal `T[]` usage (tests).
-30. #54: Parser: restrict inferred arrays `T[]` to `data` declarations only (tests).
-31. #53: Diagnostics: remove "PR subset" wording from user-facing errors (small cleanup).
-32. #52: Treat `ptr` as a 16-bit scalar in codegen (tests).
-33. #51: Inferred-length arrays in `data` declarations (`T[]`) (parser + tests).
-34. #50: Union declarations + layout + field access (parser/semantics/lowering + tests).
-35. #49: Fast-path abs `ld (ea), imm16` for `word`/`addr` destinations using `ld (nn),hl` (tests).
-36. #48: Lower `ld (ea), imm16` for `word`/`addr` destinations (tests).
-37. #47: ISA: encode `ld a,(bc|de)` and `ld (bc|de),a` (fixture + test).
-38. #46: Roadmap update for #44/#45 (reality check + gates).
-39. #45: ld abs16 ED forms for BC/DE/SP (fixture + test).
-40. #44: ld abs16 special-cases for A/HL (fixture + test).
-41. #43: Lower `ld (ea), imm8` for byte destinations (tests).
-42. #42: Roadmap anchor update for #40/#41.
-43. #41: ISA: `inc`/`dec` reg8 + `(hl)`, and `ld (hl), imm8` (fixture + test).
-44. #40: Implicit return after label (treat labels as re-entry points).
-45. #39: Listing output (`.lst`) artifact + contract test + CLI note.
-46. #38: Document examples as compiled contract (`examples/README.md`).
-47. #37: Fixups and forward references (spec + tests).
-48. #36: Expand char literal escape coverage (tests).
-49. #35: Char literals in `imm` expressions (parser + tests).
-50. #34: Examples compile gate (CI contract test + example updates).
-51. #33: Parser `select` arm ordering hardening.
-52. #32: Harden asm control keyword parsing (prevent cascaded diagnostics).
-53. #31: Roadmap anchors updated to real PR numbers (remove placeholders).
-54. #30: Diagnose `case` outside `select` during parsing (negative fixtures).
-55. #29: Deduplicate `select` join mismatch diagnostics (regression test).
-56. #28: Stacked `select case` labels share one body (spec + tests).
+1. #85: Test: extend rel8 range checks (`jr cc`, `djnz`) + roadmap sync.
+2. #84: Test: expand fixup coverage for `call`/`jr`/`djnz` (fixtures + tests).
+3. #83: Docs: assembler pipeline mapping + roadmap anchor sync.
+4. #82: Lowering: avoid dead epilogue jump; docs: terminal `ret` optional (tests).
+5. #81: Parser: avoid cascades for invalid `case` values (fixtures + tests).
+6. #80: Parser: avoid cascades for invalid `select` selector (fixtures + tests).
+7. #79: Parser: avoid cascades for invalid control syntax (fixtures + tests).
+8. #78: Parser: report unclosed asm control at EOF (fixtures + tests).
+9. #77: Parser: diagnose `case` without a value (fixtures + tests).
+10. #76: Parser: diagnose missing control operands (fixtures + tests).
+11. #75: Docs: clarify shared-case `select` syntax.
+12. #74: Parser: diagnose duplicate `else` in `if` (fixtures + tests).
+13. #73: Parser: diagnose `select` with no arms (fixtures + tests).
+14. #72: Docs: sync roadmap through PR #71.
+15. #71: ISA: ED block I/O instructions (INI/INIR/IND/INDR/OUTI/OTIR/OUTD/OTDR) (fixture + test).
+16. #70: ISA: indexed rotates/shifts (IX/IY + disp8) (fixture + test).
+17. #68: ISA: indexed bit ops (IX/IY + disp8) (fixture + test).
+18. #67: ISA: indexed inc/dec (IX/IY + disp8) (fixture + test).
+19. #66: ISA: indexed IX/IY disp8 addressing for `ld` (fixture + test).
+20. #65: ISA: ED block instructions (LDI/LDIR/LDD/LDDR/CPI/CPIR/CPD/CPDR) (fixture + test).
+21. #64: ISA: ED misc ops (`neg/rrd/rld`, `ld i,a / ld a,i / ld r,a / ld a,r`) (fixture + test).
+22. #63: ISA: `in/out` port operands end-to-end (parser + encoder + fixture + test).
+23. #62: Test: use implicit return in PR14 no-locals fixture.
+24. #61: Docs: sync roadmap completed PR anchors.
+25. #60: Revert: undo PR #59 merge (self-approval policy).
+26. #59: Docs: sync roadmap completed PR anchors (reverted by #60).
+27. #58: ISA: encode `jp (hl)`, `jp (ix)`, `jp (iy)` (fixture + test).
+28. #57: ISA: encode `im 0|1|2`, `rst <imm8>`, `reti`, `retn` (fixture + test).
+29. #56: ISA: encode misc system ops (`halt/di/ei/scf/ccf/cpl/ex*/exx`) (fixture + test).
+30. #55: Parser UX: avoid duplicate diagnostics for illegal `T[]` usage (tests).
+31. #54: Parser: restrict inferred arrays `T[]` to `data` declarations only (tests).
+32. #53: Diagnostics: remove "PR subset" wording from user-facing errors (small cleanup).
+33. #52: Treat `ptr` as a 16-bit scalar in codegen (tests).
+34. #51: Inferred-length arrays in `data` declarations (`T[]`) (parser + tests).
+35. #50: Union declarations + layout + field access (parser/semantics/lowering + tests).
+36. #49: Fast-path abs `ld (ea), imm16` for `word`/`addr` destinations using `ld (nn),hl` (tests).
+37. #48: Lower `ld (ea), imm16` for `word`/`addr` destinations (tests).
+38. #47: ISA: encode `ld a,(bc|de)` and `ld (bc|de),a` (fixture + test).
+39. #46: Roadmap update for #44/#45 (reality check + gates).
+40. #45: ld abs16 ED forms for BC/DE/SP (fixture + test).
+41. #44: ld abs16 special-cases for A/HL (fixture + test).
+42. #43: Lower `ld (ea), imm8` for byte destinations (tests).
+43. #42: Roadmap anchor update for #40/#41.
+44. #41: ISA: `inc`/`dec` reg8 + `(hl)`, and `ld (hl), imm8` (fixture + test).
+45. #40: Implicit return after label (treat labels as re-entry points).
+46. #39: Listing output (`.lst`) artifact + contract test + CLI note.
+47. #38: Document examples as compiled contract (`examples/README.md`).
+48. #37: Fixups and forward references (spec + tests).
+49. #36: Expand char literal escape coverage (tests).
+50. #35: Char literals in `imm` expressions (parser + tests).
+51. #34: Examples compile gate (CI contract test + example updates).
+52. #33: Parser `select` arm ordering hardening.
+53. #32: Harden asm control keyword parsing (prevent cascaded diagnostics).
+54. #31: Roadmap anchors updated to real PR numbers (remove placeholders).
+55. #30: Diagnose `case` outside `select` during parsing (negative fixtures).
+56. #29: Deduplicate `select` join mismatch diagnostics (regression test).
+57. #28: Stacked `select case` labels share one body (spec + tests).
 
 Next (assembler-first):
 

--- a/test/fixtures/pr37_forward_label_call_cond.zax
+++ b/test/fixtures/pr37_forward_label_call_cond.zax
@@ -1,0 +1,7 @@
+export func main(): void
+  asm
+    call nz, target
+    nop
+target:
+    nop
+end

--- a/test/fixtures/pr37_forward_label_jp_cond.zax
+++ b/test/fixtures/pr37_forward_label_jp_cond.zax
@@ -1,0 +1,7 @@
+export func main(): void
+  asm
+    jp nz, target
+    nop
+target:
+    nop
+end

--- a/test/pr37_forward_label_fixups.test.ts
+++ b/test/pr37_forward_label_fixups.test.ts
@@ -28,6 +28,15 @@ describe('PR37 forward label fixups', () => {
     expect(bin!.bytes).toEqual(Uint8Array.of(0xcd, 0x04, 0x00, 0x00, 0x00, 0xc9));
   });
 
+  it('resolves forward label for conditional call abs16 fixup', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr37_forward_label_call_cond.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    expect(bin!.bytes).toEqual(Uint8Array.of(0xc4, 0x04, 0x00, 0x00, 0x00, 0xc9));
+  });
+
   it('resolves forward label for rel8 branches', async () => {
     const entry = join(__dirname, 'fixtures', 'pr37_forward_label_rel8.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
@@ -35,6 +44,15 @@ describe('PR37 forward label fixups', () => {
     const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
     expect(bin).toBeDefined();
     expect(bin!.bytes).toEqual(Uint8Array.of(0x18, 0x01, 0x00, 0x00, 0xc9));
+  });
+
+  it('resolves forward label for conditional jp abs16 fixup', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr37_forward_label_jp_cond.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    expect(bin!.bytes).toEqual(Uint8Array.of(0xc2, 0x04, 0x00, 0x00, 0x00, 0xc9));
   });
 
   it('resolves forward label for conditional jr rel8 fixup', async () => {


### PR DESCRIPTION
 - Add forward-reference fixtures/tests for conditional abs16 fixups: `jp nz, label` and `call nz, label`.
- Sync `docs/roadmap.md` completed anchors to include PR #85.

Local checks: yarn -s format:check && yarn -s typecheck && yarn -s test.