### PR TITLE
test(cli): tighten lock metadata validation rules

### DIFF
--- a/test/pr249_cli_lock_eviction_matrix.test.ts
+++ b/test/pr249_cli_lock_eviction_matrix.test.ts
@@ -21,6 +21,17 @@ describe('PR249 CLI build-lock eviction matrix', () => {
     expect(parseLockMeta('123')).toEqual({ createdAt: 123 });
   });
 
+  it('rejects invalid pid/createdAt values in parsed lock metadata', () => {
+    expect(parseLockMeta('{"pid": -1, "createdAt": 42}')).toEqual({ createdAt: 42 });
+    expect(parseLockMeta('{"pid": 0, "createdAt": 42}')).toEqual({ createdAt: 42 });
+    expect(parseLockMeta('{"pid": 12.5, "createdAt": 42}')).toEqual({ createdAt: 42 });
+    expect(parseLockMeta('{"pid": 1234, "createdAt": -1}')).toEqual({ pid: 1234 });
+    expect(parseLockMeta('{"pid": 1234, "createdAt": 12.5}')).toEqual({ pid: 1234 });
+    expect(parseLockMeta('{"pid": -1, "createdAt": -1}')).toBeUndefined();
+    expect(parseLockMeta('-1')).toBeUndefined();
+    expect(parseLockMeta('12.5')).toBeUndefined();
+  });
+
   it('never evicts unknown or malformed lock metadata', () => {
     const isOwnerAlive = () => true;
     expect(


### PR DESCRIPTION
## Summary
- tighten lock metadata parsing to accept only valid `pid` (positive integer) and `createdAt` (non-negative integer)
- keep malformed/invalid lock payloads non-evictable while preserving stale/dead-owner eviction behavior
- expand lock decision matrix tests with invalid-value and timeout/wait-window coverage

## Validation
- yarn -s format:check
- yarn -s typecheck
- yarn -s test
