### PR TITLE
parser: canonicalize asm register tokens

### DIFF
--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -328,7 +328,7 @@ export type AsmControlNode =
  * Operand variants in `asm` instructions.
  */
 export type AsmOperandNode =
-  | { kind: 'Reg'; span: SourceSpan; name: string }
+  | { kind: 'Reg'; span: SourceSpan; /** Canonical upper-case register token. */ name: string }
   | { kind: 'Imm'; span: SourceSpan; expr: ImmExprNode }
   | { kind: 'Ea'; span: SourceSpan; expr: EaExprNode }
   | { kind: 'Mem'; span: SourceSpan; expr: EaExprNode }
@@ -383,7 +383,7 @@ export type EaExprNode =
  */
 export type EaIndexNode =
   | { kind: 'IndexImm'; span: SourceSpan; value: ImmExprNode }
-  | { kind: 'IndexReg8'; span: SourceSpan; reg: string }
+  | { kind: 'IndexReg8'; span: SourceSpan; /** Canonical upper-case reg8 token. */ reg: string }
   | { kind: 'IndexMemHL'; span: SourceSpan }
   | { kind: 'IndexEa'; span: SourceSpan; expr: EaExprNode };
 

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -444,7 +444,9 @@ function parseEaIndexFromText(
 ): EaIndexNode | undefined {
   const t = indexText.trim();
   if (t.toUpperCase() === 'HL') return { kind: 'IndexMemHL', span: indexSpan };
-  if (/^(A|B|C|D|E|H|L)$/i.test(t)) return { kind: 'IndexReg8', span: indexSpan, reg: t };
+  if (/^(A|B|C|D|E|H|L)$/i.test(t)) {
+    return { kind: 'IndexReg8', span: indexSpan, reg: canonicalRegisterToken(t) };
+  }
 
   const imm = parseImmExprFromText(filePath, t, indexSpan, diagnostics, false);
   if (imm) return { kind: 'IndexImm', span: indexSpan, value: imm };
@@ -528,7 +530,7 @@ function parseAsmOperand(
   if (t.length === 0) return undefined;
 
   if (/^(A|B|C|D|E|H|L|IXH|IXL|IYH|IYL|HL|DE|BC|SP|IX|IY|AF|AF'|I|R)$/i.test(t)) {
-    return { kind: 'Reg', span: operandSpan, name: t };
+    return { kind: 'Reg', span: operandSpan, name: canonicalRegisterToken(t) };
   }
 
   const n = parseNumberLiteral(t);
@@ -562,6 +564,11 @@ function parseAsmOperand(
     });
   }
   return undefined;
+}
+
+function canonicalRegisterToken(token: string): string {
+  if (/^af'$/i.test(token)) return "AF'";
+  return token.toUpperCase();
 }
 
 function parseAsmInstruction(

--- a/test/pr252_parser_register_token_canonicalization.test.ts
+++ b/test/pr252_parser_register_token_canonicalization.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseProgram } from '../src/frontend/parser.js';
+import type { AsmInstructionNode, FuncDeclNode, OpDeclNode } from '../src/frontend/ast.js';
+import type { Diagnostic } from '../src/diagnostics/types.js';
+
+function asmInstructions(items: { kind: string }[]): AsmInstructionNode[] {
+  return items.filter((item): item is AsmInstructionNode => item.kind === 'AsmInstruction');
+}
+
+describe('PR252 parser register token canonicalization', () => {
+  it('normalizes reg operands and ea index reg operands in functions', () => {
+    const source = `
+func main(): void
+  ld a, b
+  push aF'
+  ld hl, arr[d]
+end
+`;
+    const diagnostics: Diagnostic[] = [];
+    const program = parseProgram('reg-casing-func.zax', source, diagnostics);
+    expect(diagnostics).toEqual([]);
+
+    const func = program.files[0]?.items.find(
+      (item): item is FuncDeclNode => item.kind === 'FuncDecl',
+    );
+    expect(func).toBeDefined();
+    const instr = asmInstructions(func!.asm.items);
+
+    const ld = instr[0]!;
+    expect(ld.operands[0]?.kind).toBe('Reg');
+    expect(ld.operands[1]?.kind).toBe('Reg');
+    if (ld.operands[0]?.kind !== 'Reg' || ld.operands[1]?.kind !== 'Reg') return;
+    expect(ld.operands[0].name).toBe('A');
+    expect(ld.operands[1].name).toBe('B');
+
+    const push = instr[1]!;
+    expect(push.operands[0]?.kind).toBe('Reg');
+    if (push.operands[0]?.kind !== 'Reg') return;
+    expect(push.operands[0].name).toBe("AF'");
+
+    const indexed = instr[2]!;
+    expect(indexed.operands[1]?.kind).toBe('Ea');
+    if (indexed.operands[1]?.kind !== 'Ea') return;
+    expect(indexed.operands[1].expr.kind).toBe('EaIndex');
+    if (indexed.operands[1].expr.kind !== 'EaIndex') return;
+    expect(indexed.operands[1].expr.index.kind).toBe('IndexReg8');
+    if (indexed.operands[1].expr.index.kind !== 'IndexReg8') return;
+    expect(indexed.operands[1].expr.index.reg).toBe('D');
+  });
+
+  it('normalizes ea index reg operands in ops', () => {
+    const source = `
+op main(src: reg8)
+  ld hl, table[c]
+end
+`;
+    const diagnostics: Diagnostic[] = [];
+    const program = parseProgram('reg-casing-op.zax', source, diagnostics);
+    expect(diagnostics).toEqual([]);
+
+    const opDecl = program.files[0]?.items.find(
+      (item): item is OpDeclNode => item.kind === 'OpDecl',
+    );
+    expect(opDecl).toBeDefined();
+    const instr = asmInstructions(opDecl!.body.items);
+    expect(instr).toHaveLength(1);
+    const ld = instr[0]!;
+    expect(ld.operands[1]?.kind).toBe('Ea');
+    if (ld.operands[1]?.kind !== 'Ea') return;
+    expect(ld.operands[1].expr.kind).toBe('EaIndex');
+    if (ld.operands[1].expr.kind !== 'EaIndex') return;
+    expect(ld.operands[1].expr.index.kind).toBe('IndexReg8');
+    if (ld.operands[1].expr.index.kind !== 'IndexReg8') return;
+    expect(ld.operands[1].expr.index.reg).toBe('C');
+  });
+});


### PR DESCRIPTION
## Summary
- canonicalize parsed asm `Reg` operand tokens to upper-case in the AST
- canonicalize `EaIndex` reg8 index tokens to upper-case in the AST
- add parser matrix coverage for mixed-case register spelling in function and op bodies

## Validation
- yarn -s format:check
- yarn -s typecheck
- yarn -s test
