### PR TITLE
[v0.2] Add op-resolution diagnostic IDs and mismatch reasons

### DIFF
--- a/src/diagnostics/types.ts
+++ b/src/diagnostics/types.ts
@@ -51,6 +51,18 @@ export const DiagnosticIds = {
   /** Generic emission/lowering error (layout/packing/symbol collisions, etc.). */
   EmitError: 'ZAX300',
 
+  /** Op invocation arity mismatch against available overload set. */
+  OpArityMismatch: 'ZAX310',
+
+  /** No overload match for an op invocation with the provided operands. */
+  OpNoMatchingOverload: 'ZAX311',
+
+  /** Ambiguous overload resolution for an op invocation. */
+  OpAmbiguousOverload: 'ZAX312',
+
+  /** Cyclic op expansion detected in inline expansion graph. */
+  OpExpansionCycle: 'ZAX313',
+
   /** Generic semantic evaluation error (env building, imm evaluation, etc.). */
   SemanticsError: 'ZAX400',
 

--- a/test/pr268_op_diagnostics_matrix.test.ts
+++ b/test/pr268_op_diagnostics_matrix.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnostics/types.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -12,18 +13,23 @@ describe('PR268: op diagnostics matrix', () => {
   it('reports no-match diagnostics with operand summary and overload list', async () => {
     const entry = join(__dirname, 'fixtures', 'pr268_op_no_match_diagnostics.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const ids = res.diagnostics.map((d) => d.id);
     const messages = res.diagnostics.map((d) => d.message);
 
+    expect(ids).toContain(DiagnosticIds.OpNoMatchingOverload);
     expect(messages.some((m) => m.includes('No matching op overload for "add16"'))).toBe(true);
     expect(messages.some((m) => m.includes('call-site operands: (IX, DE)'))).toBe(true);
     expect(messages.some((m) => m.includes('available overloads:'))).toBe(true);
+    expect(messages.some((m) => m.includes('dst: expects HL, got IX'))).toBe(true);
   });
 
   it('reports arity mismatch diagnostics with available signatures', async () => {
     const entry = join(__dirname, 'fixtures', 'pr268_op_arity_mismatch_diagnostics.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const ids = res.diagnostics.map((d) => d.id);
     const messages = res.diagnostics.map((d) => d.message);
 
+    expect(ids).toContain(DiagnosticIds.OpArityMismatch);
     expect(
       messages.some((m) => m.includes('No op overload of "add16" accepts 3 operand(s).')),
     ).toBe(true);
@@ -33,8 +39,10 @@ describe('PR268: op diagnostics matrix', () => {
   it('reports ambiguous candidate signatures for incomparable matches', async () => {
     const entry = join(__dirname, 'fixtures', 'pr267_op_ambiguous_incomparable.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const ids = res.diagnostics.map((d) => d.id);
     const messages = res.diagnostics.map((d) => d.message);
 
+    expect(ids).toContain(DiagnosticIds.OpAmbiguousOverload);
     expect(messages.some((m) => m.includes('Ambiguous op overload for "choose"'))).toBe(true);
     expect(messages.some((m) => m.includes('equally specific candidates:'))).toBe(true);
   });
@@ -42,8 +50,10 @@ describe('PR268: op diagnostics matrix', () => {
   it('reports cyclic op expansion chain context', async () => {
     const entry = join(__dirname, 'fixtures', 'pr16_op_cycle.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const ids = res.diagnostics.map((d) => d.id);
     const messages = res.diagnostics.map((d) => d.message);
 
+    expect(ids).toContain(DiagnosticIds.OpExpansionCycle);
     expect(messages.some((m) => m.includes('Cyclic op expansion detected for "first".'))).toBe(
       true,
     );


### PR DESCRIPTION
## Scope
- add dedicated op-resolution diagnostic IDs for machine-readable failure classes:
  - `ZAX310` op arity mismatch
  - `ZAX311` op no matching overload
  - `ZAX312` op ambiguous overload
  - `ZAX313` op expansion cycle
- enrich no-match diagnostics with first-parameter mismatch reasons per candidate overload

## Behavior
- arity/no-match/ambiguous/cycle op diagnostics now preserve existing text while emitting stable specific IDs.
- no-match candidate list now includes a reason suffix per overload (for example: `dst: expects HL, got IX`).

## Tests
- extended `test/pr268_op_diagnostics_matrix.test.ts` to assert both message content and the new diagnostic IDs.

## Local checks
- `yarn -s format`
- `yarn -s typecheck`
- `yarn -s test`
