### PR TITLE
PR117: explicit-A ALU forms + indexed-byte diagnostics

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -236,93 +236,94 @@ Use only real GitHub PR numbers:
 
 Open / in review (anchored):
 
-- #116: ISA coverage tranche 11 (`IXH/IXL/IYH/IYL` register support across parser + encoder ALU/LD/inc/dec paths).
+- #117: ISA coverage tranche 12 (explicit `A` forms for `and/or/xor/cp` + indexed-byte-register diagnostics hardening).
 
-Next after #116 merges (anchored as soon as opened):
+Next after #117 merges (anchored as soon as opened):
 
-1. Next PR: ISA coverage tranche 12 (remaining core instruction families + diagnostics parity).
+1. Next PR: ISA coverage tranche 13 (remaining core instruction families + diagnostics parity).
 
 Completed (anchored, most recent first):
 
-1. #115: ISA coverage tranche 10 (`sll` CB-family coverage, including indexed destination forms).
-2. #114: ISA coverage tranche 9 (direct-asm `ld` abs16 families for A/HL/BC/DE/SP/IX/IY).
-3. #113: ISA coverage tranche 8 (indexed rotate/shift destination forms + indexed set/res destination forms + Windows CLI bootstrap parity).
-4. #112: ISA coverage tranche 7 (indexed ALU-A family + diagnostics parity).
-5. #111: ISA coverage tranche 6 (IX/IY abs16 transfers + diagnostics parity).
-6. #110: ISA coverage tranche 5 (indexed imm8 store + IX/IY immediate load + diagnostics parity).
-7. #108: ISA coverage tranche 4 (IX/IY 16-bit core family + diagnostics parity).
-8. #107: ISA coverage tranche 3 (in (c) + out (c),0 + diagnostics parity).
-9. #106: ISA coverage tranche 2 (daa + ex af,af' + diagnostics parity).
-10. #105: ISA coverage tranche 1 (ex (sp), ix/iy encoding + diagnostics parity).
-11. #104: Lowering/frame safety tranche 3 (op-expansion/clobber interactions under nested control flow).
-12. #103: Lowering/frame safety tranche 2 (mixed return-path stack-delta diagnostics).
-13. #102: Lowering/frame safety tranche 1 (locals + control-flow stack invariants).
-14. #101: Parser/AST closure tranche 5 (parser edge-case rejection diagnostics and TODO sweep).
-15. #100: Parser/AST closure tranche 4 (malformed-control recovery consistency in parser state machine).
-16. #99: Parser/AST closure tranche 3 (structured-control span coverage expansion).
-17. #98: Parser/AST closure tranche 2 (select malformed-header recovery + negative fixture).
-18. #97: Parser/AST closure tranche 1 (asm diagnostic span tightening + regression tests).
-19. #96: Spec audit tranche 4 (appendix mapping + CI checklist draft).
-20. #95: Spec audit tranche 3 (expanded mappings + parser span evidence).
-21. #94: Spec audit tranche 2 (normative mapping + rejection catalog).
-22. #93: Spec audit pass (v0.1 implementation matrix, tranche 1).
-23. #92: Lowering interaction torture suite (nested control + locals + stack-flow checks).
-24. #91: ISA tranche: encode `adc/sbc HL,rr` (ED forms) + tests.
-25. #90: Listing tranche: ascii gutter and sparse-byte markers.
-26. #89: CLI parity sweep (entry-last enforcement + contract tests).
-27. #88: CLI: v0.1 artifact-writing command (bin/hex/d8m/lst).
-28. #87: Test: determinism for emitted artifacts.
-29. #86: Test: conditional abs16 fixups (`jp cc`, `call cc`) + roadmap sync.
-30. #85: Test: extend rel8 range checks (`jr cc`, `djnz`) + roadmap sync.
-31. #77: Parser: diagnose `case` without a value (fixtures + tests).
-32. #76: Parser: diagnose missing control operands (fixtures + tests).
-33. #75: Docs: clarify shared-case `select` syntax.
-34. #74: Parser: diagnose duplicate `else` in `if` (fixtures + tests).
-35. #73: Parser: diagnose `select` with no arms (fixtures + tests).
-36. #72: Docs: sync roadmap through PR #71.
-37. #71: ISA: ED block I/O instructions (INI/INIR/IND/INDR/OUTI/OTIR/OUTD/OTDR) (fixture + test).
-38. #70: ISA: indexed rotates/shifts (IX/IY + disp8) (fixture + test).
-39. #68: ISA: indexed bit ops (IX/IY + disp8) (fixture + test).
-40. #67: ISA: indexed inc/dec (IX/IY + disp8) (fixture + test).
-41. #66: ISA: indexed IX/IY disp8 addressing for `ld` (fixture + test).
-42. #65: ISA: ED block instructions (LDI/LDIR/LDD/LDDR/CPI/CPIR/CPD/CPDR) (fixture + test).
-43. #64: ISA: ED misc ops (`neg/rrd/rld`, `ld i,a / ld a,i / ld r,a / ld a,r`) (fixture + test).
-44. #63: ISA: `in/out` port operands end-to-end (parser + encoder + fixture + test).
-45. #62: Test: use implicit return in PR14 no-locals fixture.
-46. #61: Docs: sync roadmap completed PR anchors.
-47. #60: Revert: undo PR #59 merge (self-approval policy).
-48. #59: Docs: sync roadmap completed PR anchors (reverted by #60).
-49. #58: ISA: encode `jp (hl)`, `jp (ix)`, `jp (iy)` (fixture + test).
-50. #57: ISA: encode `im 0|1|2`, `rst <imm8>`, `reti`, `retn` (fixture + test).
-51. #56: ISA: encode misc system ops (`halt/di/ei/scf/ccf/cpl/ex*/exx`) (fixture + test).
-52. #55: Parser UX: avoid duplicate diagnostics for illegal `T[]` usage (tests).
-53. #54: Parser: restrict inferred arrays `T[]` to `data` declarations only (tests).
-54. #53: Diagnostics: remove "PR subset" wording from user-facing errors (small cleanup).
-55. #52: Treat `ptr` as a 16-bit scalar in codegen (tests).
-56. #51: Inferred-length arrays in `data` declarations (`T[]`) (parser + tests).
-57. #50: Union declarations + layout + field access (parser/semantics/lowering + tests).
-58. #49: Fast-path abs `ld (ea), imm16` for `word`/`addr` destinations using `ld (nn),hl` (tests).
-59. #48: Lower `ld (ea), imm16` for `word`/`addr` destinations (tests).
-60. #47: ISA: encode `ld a,(bc|de)` and `ld (bc|de),a` (fixture + test).
-61. #46: Roadmap update for #44/#45 (reality check + gates).
-62. #45: ld abs16 ED forms for BC/DE/SP (fixture + test).
-63. #44: ld abs16 special-cases for A/HL (fixture + test).
-64. #43: Lower `ld (ea), imm8` for byte destinations (tests).
-65. #42: Roadmap anchor update for #40/#41.
-66. #41: ISA: `inc`/`dec` reg8 + `(hl)`, and `ld (hl), imm8` (fixture + test).
-67. #40: Implicit return after label (treat labels as re-entry points).
-68. #39: Listing output (`.lst`) artifact + contract test + CLI note.
-69. #38: Document examples as compiled contract (`examples/README.md`).
-70. #37: Fixups and forward references (spec + tests).
-71. #36: Expand char literal escape coverage (tests).
-72. #35: Char literals in `imm` expressions (parser + tests).
-73. #34: Examples compile gate (CI contract test + example updates).
-74. #33: Parser `select` arm ordering hardening.
-75. #32: Harden asm control keyword parsing (prevent cascaded diagnostics).
-76. #31: Roadmap anchors updated to real PR numbers (remove placeholders).
-77. #30: Diagnose `case` outside `select` during parsing (negative fixtures).
-78. #29: Deduplicate `select` join mismatch diagnostics (regression test).
-79. #28: Stacked `select case` labels share one body (spec + tests).
+1. #116: ISA coverage tranche 11 (`IXH/IXL/IYH/IYL` parser+encoder support across ALU/LD/inc/dec paths).
+2. #115: ISA coverage tranche 10 (`sll` CB-family coverage, including indexed destination forms).
+3. #114: ISA coverage tranche 9 (direct-asm `ld` abs16 families for A/HL/BC/DE/SP/IX/IY).
+4. #113: ISA coverage tranche 8 (indexed rotate/shift destination forms + indexed set/res destination forms + Windows CLI bootstrap parity).
+5. #112: ISA coverage tranche 7 (indexed ALU-A family + diagnostics parity).
+6. #111: ISA coverage tranche 6 (IX/IY abs16 transfers + diagnostics parity).
+7. #110: ISA coverage tranche 5 (indexed imm8 store + IX/IY immediate load + diagnostics parity).
+8. #108: ISA coverage tranche 4 (IX/IY 16-bit core family + diagnostics parity).
+9. #107: ISA coverage tranche 3 (in (c) + out (c),0 + diagnostics parity).
+10. #106: ISA coverage tranche 2 (daa + ex af,af' + diagnostics parity).
+11. #105: ISA coverage tranche 1 (ex (sp), ix/iy encoding + diagnostics parity).
+12. #104: Lowering/frame safety tranche 3 (op-expansion/clobber interactions under nested control flow).
+13. #103: Lowering/frame safety tranche 2 (mixed return-path stack-delta diagnostics).
+14. #102: Lowering/frame safety tranche 1 (locals + control-flow stack invariants).
+15. #101: Parser/AST closure tranche 5 (parser edge-case rejection diagnostics and TODO sweep).
+16. #100: Parser/AST closure tranche 4 (malformed-control recovery consistency in parser state machine).
+17. #99: Parser/AST closure tranche 3 (structured-control span coverage expansion).
+18. #98: Parser/AST closure tranche 2 (select malformed-header recovery + negative fixture).
+19. #97: Parser/AST closure tranche 1 (asm diagnostic span tightening + regression tests).
+20. #96: Spec audit tranche 4 (appendix mapping + CI checklist draft).
+21. #95: Spec audit tranche 3 (expanded mappings + parser span evidence).
+22. #94: Spec audit tranche 2 (normative mapping + rejection catalog).
+23. #93: Spec audit pass (v0.1 implementation matrix, tranche 1).
+24. #92: Lowering interaction torture suite (nested control + locals + stack-flow checks).
+25. #91: ISA tranche: encode `adc/sbc HL,rr` (ED forms) + tests.
+26. #90: Listing tranche: ascii gutter and sparse-byte markers.
+27. #89: CLI parity sweep (entry-last enforcement + contract tests).
+28. #88: CLI: v0.1 artifact-writing command (bin/hex/d8m/lst).
+29. #87: Test: determinism for emitted artifacts.
+30. #86: Test: conditional abs16 fixups (`jp cc`, `call cc`) + roadmap sync.
+31. #85: Test: extend rel8 range checks (`jr cc`, `djnz`) + roadmap sync.
+32. #77: Parser: diagnose `case` without a value (fixtures + tests).
+33. #76: Parser: diagnose missing control operands (fixtures + tests).
+34. #75: Docs: clarify shared-case `select` syntax.
+35. #74: Parser: diagnose duplicate `else` in `if` (fixtures + tests).
+36. #73: Parser: diagnose `select` with no arms (fixtures + tests).
+37. #72: Docs: sync roadmap through PR #71.
+38. #71: ISA: ED block I/O instructions (INI/INIR/IND/INDR/OUTI/OTIR/OUTD/OTDR) (fixture + test).
+39. #70: ISA: indexed rotates/shifts (IX/IY + disp8) (fixture + test).
+40. #68: ISA: indexed bit ops (IX/IY + disp8) (fixture + test).
+41. #67: ISA: indexed inc/dec (IX/IY + disp8) (fixture + test).
+42. #66: ISA: indexed IX/IY disp8 addressing for `ld` (fixture + test).
+43. #65: ISA: ED block instructions (LDI/LDIR/LDD/LDDR/CPI/CPIR/CPD/CPDR) (fixture + test).
+44. #64: ISA: ED misc ops (`neg/rrd/rld`, `ld i,a / ld a,i / ld r,a / ld a,r`) (fixture + test).
+45. #63: ISA: `in/out` port operands end-to-end (parser + encoder + fixture + test).
+46. #62: Test: use implicit return in PR14 no-locals fixture.
+47. #61: Docs: sync roadmap completed PR anchors.
+48. #60: Revert: undo PR #59 merge (self-approval policy).
+49. #59: Docs: sync roadmap completed PR anchors (reverted by #60).
+50. #58: ISA: encode `jp (hl)`, `jp (ix)`, `jp (iy)` (fixture + test).
+51. #57: ISA: encode `im 0|1|2`, `rst <imm8>`, `reti`, `retn` (fixture + test).
+52. #56: ISA: encode misc system ops (`halt/di/ei/scf/ccf/cpl/ex*/exx`) (fixture + test).
+53. #55: Parser UX: avoid duplicate diagnostics for illegal `T[]` usage (tests).
+54. #54: Parser: restrict inferred arrays `T[]` to `data` declarations only (tests).
+55. #53: Diagnostics: remove "PR subset" wording from user-facing errors (small cleanup).
+56. #52: Treat `ptr` as a 16-bit scalar in codegen (tests).
+57. #51: Inferred-length arrays in `data` declarations (`T[]`) (parser + tests).
+58. #50: Union declarations + layout + field access (parser/semantics/lowering + tests).
+59. #49: Fast-path abs `ld (ea), imm16` for `word`/`addr` destinations using `ld (nn),hl` (tests).
+60. #48: Lower `ld (ea), imm16` for `word`/`addr` destinations (tests).
+61. #47: ISA: encode `ld a,(bc|de)` and `ld (bc|de),a` (fixture + test).
+62. #46: Roadmap update for #44/#45 (reality check + gates).
+63. #45: ld abs16 ED forms for BC/DE/SP (fixture + test).
+64. #44: ld abs16 special-cases for A/HL (fixture + test).
+65. #43: Lower `ld (ea), imm8` for byte destinations (tests).
+66. #42: Roadmap anchor update for #40/#41.
+67. #41: ISA: `inc`/`dec` reg8 + `(hl)`, and `ld (hl), imm8` (fixture + test).
+68. #40: Implicit return after label (treat labels as re-entry points).
+69. #39: Listing output (`.lst`) artifact + contract test + CLI note.
+70. #38: Document examples as compiled contract (`examples/README.md`).
+71. #37: Fixups and forward references (spec + tests).
+72. #36: Expand char literal escape coverage (tests).
+73. #35: Char literals in `imm` expressions (parser + tests).
+74. #34: Examples compile gate (CI contract test + example updates).
+75. #33: Parser `select` arm ordering hardening.
+76. #32: Harden asm control keyword parsing (prevent cascaded diagnostics).
+77. #31: Roadmap anchors updated to real PR numbers (remove placeholders).
+78. #30: Diagnose `case` outside `select` during parsing (negative fixtures).
+79. #29: Deduplicate `select` join mismatch diagnostics (regression test).
+80. #28: Stacked `select case` labels share one body (spec + tests).
 
 Next (assembler-first):
 

--- a/src/z80/encode.ts
+++ b/src/z80/encode.ts
@@ -54,6 +54,10 @@ function reg8Code(name: string): number | undefined {
   }
 }
 
+function isLegacyHLReg8(name: string | undefined): boolean {
+  return name === 'H' || name === 'L';
+}
+
 function indexedReg8(
   op: AsmOperandNode,
 ): { prefix: number; code: number; display: 'IXH' | 'IXL' | 'IYH' | 'IYL' } | undefined {
@@ -558,6 +562,13 @@ export function encodeInstruction(
         diag(diagnostics, node, `ld between IX* and IY* byte registers is not supported`);
         return undefined;
       }
+      if (
+        (indexedDst && !indexedSrc && isLegacyHLReg8(src)) ||
+        (indexedSrc && !indexedDst && isLegacyHLReg8(dst))
+      ) {
+        diag(diagnostics, node, `ld with IX*/IY* does not support legacy H/L counterpart operands`);
+        return undefined;
+      }
       const d = indexedDst ? indexedDst.code : dst ? reg8Code(dst) : undefined;
       const s = indexedSrc ? indexedSrc.code : src ? reg8Code(src) : undefined;
       if (prefix === undefined || d === undefined || s === undefined) {
@@ -929,17 +940,17 @@ export function encodeInstruction(
   }
 
   if (head === 'and') {
-    const encoded = encodeAluAOrImm8OrMemHL(0xa0, 0xe6, 0xa6, 'and');
+    const encoded = encodeAluAOrImm8OrMemHL(0xa0, 0xe6, 0xa6, 'and', true);
     if (encoded) return encoded;
   }
 
   if (head === 'or') {
-    const encoded = encodeAluAOrImm8OrMemHL(0xb0, 0xf6, 0xb6, 'or');
+    const encoded = encodeAluAOrImm8OrMemHL(0xb0, 0xf6, 0xb6, 'or', true);
     if (encoded) return encoded;
   }
 
   if (head === 'xor') {
-    const encoded = encodeAluAOrImm8OrMemHL(0xa8, 0xee, 0xae, 'xor');
+    const encoded = encodeAluAOrImm8OrMemHL(0xa8, 0xee, 0xae, 'xor', true);
     if (encoded) return encoded;
   }
 

--- a/test/fixtures/pr117_alu_explicit_a_forms.zax
+++ b/test/fixtures/pr117_alu_explicit_a_forms.zax
@@ -1,0 +1,11 @@
+export func main(): void
+  asm
+    and a, b
+    and a, (hl)
+    and a, $12
+    and a, ixh
+    or a, iyl
+    xor a, (ix[2])
+    cp a, (iy[-1])
+    cp a, $34
+end

--- a/test/pr117_alu_explicit_a_forms.test.ts
+++ b/test/pr117_alu_explicit_a_forms.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR117 ISA: explicit accumulator ALU forms', () => {
+  it('encodes and/or/xor/cp with explicit A destination', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr117_alu_explicit_a_forms.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    expect(bin!.bytes).toEqual(
+      Uint8Array.of(
+        0xa0, // and a,b
+        0xa6, // and a,(hl)
+        0xe6,
+        0x12, // and a,$12
+        0xdd,
+        0xa4, // and a,ixh
+        0xfd,
+        0xb5, // or a,iyl
+        0xdd,
+        0xae,
+        0x02, // xor a,(ix+2)
+        0xfd,
+        0xbe,
+        0xff, // cp a,(iy-1)
+        0xfe,
+        0x34, // cp a,$34
+        0xc9,
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit accumulator forms for `and/or/xor/cp` (`mnemonic a, src`) across reg8/imm8/(hl)/(ix/iy+disp)/IXH/IXL/IYH/IYL
- harden indexed-byte-register `ld` diagnostics to reject ambiguous legacy H/L counterpart combinations
- include broad regression fixture coverage for new explicit-A ALU encodings
- roadmap anchors updated: #117 in review, #116 moved to completed

## Tests
- `yarn -s format:check`
- `yarn -s typecheck`
- `yarn -s test`
