### PR TITLE
test: determinism for emitted artifacts

### DIFF
--- a/test/determinism_artifacts.test.ts
+++ b/test/determinism_artifacts.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { Artifact, BinArtifact, HexArtifact, ListingArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function artifactSnapshot(a: Artifact): { kind: string; data: string } {
+  switch (a.kind) {
+    case 'bin': {
+      const bin = a as BinArtifact;
+      return { kind: 'bin', data: Buffer.from(bin.bytes).toString('hex') };
+    }
+    case 'hex': {
+      const hex = a as HexArtifact;
+      return { kind: 'hex', data: hex.text };
+    }
+    case 'd8m': {
+      return { kind: 'd8m', data: JSON.stringify(a.json) };
+    }
+    case 'lst': {
+      const lst = a as ListingArtifact;
+      return { kind: 'lst', data: lst.text };
+    }
+  }
+}
+
+async function compileSnapshot(entry: string): Promise<Array<{ kind: string; data: string }>> {
+  const res = await compile(entry, {}, { formats: defaultFormatWriters });
+  expect(res.diagnostics).toEqual([]);
+  return res.artifacts.map(artifactSnapshot);
+}
+
+describe('determinism', () => {
+  it('produces identical artifacts across repeated compiles (single module)', async () => {
+    const entry = join(__dirname, '..', 'examples', 'hello.zax');
+    const snap0 = await compileSnapshot(entry);
+    for (let i = 0; i < 5; i++) {
+      expect(await compileSnapshot(entry)).toEqual(snap0);
+    }
+  });
+
+  it('produces identical artifacts across repeated compiles (imports + packing)', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr10_import_main.zax');
+    const snap0 = await compileSnapshot(entry);
+    for (let i = 0; i < 5; i++) {
+      expect(await compileSnapshot(entry)).toEqual(snap0);
+    }
+  });
+});


### PR DESCRIPTION
 - Add a determinism suite that compiles the same entry repeatedly and asserts identical emitted artifacts (`.bin`, `.hex`, `.d8dbg.json`, `.lst`).
- Covers a single-module program and an imports+packing program to exercise module ordering.

Local checks: yarn -s format:check && yarn -s typecheck && yarn -s test.