### PR TITLE
feat: lower scalar variable array indices

### DIFF
--- a/test/fixtures/pr260_value_semantics_scalar_index.zax
+++ b/test/fixtures/pr260_value_semantics_scalar_index.zax
@@ -1,0 +1,14 @@
+section code at $0000
+section var at $1000
+
+globals
+  idxb: byte
+  idxw: word
+  arr: byte[8]
+
+export func main(): void
+  ld a, arr[idxb]
+  ld arr[idxb], a
+  ld a, arr[idxw]
+  ld arr[idxw], a
+end

--- a/test/pr260_value_semantics_scalar_index.test.ts
+++ b/test/pr260_value_semantics_scalar_index.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR260: scalar variable indices in array access', () => {
+  it('lowers byte/word scalar indices in ld array forms', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr260_value_semantics_scalar_index.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    expect(bin!.bytes.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- support typed scalar variable indices in array access lowering (`arr[idxb]`, `arr[idxw]`)
- allow dynamic `IndexImm` names to lower through scalar value loads (byte/word) into `HL`
- avoid early `Failed to evaluate array index` diagnostics so runtime fallback can handle scalar index vars
- add regression fixture/test for scalar byte/word variable indexing in `ld` forms

## Validation
- `yarn -s typecheck`
- `yarn -s vitest run test/pr260_value_semantics_scalar_index.test.ts test/pr256_value_semantics_scalar_ld.test.ts test/pr12_calls.test.ts`
- `yarn -s format:check`
