### PR TITLE
ci: add docs-only fast path and gate full matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,22 +26,17 @@ jobs:
               - 'docs/**'
               - '**/*.md'
               - '.github/ISSUE_TEMPLATE/**'
-            full:
-              - 'src/**'
-              - 'test/**'
-              - 'examples/**'
-              - 'scripts/**'
-              - '.github/workflows/**'
-              - 'package.json'
-              - 'yarn.lock'
-              - 'tsconfig*.json'
-              - 'vitest.config.*'
+            other:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!.github/ISSUE_TEMPLATE/**'
 
       - name: Classify change set
         id: classify
         shell: bash
         run: |
-          if [[ "${{ steps.filter.outputs.docs }}" == "true" && "${{ steps.filter.outputs.full }}" != "true" ]]; then
+          if [[ "${{ steps.filter.outputs.docs }}" == "true" && "${{ steps.filter.outputs.other }}" != "true" ]]; then
             echo "docs_only=true" >> "$GITHUB_OUTPUT"
             echo "run_full=false" >> "$GITHUB_OUTPUT"
             echo "Change set classified as docs-only."
@@ -74,7 +69,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Docs format check
-        run: yarn prettier -c "docs/**/*.md" "docs/*.md" ".github/ISSUE_TEMPLATE/*.yml"
+        run: yarn prettier -c "**/*.md" ".github/ISSUE_TEMPLATE/*.yml"
 
   test:
     name: test (${{ matrix.os }})


### PR DESCRIPTION
## Summary
- add a change-detection job in CI
- classify changes as docs-only vs full-CI
- run a fast ubuntu docs-format check for docs-only changes
- run full matrix (format + typecheck + coverage tests) only when code-relevant files change

## Behavior
- Docs-only changes (`docs/**`, `**/*.md`, `.github/ISSUE_TEMPLATE/**`) now skip the heavy matrix
- Any source/test/workflow/config changes still trigger full CI

## Why
Reduce CI latency and runner usage for non-development/doc updates while keeping strict coverage for code changes.
