### PR TITLE
feat: add offsetof() compile-time builtin

### DIFF
--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -361,6 +361,7 @@ export type ImmExprNode =
   | { kind: 'ImmLiteral'; span: SourceSpan; value: number }
   | { kind: 'ImmName'; span: SourceSpan; name: string }
   | { kind: 'ImmSizeof'; span: SourceSpan; typeExpr: TypeExprNode }
+  | { kind: 'ImmOffsetof'; span: SourceSpan; typeExpr: TypeExprNode; path: OffsetofPathNode }
   | { kind: 'ImmUnary'; span: SourceSpan; op: '+' | '-' | '~'; expr: ImmExprNode }
   | {
       kind: 'ImmBinary';
@@ -399,6 +400,19 @@ export type EaIndexNode =
   | { kind: 'IndexEa'; span: SourceSpan; expr: EaExprNode };
 
 /**
+ * Field path used by `offsetof(Type, path)` built-in.
+ */
+export interface OffsetofPathNode extends BaseNode {
+  kind: 'OffsetofPath';
+  base: string;
+  steps: OffsetofPathStepNode[];
+}
+
+export type OffsetofPathStepNode =
+  | { kind: 'OffsetofField'; span: SourceSpan; name: string }
+  | { kind: 'OffsetofIndex'; span: SourceSpan; expr: ImmExprNode };
+
+/**
  * Union of all AST node types.
  */
 export type Node =
@@ -418,5 +432,7 @@ export type Node =
   | ImmExprNode
   | EaExprNode
   | EaIndexNode
+  | OffsetofPathNode
+  | OffsetofPathStepNode
   | DataInitializerNode
   | OpMatcherNode;

--- a/src/semantics/env.ts
+++ b/src/semantics/env.ts
@@ -11,7 +11,7 @@ import type {
   TypeDeclNode,
   UnionDeclNode,
 } from '../frontend/ast.js';
-import { sizeOfTypeExpr } from './layout.js';
+import { offsetOfPathInTypeExpr, sizeOfTypeExpr } from './layout.js';
 
 /**
  * Immutable compilation environment for PR2: resolved constant and enum member values.
@@ -67,6 +67,15 @@ export function evalImmExpr(
     }
     case 'ImmSizeof': {
       return sizeOfTypeExpr(expr.typeExpr, env, diagnostics);
+    }
+    case 'ImmOffsetof': {
+      return offsetOfPathInTypeExpr(
+        expr.typeExpr,
+        expr.path,
+        env,
+        (inner) => evalImmExpr(inner, env, diagnostics),
+        diagnostics,
+      );
     }
     case 'ImmUnary': {
       const v = evalImmExpr(expr.expr, env, diagnostics);

--- a/src/semantics/layout.ts
+++ b/src/semantics/layout.ts
@@ -1,6 +1,13 @@
 import type { Diagnostic } from '../diagnostics/types.js';
 import { DiagnosticIds } from '../diagnostics/types.js';
-import type { TypeDeclNode, TypeExprNode, UnionDeclNode } from '../frontend/ast.js';
+import type {
+  ImmExprNode,
+  OffsetofPathNode,
+  RecordFieldNode,
+  TypeDeclNode,
+  TypeExprNode,
+  UnionDeclNode,
+} from '../frontend/ast.js';
 import type { CompileEnv } from './env.js';
 
 /**
@@ -117,4 +124,163 @@ export function sizeOfTypeExpr(
   };
 
   return sizeOf(typeExpr);
+}
+
+/**
+ * Compute the byte offset of a field path inside a type expression.
+ *
+ * Rules:
+ * - Record fields contribute storage sizes of preceding fields.
+ * - Union field offsets are always 0.
+ * - Array indices must be compile-time constants and contribute index * element storage size.
+ */
+export function offsetOfPathInTypeExpr(
+  typeExpr: TypeExprNode,
+  path: OffsetofPathNode,
+  env: CompileEnv,
+  evalImm: (expr: ImmExprNode) => number | undefined,
+  diagnostics?: Diagnostic[],
+): number | undefined {
+  type ResolvedType =
+    | { kind: 'Scalar'; name: string }
+    | { kind: 'Array'; element: TypeExprNode; length: number }
+    | { kind: 'Record'; fields: RecordFieldNode[] }
+    | { kind: 'Union'; fields: RecordFieldNode[] };
+
+  const scalarSize = (name: string): number | undefined => {
+    switch (name) {
+      case 'byte':
+        return 1;
+      case 'word':
+      case 'addr':
+      case 'ptr':
+        return 2;
+      default:
+        return undefined;
+    }
+  };
+
+  const diag = (file: string, message: string) => {
+    diagnostics?.push({ id: DiagnosticIds.TypeError, severity: 'error', message, file });
+  };
+
+  const resolveType = (
+    te: TypeExprNode,
+    visiting = new Set<string>(),
+  ): ResolvedType | undefined => {
+    switch (te.kind) {
+      case 'TypeName': {
+        if (scalarSize(te.name) !== undefined) return { kind: 'Scalar', name: te.name };
+        if (visiting.has(te.name)) {
+          diag(te.span.file, `Recursive type definition detected for "${te.name}".`);
+          return undefined;
+        }
+        const decl = env.types.get(te.name);
+        if (!decl) {
+          diag(te.span.file, `Unknown type "${te.name}".`);
+          return undefined;
+        }
+        visiting.add(te.name);
+        try {
+          if (decl.kind === 'UnionDecl') return { kind: 'Union', fields: decl.fields };
+          return resolveType(decl.typeExpr, visiting);
+        } finally {
+          visiting.delete(te.name);
+        }
+      }
+      case 'ArrayType': {
+        if (te.length === undefined) {
+          diag(
+            te.span.file,
+            `Array length is required here (inferred-length arrays like "T[]" are only permitted in data declarations with an initializer).`,
+          );
+          return undefined;
+        }
+        return { kind: 'Array', element: te.element, length: te.length };
+      }
+      case 'RecordType':
+        return { kind: 'Record', fields: te.fields };
+    }
+  };
+
+  const findField = (
+    fields: RecordFieldNode[],
+    fieldName: string,
+    file: string,
+  ): { field: RecordFieldNode; offsetBefore: number } | undefined => {
+    let offsetBefore = 0;
+    for (const f of fields) {
+      if (f.name === fieldName) return { field: f, offsetBefore };
+      const fs = sizeOfTypeExpr(f.typeExpr, env, diagnostics);
+      if (fs === undefined) return undefined;
+      offsetBefore += fs;
+    }
+    diag(file, `Unknown field "${fieldName}".`);
+    return undefined;
+  };
+
+  const initial = resolveType(typeExpr);
+  if (!initial) return undefined;
+  let cur: ResolvedType = initial;
+  let total = 0;
+  const file = path.span.file;
+
+  const selectField = (name: string): boolean => {
+    if (cur.kind === 'Record') {
+      const found = findField(cur.fields, name, file);
+      if (!found) return false;
+      total += found.offsetBefore;
+      const next = resolveType(found.field.typeExpr);
+      if (!next) return false;
+      cur = next;
+      return true;
+    }
+    if (cur.kind === 'Union') {
+      const found = findField(cur.fields, name, file);
+      if (!found) return false;
+      const next = resolveType(found.field.typeExpr);
+      if (!next) return false;
+      cur = next;
+      return true;
+    }
+    diag(file, `Cannot select field "${name}" from non-record/union type.`);
+    return false;
+  };
+
+  if (!selectField(path.base)) return undefined;
+
+  for (const step of path.steps) {
+    if (step.kind === 'OffsetofField') {
+      if (!selectField(step.name)) return undefined;
+      continue;
+    }
+
+    if (cur.kind !== 'Array') {
+      diag(file, `Cannot index into non-array type in offsetof path.`);
+      return undefined;
+    }
+
+    const idx = evalImm(step.expr);
+    if (idx === undefined) {
+      diag(file, `Failed to evaluate offsetof index expression.`);
+      return undefined;
+    }
+    if (!Number.isInteger(idx)) {
+      diag(file, `offsetof index must evaluate to an integer.`);
+      return undefined;
+    }
+    if (idx < 0 || idx >= cur.length) {
+      diag(file, `offsetof index ${idx} out of bounds for length ${cur.length}.`);
+      return undefined;
+    }
+
+    const elemSize = sizeOfTypeExpr(cur.element, env, diagnostics);
+    if (elemSize === undefined) return undefined;
+    total += idx * elemSize;
+    const next = resolveType(cur.element);
+    if (!next) return undefined;
+    cur = next;
+  }
+
+  return total;
 }

--- a/test/fixtures/pr257_offsetof_invalid.zax
+++ b/test/fixtures/pr257_offsetof_invalid.zax
@@ -1,0 +1,16 @@
+type Point
+  x: byte
+  y: byte
+end
+
+type Scene
+  sprites: Point[4]
+end
+
+const BadField = offsetof(Point, z)
+const BadIndexUnknown = offsetof(Scene, sprites[Nope].x)
+const BadIndexRange = offsetof(Scene, sprites[9].x)
+
+export func main(): void
+  ld a, 0
+end

--- a/test/fixtures/pr257_offsetof_valid.zax
+++ b/test/fixtures/pr257_offsetof_valid.zax
@@ -1,0 +1,31 @@
+type Point
+  x: byte
+  y: byte
+  color: word
+end
+
+union Payload
+  asByte: byte
+  asWord: word
+end
+
+type Node
+  tag: byte
+  payload: Payload
+end
+
+type Scene
+  header: word
+  sprites: Point[4]
+end
+
+const OffY = offsetof(Point, y)
+const Idx = 3
+const OffSpritesIdxColor = offsetof(Scene, sprites[Idx].color)
+const OffPayloadWord = offsetof(Node, payload.asWord)
+
+export func main(): void
+  ld a, OffY
+  ld hl, OffSpritesIdxColor
+  ld de, OffPayloadWord
+end

--- a/test/pr257_offsetof.test.ts
+++ b/test/pr257_offsetof.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact, D8mArtifact } from '../src/formats/types.js';
+import { DiagnosticIds } from '../src/diagnostics/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR257 offsetof() in imm expressions', () => {
+  it('evaluates offsetof(Type, fieldPath) with records, arrays, and unions', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr257_offsetof_valid.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    const d8m = res.artifacts.find((a): a is D8mArtifact => a.kind === 'd8m');
+    expect(bin).toBeDefined();
+    expect(d8m).toBeDefined();
+
+    // ld a,1 ; ld hl,16 ; ld de,1 ; ret
+    expect(bin!.bytes).toEqual(Uint8Array.of(0x3e, 0x01, 0x21, 0x10, 0x00, 0x11, 0x01, 0x00, 0xc9));
+
+    const symbols = d8m!.json['symbols'] as unknown as Array<{
+      name: string;
+      kind: string;
+      value?: number;
+      [k: string]: unknown;
+    }>;
+    expect(symbols).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'OffY', kind: 'constant', value: 1 }),
+        expect.objectContaining({ name: 'OffSpritesIdxColor', kind: 'constant', value: 16 }),
+        expect.objectContaining({ name: 'OffPayloadWord', kind: 'constant', value: 1 }),
+      ]),
+    );
+  });
+
+  it('diagnoses invalid offsetof() paths and indices', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr257_offsetof_invalid.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics.map((d) => d.id)).toEqual(
+      expect.arrayContaining([DiagnosticIds.TypeError, DiagnosticIds.SemanticsError]),
+    );
+    expect(res.diagnostics.map((d) => d.message)).toEqual(
+      expect.arrayContaining([
+        'Unknown field "z".',
+        'Failed to evaluate offsetof index expression.',
+        'offsetof index 9 out of bounds for length 4.',
+        'Failed to evaluate const "BadField".',
+        'Failed to evaluate const "BadIndexUnknown".',
+        'Failed to evaluate const "BadIndexRange".',
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `offsetof(Type, fieldPath)` as a compile-time `imm` builtin
- extend imm AST with:
  - `ImmOffsetof`
  - `OffsetofPath` (`base` + field/index steps)
- extend parser to recognize and parse `offsetof(...)` in imm expressions
- evaluate `offsetof` in semantics using storage-size layout rules:
  - records: offset accumulates preceding field storage sizes
  - unions: member contribution is `0`
  - arrays: constant index contributes `index * sizeof(element)`
  - diagnostics for unknown fields, non-array indexing, non-constant/invalid indices, and OOB indices
- update lowering imm clone/substitution helpers to handle `ImmOffsetof` safely

## Tests
- add `test/pr257_offsetof.test.ts`
- add fixtures:
  - `test/fixtures/pr257_offsetof_valid.zax`
  - `test/fixtures/pr257_offsetof_invalid.zax`

## Validation
- `yarn -s typecheck`
- `yarn -s vitest run test/pr257_offsetof.test.ts test/pr8_sizeof.test.ts`
- `yarn -s test`
