### PR TITLE
Lowering: propagate mismatch invalidation through flow joins

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,17 +18,17 @@ Progress snapshot (rough, assembler-first):
 Progress estimate (percentage):
 
 - Strict (gate-based): 0% complete until all 6 completion gates are green (Section 3).
-- Working estimate (risk-weighted): ~58% complete (range 53-65%).
+- Working estimate (risk-weighted): ~59% complete (range 54-66%).
 - Why this is not higher: closure work remains substantial across parser/AST depth, deeper lowering invariants, ISA breadth, CLI contract hardening, and acceptance gates.
 
 Working estimate scorecard (risk-weighted, subjective):
 
 - Spec gate: ~67%
 - Parser/AST gate: ~64%
-- Codegen gate: ~59%
+- Codegen gate: ~60%
 - ISA gate: ~35%
 - CLI/output gate: ~64%
-- Hardening gate: ~47%
+- Hardening gate: ~48%
 
 What moves the needle fastest:
 
@@ -236,14 +236,15 @@ Use only real GitHub PR numbers:
 
 Open / in review (anchored):
 
-- #154: Lowering invariants continuation (unknown-stack-state diagnostics at joins/back-edges/returns/fallthrough and op-expansion boundary checks + deeper regression matrix coverage).
+- none.
 
 Next PR (anchored as soon as opened):
 
-1. Next PR: Lowering invariants continuation (multi-return and nested control-path stack-invariant matrices across op expansion boundaries).
+1. Next PR: Lowering invariants continuation (mismatch-propagation hardening for multi-return and nested control paths across op expansion boundaries).
 
 Completed (anchored, most recent first):
 
+1. #154: Lowering invariants continuation (unknown-stack-state diagnostics at joins/back-edges/returns/fallthrough and op-expansion boundary checks + deeper regression matrix coverage).
 1. #153: Lowering invariants tranche 4 (explicit untracked-SP diagnostics at joins/back-edges, stack-slot-scoped return/fallthrough checks, and regression matrix coverage).
 1. #152: Parser/AST closure tranche 33 (deterministic export-target gating diagnostics, control-stack interruption recovery ordering for function/op bodies, and expanded malformed/recovery matrix coverage).
 1. #151: CLI/output hardening tranche (sparse D8M `segments` metadata + listing gap compression + sparse Intel HEX record emission + contract tests and docs sync).

--- a/docs/spec-v01-audit.md
+++ b/docs/spec-v01-audit.md
@@ -99,16 +99,16 @@ This section maps specific normative statements to implementation evidence or ex
 
 ### 8.2 `8.4/8.5` stack frame and SP safety rules
 
-| Normative intent                                                         | Status                 | Evidence / Diagnostic                                                                                                                                          |
-| ------------------------------------------------------------------------ | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Locals use SP-relative slots and synthetic epilogue cleanup              | Implemented            | `test/pr14_frame_epilogue.test.ts`, `test/pr23_lowering_safety.test.ts`                                                                                        |
-| Terminal `ret` paths avoid dead epilogue jumps                           | Implemented            | `test/pr14_frame_epilogue.test.ts` (`pr14_terminal_ret_no_dead_jump`)                                                                                          |
-| Fallthrough with locals flows into cleanup epilogue                      | Implemented            | `test/pr23_lowering_safety.test.ts` (`pr23_implicit_ret_with_locals`)                                                                                          |
-| `ret` / `ret cc` with non-zero tracked stack delta is rejected           | Intentionally rejected | diagnostic: `ret with non-zero tracked stack delta` (`test/pr23_lowering_safety.test.ts`)                                                                      |
-| Function fallthrough with non-zero stack delta is rejected               | Intentionally rejected | diagnostic: `Function \"...\" has non-zero stack delta at fallthrough` (`test/pr92_lowering_interactions.test.ts`)                                             |
-| Untracked SP mutation in op expansion is rejected                        | Intentionally rejected | diagnostic: `expansion performs untracked SP mutation; cannot verify net stack delta` (`test/pr23_lowering_safety.test.ts`)                                    |
-| Untracked SP mutation at `ret`/fallthrough with stack slots is diagnosed | Intentionally rejected | diagnostics include `ret reached after untracked SP mutation` and `has untracked SP mutation at fallthrough` (`test/pr197_untracked_stack_invariants.test.ts`) |
-| Unknown stack depth at `ret`/fallthrough with stack slots is diagnosed   | Intentionally rejected | diagnostics include `ret reached with unknown stack depth` and `has unknown stack depth at fallthrough` (`test/pr198_lowering_unknown_stack_states.test.ts`)   |
+| Normative intent                                                         | Status                 | Evidence / Diagnostic                                                                                                                                                                                            |
+| ------------------------------------------------------------------------ | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Locals use SP-relative slots and synthetic epilogue cleanup              | Implemented            | `test/pr14_frame_epilogue.test.ts`, `test/pr23_lowering_safety.test.ts`                                                                                                                                          |
+| Terminal `ret` paths avoid dead epilogue jumps                           | Implemented            | `test/pr14_frame_epilogue.test.ts` (`pr14_terminal_ret_no_dead_jump`)                                                                                                                                            |
+| Fallthrough with locals flows into cleanup epilogue                      | Implemented            | `test/pr23_lowering_safety.test.ts` (`pr23_implicit_ret_with_locals`)                                                                                                                                            |
+| `ret` / `ret cc` with non-zero tracked stack delta is rejected           | Intentionally rejected | diagnostic: `ret with non-zero tracked stack delta` (`test/pr23_lowering_safety.test.ts`)                                                                                                                        |
+| Function fallthrough with non-zero stack delta is rejected               | Intentionally rejected | diagnostic: `Function \"...\" has non-zero stack delta at fallthrough` (`test/pr92_lowering_interactions.test.ts`)                                                                                               |
+| Untracked SP mutation in op expansion is rejected                        | Intentionally rejected | diagnostic: `expansion performs untracked SP mutation; cannot verify net stack delta` (`test/pr23_lowering_safety.test.ts`)                                                                                      |
+| Untracked SP mutation at `ret`/fallthrough with stack slots is diagnosed | Intentionally rejected | diagnostics include `ret reached after untracked SP mutation` and `has untracked SP mutation at fallthrough` (`test/pr197_untracked_stack_invariants.test.ts`)                                                   |
+| Unknown stack depth at `ret`/fallthrough with stack slots is diagnosed   | Intentionally rejected | diagnostics include `ret reached with unknown stack depth` and `has unknown stack depth at fallthrough` (`test/pr198_lowering_unknown_stack_states.test.ts`, `test/pr199_lowering_mismatch_propagation.test.ts`) |
 
 ### 8.3 `10.x` structured control invariants
 
@@ -116,6 +116,7 @@ This section maps specific normative statements to implementation evidence or ex
 | --------------------------------------------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `if/else`, `while`, `repeat/until`, `select/case` parse and lower     | Implemented            | `test/pr15_structured_control.test.ts`                                                                                                 |
 | Stack depth must match at control-flow joins/back-edges               | Implemented            | diagnostics asserted in `test/pr15_structured_control.test.ts`, `test/pr92_lowering_interactions.test.ts`                              |
+| Join/back-edge mismatches invalidate downstream stack tracking        | Implemented            | mismatch paths now flow into unknown-stack return diagnostics (`test/pr199_lowering_mismatch_propagation.test.ts`)                     |
 | Untracked SP mutation at joins/back-edges is diagnosed explicitly     | Implemented            | diagnostics include `Cannot verify stack depth at ... due to untracked SP mutation` (`test/pr197_untracked_stack_invariants.test.ts`)  |
 | Unknown stack state at joins/back-edges is diagnosed with stack slots | Implemented            | diagnostics include `Cannot verify stack depth at ... due to unknown stack state` (`test/pr198_lowering_unknown_stack_states.test.ts`) |
 | Duplicate `case` values are rejected                                  | Intentionally rejected | diagnostic includes `Duplicate case value` (`test/pr15_structured_control.test.ts`)                                                    |
@@ -125,21 +126,21 @@ This section maps specific normative statements to implementation evidence or ex
 
 These are intentionally unsupported or guarded forms with expected diagnostics:
 
-| Area                     | Form                        | Diagnostic (contains)                                 | Evidence                                                                          |
-| ------------------------ | --------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Lowering / EA            | nested indexed EA           | `Nested indexed addresses are not supported yet.`     | `test/pr12_calls.test.ts`                                                         |
-| Lowering / EA            | non-constant array index    | `Non-constant array indices are not supported yet.`   | parser/lowering negative coverage                                                 |
-| Lowering / control       | select join mismatch        | `Stack depth mismatch at select join`                 | `test/pr15_structured_control.test.ts`, `test/pr92_lowering_interactions.test.ts` |
-| Lowering / control       | while back-edge mismatch    | `Stack depth mismatch at while back-edge`             | `test/pr15_structured_control.test.ts`                                            |
-| Lowering / control       | repeat/until mismatch       | `Stack depth mismatch at repeat/until`                | `test/pr15_structured_control.test.ts`                                            |
-| Lowering / control       | untracked join/back-edge    | `Cannot verify stack depth ... untracked SP mutation` | `test/pr197_untracked_stack_invariants.test.ts`                                   |
-| Lowering / control       | unknown join/back-edge      | `Cannot verify stack depth ... unknown stack state`   | `test/pr198_lowering_unknown_stack_states.test.ts`                                |
-| Lowering / returns       | ret with stack imbalance    | `ret with non-zero tracked stack delta`               | `test/pr23_lowering_safety.test.ts`                                               |
-| Lowering / returns       | ret with unknown stack      | `ret reached with unknown stack depth`                | `test/pr198_lowering_unknown_stack_states.test.ts`                                |
-| Lowering / function exit | fallthrough stack imbalance | `has non-zero stack delta at fallthrough`             | `test/pr92_lowering_interactions.test.ts`                                         |
-| Lowering / function exit | fallthrough unknown stack   | `has unknown stack depth at fallthrough`              | `test/pr198_lowering_unknown_stack_states.test.ts`                                |
-| Ops / SP safety          | untracked SP mutation       | `untracked SP mutation`                               | `test/pr23_lowering_safety.test.ts`                                               |
-| Ops / SP safety          | unknown stack tracking      | `expansion leaves stack depth untrackable`            | `test/pr198_lowering_unknown_stack_states.test.ts`                                |
+| Area                     | Form                        | Diagnostic (contains)                                 | Evidence                                                                                               |
+| ------------------------ | --------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Lowering / EA            | nested indexed EA           | `Nested indexed addresses are not supported yet.`     | `test/pr12_calls.test.ts`                                                                              |
+| Lowering / EA            | non-constant array index    | `Non-constant array indices are not supported yet.`   | parser/lowering negative coverage                                                                      |
+| Lowering / control       | select join mismatch        | `Stack depth mismatch at select join`                 | `test/pr15_structured_control.test.ts`, `test/pr92_lowering_interactions.test.ts`                      |
+| Lowering / control       | while back-edge mismatch    | `Stack depth mismatch at while back-edge`             | `test/pr15_structured_control.test.ts`                                                                 |
+| Lowering / control       | repeat/until mismatch       | `Stack depth mismatch at repeat/until`                | `test/pr15_structured_control.test.ts`                                                                 |
+| Lowering / control       | untracked join/back-edge    | `Cannot verify stack depth ... untracked SP mutation` | `test/pr197_untracked_stack_invariants.test.ts`                                                        |
+| Lowering / control       | unknown join/back-edge      | `Cannot verify stack depth ... unknown stack state`   | `test/pr198_lowering_unknown_stack_states.test.ts`, `test/pr199_lowering_mismatch_propagation.test.ts` |
+| Lowering / returns       | ret with stack imbalance    | `ret with non-zero tracked stack delta`               | `test/pr23_lowering_safety.test.ts`                                                                    |
+| Lowering / returns       | ret with unknown stack      | `ret reached with unknown stack depth`                | `test/pr198_lowering_unknown_stack_states.test.ts`, `test/pr199_lowering_mismatch_propagation.test.ts` |
+| Lowering / function exit | fallthrough stack imbalance | `has non-zero stack delta at fallthrough`             | `test/pr92_lowering_interactions.test.ts`                                                              |
+| Lowering / function exit | fallthrough unknown stack   | `has unknown stack depth at fallthrough`              | `test/pr198_lowering_unknown_stack_states.test.ts`                                                     |
+| Ops / SP safety          | untracked SP mutation       | `untracked SP mutation`                               | `test/pr23_lowering_safety.test.ts`                                                                    |
+| Ops / SP safety          | unknown stack tracking      | `expansion leaves stack depth untrackable`            | `test/pr198_lowering_unknown_stack_states.test.ts`, `test/pr199_lowering_mismatch_propagation.test.ts` |
 
 ## 10) Tranche 3 Mapping Expansion
 

--- a/test/fixtures/pr199_lowering_mismatch_propagation.zax
+++ b/test/fixtures/pr199_lowering_mismatch_propagation.zax
@@ -1,0 +1,60 @@
+op maybe_leak(cc: NZ)
+  if cc
+    push bc
+  else
+    nop
+  end
+end
+
+export func mismatch_if_else(a: byte): void
+  var
+    scratch: byte
+  end
+  if nz
+    push bc
+  else
+    nop
+  end
+  ret
+end
+
+export func mismatch_while(a: byte): void
+  var
+    scratch: byte
+  end
+  while nz
+    push bc
+  end
+  ret
+end
+
+export func mismatch_repeat(a: byte): void
+  var
+    scratch: byte
+  end
+  repeat
+    push bc
+  until z
+  ret
+end
+
+export func mismatch_select(a: byte): void
+  var
+    scratch: byte
+  end
+  select a
+    case 0
+      push bc
+    case 1
+      nop
+  end
+  ret
+end
+
+export func mismatch_op_boundary(a: byte): void
+  var
+    scratch: byte
+  end
+  maybe_leak nz
+  ret
+end

--- a/test/pr199_lowering_mismatch_propagation.test.ts
+++ b/test/pr199_lowering_mismatch_propagation.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR199 lowering mismatch propagation across joins/back-edges/op boundaries', () => {
+  it('invalidates stack tracking after mismatch diagnostics so downstream returns are guarded', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr199_lowering_mismatch_propagation.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(messages.some((m) => m.includes('Stack depth mismatch at if/else join'))).toBe(true);
+    expect(messages.some((m) => m.includes('Stack depth mismatch at while back-edge'))).toBe(true);
+    expect(messages.some((m) => m.includes('Stack depth mismatch at repeat/until'))).toBe(true);
+    expect(messages.some((m) => m.includes('Stack depth mismatch at select join'))).toBe(true);
+
+    expect(
+      messages.some((m) =>
+        m.includes(
+          'op "maybe_leak" expansion leaves stack depth untrackable; cannot verify net stack delta.',
+        ),
+      ),
+    ).toBe(true);
+
+    const unknownRetCount = messages.filter((m) =>
+      m.includes('ret reached with unknown stack depth; cannot verify function stack balance.'),
+    ).length;
+    expect(unknownRetCount).toBeGreaterThanOrEqual(5);
+  });
+});


### PR DESCRIPTION
## Summary
- propagate control-flow stack mismatch states as invalid/untrackable instead of keeping a pseudo-valid `spDelta`
- harden join/back-edge behavior so downstream `ret` checks cannot assume stack validity after prior mismatch diagnostics
- add regression matrix coverage for mismatch propagation across:
  - `if/else` joins
  - `while` back-edges
  - `repeat/until` back-edges
  - `select` joins
  - `op` expansion boundaries
- sync `docs/spec-v01-audit.md` + `docs/roadmap.md` with tranche evidence and updated working estimates

## Why this matters
Previously, some mismatch diagnostics were emitted but flow state could remain marked valid, allowing later lowering checks to reason over a fabricated stack state. This change makes mismatch diagnostics carry forward as unknown stack state, so later returns are guarded conservatively.

## Validation
- `yarn -s format:check`
- `yarn -s typecheck`
- `yarn -s test`
