### PR TITLE
docs: rewrite tutorial and index practical guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ Tests are organized by spec section and PR scope under `test/`. Golden-file comp
 | Document                           | Purpose                                                             |
 | ---------------------------------- | ------------------------------------------------------------------- |
 | `docs/zax-spec.md`                 | **Normative** language specification (includes CLI/op appendices)   |
+| `docs/ZAX-quick-guide.md`          | Practical quick guide for daily language usage (non-normative)      |
+| `docs/tutorial.md`                 | Hands-on tutorial walkthrough for v0.2 workflows (non-normative)    |
 | `docs/zax-dev-playbook.md`         | Consolidated implementation, roadmap, checklist, and workflow guide |
 | `docs/v02-transition-decisions.md` | Transition rationale and migration sequencing (non-normative)       |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,13 @@ This directory is intentionally small. Each document has a single purpose.
   - Sole normative language specification for active development.
   - Includes CLI and op-system reference appendices.
 
+## Guides (Non-normative)
+
+- `ZAX-quick-guide.md`
+  - Compact chaptered quick guide for day-to-day usage.
+- `tutorial.md`
+  - Hands-on walkthrough for building ZAX programs with v0.2 semantics.
+
 ## Transition Records (Non-normative)
 
 - `v02-transition-decisions.md`


### PR DESCRIPTION
## Scope
This PR is a doc-first increment that replaces the broken transcript-like tutorial with a clean, practical v0.2 walkthrough and makes non-normative guide docs discoverable from both docs index and repo README.

## Changes
- Rewrite `docs/tutorial.md` into a coherent non-normative tutorial aligned with `docs/zax-spec.md`.
- Add a `Guides (Non-normative)` section in `docs/README.md` for:
  - `docs/ZAX-quick-guide.md`
  - `docs/tutorial.md`
- Expand `README.md` documentation table to include the quick guide and tutorial.

## Migration Impact
- No compiler/runtime behavior changes.
- Clarifies high-impact v0.1 -> v0.2 migration points in one place:
  - `arr[HL]` vs `arr[(HL)]`
  - storage-size (`sizeof`) semantics for padded composites
  - qualified enum member usage
  - typed-call boundary expectations

## Validation
- `yarn -s prettier -c README.md docs/README.md docs/tutorial.md`

## Notes
- Tutorial remains explicitly non-normative and defers language authority to `docs/zax-spec.md`.
