### PR TITLE
[v0.2] Add nested runtime-index store/load matrix coverage

### DIFF
--- a/docs/ZAX-quick-guide.md
+++ b/docs/ZAX-quick-guide.md
@@ -161,6 +161,8 @@ arr[CONST1 + CONST2 * 4][idx]
 arr[idx].field
 arr[idx + 3]
 arr[(idxw << 1) + 6]
+grid[idx][0]
+grid[0][idx]
 ```
 
 Current lowering supports single-atom affine forms using constants with `+`, `-`, `*` (power-of-2 multipliers), and `<<`.

--- a/test/fixtures/pr278_nested_runtime_store_matrix.zax
+++ b/test/fixtures/pr278_nested_runtime_store_matrix.zax
@@ -1,0 +1,24 @@
+section code at $0000
+section var at $1000
+
+globals
+  idx: byte
+  idxw: word
+  grid: byte[4][8]
+  mat: word[8][8]
+  arr: byte[32]
+
+export func main(): void
+  ld a, 1
+  ld grid[idx][0], a
+  ld grid[0][idx], a
+  ld arr[idx + 1], a
+
+  ld a, grid[idx][0]
+  ld hl, $1234
+  ld mat[idx][0], hl
+  ld hl, mat[0][idx]
+
+  ld a, arr[idxw + 2]
+  ret
+end

--- a/test/pr278_nested_runtime_store_matrix.test.ts
+++ b/test/pr278_nested_runtime_store_matrix.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR278: nested runtime-index store matrix (one atom)', () => {
+  it('accepts one-atom nested load/store paths across byte and word elements', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr278_nested_runtime_store_matrix.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    expect(bin!.bytes.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Scope
- add PR278 fixture/test matrix for one-atom nested runtime index load/store paths
- cover byte and word element shapes (`grid[idx][0]`, `grid[0][idx]`, `mat[idx][0]`, `mat[0][idx]`)
- include affine runtime scalar index form (`arr[idxw + 2]`) in the same matrix
- confirm behavior remains compatible with existing runtime-atom enforcement tests
- quick-guide examples updated with one-atom nested forms

## Why this is a substantial v0.2 increment
- expands regression protection into previously unverified store-side and word-width nested runtime-index paths
- directly tracks transition-decision §1.2 single-runtime-atom nested indexing expectations

## Local validation
- `yarn -s typecheck`
- `yarn -s vitest run test/pr278_nested_runtime_store_matrix.test.ts test/pr264_runtime_atom_budget_matrix.test.ts test/pr262_ld_nested_runtime_index.test.ts`
