### PR TITLE
[v0.2] Harden typed-call value semantics vs direct ea budget

### DIFF
--- a/docs/ZAX-quick-guide.md
+++ b/docs/ZAX-quick-guide.md
@@ -262,6 +262,9 @@ end
 
 Keep call-site arguments simple; stage dynamic address/value work first.
 
+- Scalar value-semantic arguments (`var`, `rec.field`, `arr[idx]`) may use the normal source `ea` runtime-atom rule (max one runtime atom).
+- Direct address arguments (`ea`/`(ea)` as address-style call-site forms) remain runtime-atom-free in v0.2.
+
 ## Chapter 7 - The `op` System
 
 ### 7.1 What `op` Is

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -3291,7 +3291,16 @@ export function emitProgram(
                 );
                 return;
               }
+              const requiresDirectCallSiteEaBudget = (arg: AsmOperandNode): boolean => {
+                if (arg.kind === 'Mem') return true;
+                if (arg.kind !== 'Ea') return false;
+                // Scalar-typed ea values in typed call-arg position are value-semantic and
+                // are lowered like loads, so they follow the general source ea atom budget.
+                // Address-style call-site ea arguments stay runtime-atom-free in v0.2.
+                return resolveScalarTypeForEa(arg.expr) === undefined;
+              };
               for (const arg of args) {
+                if (!requiresDirectCallSiteEaBudget(arg)) continue;
                 if (!enforceDirectCallSiteEaBudget(arg, calleeName)) return;
               }
 

--- a/test/fixtures/pr273_call_address_runtime_index_reject.zax
+++ b/test/fixtures/pr273_call_address_runtime_index_reject.zax
@@ -1,0 +1,15 @@
+section code at $0000
+section data at $0080
+section var at $1000
+
+globals
+  idx: byte
+
+extern func takeAddr(p: word): void at $1234
+
+data
+  arr: byte[4] = [ 1, 2, 3, 4 ]
+
+export func main(): void
+  takeAddr arr[idx]
+end

--- a/test/fixtures/pr273_call_scalar_runtime_index_value_ok.zax
+++ b/test/fixtures/pr273_call_scalar_runtime_index_value_ok.zax
@@ -1,0 +1,14 @@
+section code at $0000
+section var at $1000
+
+globals
+  idx: byte
+  arr: byte[16]
+
+export func sink(v: byte): void
+  ret
+end
+
+export func main(): void
+  sink arr[idx]
+end

--- a/test/pr273_call_scalar_value_runtime_index.test.ts
+++ b/test/pr273_call_scalar_value_runtime_index.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR273: typed call arg value semantics vs direct ea budget', () => {
+  it('accepts scalar value-semantic ea args with runtime index in typed call position', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr273_call_scalar_runtime_index_value_ok.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+  });
+
+  it('still rejects runtime call-site address ea args that must remain atom-free in v0.2', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr273_call_address_runtime_index_reject.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toHaveLength(1);
+    expect(res.diagnostics[0]?.message).toContain(
+      'Direct call-site ea argument for "takeAddr" must be runtime-atom-free in v0.2',
+    );
+  });
+});


### PR DESCRIPTION
## Scope
- enforce direct call-site `ea/(ea)` runtime-atom-free policy only for address-style args
- preserve scalar value semantics for typed call arguments (`var`, `field`, `element`) so single-atom runtime indexed value loads remain valid
- add PR273 regression matrix:
  - allow scalar value-semantic runtime-index call args
  - continue rejecting runtime-index direct address-style call-site `ea` args
- document the distinction in quick guide call rules

## Local validation
- `yarn -s typecheck`
- `yarn -s vitest run test/pr273_call_scalar_value_runtime_index.test.ts test/pr12_calls.test.ts test/pr256_value_semantics_scalar_ld.test.ts`
