### PR TITLE
parser: canonicalize asm instruction heads

### DIFF
--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -305,6 +305,7 @@ export interface AsmLabelNode extends BaseNode {
  */
 export interface AsmInstructionNode extends BaseNode {
   kind: 'AsmInstruction';
+  /** Canonical lower-case instruction mnemonic. */
   head: string;
   operands: AsmOperandNode[];
 }

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -601,7 +601,7 @@ function parseAsmInstruction(
     }
   }
 
-  return { kind: 'AsmInstruction', span: instrSpan, head, operands };
+  return { kind: 'AsmInstruction', span: instrSpan, head: headLower, operands };
 }
 
 type AsmControlFrame =

--- a/test/pr250_parser_instruction_head_casing.test.ts
+++ b/test/pr250_parser_instruction_head_casing.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseProgram } from '../src/frontend/parser.js';
+import type { AsmInstructionNode, FuncDeclNode, OpDeclNode } from '../src/frontend/ast.js';
+import type { Diagnostic } from '../src/diagnostics/types.js';
+
+describe('PR250 parser asm head canonicalization', () => {
+  it('normalizes function-body instruction heads to lower-case', () => {
+    const source = `
+func main(): void
+  LD A, 1
+  dJnZ loop
+  loop:
+  Ret
+end
+`;
+    const diagnostics: Diagnostic[] = [];
+    const program = parseProgram('mixed-case-func.zax', source, diagnostics);
+    expect(diagnostics).toEqual([]);
+
+    const func = program.files[0]?.items.find(
+      (item): item is FuncDeclNode => item.kind === 'FuncDecl',
+    );
+    expect(func).toBeDefined();
+    const heads = func!.asm.items
+      .filter((item): item is AsmInstructionNode => item.kind === 'AsmInstruction')
+      .map((instr) => instr.head);
+    expect(heads).toEqual(['ld', 'djnz', 'ret']);
+  });
+
+  it('normalizes op-body instruction heads to lower-case', () => {
+    const source = `
+op emit_nops(count: imm8)
+  NOP
+  dJnZ count
+end
+`;
+    const diagnostics: Diagnostic[] = [];
+    const program = parseProgram('mixed-case-op.zax', source, diagnostics);
+    expect(diagnostics).toEqual([]);
+
+    const opDecl = program.files[0]?.items.find(
+      (item): item is OpDeclNode => item.kind === 'OpDecl',
+    );
+    expect(opDecl).toBeDefined();
+    const heads = opDecl!.body.items
+      .filter((item): item is AsmInstructionNode => item.kind === 'AsmInstruction')
+      .map((instr) => instr.head);
+    expect(heads).toEqual(['nop', 'djnz']);
+  });
+});


### PR DESCRIPTION
## Summary
- canonicalize parsed asm instruction mnemonics to lower-case in the AST (`AsmInstruction.head`)
- document that `AsmInstruction.head` is canonical lower-case
- add parser coverage for mixed-case instruction mnemonics in both function and op bodies

## Validation
- yarn -s format:check
- yarn -s typecheck
- yarn -s test
