### PR TITLE
[v0.2] Add optional op stack-policy analysis mode

### DIFF
--- a/docs/zax-dev-playbook.md
+++ b/docs/zax-dev-playbook.md
@@ -64,6 +64,7 @@ Use one of the following tags on every scoped issue/PR:
 - `op` bodies are inline; stack/register discipline is developer-managed.
 - Hidden lowering should stay bounded and predictable.
 - D8M emission includes source-attributed per-file segments; op-expanded instruction ranges are tagged as `macro` and attributed to op call-site lines.
+- Compiler API exposes optional `opStackPolicy` (`off`/`warn`/`error`) for static op-body stack-risk diagnostics at invocation sites in stack-slot functions.
 
 ### 1.4 Rollout Waves
 

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -314,6 +314,7 @@ export const compile: CompileFn = async (
 
   const { map, symbols } = emitProgram(program, env, diagnostics, {
     ...(options.includeDirs ? { includeDirs: options.includeDirs } : {}),
+    ...(options.opStackPolicy ? { opStackPolicy: options.opStackPolicy } : {}),
   });
   if (hasErrors(diagnostics)) {
     return { diagnostics, artifacts: [] };

--- a/src/diagnostics/types.ts
+++ b/src/diagnostics/types.ts
@@ -66,6 +66,9 @@ export const DiagnosticIds = {
   /** Op expansion produced an invalid concrete instruction after substitution. */
   OpInvalidExpansion: 'ZAX314',
 
+  /** Static op stack-policy risk detected at invocation site. */
+  OpStackPolicyRisk: 'ZAX315',
+
   /** Generic semantic evaluation error (env building, imm evaluation, etc.). */
   SemanticsError: 'ZAX400',
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -2,6 +2,7 @@ import type { Diagnostic } from './diagnostics/types.js';
 import type { Artifact, FormatWriters } from './formats/types.js';
 
 export type CaseStyleMode = 'off' | 'upper' | 'lower' | 'consistent';
+export type OpStackPolicyMode = 'off' | 'warn' | 'error';
 
 /**
  * Options that influence compilation behavior and which artifacts are produced.
@@ -30,6 +31,8 @@ export interface CompilerOptions {
   emitListing?: boolean;
   /** Optional case-style lint mode for asm keywords/register tokens. */
   caseStyle?: CaseStyleMode;
+  /** Optional op stack-policy static risk mode (`off` by default). */
+  opStackPolicy?: OpStackPolicyMode;
 }
 
 /**

--- a/test/fixtures/pr271_op_stack_policy_delta_warn.zax
+++ b/test/fixtures/pr271_op_stack_policy_delta_warn.zax
@@ -1,0 +1,11 @@
+op leak()
+  push bc
+end
+
+export func main(): void
+  var
+    tmp: byte
+  end
+  leak
+  pop bc
+end

--- a/test/fixtures/pr271_op_stack_policy_untracked_warn.zax
+++ b/test/fixtures/pr271_op_stack_policy_untracked_warn.zax
@@ -1,0 +1,10 @@
+op smash()
+  ld sp, hl
+end
+
+export func main(): void
+  var
+    tmp: byte
+  end
+  smash
+end

--- a/test/pr271_op_stack_policy_alignment.test.ts
+++ b/test/pr271_op_stack_policy_alignment.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnostics/types.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+
+type Diag = {
+  id: string;
+  severity: string;
+  message: string;
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR271: op stack-policy alignment (optional mode)', () => {
+  it('is off by default and preserves baseline diagnostics', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr271_op_stack_policy_delta_warn.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+  });
+
+  it('warn mode reports non-zero static op stack delta at stack-slot call sites', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr271_op_stack_policy_delta_warn.zax');
+    const res = await compile(entry, { opStackPolicy: 'warn' }, { formats: defaultFormatWriters });
+    const actual: Diag[] = res.diagnostics.map((d) => ({
+      id: d.id,
+      severity: d.severity,
+      message: d.message,
+    }));
+
+    expect(actual.some((d) => d.id === DiagnosticIds.OpStackPolicyRisk)).toBe(true);
+    expect(actual.some((d) => d.severity === 'warning')).toBe(true);
+    expect(actual.some((d) => d.message.includes('non-zero static stack delta (-2)'))).toBe(true);
+  });
+
+  it('warn mode reports untracked SP mutation risk in op body summaries', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr271_op_stack_policy_untracked_warn.zax');
+    const res = await compile(entry, { opStackPolicy: 'warn' }, { formats: defaultFormatWriters });
+    const messages = res.diagnostics.map((d) => d.message);
+    const ids = res.diagnostics.map((d) => d.id);
+
+    expect(ids).toContain(DiagnosticIds.OpStackPolicyRisk);
+    expect(
+      messages.some((m) => m.includes('may mutate SP in an untracked way (static body analysis)')),
+    ).toBe(true);
+  });
+
+  it('error mode upgrades stack-policy risks to errors', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr271_op_stack_policy_delta_warn.zax');
+    const res = await compile(entry, { opStackPolicy: 'error' }, { formats: defaultFormatWriters });
+
+    expect(
+      res.diagnostics.some(
+        (d) => d.id === DiagnosticIds.OpStackPolicyRisk && d.severity === 'error',
+      ),
+    ).toBe(true);
+    expect(res.artifacts).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Scope
- Add optional v0.2 op stack-policy analysis mode at compile time.
- Surface static op stack risks at invocation sites in stack-slot functions.
- Keep default behavior unchanged (`off`).

## Implementation
- `src/pipeline.ts`: add `opStackPolicy` compiler option (`off` | `warn` | `error`).
- `src/compile.ts`: thread option into lowering.
- `src/diagnostics/types.ts`: add `ZAX315` (`OpStackPolicyRisk`).
- `src/lowering/emit.ts`:
  - implement static op-body stack summary (`delta`, untracked-SP mutation),
  - recursively compose nested op summaries when uniquely resolvable,
  - emit `ZAX315` at op invocation sites under `warn`/`error` modes.
- `docs/zax-dev-playbook.md`: document the new optional mode.

## Tests
- Added `test/pr271_op_stack_policy_alignment.test.ts` with matrix cases:
  - default-off baseline,
  - warn mode for non-zero static op delta,
  - warn mode for untracked SP mutation risk,
  - error mode severity promotion and artifact suppression.
- Added fixtures:
  - `test/fixtures/pr271_op_stack_policy_delta_warn.zax`
  - `test/fixtures/pr271_op_stack_policy_untracked_warn.zax`

## Local checks
- `yarn -s format`
- `yarn -s typecheck`
- `yarn -s test`

All passed locally (full suite: 216 files, 467 tests).
