### PR TITLE
Lowering suite: nested-control + stack-flow interaction tests

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -236,25 +236,24 @@ Use only real GitHub PR numbers:
 
 Open / in review (anchored):
 
-- #91: ISA coverage tranche (`adc/sbc HL,rr` ED forms + tests).
+- #92: Lowering interaction torture suite (nested control + locals + stack-flow checks).
 
-Next after #91 merges (anchored as soon as opened):
+Next after #92 merges (anchored as soon as opened):
 
-1. Next PR: Lowering interaction torture suite (nested control + calls + locals + ops + SP tracking).
-2. Next PR: Spec audit pass (map each v0.1 rule to a test or a stable rejection diagnostic).
+1. Next PR: Spec audit pass (map each v0.1 rule to a test or a stable rejection diagnostic).
 
 Completed (anchored, most recent first):
 
-1. #90: Listing tranche: ascii gutter and sparse-byte markers.
-2. #89: CLI parity sweep (entry-last enforcement + contract tests).
-3. #88: CLI: v0.1 artifact-writing command (bin/hex/d8m/lst).
-4. #87: Test: determinism for emitted artifacts.
-5. #86: Test: conditional abs16 fixups (`jp cc`, `call cc`) + roadmap sync.
-6. #85: Test: extend rel8 range checks (`jr cc`, `djnz`) + roadmap sync.
-7. #84: Test: expand fixup coverage for `call`/`jr`/`djnz` (fixtures + tests).
-8. #83: Docs: assembler pipeline mapping + roadmap anchor sync.
-9. #82: Lowering: avoid dead epilogue jump; docs: terminal `ret` optional (tests).
-10. #81: Parser: avoid cascades for invalid `case` values (fixtures + tests).
+1. #91: ISA tranche: encode `adc/sbc HL,rr` (ED forms) + tests.
+2. #90: Listing tranche: ascii gutter and sparse-byte markers.
+3. #89: CLI parity sweep (entry-last enforcement + contract tests).
+4. #88: CLI: v0.1 artifact-writing command (bin/hex/d8m/lst).
+5. #87: Test: determinism for emitted artifacts.
+6. #86: Test: conditional abs16 fixups (`jp cc`, `call cc`) + roadmap sync.
+7. #85: Test: extend rel8 range checks (`jr cc`, `djnz`) + roadmap sync.
+8. #84: Test: expand fixup coverage for `call`/`jr`/`djnz` (fixtures + tests).
+9. #83: Docs: assembler pipeline mapping + roadmap anchor sync.
+10. #82: Lowering: avoid dead epilogue jump; docs: terminal `ret` optional (tests).
 11. #77: Parser: diagnose `case` without a value (fixtures + tests).
 12. #76: Parser: diagnose missing control operands (fixtures + tests).
 13. #75: Docs: clarify shared-case `select` syntax.

--- a/test/fixtures/pr92_balanced_nested_locals_ops.zax
+++ b/test/fixtures/pr92_balanced_nested_locals_ops.zax
@@ -1,0 +1,28 @@
+op preservebc()
+  push bc
+  pop bc
+end
+
+func helper(x: byte): void
+  asm
+    preservebc
+end
+
+export func main(arg0: byte): void
+  var
+    x: byte
+  asm
+    select A
+      case 0
+        if NZ
+          while NZ
+            preservebc
+          end
+        end
+      else
+        preservebc
+    end
+    helper 7
+    ld a, (arg0)
+    ld a, (x)
+end

--- a/test/fixtures/pr92_fallthrough_stack_delta.zax
+++ b/test/fixtures/pr92_fallthrough_stack_delta.zax
@@ -1,0 +1,4 @@
+export func main(): void
+  asm
+    push bc
+end

--- a/test/fixtures/pr92_select_stack_mismatch_with_locals.zax
+++ b/test/fixtures/pr92_select_stack_mismatch_with_locals.zax
@@ -1,0 +1,12 @@
+export func main(): void
+  var
+    x: word
+  asm
+    select A
+      case 0
+        push bc
+      else
+        nop
+    end
+    ld a, (x)
+end

--- a/test/pr92_lowering_interactions.test.ts
+++ b/test/pr92_lowering_interactions.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR92 lowering interaction torture suite', () => {
+  it('accepts balanced nested control + locals + op/call interactions', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr92_balanced_nested_locals_ops.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    expect(bin!.bytes[bin!.bytes.length - 1]).toBe(0xc9);
+  });
+
+  it('diagnoses select-join stack mismatch when locals are present', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr92_select_stack_mismatch_with_locals.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(
+      res.diagnostics.some((d) => d.message.includes('Stack depth mismatch at select join')),
+    ).toBe(true);
+  });
+
+  it('diagnoses non-zero stack delta at function fallthrough', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr92_fallthrough_stack_delta.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(
+      res.diagnostics.some((d) =>
+        d.message.includes('Function "main" has non-zero stack delta at fallthrough'),
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a lowering interaction torture suite focused on nested control + locals + stack-flow invariants
- add balanced integration fixture covering `select` + `if` + `while` + local slots + op/call interaction
- add negative fixture for select-join stack mismatch with locals
- add negative fixture for non-zero stack delta at function fallthrough
- sync roadmap anchors (`#91` completed, `#92` in review)

## Validation
- `yarn -s format:check`
- `yarn -s typecheck`
- `yarn -s test`
