### PR TITLE
feat: explicit diagnostics for unqualified enum members

### DIFF
--- a/test/fixtures/pr265_enum_unqualified_ambiguous.zax
+++ b/test/fixtures/pr265_enum_unqualified_ambiguous.zax
@@ -1,0 +1,4 @@
+enum ModeA On, Off
+enum ModeB On, Off
+
+const Bad = On

--- a/test/pr4_enum.test.ts
+++ b/test/pr4_enum.test.ts
@@ -42,8 +42,26 @@ describe('PR4 enum parsing', () => {
     const entry = join(__dirname, 'fixtures', 'pr259_enum_unqualified_member.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
+    expect(
+      res.diagnostics.some((d) =>
+        d.message.includes('Unqualified enum member "Write" is not allowed; use "Mode.Write".'),
+      ),
+    ).toBe(true);
     expect(res.diagnostics.some((d) => d.message.includes('Failed to evaluate const "Bad".'))).toBe(
       true,
     );
+  });
+
+  it('diagnoses ambiguous unqualified enum member references', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr265_enum_unqualified_ambiguous.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(
+      res.diagnostics.some((d) =>
+        d.message.includes(
+          'Unqualified enum member "On" is ambiguous; use one of: ModeA.On, ModeB.On.',
+        ),
+      ),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- adds explicit diagnostics for unqualified enum member usage in imm expressions
- keeps qualified enum behavior unchanged (`EnumType.Member` still resolves normally)
- adds ambiguity diagnostics when multiple enums expose the same member name
- expands enum tests to lock both direct and ambiguous unqualified-member errors

## Why
The canonical v0.2 spec now requires enum members to be qualified and calls out migration diagnostics. Existing behavior mostly surfaced a generic `Failed to evaluate const` error. This change makes enum-qualification failures explicit and actionable.

## Changes
- `src/semantics/env.ts`
  - on unresolved `ImmName`, detect matching qualified enum candidates (`*.Member`)
  - emit explicit diagnostics:
    - single match: `Unqualified enum member "X" is not allowed; use "Type.X".`
    - multiple matches: `Unqualified enum member "X" is ambiguous; use one of: ...`
- `test/pr4_enum.test.ts`
  - assert explicit unqualified-member diagnostic for `Write`
  - add ambiguous-member coverage for `On`
- `test/fixtures/pr265_enum_unqualified_ambiguous.zax`
  - new fixture with `ModeA.On` + `ModeB.On`

## Validation
- `yarn -s typecheck`
- `yarn -s test` (211 files, 442 tests passing)
