### PR TITLE
PR196: parser recovery hardening (export gating + control interruption)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,17 +18,17 @@ Progress snapshot (rough, assembler-first):
 Progress estimate (percentage):
 
 - Strict (gate-based): 0% complete until all 6 completion gates are green (Section 3).
-- Working estimate (risk-weighted): ~52% complete (range 47-59%).
+- Working estimate (risk-weighted): ~54% complete (range 49-61%).
 - Why this is not higher: closure work remains substantial across parser/AST depth, lowering invariants, ISA breadth, CLI contract hardening, and acceptance gates.
 
 Working estimate scorecard (risk-weighted, subjective):
 
-- Spec gate: ~63%
-- Parser/AST gate: ~58%
+- Spec gate: ~66%
+- Parser/AST gate: ~63%
 - Codegen gate: ~50%
 - ISA gate: ~35%
 - CLI/output gate: ~64%
-- Hardening gate: ~35%
+- Hardening gate: ~39%
 
 What moves the needle fastest:
 
@@ -52,18 +52,18 @@ The codebase has meaningful progress, but it is **not near complete** for a prod
 
 1. Instruction encoding coverage is narrow.
 
-- `src/z80/encode.ts` is ~796 lines and now covers a meaningful chunk of the ISA.
+- `src/z80/encode.ts` is ~1,469 lines and now covers a meaningful chunk of the ISA.
 - Large portions of Z80 ISA still need explicit coverage and negative tests (especially less-common ED/CB/DD/FD forms and invalid operand shapes).
 
 1. Parser/AST behavior is not fully settled.
 
-- `src/frontend/parser.ts` is large (~1,968 lines); behavior is still subset-constrained and needs broader negative coverage.
+- `src/frontend/parser.ts` is large (~3,326 lines); behavior is still subset-constrained and needs broader negative coverage.
 - Several grammar/behavior areas are subset-constrained or intentionally unsupported today.
 - Parser robustness/error recovery strategy is still shallow.
 
 1. Lowering/codegen complexity remains high-risk.
 
-- `src/lowering/emit.ts` is ~2,808 lines and centralizes many responsibilities.
+- `src/lowering/emit.ts` is ~3,206 lines and centralizes many responsibilities.
 - Complex concerns (SP tracking, frame cleanup rewriting, op expansion, section/address map coordination) are tightly coupled.
 - Some semantics are intentionally subset-limited in lowering today.
 
@@ -236,14 +236,15 @@ Use only real GitHub PR numbers:
 
 Open / in review (anchored):
 
-- #138: Parser/AST closure tranche 32 (malformed `bin`/`hex` header diagnostics matrix + canonical top-level malformed-header expectation table and broad matrix hardening).
+- None currently.
 
-Next after #138 merges (anchored as soon as opened):
+Next PR (anchored as soon as opened):
 
-1. Next PR: Parser/AST closure pass (malformed declaration/recovery ordering for mixed keyword-shaped lines across `extern`/`data`/`var` and additional deterministic message-order matrices).
+1. Next PR: Lowering invariants tranche (explicit SP/frame invariant checks across nested control + op expansion + mixed return paths, with expanded negative matrices).
 
 Completed (anchored, most recent first):
 
+1. #151: CLI/output hardening tranche (sparse D8M `segments` metadata + listing gap compression + sparse Intel HEX record emission + contract tests and docs sync).
 1. #137: Parser/AST closure tranche 31 (malformed `func`/`op`/`extern` header diagnostics parity + explicit expected-shape errors + malformed header matrix hardening and legacy top-level malformed-keyword expectation updates).
 1. #136: ISA+parser tranche 29/30 (known-head no-cascade safeguard + expanded ED/CB/zero-operand hardening + `(ix+disp)/(iy+disp)` parity + malformed control/top-level keyword recovery + whitespace/case-insensitive top-level and export parsing parity + extern block parsing for multi-func declarations + lowering support for `extern <binName> ... end` relative offsets against `bin` base symbols (including import-crossing fixup coverage) + type/union unterminated-block recovery at next top-level declaration + var/data keyword-collision diagnostics parity for declaration names + extern/data block-boundary recovery normalization for malformed top-level transitions + reserved top-level keyword collision diagnostics for declaration names (`type/union/enum/const/bin/hex/extern func`) + duplicate/keyword validation for func/op parameters and header-name consistency checks + duplicate-name diagnostics parity for `type`/`union` fields, enum members, and module/function `var` + `data` declarations + malformed declaration-header diagnostics normalization for `enum/const/bin/hex` + explicit interrupted-block diagnostics parity for `type`/`union`/`extern` when a new top-level declaration appears before `end` + interrupted `func` pre-asm recovery diagnostics parity so parser continues at next top-level declaration instead of aborting module parse + malformed block-body line diagnostics normalization across `type/union/var/data/extern` with expected-shape guidance and consolidated matrix coverage + interrupted `func` asm-body / `op` body recovery diagnostics parity so parser resumes top-level declarations when `end` is missing + mixed malformed + keyword-collision ordering stability pass).
 1. #135: ISA coverage tranche 28 (ED/CB diagnostics parity hardening + ALU no-cascade parity matrix).

--- a/docs/spec-v01-audit.md
+++ b/docs/spec-v01-audit.md
@@ -138,12 +138,13 @@ This tranche extends explicit mapping for additional normative areas and parser 
 
 ### 10.1 Imports, cycles, and search paths (`3.x`)
 
-| Normative intent                                                    | Status                 | Evidence / Diagnostic                                                     |
-| ------------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------- |
-| Import graph is resolved deterministically with dependency ordering | Implemented            | `test/pr10_imports.test.ts`                                               |
-| Import cycles are rejected with stable diagnostics                  | Intentionally rejected | diagnostic contains `Import cycle detected` (`test/pr10_imports.test.ts`) |
-| Include search paths are honored in order                           | Implemented            | `test/pr11_include_dirs.test.ts`                                          |
-| Missing import diagnostics include attempted paths                  | Implemented            | `test/pr11_include_dirs.test.ts`                                          |
+| Normative intent                                                                                     | Status                 | Evidence / Diagnostic                                                     |
+| ---------------------------------------------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------- |
+| Import graph is resolved deterministically with dependency ordering                                  | Implemented            | `test/pr10_imports.test.ts`                                               |
+| Import cycles are rejected with stable diagnostics                                                   | Intentionally rejected | diagnostic contains `Import cycle detected` (`test/pr10_imports.test.ts`) |
+| Include search paths are honored in order                                                            | Implemented            | `test/pr11_include_dirs.test.ts`                                          |
+| Missing import diagnostics include attempted paths                                                   | Implemented            | `test/pr11_include_dirs.test.ts`                                          |
+| `export` is limited to `const`/`func`/`op` and other targets are rejected without parse-side effects | Implemented            | `test/pr157_export_malformed_matrix.test.ts`                              |
 
 ### 10.2 Data/layout contracts (`2.2`, `5.x`, `6.x`)
 
@@ -166,12 +167,13 @@ This tranche extends explicit mapping for additional normative areas and parser 
 
 The following tests assert line/column-bearing diagnostics to ensure span stability:
 
-| Evidence                               | What is asserted                                                                      |
-| -------------------------------------- | ------------------------------------------------------------------------------------- |
-| `test/pr12_calls.test.ts`              | Wrong-arity call diagnostics include stable `file`, `line`, `column`                  |
-| `test/semantics_layout.test.ts`        | Type diagnostics are generated from source spans in semantic evaluation               |
-| `test/pr15_structured_control.test.ts` | Parser/lowering diagnostics remain single and stable for malformed control constructs |
-| `test/parser_nested_index.test.ts`     | Invalid nested expression path reports deterministic parse failure without cascades   |
+| Evidence                                                | What is asserted                                                                                          |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `test/pr12_calls.test.ts`                               | Wrong-arity call diagnostics include stable `file`, `line`, `column`                                      |
+| `test/semantics_layout.test.ts`                         | Type diagnostics are generated from source spans in semantic evaluation                                   |
+| `test/pr15_structured_control.test.ts`                  | Parser/lowering diagnostics remain single and stable for malformed control constructs                     |
+| `test/parser_nested_index.test.ts`                      | Invalid nested expression path reports deterministic parse failure without cascades                       |
+| `test/pr196_parser_control_interruption_matrix.test.ts` | Control-stack interruption recovery preserves deterministic diagnostic ordering across function/op bodies |
 
 ## 12) Remaining Open Items
 

--- a/test/fixtures/pr157_export_malformed_matrix.zax
+++ b/test/fixtures/pr157_export_malformed_matrix.zax
@@ -1,8 +1,18 @@
 export
 export	
+export foo
+export import core
+export type T byte
+export union U
+export globals
+export var
 export	section code
 export	align 1
 export	extern func ext(): void at 0
+export enum E A
+export data
+export bin blob in code from "fixtures/blob.bin"
+export hex h from "fixtures/blob.hex"
 
 func main(): void
     nop

--- a/test/fixtures/pr196_parser_control_interruption_matrix.zax
+++ b/test/fixtures/pr196_parser_control_interruption_matrix.zax
@@ -1,0 +1,19 @@
+func broken_if(): void
+  if z
+    nop
+const A = 1
+
+op broken_select(x: reg8)
+  select x
+    case 1
+      nop
+enum Mode Read
+
+func broken_repeat(): void
+  repeat
+    nop
+type T byte
+
+func ok(): void
+  ret
+end

--- a/test/pr157_export_malformed_matrix.test.ts
+++ b/test/pr157_export_malformed_matrix.test.ts
@@ -15,11 +15,23 @@ describe('PR157 parser: malformed export matrix', () => {
     expect(res.artifacts).toEqual([]);
 
     const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('Invalid export statement');
-    expect(messages).toContain('export is only permitted on const/func/op declarations');
-    expect(messages).toContain('export not supported on section directives');
-    expect(messages).toContain('export not supported on align directives');
-    expect(messages).toContain('export not supported on extern declarations');
+    expect(messages).toEqual([
+      'Invalid export statement',
+      'Invalid export statement',
+      'export is only permitted on const/func/op declarations',
+      'export not supported on import statements',
+      'export not supported on type declarations',
+      'export not supported on union declarations',
+      'export not supported on globals declarations',
+      'export not supported on var declarations',
+      'export not supported on section directives',
+      'export not supported on align directives',
+      'export not supported on extern declarations',
+      'export not supported on enum declarations',
+      'export not supported on data declarations',
+      'export not supported on bin declarations',
+      'export not supported on hex declarations',
+    ]);
     expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
   });
 });

--- a/test/pr196_parser_control_interruption_matrix.test.ts
+++ b/test/pr196_parser_control_interruption_matrix.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR196 parser: control-stack interruption recovery matrix', () => {
+  it('emits stable control-mismatch diagnostics before interruption diagnostics and resumes parsing', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr196_parser_control_interruption_matrix.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+
+    const messages = res.diagnostics.map((d) => d.message);
+    expect(messages).toEqual([
+      '"if" without matching "end"',
+      'Unterminated func "broken_if": expected "end" before "const"',
+      '"select" without matching "end"',
+      'Unterminated op "broken_select": expected "end" before "enum"',
+      '"repeat" without matching "until <cc>"',
+      'Unterminated func "broken_repeat": expected "end" before "type"',
+    ]);
+    expect(messages.some((m) => m.startsWith('Unsupported instruction:'))).toBe(false);
+    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- harden parser `export` handling: unsupported export targets now emit deterministic diagnostics and stop before parsing side effects
- preserve explicit `export asm` top-level diagnostic behavior while keeping new export gating
- improve function/op body recovery when a new top-level declaration appears while control stack is still open (`if`/`while`/`select`/`repeat`)
- emit stable control-mismatch diagnostics before interruption diagnostics for deterministic ordering
- extend parser matrix coverage for unsupported export targets and control-stack interruption recovery

## Files
- `src/frontend/parser.ts`
- `test/pr157_export_malformed_matrix.test.ts`
- `test/fixtures/pr157_export_malformed_matrix.zax`
- `test/pr196_parser_control_interruption_matrix.test.ts`
- `test/fixtures/pr196_parser_control_interruption_matrix.zax`

## Validation
- `yarn -s format:check`
- `yarn -s typecheck`
- `yarn -s test`
