### PR TITLE
[v0.2] Add op invalid-expansion diagnostics matrix and chain context

### DIFF
--- a/src/diagnostics/types.ts
+++ b/src/diagnostics/types.ts
@@ -63,6 +63,9 @@ export const DiagnosticIds = {
   /** Cyclic op expansion detected in inline expansion graph. */
   OpExpansionCycle: 'ZAX313',
 
+  /** Op expansion produced an invalid concrete instruction after substitution. */
+  OpInvalidExpansion: 'ZAX314',
+
   /** Generic semantic evaluation error (env building, imm evaluation, etc.). */
   SemanticsError: 'ZAX400',
 

--- a/test/fixtures/pr270_nonop_invalid_instruction_baseline.zax
+++ b/test/fixtures/pr270_nonop_invalid_instruction_baseline.zax
@@ -1,0 +1,3 @@
+export func main(): void
+  ld A, SP
+end

--- a/test/fixtures/pr270_op_invalid_expansion_diagnostics.zax
+++ b/test/fixtures/pr270_op_invalid_expansion_diagnostics.zax
@@ -1,0 +1,7 @@
+op clobber_a_with(src: reg16)
+  ld A, src
+end
+
+export func main(): void
+  clobber_a_with SP
+end

--- a/test/fixtures/pr270_op_invalid_expansion_multi_failure.zax
+++ b/test/fixtures/pr270_op_invalid_expansion_multi_failure.zax
@@ -1,0 +1,8 @@
+op bad_pair(src: reg16)
+  ld A, src
+  ld C, src
+end
+
+export func main(): void
+  bad_pair SP
+end

--- a/test/fixtures/pr270_op_invalid_expansion_nested_chain.zax
+++ b/test/fixtures/pr270_op_invalid_expansion_nested_chain.zax
@@ -1,0 +1,11 @@
+op bad_inner(src: reg16)
+  ld A, src
+end
+
+op mid(src: reg16)
+  bad_inner src
+end
+
+export func main(): void
+  mid SP
+end


### PR DESCRIPTION
## Scope
- Add explicit `ZAX314` diagnostics for invalid concrete instructions produced by op expansion.
- Attribute `ZAX314` to the root op call site while preserving concrete expanded-instruction context.
- Include nested op expansion chain context in the diagnostic body.

## Implementation
- `src/diagnostics/types.ts`: add `OpInvalidExpansion` (`ZAX314`).
- `src/lowering/emit.ts`:
  - detect encode/lowering failures occurring inside active op expansion frames,
  - emit `ZAX314` with call-site attribution,
  - include expanded instruction + op definition location + full expansion chain,
  - keep non-op failures on existing encode/emit diagnostics.

## Tests
- Expanded `test/pr268_op_diagnostics_matrix.test.ts` to 8 scenarios including:
  - single invalid expansion,
  - nested invalid expansion with chain,
  - multi-failure expansion (one `ZAX314` per failing instruction),
  - non-op invalid-instruction baseline guard.
- Added fixtures:
  - `test/fixtures/pr270_op_invalid_expansion_diagnostics.zax`
  - `test/fixtures/pr270_op_invalid_expansion_nested_chain.zax`
  - `test/fixtures/pr270_op_invalid_expansion_multi_failure.zax`
  - `test/fixtures/pr270_nonop_invalid_instruction_baseline.zax`

## Local checks
- `yarn -s format`
- `yarn -s typecheck`
- `yarn -s test`

All passed locally.
