### PR TITLE
[v0.2] Warn on redundant grouped constant index forms

### DIFF
--- a/docs/ZAX-quick-guide.md
+++ b/docs/ZAX-quick-guide.md
@@ -147,6 +147,7 @@ arr[(HL)]
 
 - `arr[HL]` means direct 16-bit index from `HL`
 - `arr[(HL)]` means index comes from byte at memory address `(HL)`
+- `arr[(3+5)]` is valid but warns as redundant grouping (same as `arr[3+5]`)
 
 ### 3.3 Runtime Atom Rule
 

--- a/src/diagnostics/types.ts
+++ b/src/diagnostics/types.ts
@@ -86,6 +86,9 @@ export const DiagnosticIds = {
 
   /** Case-style lint warning for keyword/register casing policy. */
   CaseStyleLint: 'ZAX500',
+
+  /** Redundant outer parentheses in a constant-only array index expression. */
+  IndexParenRedundant: 'ZAX501',
 } as const;
 
 /**

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -540,6 +540,20 @@ function parseEaIndexFromText(
       }
       return { kind: 'IndexMemIxIy', span: indexSpan, base, ...(disp ? { disp } : {}) };
     }
+    // Lint warning only for constant-only grouped index forms like arr[(3+5)].
+    if (!/[A-Za-z_]/.test(inner)) {
+      const grouped = parseImmExprFromText(filePath, inner, indexSpan, diagnostics, false);
+      if (grouped) {
+        diagnostics.push({
+          id: DiagnosticIds.IndexParenRedundant,
+          severity: 'warning',
+          message: `Redundant outer parentheses in constant index expression "${t}".`,
+          file: indexSpan.file,
+          line: indexSpan.start.line,
+          column: indexSpan.start.column,
+        });
+      }
+    }
   }
   if (/^(HL|DE|BC)$/i.test(t)) {
     return { kind: 'IndexReg16', span: indexSpan, reg: canonicalRegisterToken(t) };

--- a/test/fixtures/pr277_index_redundant_paren_warning.zax
+++ b/test/fixtures/pr277_index_redundant_paren_warning.zax
@@ -1,0 +1,12 @@
+section code at $0000
+section var at $1000
+
+globals
+  arr: byte[16]
+
+export func main(): void
+  ld a, arr[(3 + 5)]
+  ld a, arr[(HL)]
+  ld a, arr[(IX+1)]
+  ret
+end

--- a/test/pr277_index_redundant_paren_warning.test.ts
+++ b/test/pr277_index_redundant_paren_warning.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnostics/types.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR277: redundant grouped index warning', () => {
+  it('warns for constant-only grouped index forms and ignores indirect Z80 patterns', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr277_index_redundant_paren_warning.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    const warnings = res.diagnostics.filter((d) => d.id === DiagnosticIds.IndexParenRedundant);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.message).toContain('Redundant outer parentheses in constant index');
+    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Scope
- add `ZAX501` warning diagnostic for redundant outer parentheses in constant-only array index forms
- parser behavior: warn on grouped constants like `arr[(3+5)]` while preserving semantics
- do not warn on indirect Z80 index patterns (`arr[(HL)]`, `arr[(IX+d)]`, `arr[(IY-d)]`)
- add PR277 fixture/test coverage
- update quick-guide indexing semantics note

## Why this is v0.2-relevant
- aligns parser/index UX with v0.2 index pattern-recognition direction in transition decisions (§1.3)
- adds non-breaking migration lint without changing lowering semantics

## Local validation
- `yarn -s typecheck`
- `yarn -s vitest run test/pr277_index_redundant_paren_warning.test.ts test/parser_nested_index.test.ts test/pr264_runtime_atom_budget_matrix.test.ts`
