### PR TITLE
[v0.2] Distinguish typed vs raw call boundary diagnostics

### DIFF
--- a/docs/ZAX-quick-guide.md
+++ b/docs/ZAX-quick-guide.md
@@ -267,6 +267,7 @@ Keep call-site arguments simple; stage dynamic address/value work first.
 
 - Scalar value-semantic arguments (`var`, `rec.field`, `arr[idx]`) may use the normal source `ea` runtime-atom rule (max one runtime atom).
 - Direct address arguments (`ea`/`(ea)` as address-style call-site forms) remain runtime-atom-free in v0.2.
+- Stack-verification diagnostics distinguish typed call boundaries from raw `call` instructions.
 
 ## Chapter 7 - The `op` System
 

--- a/test/fixtures/pr275_typed_vs_raw_call_boundary_diag.zax
+++ b/test/fixtures/pr275_typed_vs_raw_call_boundary_diag.zax
@@ -1,0 +1,34 @@
+func callee_typed(a: byte): void
+  var
+    slot: byte
+  end
+  ret
+end
+
+func typed_unknown(a: byte): void
+  var
+    slot: byte
+  end
+  select a
+    case 0
+      push bc
+    case 1
+      nop
+  end
+  callee_typed a
+  ret
+end
+
+func raw_unknown(a: byte): void
+  var
+    slot: byte
+  end
+  select a
+    case 0
+      push bc
+    case 1
+      nop
+  end
+  call callee_typed
+  ret
+end

--- a/test/pr224_lowering_call_boundary_stack_matrix.test.ts
+++ b/test/pr224_lowering_call_boundary_stack_matrix.test.ts
@@ -18,13 +18,15 @@ describe('PR224 lowering: call-boundary stack invariant matrix', () => {
 
     expect(
       messages.some((m) =>
-        m.includes('call reached with unknown stack depth; cannot verify callee stack contract.'),
+        m.includes(
+          'typed call "callee_safe" reached with unknown stack depth; cannot verify typed-call boundary contract.',
+        ),
       ),
     ).toBe(true);
     expect(
       messages.some((m) =>
         m.includes(
-          'call reached after untracked SP mutation; cannot verify callee stack contract.',
+          'typed call "callee_safe" reached after untracked SP mutation; cannot verify typed-call boundary contract.',
         ),
       ),
     ).toBe(true);
@@ -52,6 +54,10 @@ describe('PR224 lowering: call-boundary stack invariant matrix', () => {
       ),
     ).toBe(true);
 
-    expect(messages.some((m) => m.includes('callee_safe'))).toBe(false);
+    expect(
+      messages.some((m) =>
+        m.includes('Function "callee_safe" has unknown stack depth at fallthrough'),
+      ),
+    ).toBe(false);
   });
 });

--- a/test/pr228_lowering_call_boundary_unknown_untracked_matrix.test.ts
+++ b/test/pr228_lowering_call_boundary_unknown_untracked_matrix.test.ts
@@ -27,7 +27,8 @@ describe('PR228 lowering: call-boundary unknown/untracked stack matrix', () => {
     expect(actual).toEqual([
       { message: 'Stack depth mismatch at select join (-2 vs 0).', line: 18, column: 3 },
       {
-        message: 'call reached with unknown stack depth; cannot verify callee stack contract.',
+        message:
+          'typed call "callee" reached with unknown stack depth; cannot verify typed-call boundary contract.',
         line: 19,
         column: 3,
       },
@@ -37,7 +38,8 @@ describe('PR228 lowering: call-boundary unknown/untracked stack matrix', () => {
         column: 3,
       },
       {
-        message: 'call reached after untracked SP mutation; cannot verify callee stack contract.',
+        message:
+          'typed call "callee" reached after untracked SP mutation; cannot verify typed-call boundary contract.',
         line: 28,
         column: 3,
       },

--- a/test/pr275_typed_vs_raw_call_boundary_diagnostics.test.ts
+++ b/test/pr275_typed_vs_raw_call_boundary_diagnostics.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR275: typed vs raw call-boundary diagnostics', () => {
+  it('distinguishes typed-call boundary contract diagnostics from raw call diagnostics', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr275_typed_vs_raw_call_boundary_diag.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(
+      messages.some((m) =>
+        m.includes(
+          'typed call "callee_typed" reached with unknown stack depth; cannot verify typed-call boundary contract.',
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      messages.some((m) =>
+        m.includes('call reached with unknown stack depth; cannot verify callee stack contract.'),
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Scope
- distinguish stack-verification diagnostics for typed call boundaries vs raw Z80 `call`/`rst`
- keep raw `call`/`rst` diagnostics stable (`callee stack contract` wording)
- emit typed-call-specific wording (`typed-call boundary contract`) for typed callable invocations
- expand boundary matrix with PR275 mixed typed/raw fixture coverage
- update existing call-boundary matrix expectations for typed-call wording
- update quick-guide call section note

## Why this is a larger v0.2 step
- tightens §7.3 behavior contract visibility (typed boundary guarantees vs raw instruction semantics)
- touches lowering semantics + multiple call-boundary regression matrices + docs

## Local validation
- `yarn -s typecheck`
- `yarn -s vitest run test/pr224_lowering_call_boundary_stack_matrix.test.ts test/pr228_lowering_call_boundary_unknown_untracked_matrix.test.ts test/pr239_lowering_call_boundary_nonzero_stack_matrix.test.ts test/pr230_lowering_rst_call_boundary_matrix.test.ts test/pr275_typed_vs_raw_call_boundary_diagnostics.test.ts`
