### PR TITLE
PR114: direct-asm ld abs16 families

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -236,90 +236,91 @@ Use only real GitHub PR numbers:
 
 Open / in review (anchored):
 
-- #113: ISA coverage tranche 8 (indexed rotate/shift destination forms + indexed set/res destination forms + Windows CLI bootstrap parity).
+- #114: ISA coverage tranche 9 (direct-asm `ld` abs16 families for A/HL/BC/DE/SP/IX/IY).
 
-Next after #113 merges (anchored as soon as opened):
+Next after #114 merges (anchored as soon as opened):
 
-1. Next PR: ISA coverage tranche 9 (remaining core instruction families + diagnostics parity).
+1. Next PR: ISA coverage tranche 10 (remaining core instruction families + diagnostics parity).
 
 Completed (anchored, most recent first):
 
-1. #112: ISA coverage tranche 7 (indexed ALU-A family + diagnostics parity).
-2. #111: ISA coverage tranche 6 (IX/IY abs16 transfers + diagnostics parity).
-3. #110: ISA coverage tranche 5 (indexed imm8 store + IX/IY immediate load + diagnostics parity).
-4. #108: ISA coverage tranche 4 (IX/IY 16-bit core family + diagnostics parity).
-5. #107: ISA coverage tranche 3 (in (c) + out (c),0 + diagnostics parity).
-6. #106: ISA coverage tranche 2 (daa + ex af,af' + diagnostics parity).
-7. #105: ISA coverage tranche 1 (ex (sp), ix/iy encoding + diagnostics parity).
-8. #104: Lowering/frame safety tranche 3 (op-expansion/clobber interactions under nested control flow).
-9. #103: Lowering/frame safety tranche 2 (mixed return-path stack-delta diagnostics).
-10. #102: Lowering/frame safety tranche 1 (locals + control-flow stack invariants).
-11. #101: Parser/AST closure tranche 5 (parser edge-case rejection diagnostics and TODO sweep).
-12. #100: Parser/AST closure tranche 4 (malformed-control recovery consistency in parser state machine).
-13. #99: Parser/AST closure tranche 3 (structured-control span coverage expansion).
-14. #98: Parser/AST closure tranche 2 (select malformed-header recovery + negative fixture).
-15. #97: Parser/AST closure tranche 1 (asm diagnostic span tightening + regression tests).
-16. #96: Spec audit tranche 4 (appendix mapping + CI checklist draft).
-17. #95: Spec audit tranche 3 (expanded mappings + parser span evidence).
-18. #94: Spec audit tranche 2 (normative mapping + rejection catalog).
-19. #93: Spec audit pass (v0.1 implementation matrix, tranche 1).
-20. #92: Lowering interaction torture suite (nested control + locals + stack-flow checks).
-21. #91: ISA tranche: encode `adc/sbc HL,rr` (ED forms) + tests.
-22. #90: Listing tranche: ascii gutter and sparse-byte markers.
-23. #89: CLI parity sweep (entry-last enforcement + contract tests).
-24. #88: CLI: v0.1 artifact-writing command (bin/hex/d8m/lst).
-25. #87: Test: determinism for emitted artifacts.
-26. #86: Test: conditional abs16 fixups (`jp cc`, `call cc`) + roadmap sync.
-27. #85: Test: extend rel8 range checks (`jr cc`, `djnz`) + roadmap sync.
-28. #77: Parser: diagnose `case` without a value (fixtures + tests).
-29. #76: Parser: diagnose missing control operands (fixtures + tests).
-30. #75: Docs: clarify shared-case `select` syntax.
-31. #74: Parser: diagnose duplicate `else` in `if` (fixtures + tests).
-32. #73: Parser: diagnose `select` with no arms (fixtures + tests).
-33. #72: Docs: sync roadmap through PR #71.
-34. #71: ISA: ED block I/O instructions (INI/INIR/IND/INDR/OUTI/OTIR/OUTD/OTDR) (fixture + test).
-35. #70: ISA: indexed rotates/shifts (IX/IY + disp8) (fixture + test).
-36. #68: ISA: indexed bit ops (IX/IY + disp8) (fixture + test).
-37. #67: ISA: indexed inc/dec (IX/IY + disp8) (fixture + test).
-38. #66: ISA: indexed IX/IY disp8 addressing for `ld` (fixture + test).
-39. #65: ISA: ED block instructions (LDI/LDIR/LDD/LDDR/CPI/CPIR/CPD/CPDR) (fixture + test).
-40. #64: ISA: ED misc ops (`neg/rrd/rld`, `ld i,a / ld a,i / ld r,a / ld a,r`) (fixture + test).
-41. #63: ISA: `in/out` port operands end-to-end (parser + encoder + fixture + test).
-42. #62: Test: use implicit return in PR14 no-locals fixture.
-43. #61: Docs: sync roadmap completed PR anchors.
-44. #60: Revert: undo PR #59 merge (self-approval policy).
-45. #59: Docs: sync roadmap completed PR anchors (reverted by #60).
-46. #58: ISA: encode `jp (hl)`, `jp (ix)`, `jp (iy)` (fixture + test).
-47. #57: ISA: encode `im 0|1|2`, `rst <imm8>`, `reti`, `retn` (fixture + test).
-48. #56: ISA: encode misc system ops (`halt/di/ei/scf/ccf/cpl/ex*/exx`) (fixture + test).
-49. #55: Parser UX: avoid duplicate diagnostics for illegal `T[]` usage (tests).
-50. #54: Parser: restrict inferred arrays `T[]` to `data` declarations only (tests).
-51. #53: Diagnostics: remove "PR subset" wording from user-facing errors (small cleanup).
-52. #52: Treat `ptr` as a 16-bit scalar in codegen (tests).
-53. #51: Inferred-length arrays in `data` declarations (`T[]`) (parser + tests).
-54. #50: Union declarations + layout + field access (parser/semantics/lowering + tests).
-55. #49: Fast-path abs `ld (ea), imm16` for `word`/`addr` destinations using `ld (nn),hl` (tests).
-56. #48: Lower `ld (ea), imm16` for `word`/`addr` destinations (tests).
-57. #47: ISA: encode `ld a,(bc|de)` and `ld (bc|de),a` (fixture + test).
-58. #46: Roadmap update for #44/#45 (reality check + gates).
-59. #45: ld abs16 ED forms for BC/DE/SP (fixture + test).
-60. #44: ld abs16 special-cases for A/HL (fixture + test).
-61. #43: Lower `ld (ea), imm8` for byte destinations (tests).
-62. #42: Roadmap anchor update for #40/#41.
-63. #41: ISA: `inc`/`dec` reg8 + `(hl)`, and `ld (hl), imm8` (fixture + test).
-64. #40: Implicit return after label (treat labels as re-entry points).
-65. #39: Listing output (`.lst`) artifact + contract test + CLI note.
-66. #38: Document examples as compiled contract (`examples/README.md`).
-67. #37: Fixups and forward references (spec + tests).
-68. #36: Expand char literal escape coverage (tests).
-69. #35: Char literals in `imm` expressions (parser + tests).
-70. #34: Examples compile gate (CI contract test + example updates).
-71. #33: Parser `select` arm ordering hardening.
-72. #32: Harden asm control keyword parsing (prevent cascaded diagnostics).
-73. #31: Roadmap anchors updated to real PR numbers (remove placeholders).
-74. #30: Diagnose `case` outside `select` during parsing (negative fixtures).
-75. #29: Deduplicate `select` join mismatch diagnostics (regression test).
-76. #28: Stacked `select case` labels share one body (spec + tests).
+1. #113: ISA coverage tranche 8 (indexed rotate/shift destination forms + indexed set/res destination forms + Windows CLI bootstrap parity).
+2. #112: ISA coverage tranche 7 (indexed ALU-A family + diagnostics parity).
+3. #111: ISA coverage tranche 6 (IX/IY abs16 transfers + diagnostics parity).
+4. #110: ISA coverage tranche 5 (indexed imm8 store + IX/IY immediate load + diagnostics parity).
+5. #108: ISA coverage tranche 4 (IX/IY 16-bit core family + diagnostics parity).
+6. #107: ISA coverage tranche 3 (in (c) + out (c),0 + diagnostics parity).
+7. #106: ISA coverage tranche 2 (daa + ex af,af' + diagnostics parity).
+8. #105: ISA coverage tranche 1 (ex (sp), ix/iy encoding + diagnostics parity).
+9. #104: Lowering/frame safety tranche 3 (op-expansion/clobber interactions under nested control flow).
+10. #103: Lowering/frame safety tranche 2 (mixed return-path stack-delta diagnostics).
+11. #102: Lowering/frame safety tranche 1 (locals + control-flow stack invariants).
+12. #101: Parser/AST closure tranche 5 (parser edge-case rejection diagnostics and TODO sweep).
+13. #100: Parser/AST closure tranche 4 (malformed-control recovery consistency in parser state machine).
+14. #99: Parser/AST closure tranche 3 (structured-control span coverage expansion).
+15. #98: Parser/AST closure tranche 2 (select malformed-header recovery + negative fixture).
+16. #97: Parser/AST closure tranche 1 (asm diagnostic span tightening + regression tests).
+17. #96: Spec audit tranche 4 (appendix mapping + CI checklist draft).
+18. #95: Spec audit tranche 3 (expanded mappings + parser span evidence).
+19. #94: Spec audit tranche 2 (normative mapping + rejection catalog).
+20. #93: Spec audit pass (v0.1 implementation matrix, tranche 1).
+21. #92: Lowering interaction torture suite (nested control + locals + stack-flow checks).
+22. #91: ISA tranche: encode `adc/sbc HL,rr` (ED forms) + tests.
+23. #90: Listing tranche: ascii gutter and sparse-byte markers.
+24. #89: CLI parity sweep (entry-last enforcement + contract tests).
+25. #88: CLI: v0.1 artifact-writing command (bin/hex/d8m/lst).
+26. #87: Test: determinism for emitted artifacts.
+27. #86: Test: conditional abs16 fixups (`jp cc`, `call cc`) + roadmap sync.
+28. #85: Test: extend rel8 range checks (`jr cc`, `djnz`) + roadmap sync.
+29. #77: Parser: diagnose `case` without a value (fixtures + tests).
+30. #76: Parser: diagnose missing control operands (fixtures + tests).
+31. #75: Docs: clarify shared-case `select` syntax.
+32. #74: Parser: diagnose duplicate `else` in `if` (fixtures + tests).
+33. #73: Parser: diagnose `select` with no arms (fixtures + tests).
+34. #72: Docs: sync roadmap through PR #71.
+35. #71: ISA: ED block I/O instructions (INI/INIR/IND/INDR/OUTI/OTIR/OUTD/OTDR) (fixture + test).
+36. #70: ISA: indexed rotates/shifts (IX/IY + disp8) (fixture + test).
+37. #68: ISA: indexed bit ops (IX/IY + disp8) (fixture + test).
+38. #67: ISA: indexed inc/dec (IX/IY + disp8) (fixture + test).
+39. #66: ISA: indexed IX/IY disp8 addressing for `ld` (fixture + test).
+40. #65: ISA: ED block instructions (LDI/LDIR/LDD/LDDR/CPI/CPIR/CPD/CPDR) (fixture + test).
+41. #64: ISA: ED misc ops (`neg/rrd/rld`, `ld i,a / ld a,i / ld r,a / ld a,r`) (fixture + test).
+42. #63: ISA: `in/out` port operands end-to-end (parser + encoder + fixture + test).
+43. #62: Test: use implicit return in PR14 no-locals fixture.
+44. #61: Docs: sync roadmap completed PR anchors.
+45. #60: Revert: undo PR #59 merge (self-approval policy).
+46. #59: Docs: sync roadmap completed PR anchors (reverted by #60).
+47. #58: ISA: encode `jp (hl)`, `jp (ix)`, `jp (iy)` (fixture + test).
+48. #57: ISA: encode `im 0|1|2`, `rst <imm8>`, `reti`, `retn` (fixture + test).
+49. #56: ISA: encode misc system ops (`halt/di/ei/scf/ccf/cpl/ex*/exx`) (fixture + test).
+50. #55: Parser UX: avoid duplicate diagnostics for illegal `T[]` usage (tests).
+51. #54: Parser: restrict inferred arrays `T[]` to `data` declarations only (tests).
+52. #53: Diagnostics: remove "PR subset" wording from user-facing errors (small cleanup).
+53. #52: Treat `ptr` as a 16-bit scalar in codegen (tests).
+54. #51: Inferred-length arrays in `data` declarations (`T[]`) (parser + tests).
+55. #50: Union declarations + layout + field access (parser/semantics/lowering + tests).
+56. #49: Fast-path abs `ld (ea), imm16` for `word`/`addr` destinations using `ld (nn),hl` (tests).
+57. #48: Lower `ld (ea), imm16` for `word`/`addr` destinations (tests).
+58. #47: ISA: encode `ld a,(bc|de)` and `ld (bc|de),a` (fixture + test).
+59. #46: Roadmap update for #44/#45 (reality check + gates).
+60. #45: ld abs16 ED forms for BC/DE/SP (fixture + test).
+61. #44: ld abs16 special-cases for A/HL (fixture + test).
+62. #43: Lower `ld (ea), imm8` for byte destinations (tests).
+63. #42: Roadmap anchor update for #40/#41.
+64. #41: ISA: `inc`/`dec` reg8 + `(hl)`, and `ld (hl), imm8` (fixture + test).
+65. #40: Implicit return after label (treat labels as re-entry points).
+66. #39: Listing output (`.lst`) artifact + contract test + CLI note.
+67. #38: Document examples as compiled contract (`examples/README.md`).
+68. #37: Fixups and forward references (spec + tests).
+69. #36: Expand char literal escape coverage (tests).
+70. #35: Char literals in `imm` expressions (parser + tests).
+71. #34: Examples compile gate (CI contract test + example updates).
+72. #33: Parser `select` arm ordering hardening.
+73. #32: Harden asm control keyword parsing (prevent cascaded diagnostics).
+74. #31: Roadmap anchors updated to real PR numbers (remove placeholders).
+75. #30: Diagnose `case` outside `select` during parsing (negative fixtures).
+76. #29: Deduplicate `select` join mismatch diagnostics (regression test).
+77. #28: Stacked `select case` labels share one body (spec + tests).
 
 Next (assembler-first):
 

--- a/test/fixtures/pr114_isa_ld_abs16_direct_asm.zax
+++ b/test/fixtures/pr114_isa_ld_abs16_direct_asm.zax
@@ -1,0 +1,31 @@
+section code at $0000
+section var at $1000
+
+var
+  w0: word
+  w1: word
+  w2: word
+  w3: word
+  w4: word
+  w5: word
+  w6: word
+  w7: word
+  b0: byte
+
+export func main(): void
+  asm
+    ld a, (b0)
+    ld (b0), a
+    ld hl, (w0)
+    ld (w0), hl
+    ld bc, (w1)
+    ld (w1), bc
+    ld de, (w2)
+    ld (w2), de
+    ld sp, (w3)
+    ld (w3), sp
+    ld ix, (w4)
+    ld (w4), ix
+    ld iy, (w5)
+    ld (w5), iy
+end

--- a/test/pr114_isa_ld_abs16_direct_asm.test.ts
+++ b/test/pr114_isa_ld_abs16_direct_asm.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR114 ISA: direct asm ld abs16 families', () => {
+  it('encodes ld rr,(nn) and ld (nn),rr for A/HL/BC/DE/SP/IX/IY', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr114_isa_ld_abs16_direct_asm.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    expect(bin!.bytes).toEqual(
+      Uint8Array.of(
+        0x3a,
+        0x10,
+        0x10, // ld a,(b0)
+        0x32,
+        0x10,
+        0x10, // ld (b0),a
+        0x2a,
+        0x00,
+        0x10, // ld hl,(w0)
+        0x22,
+        0x00,
+        0x10, // ld (w0),hl
+        0xed,
+        0x4b,
+        0x02,
+        0x10, // ld bc,(w1)
+        0xed,
+        0x43,
+        0x02,
+        0x10, // ld (w1),bc
+        0xed,
+        0x5b,
+        0x04,
+        0x10, // ld de,(w2)
+        0xed,
+        0x53,
+        0x04,
+        0x10, // ld (w2),de
+        0xed,
+        0x7b,
+        0x06,
+        0x10, // ld sp,(w3)
+        0xed,
+        0x73,
+        0x06,
+        0x10, // ld (w3),sp
+        0xdd,
+        0x2a,
+        0x08,
+        0x10, // ld ix,(w4)
+        0xdd,
+        0x22,
+        0x08,
+        0x10, // ld (w4),ix
+        0xfd,
+        0x2a,
+        0x0a,
+        0x10, // ld iy,(w5)
+        0xfd,
+        0x22,
+        0x0a,
+        0x10, // ld (w5),iy
+        0xc9,
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add direct-asm abs16 `ld` families in the encoder for both directions:
  - `ld a,(nn)` / `ld (nn),a`
  - `ld hl,(nn)` / `ld (nn),hl`
  - `ld bc/de/sp,(nn)` / `ld (nn),bc/de/sp`
  - `ld ix/iy,(nn)` / `ld (nn),ix/iy`
- evaluate simple absolute EA forms for mem operands in encoder (`EaName`, `EaAdd`, `EaSub`)
- add fixture + regression test for direct-asm abs16 `ld` coverage
- sync roadmap anchors for PR114 in-review

## Tests
- `yarn -s format:check`
- `yarn -s typecheck`
- `yarn -s test`
