### PR TITLE
test: lock arr[HL] and arr[(HL)] index semantics

### DIFF
--- a/test/fixtures/pr261_call_ea_index_reg16hl.zax
+++ b/test/fixtures/pr261_call_ea_index_reg16hl.zax
@@ -1,0 +1,13 @@
+; PR261 fixture: ea indexing with HL as 16-bit index register
+section code at $0000
+section data at $0080
+
+extern func takeAddr(p: word): void at $1234
+
+data
+  arr: byte[4] = [ 1, 2, 3, 4 ]
+
+export func main(): void
+    ld hl, 2
+    takeAddr arr[HL]
+end

--- a/test/pr12_calls.test.ts
+++ b/test/pr12_calls.test.ts
@@ -185,6 +185,41 @@ describe('PR12 calls (extern + func)', () => {
     expect(bin!.bytes).toEqual(expected);
   });
 
+  it('supports ea indexing with HL as 16-bit index register', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr261_call_ea_index_reg16hl.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+
+    const code = Uint8Array.of(
+      0x21,
+      0x02,
+      0x00, // ld hl, 2
+      ...callVoidPrefix,
+      0x11,
+      0x80,
+      0x00, // ld de, $0080
+      0x19, // add hl, de
+      0xe5, // push hl
+      0xcd,
+      0x34,
+      0x12, // call $1234
+      0xc1, // pop bc
+      ...callVoidSuffix,
+      0xc9, // ret
+    );
+    const gap = new Uint8Array(0x80 - code.length);
+    const data = Uint8Array.of(0x01, 0x02, 0x03, 0x04);
+    const expected = new Uint8Array(code.length + gap.length + data.length);
+    expected.set(code, 0);
+    expected.set(gap, code.length);
+    expected.set(data, code.length + gap.length);
+
+    expect(bin!.bytes).toEqual(expected);
+  });
+
   it('supports ea indexing with (HL) (byte read from memory at HL)', async () => {
     const entry = join(__dirname, 'fixtures', 'pr13_call_ea_index_memhl.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });


### PR DESCRIPTION
## Summary
- add parser regression coverage to distinguish `arr[HL]` (16-bit register index) from `arr[(HL)]` (indirect byte index)
- add lowering/call fixture coverage for `arr[HL]` in extern call argument lowering
- keep existing `arr[(HL)]` behavior explicitly covered alongside new `arr[HL]` case

## Validation
- `yarn -s vitest run test/pr12_calls.test.ts test/parser_nested_index.test.ts`
- `yarn typecheck`
- `yarn -s format:check`
