### PR TITLE
[v0.2] Lower single-atom affine runtime ea/index expressions

### DIFF
--- a/docs/ZAX-quick-guide.md
+++ b/docs/ZAX-quick-guide.md
@@ -155,7 +155,12 @@ Allowed:
 arr[CONST1 + CONST2 * 4]
 arr[CONST1 + CONST2 * 4][idx]
 arr[idx].field
+arr[idx + 3]
+arr[(idxw << 1) + 6]
 ```
+
+Current lowering supports single-atom affine forms using constants with `+`, `-`, `*` (power-of-2 multipliers), and `<<`.
+Runtime expressions that require non-affine ops (`/`, `%`, `&`, `|`, `^`, `>>`) should be staged first.
 
 Rejected in one expression:
 

--- a/test/fixtures/pr272_runtime_affine_invalid.zax
+++ b/test/fixtures/pr272_runtime_affine_invalid.zax
@@ -1,0 +1,12 @@
+section code at $0000
+section var at $1000
+
+globals
+  idx: byte
+  arr: byte[64]
+
+export func main(): void
+  ld a, arr[idx * 3]
+  ld a, arr[idx >> 1]
+  ld a, (arr + (idx / 2))
+end

--- a/test/fixtures/pr272_runtime_affine_valid.zax
+++ b/test/fixtures/pr272_runtime_affine_valid.zax
@@ -1,0 +1,18 @@
+section code at $0000
+section var at $1000
+
+globals
+  idx: byte
+  idxw: word
+  arr: byte[64]
+
+export func main(): void
+  ld a, arr[idx + 1]
+  ld a, arr[1 + idx]
+  ld a, arr[idxw + 2]
+  ld a, arr[idx << 1]
+  ld a, arr[(idx * 2) + 3]
+  ld a, (arr + idx + 4)
+  ld a, (arr + (idxw << 1) + 6)
+  ret
+end

--- a/test/pr272_runtime_affine_index_offset.test.ts
+++ b/test/pr272_runtime_affine_index_offset.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR272: runtime affine index/offset lowering', () => {
+  it('accepts single-atom affine index and ea offset forms', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr272_runtime_affine_valid.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+  });
+
+  it('rejects unsupported runtime operators and non-power-of-2 multipliers', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr272_runtime_affine_invalid.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.artifacts).toEqual([]);
+    const messages = res.diagnostics.map((d) => d.message);
+    expect(messages.some((m) => m.includes('runtime multiplier must be a power-of-2'))).toBe(true);
+    expect(
+      messages.some((m) =>
+        m.includes('is unsupported. Use a single scalar runtime atom with +, -, *, <<'),
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Scope
- extend lowering fallback for unresolved `ea` expressions to support runtime affine forms (single scalar atom)
- support runtime `IndexImm` and `EaAdd`/`EaSub` materialization using shift/add lowering only (no multiply instruction generation)
- add diagnostics for unsupported runtime operators and non-power-of-2 runtime multipliers
- avoid noisy `Failed to evaluate EA offset` diagnostics when unresolved offsets are intentionally lowered dynamically
- add PR272 test+fixtures for valid affine forms and invalid non-affine/runtime-multiplier forms
- update quick-guide runtime-atom section with affine runtime examples

## Local validation
- `yarn -s typecheck`
- `yarn -s vitest run test/pr272_runtime_affine_index_offset.test.ts test/pr264_runtime_atom_budget_matrix.test.ts test/pr262_ld_nested_runtime_index.test.ts`
