### PR TITLE
[v0.2] Add typed-call preservation wrapper matrix

### DIFF
--- a/docs/ZAX-quick-guide.md
+++ b/docs/ZAX-quick-guide.md
@@ -261,6 +261,11 @@ end
 - `void` typed calls: no boundary-visible clobbers
 - non-`void` typed calls: `HL` is visible return channel (`L` for byte returns)
 
+Lowering consequence:
+
+- `void` call wrappers preserve/restore `HL`
+- non-`void` call wrappers intentionally leave `HL` as the published return channel
+
 ### 6.3 Practical Rule
 
 Keep call-site arguments simple; stage dynamic address/value work first.

--- a/test/fixtures/pr276_typed_call_preservation_matrix.zax
+++ b/test/fixtures/pr276_typed_call_preservation_matrix.zax
@@ -1,0 +1,18 @@
+section code at $0000
+section var at $1000
+
+extern func getb(seed: byte): byte at $1234
+extern func getw(seed: word): word at $1240
+extern func ping(seed: byte): void at $1250
+
+globals
+  out: word
+
+export func main(): void
+  ping 1
+  getb 7
+  ld a, l
+  getw 9
+  ld out, hl
+  ret
+end

--- a/test/pr276_typed_call_preservation_matrix.test.ts
+++ b/test/pr276_typed_call_preservation_matrix.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR276: typed-call preservation wrappers (void vs non-void)', () => {
+  it('keeps HL preserved for void calls and exposes HL for non-void calls', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr276_typed_call_preservation_matrix.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    expect(bin!.bytes).toEqual(
+      Uint8Array.of(
+        // ping 1 (void): preserve AF/BC/DE/IX/IY/HL
+        0xf5,
+        0xc5,
+        0xd5,
+        0xdd,
+        0xe5,
+        0xfd,
+        0xe5,
+        0xe5,
+        0x21,
+        0x01,
+        0x00,
+        0xe5,
+        0xcd,
+        0x50,
+        0x12,
+        0xc1,
+        0xe1,
+        0xfd,
+        0xe1,
+        0xdd,
+        0xe1,
+        0xd1,
+        0xc1,
+        0xf1,
+        // getb 7 (byte return): HL is return channel, so no HL preserve/restore
+        0xf5,
+        0xc5,
+        0xd5,
+        0xdd,
+        0xe5,
+        0xfd,
+        0xe5,
+        0x21,
+        0x07,
+        0x00,
+        0xe5,
+        0xcd,
+        0x34,
+        0x12,
+        0xc1,
+        0xfd,
+        0xe1,
+        0xdd,
+        0xe1,
+        0xd1,
+        0xc1,
+        0xf1,
+        0x7d, // ld a, l
+        // getw 9 (word return): HL remains visible return channel
+        0xf5,
+        0xc5,
+        0xd5,
+        0xdd,
+        0xe5,
+        0xfd,
+        0xe5,
+        0x21,
+        0x09,
+        0x00,
+        0xe5,
+        0xcd,
+        0x40,
+        0x12,
+        0xc1,
+        0xfd,
+        0xe1,
+        0xdd,
+        0xe1,
+        0xd1,
+        0xc1,
+        0xf1,
+        0x22,
+        0x00,
+        0x10, // ld ($1000), hl
+        0xc9, // ret
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Scope
- add PR276 matrix fixture/test for typed call wrapper behavior across `void` and non-`void` extern calls
- assert emitted bytes for preservation wrappers and return-channel behavior (`HL` preserved for `void`, exposed for non-`void`)
- keep existing call contracts covered while adding precise wrapper-shape regression protection
- update quick-guide call-boundary section with wrapper consequence note

## Why this matters for v0.2 readiness
- strengthens §7.3 call-boundary contract verification with exact byte-level assertions
- adds explicit guardrails for future lowering refactors touching call wrappers

## Local validation
- `yarn -s typecheck`
- `yarn -s vitest run test/pr276_typed_call_preservation_matrix.test.ts test/pr12_calls.test.ts test/pr275_typed_vs_raw_call_boundary_diagnostics.test.ts`
