### PR TITLE
[v0.2] Harden negative CLI contracts for empty/encode/emit failures

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -289,6 +289,22 @@ export const compile: CompileFn = async (
     return { diagnostics, artifacts: [] };
   }
 
+  const hasNonImportDeclaration = program.files.some((moduleFile) =>
+    moduleFile.items.some((item) => item.kind !== 'Import'),
+  );
+  if (!hasNonImportDeclaration) {
+    diagnostics.push({
+      id: DiagnosticIds.SemanticsError,
+      severity: 'error',
+      message: 'Program contains no declarations or instruction streams.',
+      file: program.entryFile,
+      ...(program.span?.start
+        ? { line: program.span.start.line, column: program.span.start.column }
+        : {}),
+    });
+    return { diagnostics, artifacts: [] };
+  }
+
   lintCaseStyle(program, sourceTexts, options.caseStyle ?? 'off', diagnostics);
 
   const env = buildEnv(program, diagnostics);


### PR DESCRIPTION
## Scope
- tighten negative CLI contract coverage for unresolved classes explicitly called out in issue #4:
  - encoder failures (`ZAX200`)
  - emitter/lowering failures (`ZAX300`)
  - empty entry module failure (`ZAX400`)
- convert empty-entry compilation from silent success to explicit compile failure

## Behavior changes
- compiling an entry program with no declarations/instruction streams now emits:
  - `error [ZAX400]: Program contains no declarations or instruction streams.`
  - exit code `1` in CLI mode
  - no artifacts written

## Tests
- extended `test/cli_failure_contract_matrix.test.ts` with new negative cases:
  - encoder diagnostic contract
  - emit/lowering diagnostic contract
  - empty entry diagnostic contract

## Local checks
- `yarn -s format`
- `yarn -s typecheck`
- `yarn -s test`
