### PR TITLE
[v0.2] Add D8M op-expansion call-site source segments

### DIFF
--- a/docs/zax-dev-playbook.md
+++ b/docs/zax-dev-playbook.md
@@ -63,6 +63,7 @@ Use one of the following tags on every scoped issue/PR:
 - Typed call boundaries are preservation-safe per `docs/zax-spec.md`.
 - `op` bodies are inline; stack/register discipline is developer-managed.
 - Hidden lowering should stay bounded and predictable.
+- D8M emission includes source-attributed per-file segments; op-expanded instruction ranges are tagged as `macro` and attributed to op call-site lines.
 
 ### 1.4 Rollout Waves
 

--- a/src/formats/types.ts
+++ b/src/formats/types.ts
@@ -17,6 +17,25 @@ export interface EmittedByteMap {
    */
   bytes: Map<number, number>;
   writtenRange?: AddressRange;
+  /**
+   * Optional source-attributed code segments emitted by lowering.
+   *
+   * Addresses are absolute in the final 16-bit address space.
+   */
+  sourceSegments?: EmittedSourceSegment[];
+}
+
+/**
+ * Source-attributed emitted range used by debug-map writers.
+ */
+export interface EmittedSourceSegment {
+  start: number;
+  end: number;
+  file: string;
+  line: number;
+  column: number;
+  kind: 'code' | 'data' | 'directive' | 'label' | 'macro' | 'unknown';
+  confidence: 'high' | 'medium' | 'low';
 }
 
 /**

--- a/test/fixtures/pr269_d8m_op_macro_callsite.zax
+++ b/test/fixtures/pr269_d8m_op_macro_callsite.zax
@@ -1,0 +1,9 @@
+op write_pair(dst: reg8)
+  ld dst, 1
+  ld dst, 2
+end
+
+export func main(): void
+  write_pair B
+  nop
+end

--- a/test/pr200_d8m_appendix_mapping.test.ts
+++ b/test/pr200_d8m_appendix_mapping.test.ts
@@ -57,11 +57,9 @@ describe('PR200 D8M appendix mapping closure', () => {
     const fileEntry = json.files['pr200_d8m_appendix_mapping.zax'];
     if (!fileEntry) throw new Error('Expected per-file D8M entry for fixture source');
     expect(fileEntry.segments?.length).toBeGreaterThan(0);
-    expect(fileEntry.segments?.[0]).toMatchObject({
-      lstLine: 0,
-      kind: 'unknown',
-      confidence: 'low',
-    });
+    expect(
+      fileEntry.segments?.some((segment) => segment.lstLine > 0 && segment.confidence === 'high'),
+    ).toBe(true);
 
     const fileSymbols = fileEntry.symbols ?? [];
     expect(

--- a/test/pr269_d8m_op_macro_callsite_mapping.test.ts
+++ b/test/pr269_d8m_op_macro_callsite_mapping.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { D8mArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+type D8mSegment = {
+  start: number;
+  end: number;
+  lstLine: number;
+  kind: 'code' | 'data' | 'directive' | 'label' | 'macro' | 'unknown';
+  confidence: 'high' | 'medium' | 'low';
+};
+
+describe('PR269 D8M op expansion call-site attribution', () => {
+  it('marks expanded op instruction ranges as macro segments attributed to the call site', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr269_d8m_op_macro_callsite.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const d8m = res.artifacts.find((a): a is D8mArtifact => a.kind === 'd8m');
+    expect(d8m).toBeDefined();
+
+    const json = d8m!.json as unknown as {
+      files: Record<string, { segments?: D8mSegment[] }>;
+    };
+
+    const fileEntry = json.files['pr269_d8m_op_macro_callsite.zax'];
+    if (!fileEntry) throw new Error('Expected per-file D8M entry for fixture source');
+
+    const segments = fileEntry.segments ?? [];
+    expect(
+      segments.some(
+        (segment) =>
+          segment.kind === 'macro' &&
+          segment.confidence === 'high' &&
+          segment.lstLine === 7 &&
+          segment.start === 0 &&
+          segment.end === 4,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Scope
- Add lowering-emitted source segments to emitted byte maps for D8M attribution.
- Tag op-expanded instruction ranges as `macro` with call-site line attribution.
- Preserve deterministic fallback D8M segments while adding source-attributed segments.

## Implementation
- `src/lowering/emit.ts`: track code source ranges during emission/fixups and propagate macro call-site tagging during op expansion.
- `src/formats/types.ts`: add `EmittedSourceSegment` and optional `sourceSegments` on emitted map.
- `src/formats/writeD8m.ts`: serialize source-attributed per-file segments with stable ordering.

## Tests
- Added `test/pr269_d8m_op_macro_callsite_mapping.test.ts` + fixture to assert macro segment kind/confidence/call-site line.
- Updated `test/pr200_d8m_appendix_mapping.test.ts` to assert high-confidence line-attributed segments.
- Ran local checks: `yarn -s format`, `yarn -s typecheck`, `yarn -s test` (all pass).

## Notes
- Includes a non-normative playbook note documenting D8M macro call-site attribution behavior.
