### PR TITLE
v0.2: optional warning for raw call to typed targets

### DIFF
--- a/docs/ZAX-quick-guide.md
+++ b/docs/ZAX-quick-guide.md
@@ -78,6 +78,7 @@ Useful contract options:
 - `--case-style <m>` (`off|upper|lower|consistent`) for case-style linting
 - `--op-stack-policy <m>` (`off|warn|error`) for optional op stack-policy diagnostics at typed call boundaries
 - `--type-padding-warn` to emit warnings when composite type storage is padded to power-of-2 size
+- `--raw-typed-call-warn` to warn when raw `call` targets typed callable symbols
 
 ## Chapter 2 - Storage Model
 
@@ -276,6 +277,7 @@ Keep call-site arguments simple; stage dynamic address/value work first.
 - Scalar value-semantic arguments (`var`, `rec.field`, `arr[idx]`) may use the normal source `ea` runtime-atom rule (max one runtime atom).
 - Direct address arguments (`ea`/`(ea)` as address-style call-site forms) remain runtime-atom-free in v0.2.
 - Stack-verification diagnostics distinguish typed call boundaries from raw `call` instructions.
+- `--raw-typed-call-warn` is available as an advisory lint when raw `call`/`call cc,nn` targets a typed callable symbol.
 
 ## Chapter 7 - The `op` System
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ type CliOptions = {
   caseStyle: CaseStyleMode;
   opStackPolicy: OpStackPolicyMode;
   typePaddingWarnings: boolean;
+  rawTypedCallWarnings: boolean;
   includeDirs: string[];
 };
 
@@ -41,6 +42,7 @@ function usage(): string {
     '      --case-style <m>  Case-style lint mode: off|upper|lower|consistent',
     '      --op-stack-policy <m> Op stack-policy mode: off|warn|error',
     '      --type-padding-warn Emit warnings for power-of-2 type storage padding',
+    '      --raw-typed-call-warn Emit warnings for raw call to typed callable targets',
     '  -I, --include <dir>   Add import search path (repeatable)',
     '  -V, --version         Print version',
     '  -h, --help            Show help',
@@ -66,6 +68,7 @@ function parseArgs(argv: string[]): CliOptions | CliExit {
   let caseStyle: CaseStyleMode = 'off';
   let opStackPolicy: OpStackPolicyMode = 'off';
   let typePaddingWarnings = false;
+  let rawTypedCallWarnings = false;
   const includeDirs: string[] = [];
   let entryFile: string | undefined;
 
@@ -152,6 +155,10 @@ function parseArgs(argv: string[]): CliOptions | CliExit {
       typePaddingWarnings = true;
       continue;
     }
+    if (a === '--raw-typed-call-warn') {
+      rawTypedCallWarnings = true;
+      continue;
+    }
     if (a === '-I' || a === '--include' || a.startsWith('--include=')) {
       if (a.startsWith('--include=')) {
         const v = a.slice('--include='.length);
@@ -202,6 +209,7 @@ function parseArgs(argv: string[]): CliOptions | CliExit {
     caseStyle,
     opStackPolicy,
     typePaddingWarnings,
+    rawTypedCallWarnings,
     includeDirs,
   };
 }
@@ -310,6 +318,7 @@ export async function runCli(argv: string[]): Promise<number> {
         caseStyle: parsed.caseStyle,
         opStackPolicy: parsed.opStackPolicy,
         typePaddingWarnings: parsed.typePaddingWarnings,
+        rawTypedCallWarnings: parsed.rawTypedCallWarnings,
         includeDirs: parsed.includeDirs,
       },
       { formats: defaultFormatWriters },

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -317,6 +317,9 @@ export const compile: CompileFn = async (
   const { map, symbols } = emitProgram(program, env, diagnostics, {
     ...(options.includeDirs ? { includeDirs: options.includeDirs } : {}),
     ...(options.opStackPolicy ? { opStackPolicy: options.opStackPolicy } : {}),
+    ...(options.rawTypedCallWarnings !== undefined
+      ? { rawTypedCallWarnings: options.rawTypedCallWarnings }
+      : {}),
   });
   if (hasErrors(diagnostics)) {
     return { diagnostics, artifacts: [] };

--- a/src/diagnostics/types.ts
+++ b/src/diagnostics/types.ts
@@ -68,6 +68,8 @@ export const DiagnosticIds = {
 
   /** Static op stack-policy risk detected at invocation site. */
   OpStackPolicyRisk: 'ZAX315',
+  /** Raw call targets a typed callable and bypasses typed-call boundary semantics. */
+  RawCallTypedTargetWarning: 'ZAX316',
 
   /** Generic semantic evaluation error (env building, imm evaluation, etc.). */
   SemanticsError: 'ZAX400',

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -35,6 +35,8 @@ export interface CompilerOptions {
   opStackPolicy?: OpStackPolicyMode;
   /** Emit v0.2 type storage padding warnings for named composite types. */
   typePaddingWarnings?: boolean;
+  /** Emit warnings when raw `call` targets a typed callable symbol. */
+  rawTypedCallWarnings?: boolean;
 }
 
 /**

--- a/test/cli_contract_matrix.test.ts
+++ b/test/cli_contract_matrix.test.ts
@@ -180,4 +180,24 @@ describe('cli contract matrix', () => {
 
     await rm(work, { recursive: true, force: true });
   });
+
+  it('forwards --raw-typed-call-warn to compile', async () => {
+    const fixture = join(__dirname, 'fixtures', 'pr278_raw_call_typed_target_warning.zax');
+    const work = await mkdtemp(join(tmpdir(), 'zax-cli-raw-typed-call-warn-'));
+    const offOut = join(work, 'off.hex');
+    const onOut = join(work, 'on.hex');
+
+    const offRes = await runCli(['--output', offOut, fixture]);
+    expect(offRes.code).toBe(0);
+    expect(offRes.stderr).not.toContain('[ZAX316]');
+    expect(await exists(offOut)).toBe(true);
+
+    const onRes = await runCli(['--raw-typed-call-warn', '--output', onOut, fixture]);
+    expect(onRes.code).toBe(0);
+    expect(onRes.stderr).toContain('warning: [ZAX316]');
+    expect(onRes.stderr).toContain('Raw call targets typed callable');
+    expect(await exists(onOut)).toBe(true);
+
+    await rm(work, { recursive: true, force: true });
+  });
 });

--- a/test/fixtures/pr278_raw_call_typed_target_warning.zax
+++ b/test/fixtures/pr278_raw_call_typed_target_warning.zax
@@ -1,0 +1,15 @@
+extern
+  func ext_ping(): void at $1234
+end
+
+func callee_typed(): void
+  ret
+end
+
+export func main(): void
+  call callee_typed
+  call nz, ext_ping
+  call local_label
+local_label:
+  ret
+end

--- a/test/pr278_raw_call_typed_target_warning.test.ts
+++ b/test/pr278_raw_call_typed_target_warning.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnostics/types.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR278: optional raw-call typed-target warnings', () => {
+  it('is off by default and preserves baseline behavior', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr278_raw_call_typed_target_warning.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.some((d) => d.id === DiagnosticIds.RawCallTypedTargetWarning)).toBe(
+      false,
+    );
+  });
+
+  it('warns when raw call/call cc targets typed callable symbols', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr278_raw_call_typed_target_warning.zax');
+    const res = await compile(
+      entry,
+      { rawTypedCallWarnings: true },
+      { formats: defaultFormatWriters },
+    );
+
+    const warnings = res.diagnostics.filter(
+      (d) => d.id === DiagnosticIds.RawCallTypedTargetWarning,
+    );
+    expect(warnings).toHaveLength(2);
+    expect(warnings.every((d) => d.severity === 'warning')).toBe(true);
+    expect(warnings.some((d) => d.message.includes('"callee_typed"'))).toBe(true);
+    expect(warnings.some((d) => d.message.includes('"ext_ping"'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add diagnostic `ZAX316` (`RawCallTypedTargetWarning`) for raw `call`/`call cc,nn` to typed callable symbols
- add compiler option `rawTypedCallWarnings` and CLI flag `--raw-typed-call-warn`
- keep behavior unchanged by default (warning mode is opt-in)
- document the new advisory mode in the quick guide

## Implementation notes
- warning is emitted only for symbolic raw call targets that resolve to known typed callables (`func` / typed `extern func`)
- warning is suppressed for non-zero symbolic addends (raw entrypoint arithmetic stays raw)

## Tests
- add `test/pr278_raw_call_typed_target_warning.test.ts`
- add fixture `test/fixtures/pr278_raw_call_typed_target_warning.zax`
- extend `test/cli_contract_matrix.test.ts` to verify CLI forwarding

## Local checks
- `yarn -s format`
- `yarn -s typecheck`
- `yarn -s test`

All passed locally.
