### PR TITLE
[NORMATIVE-MUST] Enforce runtime-atom-free direct call-site ea/(ea) args (Queue A #222)

### DIFF
--- a/docs/zax-dev-playbook.md
+++ b/docs/zax-dev-playbook.md
@@ -56,6 +56,7 @@ Use one of the following tags on every scoped issue/PR:
 - v0.2 direct call-site `ea`/`(ea)` arguments: runtime-atom-free.
 - User model: one moving part per expression; stage multi-dynamic work over lines.
 - Implementation note: the lowering path rejects `ea` expressions over budget with explicit diagnostics (for example, `grid[row][col]` / `arr[i + j]` when both names are runtime scalar indices).
+- Implementation note: direct call-site `ea`/`(ea)` argument forms now reject any runtime-atom use and include staged-lowering guidance in diagnostics.
 
 ### 1.3 Preservation and Lowering Model
 

--- a/test/fixtures/pr22_call_ea_index_nested.zax
+++ b/test/fixtures/pr22_call_ea_index_nested.zax
@@ -1,4 +1,4 @@
-; PR22 fixture: nested indexed EA with one runtime atom remains supported
+; PR22 fixture: direct call-site nested indexed EA is rejected by the call-site atom budget
 section code at $0000
 section data at $0040
 

--- a/test/fixtures/pr265_call_ea_index_const.zax
+++ b/test/fixtures/pr265_call_ea_index_const.zax
@@ -1,0 +1,14 @@
+; PR265 fixture: runtime-atom-free direct call-site ea/(ea) forms remain allowed
+section code at $0000
+section data at $0080
+
+extern func takeAddr(p: word): void at $1234
+extern func takeByte(v: byte): void at $1234
+
+data
+  arr: byte[4] = [ 1, 2, 3, 4 ]
+
+export func main(): void
+    takeAddr arr[2]
+    takeByte (arr[2])
+end

--- a/test/pr12_calls.test.ts
+++ b/test/pr12_calls.test.ts
@@ -148,162 +148,60 @@ describe('PR12 calls (extern + func)', () => {
     expect(bin!.bytes).toEqual(expected);
   });
 
-  it('supports ea indexing with reg8', async () => {
+  it('allows runtime-atom-free direct call-site ea/(ea) constant index forms', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr265_call_ea_index_const.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+  });
+
+  it('rejects direct call-site ea args with reg8 runtime index', async () => {
     const entry = join(__dirname, 'fixtures', 'pr13_call_ea_index_reg8.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics).toEqual([]);
-
-    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
-    expect(bin).toBeDefined();
-
-    const code = Uint8Array.of(
-      0x06,
-      0x02, // ld b, 2
-      ...callVoidPrefix,
-      0x68, // ld l, b
-      0x26,
-      0x00, // ld h, 0
-      0xe5, // push hl (scaled index)
-      0x21,
-      0x80,
-      0x00, // ld hl, $0080
-      0xd1, // pop de
-      0x19, // add hl, de
-      0xe5, // push hl
-      0xcd,
-      0x34,
-      0x12, // call $1234
-      0xc1, // pop bc
-      ...callVoidSuffix,
-      0xc9, // ret
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toContain(
+      'Direct call-site ea argument for "takeAddr" must be runtime-atom-free in v0.2',
     );
-    const gap = new Uint8Array(0x80 - code.length);
-    const data = Uint8Array.of(0x01, 0x02, 0x03, 0x04);
-    const expected = new Uint8Array(code.length + gap.length + data.length);
-    expected.set(code, 0);
-    expected.set(gap, code.length);
-    expected.set(data, code.length + gap.length);
-
-    expect(bin!.bytes).toEqual(expected);
+    expect(res.diagnostics[0]?.line).toBe(12);
+    expect(res.diagnostics[0]?.column).toBe(5);
   });
 
-  it('supports ea indexing with HL as 16-bit index register', async () => {
+  it('rejects direct call-site ea args with reg16 runtime index', async () => {
     const entry = join(__dirname, 'fixtures', 'pr261_call_ea_index_reg16hl.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics).toEqual([]);
-
-    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
-    expect(bin).toBeDefined();
-
-    const code = Uint8Array.of(
-      0x21,
-      0x02,
-      0x00, // ld hl, 2
-      ...callVoidPrefix,
-      0xe5, // push hl (scaled index)
-      0x21,
-      0x80,
-      0x00, // ld hl, $0080
-      0xd1, // pop de
-      0x19, // add hl, de
-      0xe5, // push hl
-      0xcd,
-      0x34,
-      0x12, // call $1234
-      0xc1, // pop bc
-      ...callVoidSuffix,
-      0xc9, // ret
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toContain(
+      'Direct call-site ea argument for "takeAddr" must be runtime-atom-free in v0.2',
     );
-    const gap = new Uint8Array(0x80 - code.length);
-    const data = Uint8Array.of(0x01, 0x02, 0x03, 0x04);
-    const expected = new Uint8Array(code.length + gap.length + data.length);
-    expected.set(code, 0);
-    expected.set(gap, code.length);
-    expected.set(data, code.length + gap.length);
-
-    expect(bin!.bytes).toEqual(expected);
+    expect(res.diagnostics[0]?.line).toBe(12);
+    expect(res.diagnostics[0]?.column).toBe(5);
   });
 
-  it('supports ea indexing with (HL) (byte read from memory at HL)', async () => {
+  it('rejects direct call-site ea args with (HL) runtime index source', async () => {
     const entry = join(__dirname, 'fixtures', 'pr13_call_ea_index_memhl.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics).toEqual([]);
-
-    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
-    expect(bin).toBeDefined();
-
-    const code = Uint8Array.of(
-      0x21,
-      0x80,
-      0x00, // ld hl, $0080
-      ...callVoidPrefix,
-      0x7e, // ld a, (hl)
-      0x6f, // ld l, a
-      0x26,
-      0x00, // ld h, 0
-      0xe5, // push hl (scaled index)
-      0x21,
-      0x81,
-      0x00, // ld hl, $0081
-      0xd1, // pop de
-      0x19, // add hl, de
-      0xe5, // push hl
-      0xcd,
-      0x34,
-      0x12, // call $1234
-      0xc1, // pop bc
-      ...callVoidSuffix,
-      0xc9, // ret
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toContain(
+      'Direct call-site ea argument for "takeAddr" must be runtime-atom-free in v0.2',
     );
-    const gap = new Uint8Array(0x80 - code.length);
-    const data = Uint8Array.of(0x02, 0x01, 0x02, 0x03, 0x04);
-    const expected = new Uint8Array(code.length + gap.length + data.length);
-    expected.set(code, 0);
-    expected.set(gap, code.length);
-    expected.set(data, code.length + gap.length);
-
-    expect(bin!.bytes).toEqual(expected);
+    expect(res.diagnostics[0]?.line).toBe(13);
+    expect(res.diagnostics[0]?.column).toBe(5);
   });
 
-  it('supports nested indexed addresses during lowering', async () => {
+  it('rejects direct call-site nested indexed ea args', async () => {
     const entry = join(__dirname, 'fixtures', 'pr22_call_ea_index_nested.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics).toEqual([]);
-
-    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
-    expect(bin).toBeDefined();
-
-    const code = Uint8Array.of(
-      ...callVoidPrefix,
-      0x3a,
-      0x44,
-      0x00, // ld a, ($0044) table[0]
-      0x26,
-      0x00, // ld h, 0
-      0x6f, // ld l, a
-      0xe5, // push hl (scaled index)
-      0xe1, // pop hl
-      0xe5, // push hl (preserve scaled index)
-      0x21,
-      0x40,
-      0x00, // ld hl, $0040 (arr base)
-      0xd1, // pop de
-      0x19, // add hl, de
-      0xe5, // push hl (effective address)
-      0xcd,
-      0x34,
-      0x12, // call $1234
-      0xc1, // pop bc
-      ...callVoidSuffix,
-      0xc9, // ret
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toContain(
+      'Direct call-site ea argument for "takeAddr" must be runtime-atom-free in v0.2',
     );
-    const gap = new Uint8Array(0x40 - code.length);
-    const data = Uint8Array.of(10, 20, 30, 40, 1, 2);
-    const expected = new Uint8Array(code.length + gap.length + data.length);
-    expected.set(code, 0);
-    expected.set(gap, code.length);
-    expected.set(data, code.length + gap.length);
-
-    expect(bin!.bytes).toEqual(expected);
+    expect(res.diagnostics[0]?.line).toBe(12);
+    expect(res.diagnostics[0]?.column).toBe(5);
   });
 });


### PR DESCRIPTION
## Scope
Implements Queue A issue #222 by enforcing v0.2 direct call-site argument complexity rules for `ea`/`(ea)` forms.

## What changed
- Added direct call-site `ea` atom-budget validation in lowering:
  - Rejects direct call-site `ea`/`(ea)` call arguments when runtime-atom count is non-zero.
  - Emits staged-lowering guidance diagnostics.
  - File: `src/lowering/emit.ts`
- Tightened runtime-atom counting for nested `IndexEa` paths used by addressing checks.
- Updated call tests to align with v0.2 behavior:
  - Dynamic direct call-site index forms are now expected to fail.
  - Added positive coverage for runtime-atom-free constant-index direct forms.
  - Files:
    - `test/pr12_calls.test.ts`
    - `test/fixtures/pr265_call_ea_index_const.zax`
- Updated fixture/doc wording to reflect current semantics:
  - `test/fixtures/pr22_call_ea_index_nested.zax`
  - `docs/zax-dev-playbook.md`

## Validation
- `yarn format`
- `yarn typecheck`
- `yarn test` (212 files / 445 tests passing)
