### PR TITLE
parser: harden param-list delimiter diagnostics

### DIFF
--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -957,6 +957,18 @@ function parseParamsFromText(
   if (trimmed.length === 0) return [];
 
   const parts = trimmed.split(',').map((p) => p.trim());
+  if (parts.some((p) => p.length === 0)) {
+    diag(
+      diagnostics,
+      filePath,
+      `Invalid parameter list: trailing or empty entries are not permitted.`,
+      {
+        line: paramsSpan.start.line,
+        column: paramsSpan.start.column,
+      },
+    );
+    return undefined;
+  }
   const out: ParamNode[] = [];
   const seen = new Set<string>();
   for (const part of parts) {
@@ -1055,6 +1067,18 @@ function parseOpParamsFromText(
   if (trimmed.length === 0) return [];
 
   const parts = trimmed.split(',').map((p) => p.trim());
+  if (parts.some((p) => p.length === 0)) {
+    diag(
+      diagnostics,
+      filePath,
+      `Invalid op parameter list: trailing or empty entries are not permitted.`,
+      {
+        line: paramsSpan.start.line,
+        column: paramsSpan.start.column,
+      },
+    );
+    return undefined;
+  }
   const out: OpParamNode[] = [];
   const seen = new Set<string>();
   for (const part of parts) {

--- a/test/fixtures/pr186_param_list_delimiter_matrix.zax
+++ b/test/fixtures/pr186_param_list_delimiter_matrix.zax
@@ -1,0 +1,25 @@
+func badFuncTrailing(a: byte,): void
+  asm
+    ret
+  end
+
+func badFuncEmpty(a: byte,, b: byte): void
+  asm
+    ret
+  end
+
+op badOpTrailing(a: reg8,)
+  ret
+end
+
+op badOpEmpty(a: reg8,, b: imm8)
+  ret
+end
+
+extern func badExternTrailing(a: byte,): byte at $1200
+extern func badExternEmpty(a: byte,, b: byte): byte at $1202
+
+func main(): void
+  asm
+    ret
+  end

--- a/test/pr186_param_list_delimiter_matrix.test.ts
+++ b/test/pr186_param_list_delimiter_matrix.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR186 parser: parameter list delimiter diagnostics matrix', () => {
+  it('emits explicit diagnostics for trailing/empty func/op/extern parameter entries', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr186_param_list_delimiter_matrix.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(messages).toContain(
+      'Invalid parameter list: trailing or empty entries are not permitted.',
+    );
+    expect(messages).toContain(
+      'Invalid op parameter list: trailing or empty entries are not permitted.',
+    );
+
+    expect(
+      messages.some((m) => m.includes('Invalid parameter declaration: expected <name>: <type>')),
+    ).toBe(false);
+    expect(
+      messages.some((m) =>
+        m.includes('Invalid op parameter declaration: expected <name>: <matcher>'),
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary\n- add explicit parser diagnostics for trailing/empty parameter entries in  parameter lists\n- add explicit parser diagnostics for trailing/empty parameter entries in  parameter lists\n- extend coverage to  via shared parameter parser behavior\n- add PR186 matrix fixture/test for malformed delimiter cases\n\n## Validation\n- yarn -s format:check\n- yarn -s typecheck\n- yarn -s test