### PR TITLE
[v0.2] Expand op overload diagnostics matrix

### DIFF
--- a/test/fixtures/pr268_op_arity_mismatch_diagnostics.zax
+++ b/test/fixtures/pr268_op_arity_mismatch_diagnostics.zax
@@ -1,0 +1,7 @@
+op add16(dst: reg16, src: reg16)
+  nop
+end
+
+export func main(): void
+  add16 HL, DE, BC
+end

--- a/test/fixtures/pr268_op_no_match_diagnostics.zax
+++ b/test/fixtures/pr268_op_no_match_diagnostics.zax
@@ -1,0 +1,11 @@
+op add16(dst: HL, src: reg16)
+  nop
+end
+
+op add16(dst: DE, src: reg16)
+  nop
+end
+
+export func main(): void
+  add16 IX, DE
+end

--- a/test/pr268_op_diagnostics_matrix.test.ts
+++ b/test/pr268_op_diagnostics_matrix.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR268: op diagnostics matrix', () => {
+  it('reports no-match diagnostics with operand summary and overload list', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr268_op_no_match_diagnostics.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(messages.some((m) => m.includes('No matching op overload for "add16"'))).toBe(true);
+    expect(messages.some((m) => m.includes('call-site operands: (IX, DE)'))).toBe(true);
+    expect(messages.some((m) => m.includes('available overloads:'))).toBe(true);
+  });
+
+  it('reports arity mismatch diagnostics with available signatures', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr268_op_arity_mismatch_diagnostics.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(
+      messages.some((m) => m.includes('No op overload of "add16" accepts 3 operand(s).')),
+    ).toBe(true);
+    expect(messages.some((m) => m.includes('available overloads:'))).toBe(true);
+  });
+
+  it('reports ambiguous candidate signatures for incomparable matches', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr267_op_ambiguous_incomparable.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(messages.some((m) => m.includes('Ambiguous op overload for "choose"'))).toBe(true);
+    expect(messages.some((m) => m.includes('equally specific candidates:'))).toBe(true);
+  });
+
+  it('reports cyclic op expansion chain context', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr16_op_cycle.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(messages.some((m) => m.includes('Cyclic op expansion detected for "first".'))).toBe(
+      true,
+    );
+    expect(messages.some((m) => m.includes('expansion chain: first'))).toBe(true);
+    expect(messages.some((m) => m.includes('-> second'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Scope
- expand v0.2 op invocation diagnostics for three resolution failure classes:
  - arity mismatch
  - no matcher-compatible overload
  - ambiguous specificity ties
- include expansion-chain context for cyclic op expansion errors

## Behavior changes
- `No op overload ... accepts N operand(s)` now reports available signatures for the name.
- `No matching op overload ...` now includes call-site operand rendering and available matching-arity overload definitions.
- `Ambiguous op overload ...` now includes call-site operands and equally specific candidate definitions.
- cyclic expansion diagnostics now include the detected chain (`op_a -> op_b -> op_a`) with declaration locations.

## Tests
- added `test/pr268_op_diagnostics_matrix.test.ts` covering:
  - no-match detail output
  - arity mismatch output
  - ambiguous candidate listing
  - cycle chain output
- added fixtures:
  - `test/fixtures/pr268_op_no_match_diagnostics.zax`
  - `test/fixtures/pr268_op_arity_mismatch_diagnostics.zax`

## Local checks
- `yarn -s format`
- `yarn -s typecheck`
- `yarn -s test`
