### PR TITLE
[v0.2] Add CLI --op-stack-policy contract and coverage

### DIFF
--- a/docs/ZAX-quick-guide.md
+++ b/docs/ZAX-quick-guide.md
@@ -73,6 +73,11 @@ Common outputs:
 - `.d8dbg.json`
 - `.lst`
 
+Useful contract options:
+
+- `--case-style <m>` (`off|upper|lower|consistent`) for case-style linting
+- `--op-stack-policy <m>` (`off|warn|error`) for optional op stack-policy diagnostics at typed call boundaries
+
 ## Chapter 2 - Storage Model
 
 ### 2.1 Scalar Types


### PR DESCRIPTION
## Scope
- add CLI parsing/validation for `--op-stack-policy=<off|warn|error>`
- thread parsed mode into compile options (`opStackPolicy`)
- extend CLI contract matrix for missing-value and unsupported-value coverage
- add end-to-end CLI contract test proving warn vs error forwarding behavior for `ZAX315`
- document the option in the quick guide CLI section

## Validation
- `yarn -s typecheck`
- `yarn -s vitest run test/cli_contract_matrix.test.ts test/cli_case_style_lint.test.ts`
