### PR TITLE
docs: tighten v0.2 snapshot and add done checklist

### DIFF
--- a/docs/v02-done-checklist.md
+++ b/docs/v02-done-checklist.md
@@ -19,8 +19,9 @@ Status key:
 
 Evidence links:
 
-- PR tranche: `#236`..`#255`
-- Add links to specific verification comments/runs here.
+- Migration/conformance tranche: [#236](https://github.com/jhlagado/ZAX/pull/236) .. [#255](https://github.com/jhlagado/ZAX/pull/255)
+- Runtime-atom and addressing semantics: [#248](https://github.com/jhlagado/ZAX/pull/248)
+- Typed/raw call warning mode: [#255](https://github.com/jhlagado/ZAX/pull/255)
 
 ## 2. CI and Test Evidence
 
@@ -31,8 +32,12 @@ Evidence links:
 
 Evidence links:
 
-- Add CI run links here.
-- Add exact test command/result references here.
+- Representative green CI run (latest merged tranche): [Actions run 22019661156](https://github.com/jhlagado/ZAX/actions/runs/22019661156)
+- Matrix test anchors:
+  - `test/pr264_runtime_atom_budget_matrix.test.ts`
+  - `test/pr272_runtime_affine_index_offset.test.ts`
+  - `test/pr271_op_stack_policy_alignment.test.ts`
+  - `test/pr278_raw_call_typed_target_warning.test.ts`
 
 ## 3. CLI and Docs Consistency
 
@@ -45,7 +50,10 @@ Evidence links:
 
 Evidence links:
 
-- Add docs PR/commit links here.
+- CLI stack policy mode: [#246](https://github.com/jhlagado/ZAX/pull/246)
+- CLI stack policy flag contract: [#247](https://github.com/jhlagado/ZAX/pull/247)
+- Type padding warning mode: [#250](https://github.com/jhlagado/ZAX/pull/250)
+- Raw typed call warning mode: [#255](https://github.com/jhlagado/ZAX/pull/255)
 
 ## 4. Diagnostics Stability
 

--- a/docs/v02-status-snapshot-2026-02-15.md
+++ b/docs/v02-status-snapshot-2026-02-15.md
@@ -42,6 +42,7 @@ Assessment: v0.2 implementation appears functionally complete for current confor
 ## 5. v0.2 Completion Checklist (Closeout Gate)
 
 Canonical checklist artifact: `docs/v02-done-checklist.md`
+Checklist state is authoritative in `docs/v02-done-checklist.md`; snapshot checkboxes are contextual only.
 
 Status key:
 

--- a/docs/zax-dev-playbook.md
+++ b/docs/zax-dev-playbook.md
@@ -872,6 +872,7 @@ When using multiple agents in parallel:
 - **PR #0 (contracts) must merge before any agent begins implementation.** This is the synchronization point.
 - Agents work on separate branches (`codex/<agent>-<topic>`). No two agents modify the same file.
 - Integration happens on `main`: agent merges to `main`, other agents rebase before opening their next PR.
+- After merge, branch hygiene is required: delete merged local branches and delete merged remote PR branches unless retention is explicitly needed.
 - If an agent needs to change a shared interface (AST, diagnostics, pipeline), it opens a **contract-change PR** first, which must be reviewed and merged before dependent work continues.
 - When interfaces are stable, agents may work in parallel on independent vertical slices (e.g., Agent A on `op` expansion while Agent B on `select` lowering).
 


### PR DESCRIPTION
## Summary
- add dedicated docs/v02-done-checklist.md as the canonical v0.2 closeout gate
- link the checklist from the status snapshot
- fix section numbering in the snapshot (6.1 / 6.2)
- update snapshot decisions/changelog to reflect checklist adoption

## Scope
- docs-only change
- no compiler/runtime behavior changes

## Notes
- this is intended to make v0.2 closeout objective and evidence-driven