### PR TITLE
docs: add v0.2 status snapshot (2026-02-15)

### DIFF
--- a/docs/v02-status-snapshot-2026-02-15.md
+++ b/docs/v02-status-snapshot-2026-02-15.md
@@ -1,0 +1,111 @@
+# ZAX v0.2 Status Snapshot (February 15, 2026)
+
+This document is a working project-state snapshot to drive final v0.2 closeout planning.
+
+Normative language behavior remains defined by `/Users/johnhardy/Documents/projects/ZAX-codex-dev/docs/zax-spec.md`.
+
+## 1. Snapshot Scope
+
+- Snapshot date: **February 15, 2026**
+- Repository: `jhlagado/ZAX`
+- Purpose: capture current delivery state, open risk, and remaining work for v0.2 completion
+
+## 2. Verified GitHub State (as of February 15, 2026)
+
+- Open pull requests: **0**
+- Open issues: **0**
+- Most recent merged PR on `main`: [#255](https://github.com/jhlagado/ZAX/pull/255)
+  - Title: `v0.2: optional warning for raw call to typed targets`
+  - Merged with green CI on ubuntu/macos/windows checks
+
+## 3. Recent Delivery Run (v0.2 Catch-Up)
+
+The main v0.2 catch-up tranche merged in rapid sequence on February 14, 2026 (PRs `#236` through `#255`), including:
+
+- runtime-atom enforcement for source-level `ea` expressions
+- runtime-atom-free direct `ea`/`(ea)` call-site enforcement
+- op stack-policy alignment and CLI policy modes
+- typed vs raw call-boundary diagnostics clarity
+- typed-call preservation wrapper behavior matrix
+- redundant grouped index warning behavior
+- nested runtime-index load/store matrix coverage
+- optional warning mode for raw `call` to typed targets
+
+## 4. Spec/Implementation Alignment Status
+
+### 4.1 Normative posture
+
+- `/Users/johnhardy/Documents/projects/ZAX-codex-dev/docs/zax-spec.md` is authoritative.
+- `/Users/johnhardy/Documents/projects/ZAX-codex-dev/docs/v02-transition-decisions.md` is transition history (non-normative).
+
+### 4.2 Migration coverage status
+
+- Appendix C in `/Users/johnhardy/Documents/projects/ZAX-codex-dev/docs/zax-spec.md` is fully checked.
+- Core v0.2 migration items are now represented in merged implementation/tests.
+
+### 4.3 Current quality signal
+
+- CI for latest merged PR was green across OS matrix.
+- Recent work added matrix-style tests for major behavior surfaces.
+- No currently open GitHub issue is tracking an unresolved blocker.
+
+## 5. Remaining Work to Finish v0.2
+
+This section separates v0.2 closeout from deferred v0.3 features.
+
+### 5.1 v0.2 closeout tasks (in scope now)
+
+1. **Tracker/document hygiene pass**
+
+- Update stale wording in `/Users/johnhardy/Documents/projects/ZAX-codex-dev/docs/zax-dev-playbook.md` where status rows still say "In progress" for already closed items.
+- Ensure active queue table matches actual issue/PR state after PR #255 merge.
+
+2. **Release-readiness consolidation**
+
+- Create one focused v0.2 closeout issue summarizing final acceptance criteria.
+- Add explicit evidence links (tests, CI runs, key merged PRs).
+
+3. **Optional polish pass (only if gaps found)**
+
+- CLI/help/docs wording consistency sweep for new warning/policy flags.
+- Minor diagnostic text consistency pass.
+
+### 5.2 Out of scope for v0.2 (deferred)
+
+Per transition decisions and spec notes, these are not required to declare v0.2 complete:
+
+- source-interleaved listing quality upgrade (beyond current deterministic listing)
+- Debug80 integration
+- explicit `^` dereference / `@` address-of operators
+- typed-pointer and typed-register-field extensions
+
+## 6. Proposed Timeline
+
+### Phase A: v0.2 closeout prep (0.5-1 day)
+
+- clean tracker docs and align status tables
+- create/confirm v0.2 closeout issue and acceptance checklist
+
+### Phase B: v0.2 closeout execution (1-2 days)
+
+- perform targeted polish/fixes only if acceptance checklist reveals gaps
+- run full local checks and CI confirmation
+
+### Phase C: v0.2 completion declaration (same day as Phase B end)
+
+- final signoff note in docs/issue
+- lock v0.2 baseline and open v0.3 planning track
+
+Estimated remaining effort for v0.2 finish: **1.5 to 3 days**.
+
+## 7. Open Questions for Refinement
+
+These should be settled before implementation resumes:
+
+1. Should we define a formal "v0.2 done" checklist file in `docs/`?
+2. Do you want a strict "no new features, only closeout hygiene" policy for the next PRs?
+3. Should we start a v0.3 backlog doc now or only after v0.2 is explicitly closed?
+
+## 8. Change Log
+
+- February 15, 2026: initial snapshot created for refinement.


### PR DESCRIPTION
## Summary
- add a current-state v0.2 snapshot document
- capture verified PR/issue state, merged catch-up work, remaining v0.2 tasks, and closeout timeline
- provide a refinement base before final v0.2 finishing work begins

## File
- `docs/v02-status-snapshot-2026-02-15.md`

## Notes
- docs-only change
- formatted with prettier
