### PR TITLE
ISA tranche: encode adc/sbc HL,rr (ED forms)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -236,26 +236,25 @@ Use only real GitHub PR numbers:
 
 Open / in review (anchored):
 
-- #90: `.lst` improvement tranche (ascii gutter + sparse-byte markers).
+- #91: ISA coverage tranche (`adc/sbc HL,rr` ED forms + tests).
 
-Next after #90 merges (anchored as soon as opened):
+Next after #91 merges (anchored as soon as opened):
 
-1. Next PR: ISA coverage tranche driven by examples (add missing encodings + negative tests).
-2. Next PR: Lowering interaction torture suite (nested control + calls + locals + ops + SP tracking).
-3. Next PR: Spec audit pass (map each v0.1 rule to a test or a stable rejection diagnostic).
+1. Next PR: Lowering interaction torture suite (nested control + calls + locals + ops + SP tracking).
+2. Next PR: Spec audit pass (map each v0.1 rule to a test or a stable rejection diagnostic).
 
 Completed (anchored, most recent first):
 
-1. #89: CLI parity sweep (entry-last enforcement + contract tests).
-2. #88: CLI: v0.1 artifact-writing command (bin/hex/d8m/lst).
-3. #87: Test: determinism for emitted artifacts.
-4. #86: Test: conditional abs16 fixups (`jp cc`, `call cc`) + roadmap sync.
-5. #85: Test: extend rel8 range checks (`jr cc`, `djnz`) + roadmap sync.
-6. #84: Test: expand fixup coverage for `call`/`jr`/`djnz` (fixtures + tests).
-7. #83: Docs: assembler pipeline mapping + roadmap anchor sync.
-8. #82: Lowering: avoid dead epilogue jump; docs: terminal `ret` optional (tests).
-9. #81: Parser: avoid cascades for invalid `case` values (fixtures + tests).
-10. #80: Parser: avoid cascades for invalid `select` selector (fixtures + tests).
+1. #90: Listing tranche: ascii gutter and sparse-byte markers.
+2. #89: CLI parity sweep (entry-last enforcement + contract tests).
+3. #88: CLI: v0.1 artifact-writing command (bin/hex/d8m/lst).
+4. #87: Test: determinism for emitted artifacts.
+5. #86: Test: conditional abs16 fixups (`jp cc`, `call cc`) + roadmap sync.
+6. #85: Test: extend rel8 range checks (`jr cc`, `djnz`) + roadmap sync.
+7. #84: Test: expand fixup coverage for `call`/`jr`/`djnz` (fixtures + tests).
+8. #83: Docs: assembler pipeline mapping + roadmap anchor sync.
+9. #82: Lowering: avoid dead epilogue jump; docs: terminal `ret` optional (tests).
+10. #81: Parser: avoid cascades for invalid `case` values (fixtures + tests).
 11. #77: Parser: diagnose `case` without a value (fixtures + tests).
 12. #76: Parser: diagnose missing control operands (fixtures + tests).
 13. #75: Docs: clarify shared-case `select` syntax.

--- a/src/z80/encode.ts
+++ b/src/z80/encode.ts
@@ -687,11 +687,43 @@ export function encodeInstruction(
   }
 
   if (head === 'adc') {
+    if (ops.length === 2 && regName(ops[0]!) === 'HL') {
+      const src = regName(ops[1]!);
+      switch (src) {
+        case 'BC':
+          return Uint8Array.of(0xed, 0x4a);
+        case 'DE':
+          return Uint8Array.of(0xed, 0x5a);
+        case 'HL':
+          return Uint8Array.of(0xed, 0x6a);
+        case 'SP':
+          return Uint8Array.of(0xed, 0x7a);
+        default:
+          diag(diagnostics, node, `adc HL, rr expects BC/DE/HL/SP`);
+          return undefined;
+      }
+    }
     const encoded = encodeAluAOrImm8OrMemHL(0x88, 0xce, 0x8e, 'adc', true);
     if (encoded) return encoded;
   }
 
   if (head === 'sbc') {
+    if (ops.length === 2 && regName(ops[0]!) === 'HL') {
+      const src = regName(ops[1]!);
+      switch (src) {
+        case 'BC':
+          return Uint8Array.of(0xed, 0x42);
+        case 'DE':
+          return Uint8Array.of(0xed, 0x52);
+        case 'HL':
+          return Uint8Array.of(0xed, 0x62);
+        case 'SP':
+          return Uint8Array.of(0xed, 0x72);
+        default:
+          diag(diagnostics, node, `sbc HL, rr expects BC/DE/HL/SP`);
+          return undefined;
+      }
+    }
     const encoded = encodeAluAOrImm8OrMemHL(0x98, 0xde, 0x9e, 'sbc', true);
     if (encoded) return encoded;
   }

--- a/test/fixtures/pr91_isa_hl16_adc_sbc.zax
+++ b/test/fixtures/pr91_isa_hl16_adc_sbc.zax
@@ -1,0 +1,11 @@
+export func main(): void
+  asm
+    adc hl, bc
+    adc hl, de
+    adc hl, hl
+    adc hl, sp
+    sbc hl, bc
+    sbc hl, de
+    sbc hl, hl
+    sbc hl, sp
+end

--- a/test/fixtures/pr91_isa_hl16_adc_sbc_invalid.zax
+++ b/test/fixtures/pr91_isa_hl16_adc_sbc_invalid.zax
@@ -1,0 +1,4 @@
+export func main(): void
+  asm
+    adc hl, af
+end

--- a/test/pr91_isa_hl16_adc_sbc.test.ts
+++ b/test/pr91_isa_hl16_adc_sbc.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR91: ISA adc/sbc HL,rr', () => {
+  it('encodes adc/sbc HL,BC/DE/HL/SP (ED forms)', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr91_isa_hl16_adc_sbc.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+
+    expect(bin!.bytes).toEqual(
+      Uint8Array.of(
+        0xed,
+        0x4a,
+        0xed,
+        0x5a,
+        0xed,
+        0x6a,
+        0xed,
+        0x7a,
+        0xed,
+        0x42,
+        0xed,
+        0x52,
+        0xed,
+        0x62,
+        0xed,
+        0x72,
+        0xc9,
+      ),
+    );
+  });
+
+  it('diagnoses unsupported rr in adc HL,rr', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr91_isa_hl16_adc_sbc_invalid.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics.some((d) => d.message.includes('adc HL, rr expects BC/DE/HL/SP'))).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add ED-form encodings for `adc hl, rr` and `sbc hl, rr` with `rr ∈ {BC, DE, HL, SP}`
- keep existing `adc/sbc A,*` behavior unchanged
- add fixture + tests for positive encoding coverage
- add negative test for invalid `rr` in `adc hl, rr`
- sync roadmap anchors (`#90` completed, `#91` in review)

## Validation
- `yarn -s format:check`
- `yarn -s typecheck`
- `yarn -s test`
