### PR TITLE
v0.2 closeout: finalize evidence, status docs, and completion note

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,14 @@ This directory is intentionally small. Each document has a single purpose.
 
 - `zax-dev-playbook.md`
   - Consolidated implementation and process guide (roadmap, checklist, pipeline notes, contributor workflow, and normative-priority execution model).
+- `v02-status-snapshot-2026-02-15.md`
+  - v0.2 status snapshot and completion-state summary.
+- `v02-done-checklist.md`
+  - v0.2 release-closeout checklist with evidence links.
+- `v02-completion-note-2026-02-15.md`
+  - v0.2 completion declaration and closure summary.
+- `v03-planning-track.md`
+  - Post-v0.2 planning scaffold for v0.3 sequencing.
 
 ## Consolidation Policy
 

--- a/docs/v02-completion-note-2026-02-15.md
+++ b/docs/v02-completion-note-2026-02-15.md
@@ -1,0 +1,33 @@
+# ZAX v0.2 Completion Note (February 15, 2026)
+
+This note records formal v0.2 closeout.
+
+## Completion Declaration
+
+v0.2 closeout is declared **complete** as of February 15, 2026.
+
+Normative language behavior is defined by `docs/zax-spec.md`.
+
+## Evidence Pointers
+
+- Closeout gate checklist: `docs/v02-done-checklist.md`
+- Status snapshot: `docs/v02-status-snapshot-2026-02-15.md`
+- Core catch-up merge tranche: [#236](https://github.com/jhlagado/ZAX/pull/236) .. [#255](https://github.com/jhlagado/ZAX/pull/255)
+- Representative green `main` CI runs:
+  - [22027269309](https://github.com/jhlagado/ZAX/actions/runs/22027269309)
+  - [22027452113](https://github.com/jhlagado/ZAX/actions/runs/22027452113)
+
+## Scope Closure Notes
+
+The v0.2 closeout covered:
+
+- runtime-atom and call-boundary policy enforcement
+- typed-call and raw-call warning/preservation alignment
+- checklist/evidence publication for conformance, diagnostics, determinism, and examples acceptance
+- stale tracker cleanup in docs/playbook
+
+Out-of-scope deferred items remain explicitly tracked for post-v0.2 planning:
+
+- source-interleaved listing upgrades
+- Debug80 integration
+- explicit `^`/`@` operators and typed-pointer extensions

--- a/docs/v02-done-checklist.md
+++ b/docs/v02-done-checklist.md
@@ -15,29 +15,32 @@ Status key:
 - `[x]` v0.2 migration semantics implemented and represented in tests.
 - `[x]` Runtime-atom budget and direct call-site `ea`/`(ea)` constraints enforced.
 - `[x]` Typed/raw call-boundary diagnostics and policy modes implemented.
-- `[ ]` Appendix-C-to-implementation evidence links recorded in this file.
+- `[x]` Appendix-C-to-implementation evidence links recorded in this file.
 
 Evidence links:
 
-- Migration/conformance tranche: [#236](https://github.com/jhlagado/ZAX/pull/236) .. [#255](https://github.com/jhlagado/ZAX/pull/255)
-- Runtime-atom and addressing semantics: [#248](https://github.com/jhlagado/ZAX/pull/248)
-- Typed/raw call warning mode: [#255](https://github.com/jhlagado/ZAX/pull/255)
+- Migration conformance tranche: [#236](https://github.com/jhlagado/ZAX/pull/236) .. [#255](https://github.com/jhlagado/ZAX/pull/255)
+- Spec migration tracker: `docs/zax-spec.md` Appendix C
+- Runtime-atom enforcement: [#236](https://github.com/jhlagado/ZAX/pull/236), [#237](https://github.com/jhlagado/ZAX/pull/237), [#248](https://github.com/jhlagado/ZAX/pull/248)
+- Typed/raw call policy and warning modes: [#251](https://github.com/jhlagado/ZAX/pull/251), [#252](https://github.com/jhlagado/ZAX/pull/252), [#255](https://github.com/jhlagado/ZAX/pull/255)
 
 ## 2. CI and Test Evidence
 
 - `[x]` `main` green on ubuntu/macos/windows.
 - `[x]` High-risk matrix suites exist for lowering/diagnostics.
-- `[ ]` Determinism evidence captured (repeat run equality for emitted artifacts).
-- `[ ]` `examples/*.zax` acceptance evidence captured across CI matrix.
+- `[x]` Determinism evidence captured (repeat run equality for emitted artifacts).
+- `[x]` `examples/*.zax` acceptance evidence captured across CI matrix.
 
 Evidence links:
 
-- Representative green CI run (latest merged tranche): [Actions run 22019661156](https://github.com/jhlagado/ZAX/actions/runs/22019661156)
-- Matrix test anchors:
-  - `test/pr264_runtime_atom_budget_matrix.test.ts`
-  - `test/pr272_runtime_affine_index_offset.test.ts`
-  - `test/pr271_op_stack_policy_alignment.test.ts`
-  - `test/pr278_raw_call_typed_target_warning.test.ts`
+- Representative green CI runs on `main`:
+  - [run 22027269309](https://github.com/jhlagado/ZAX/actions/runs/22027269309)
+  - [run 22027452113](https://github.com/jhlagado/ZAX/actions/runs/22027452113)
+- Determinism tests:
+  - `test/determinism_artifacts.test.ts`
+  - `test/cli_determinism_contract.test.ts`
+- Examples acceptance test:
+  - `test/examples_compile.test.ts`
 
 ## 3. CLI and Docs Consistency
 
@@ -45,34 +48,55 @@ Evidence links:
   - `--op-stack-policy`
   - `--type-padding-warn`
   - `--raw-typed-call-warn`
-- `[ ]` Quick guide, playbook, and status snapshot wording are aligned.
-- `[ ]` `docs/zax-dev-playbook.md` stale "in progress" sections reconciled.
+- `[x]` Quick guide, playbook, and status snapshot wording are aligned.
+- `[x]` `docs/zax-dev-playbook.md` stale "in progress" sections reconciled.
 
 Evidence links:
 
-- CLI stack policy mode: [#246](https://github.com/jhlagado/ZAX/pull/246)
-- CLI stack policy flag contract: [#247](https://github.com/jhlagado/ZAX/pull/247)
-- Type padding warning mode: [#250](https://github.com/jhlagado/ZAX/pull/250)
-- Raw typed call warning mode: [#255](https://github.com/jhlagado/ZAX/pull/255)
+- CLI flag implementations:
+  - [#246](https://github.com/jhlagado/ZAX/pull/246)
+  - [#247](https://github.com/jhlagado/ZAX/pull/247)
+  - [#250](https://github.com/jhlagado/ZAX/pull/250)
+  - [#255](https://github.com/jhlagado/ZAX/pull/255)
+- Docs closeout/status files:
+  - [#256](https://github.com/jhlagado/ZAX/pull/256)
+  - [#257](https://github.com/jhlagado/ZAX/pull/257)
+  - [#258](https://github.com/jhlagado/ZAX/pull/258)
 
 ## 4. Diagnostics Stability
 
-- `[ ]` Core v0.2 migration diagnostics confirmed stable:
+- `[x]` Core v0.2 migration diagnostics confirmed stable:
   - enum qualification
   - `arr[HL]` vs `arr[(HL)]`
   - runtime-atom budget
   - call-boundary warnings
-- `[ ]` No legacy "subset/PR" wording remains in user-facing diagnostics.
+- `[x]` No legacy "subset/PR" wording remains in user-facing diagnostics.
 
 Evidence links:
 
-- Add test files and grep/audit links here.
+- Enum qualification diagnostics:
+  - `test/pr4_enum.test.ts`
+- `arr[HL]` vs `arr[(HL)]` parsing semantics:
+  - `test/parser_nested_index.test.ts`
+- Runtime-atom diagnostics:
+  - `test/pr264_runtime_atom_budget_matrix.test.ts`
+  - `test/pr262_ld_nested_runtime_index.test.ts`
+- Call-boundary and raw-typed-call diagnostics:
+  - `test/pr275_typed_vs_raw_call_boundary_diagnostics.test.ts`
+  - `test/pr278_raw_call_typed_target_warning.test.ts`
+- Legacy wording audit anchor:
+  - `src/lowering/emit.ts` (`bin declarations cannot target section "var" in v0.2.`)
 
 ## 5. Scope Freeze and Declaration
 
-- `[ ]` Closeout-only policy confirmed for final v0.2 PRs.
-- `[ ]` Final v0.2 completion note published.
-- `[ ]` v0.3 planning track opened after v0.2 declaration.
+- `[x]` Closeout-only policy confirmed for final v0.2 PRs.
+- `[x]` Final v0.2 completion note published.
+- `[x]` v0.3 planning track opened after v0.2 declaration.
+
+Evidence links:
+
+- v0.2 completion note: `docs/v02-completion-note-2026-02-15.md`
+- v0.3 planning track: `docs/v03-planning-track.md`
 
 ## 6. Out of Scope for v0.2
 
@@ -82,3 +106,8 @@ These are intentionally deferred and do not block v0.2 completion:
 - Debug80 integration
 - explicit `^` dereference / `@` address-of operators
 - typed-pointer and typed-register-field extensions
+
+## 7. Signoff
+
+- v0.2 closeout gate status: **COMPLETE**
+- Declared on: **February 15, 2026**

--- a/docs/v02-status-snapshot-2026-02-15.md
+++ b/docs/v02-status-snapshot-2026-02-15.md
@@ -69,45 +69,44 @@ Status key:
 
 ## 6. Remaining Work to Finish v0.2
 
-### 6.1 In-scope closeout tasks
+Status: **No blocking v0.2 closeout tasks remain.**
+
+### 6.1 Completed closeout tasks
 
 1. **Status/doc reconciliation**
 
-- Refresh `docs/zax-dev-playbook.md` status narrative and next-PR sections to reflect actual current state.
-- Keep this snapshot in sync with that playbook update.
+- Refreshed `docs/zax-dev-playbook.md` status narrative and queue rows.
+- Kept this snapshot aligned with playbook/checklist ownership.
 
 2. **Completion evidence publication**
 
-- Create one closeout tracker artifact (issue or doc section) with:
-  - final acceptance checklist
-  - links to representative passing CI runs
-  - links to key completion PRs (`#236`..`#255`)
+- Published `docs/v02-done-checklist.md` with evidence links for conformance, CI, diagnostics, and docs.
 
 3. **Final wording polish**
 
-- Perform one pass for CLI/help/docs consistency around:
+- Completed wording consistency pass for:
   - `--op-stack-policy`
   - `--type-padding-warn`
   - `--raw-typed-call-warn`
 
 4. **Behavioral edge verification**
 
-- Confirm negative immediate handling matches spec semantics (two’s-complement truncation in imm8/imm16 contexts).
-- Re-verify that example snippets in guides align to accepted parser syntax (enum forms, `select/case` shape, zero-arg `op()`).
+- Verified negative immediate semantics via merged v0.2 test tranche.
+- Verified guide syntax alignment via docs cleanup + examples acceptance suite.
 
 5. **Diagnostics stability pass**
 
-- Ensure diagnostic IDs remain stable for common v0.2 migration errors (enum qualification, `arr[(HL)]` vs `arr[HL]`, runtime-atom budget, call-boundary warnings).
-- Confirm no “subset/PR” wording remains in user-facing diagnostics.
+- Confirmed stable diagnostics coverage for migration-critical cases.
+- Removed remaining legacy "current subset" user-facing wording in lowering.
 
 6. **Acceptance and determinism evidence**
 
-- Capture at least one multi-run determinism check (same inputs produce identical artifacts).
-- Ensure `examples/*.zax` compile cleanly on macOS/Linux/Windows as part of evidence bundle.
+- Determinism evidence captured in dedicated test suites.
+- `examples/*.zax` acceptance evidence captured in CI matrix.
 
 7. **Issue-tracker hygiene**
 
-- Convert any legacy catch‑all issues into v0.2 change‑task‑shaped items with acceptance criteria/tests, or close them as obsolete.
+- Legacy catch-all tracker items were closed or folded into explicit artifacts.
 
 ### 6.2 Explicitly out of scope for v0.2
 
@@ -120,30 +119,33 @@ Not required for declaring v0.2 complete:
 
 ## 7. Proposed Timeline
 
-### Phase A: closeout prep (0.5-1 day)
+### Phase A: closeout prep (complete)
 
 - update playbook/snapshot status sections
 - define final checklist artifact shape
 
-### Phase B: closeout execution (0.5-1.5 days)
+### Phase B: closeout execution (complete)
 
 - publish evidence bundle and links
 - run targeted consistency/polish pass if needed
 
-### Phase C: completion declaration (same day as Phase B end)
+### Phase C: completion declaration (complete)
 
 - publish v0.2 completion note
 - freeze v0.2 scope and open v0.3 planning track
 
-Estimated remaining effort to formally close v0.2: **1 to 2.5 days**.
+Estimated remaining effort to formally close v0.2: **0 days (closed)**.
 
-## 8. Decisions Needed
+## 8. Next Stage
 
-1. Should next PRs be restricted to closeout-only (no feature additions)?
-2. Should v0.3 planning start immediately after closeout declaration, or after a short stabilization window?
+v0.2 is closed.
+
+- Completion declaration: `docs/v02-completion-note-2026-02-15.md`
+- Next planning track: `docs/v03-planning-track.md`
 
 ## 9. Change Log
 
 - February 15, 2026: initial snapshot created.
 - February 15, 2026: revised with current zero-open PR/issue status, explicit closeout checklist, and updated timeline.
 - February 15, 2026: linked dedicated closeout checklist file and corrected section numbering.
+- February 15, 2026: closeout tasks marked complete and snapshot transitioned to post-closeout state.

--- a/docs/v03-planning-track.md
+++ b/docs/v03-planning-track.md
@@ -1,0 +1,43 @@
+# ZAX v0.3 Planning Track
+
+This document is the post-v0.2 planning scaffold.
+
+Normative language behavior for shipped versions remains in `docs/zax-spec.md`.
+
+## 1. Inputs from v0.2 Closeout
+
+- v0.2 completion note: `docs/v02-completion-note-2026-02-15.md`
+- v0.2 done checklist: `docs/v02-done-checklist.md`
+- transition history and deferred decisions: `docs/v02-transition-decisions.md`
+
+## 2. Initial Candidate Themes
+
+1. Listing quality uplift
+
+- source-interleaved `.lst` design and implementation plan
+
+2. Debug80 integration tranche
+
+- integration gate criteria, acceptance tests, and rollout plan
+
+3. Explicit pointer/address operators
+
+- scoped design for `^` and `@` operators and typed-pointer ergonomics
+
+4. Optional typed-register field access extensions
+
+- evaluate `IX/IY`-scoped typed field patterns
+
+## 3. Planning Rules
+
+- Keep v0.2 behavior stable while v0.3 planning is in progress.
+- For each v0.3 candidate, define:
+  - problem statement
+  - minimal viable scope
+  - diagnostics/compatibility impact
+  - required tests
+  - go/no-go criteria
+
+## 4. Next Step
+
+Open one issue per selected v0.3 candidate and prioritize by risk and user value.

--- a/docs/zax-dev-playbook.md
+++ b/docs/zax-dev-playbook.md
@@ -68,9 +68,9 @@ Use one of the following tags on every scoped issue/PR:
 
 ### 1.4 Rollout Waves
 
-- Wave 1: runtime-atom enforcement for source-level `ea` expressions (#221).
-- Wave 2: runtime-atom-free direct call-site `ea`/`(ea)` enforcement (#222).
-- Wave 3: op stack-policy alignment across docs/implementation/tests (#223).
+- Wave 1: runtime-atom enforcement for source-level `ea` expressions (#221) — landed.
+- Wave 2: runtime-atom-free direct call-site `ea`/`(ea)` enforcement (#222) — landed.
+- Wave 3: op stack-policy alignment across docs/implementation/tests (#223) — landed.
 
 ## 2. Roadmap (Consolidated)
 
@@ -83,7 +83,7 @@ Core policy:
 - Build a fully working assembler first.
 - Defer Debug80 integration until assembler completion gates are met.
 
-**Last updated:** 2026-02-14
+**Last updated:** 2026-02-15
 
 Progress snapshot (rough, assembler-first):
 
@@ -531,13 +531,13 @@ Normative language behavior is defined in `docs/zax-spec.md`.
 
 ## Active Queue
 
-| Area                    | Change                                                       | Issue                                              | Status      | PR                                               |
-| ----------------------- | ------------------------------------------------------------ | -------------------------------------------------- | ----------- | ------------------------------------------------ |
-| docs                    | Runtime-atom model and single-expression budget              | —                                                  | In progress | [#219](https://github.com/jhlagado/ZAX/pull/219) |
-| semantics/lowering      | Enforce runtime-atom quota for source-level `ea` expressions | [#221](https://github.com/jhlagado/ZAX/issues/221) | Done        | [#236](https://github.com/jhlagado/ZAX/pull/236) |
-| semantics/lowering      | Enforce runtime-atom-free direct `ea`/`(ea)` call-site args  | [#222](https://github.com/jhlagado/ZAX/issues/222) | Done        | [#237](https://github.com/jhlagado/ZAX/pull/237) |
-| lowering/spec-alignment | Resolve op stack-policy mismatch (docs vs implementation)    | [#223](https://github.com/jhlagado/ZAX/issues/223) | Done        | [#238](https://github.com/jhlagado/ZAX/pull/238) |
-| semantics/lowering      | Accept negative immediates with width truncation             | [#235](https://github.com/jhlagado/ZAX/issues/235) | In progress | —                                                |
+| Area                    | Change                                                       | Issue                                              | Status | PR                                               |
+| ----------------------- | ------------------------------------------------------------ | -------------------------------------------------- | ------ | ------------------------------------------------ |
+| docs                    | Runtime-atom model and single-expression budget              | —                                                  | Done   | [#219](https://github.com/jhlagado/ZAX/pull/219) |
+| semantics/lowering      | Enforce runtime-atom quota for source-level `ea` expressions | [#221](https://github.com/jhlagado/ZAX/issues/221) | Done   | [#236](https://github.com/jhlagado/ZAX/pull/236) |
+| semantics/lowering      | Enforce runtime-atom-free direct `ea`/`(ea)` call-site args  | [#222](https://github.com/jhlagado/ZAX/issues/222) | Done   | [#237](https://github.com/jhlagado/ZAX/pull/237) |
+| lowering/spec-alignment | Resolve op stack-policy mismatch (docs vs implementation)    | [#223](https://github.com/jhlagado/ZAX/issues/223) | Done   | [#238](https://github.com/jhlagado/ZAX/pull/238) |
+| semantics/lowering      | Accept negative immediates with width truncation             | [#235](https://github.com/jhlagado/ZAX/issues/235) | Done   | [#239](https://github.com/jhlagado/ZAX/pull/239) |
 
 ## Rollout Schedule (Spec-First, Implementation Catch-Up)
 
@@ -552,7 +552,7 @@ This section makes implementation lag explicit so contributors can plan work aga
 ## Team Signal
 
 - `docs/zax-spec.md` remains canonical for target behavior.
-- Until Waves 1-3 land, some implementation paths are intentionally behind the spec and are tracked by the issues above.
+- Waves 1-3 are landed on `main`; policy/implementation/test alignment work is complete for this tranche.
 - New feature work touching addressing/calls/ops should cross-check this schedule before adding behavior.
 
 ## Status Legend

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -2768,7 +2768,7 @@ export function emitProgram(
           diag(
             diagnostics,
             binDecl.span.file,
-            `bin declarations cannot target section "var" in current subset.`,
+            `bin declarations cannot target section "var" in v0.2.`,
           );
           continue;
         }


### PR DESCRIPTION
## Summary
- finalize v0.2 closeout checklist with concrete evidence links and signoff state
- transition v0.2 status snapshot to post-closeout state
- update playbook stale queue/wave status items to landed/done
- add explicit v0.2 completion declaration and v0.3 planning scaffold docs
- remove remaining user-facing legacy wording (`current subset` -> `v0.2`) in lowering diagnostic

## Files
- `docs/v02-done-checklist.md`
- `docs/v02-status-snapshot-2026-02-15.md`
- `docs/zax-dev-playbook.md`
- `docs/v02-completion-note-2026-02-15.md`
- `docs/v03-planning-track.md`
- `docs/README.md`
- `src/lowering/emit.ts`

## Validation
- `yarn -s format`
- `yarn -s typecheck`
- `yarn -s test`

All passed locally.
