### PR TITLE
feat(v0.2): add tiered golden .asm corpus for lowering

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,8 @@ This directory is intentionally small. Each document has a single purpose.
   - Post-v0.2 planning scaffold for v0.3 sequencing.
 - `github-backlog-workflow.md`
   - GitHub-only backlog operating model (Jira-style issue workflow using milestones + labels + acceptance gates).
+- `v02-codegen-golden-corpus.md`
+  - Tiered `.asm` golden-corpus workflow for v0.2 codegen verification.
 
 ## Consolidation Policy
 

--- a/docs/v02-codegen-golden-corpus.md
+++ b/docs/v02-codegen-golden-corpus.md
@@ -1,0 +1,46 @@
+# v0.2 Codegen Golden Corpus
+
+This document defines how the tiered lowering corpus works and how to extend it safely.
+
+## Purpose
+
+The corpus provides deterministic, human-reviewable evidence that ZAX lowering emits expected
+code across increasing complexity:
+
+- basic control flow
+- intermediate indexing/lowering paths
+- advanced typed-call and value/return-channel behavior
+
+## Current Tier Cases
+
+- basic: `test/fixtures/corpus/basic_control_flow.zax`
+- intermediate: `test/fixtures/corpus/intermediate_indexing.zax`
+- advanced: `test/fixtures/corpus/advanced_typed_calls.zax`
+- negative runtime-atom case: `test/fixtures/corpus/invalid_runtime_atom_budget.zax`
+
+Golden snapshots:
+
+- `test/fixtures/corpus/golden/basic_control_flow.asm`
+- `test/fixtures/corpus/golden/intermediate_indexing.asm`
+- `test/fixtures/corpus/golden/advanced_typed_calls.asm`
+
+Test harness:
+
+- `test/pr282_tiered_golden_corpus.test.ts`
+
+## Update Workflow
+
+When changing lowering behavior intentionally:
+
+1. Update/add corpus fixture(s).
+2. Regenerate the affected `.asm` golden snapshot(s).
+3. Keep one focused rationale per changed golden in the PR description.
+4. Run full local gates (`format`, `typecheck`, `test`) before push.
+
+## Anti-Overfitting Rules
+
+- Prefer small fixtures with one main intent each.
+- Do not lock down volatile, non-semantic incidental output unless it is part of the deterministic
+  contract.
+- Add a negative case for each new constrained behavior where practical.
+- If a golden changes for unrelated reasons, split the refactor from semantic changes.

--- a/test/fixtures/corpus/advanced_typed_calls.zax
+++ b/test/fixtures/corpus/advanced_typed_calls.zax
@@ -1,0 +1,21 @@
+section code at $0000
+section var at $1000
+
+extern func getb(seed: byte): byte at $1234
+extern func getw(seed: word): word at $1240
+extern func ping(seed: byte): void at $1250
+
+globals
+  idx: byte
+  arr: byte[16]
+  out: word
+
+export func main(): void
+  ping 1
+  getb arr[idx]
+  ld a, l
+  getw 9
+  ld out, hl
+  ret
+end
+

--- a/test/fixtures/corpus/basic_control_flow.zax
+++ b/test/fixtures/corpus/basic_control_flow.zax
@@ -1,0 +1,25 @@
+section code at $0000
+
+export func main(): void
+  if nz
+    nop
+  else
+    nop
+  end
+
+  while nz
+    nop
+  end
+
+  repeat
+    nop
+  until z
+
+  select a
+    case 0
+      nop
+    else
+      nop
+  end
+end
+

--- a/test/fixtures/corpus/golden/advanced_typed_calls.asm
+++ b/test/fixtures/corpus/golden/advanced_typed_calls.asm
@@ -1,0 +1,75 @@
+; ZAX lowered .asm trace
+; range: $0000..$005A (end exclusive)
+
+; func main begin
+main:
+0000: F5           push AF
+0001: C5           push BC
+0002: D5           push DE
+0003: DD E5        push IX
+0005: FD E5        push IY
+0007: E5           push HL
+0008: 21 01 00     ld HL, $0001
+000B: E5           push HL
+000C: CD 00 00     db $CD, lo(ping), hi(ping)
+000F: C1           pop BC
+0010: E1           pop HL
+0011: FD E1        pop IY
+0013: DD E1        pop IX
+0015: D1           pop DE
+0016: C1           pop BC
+0017: F1           pop AF
+0018: F5           push AF
+0019: C5           push BC
+001A: D5           push DE
+001B: DD E5        push IX
+001D: FD E5        push IY
+001F: 3A 00 00     db $3A, lo(idx), hi(idx)
+0022: 26 00        ld H, $0000
+0024: 6F           ld L, A
+0025: E5           push HL
+0026: E1           pop HL
+0027: E5           push HL
+0028: 21 00 00     db $21, lo(arr), hi(arr)
+002B: D1           pop DE
+002C: 19           add HL, DE
+002D: E5           push HL
+002E: E1           pop HL
+002F: 7E           ld a, (hl)
+0030: 26 00        ld H, $0000
+0032: 6F           ld L, A
+0033: E5           push HL
+0034: CD 00 00     db $CD, lo(getb), hi(getb)
+0037: C1           pop BC
+0038: FD E1        pop IY
+003A: DD E1        pop IX
+003C: D1           pop DE
+003D: C1           pop BC
+003E: F1           pop AF
+003F: 7D           ld A, L
+0040: F5           push AF
+0041: C5           push BC
+0042: D5           push DE
+0043: DD E5        push IX
+0045: FD E5        push IY
+0047: 21 09 00     ld HL, $0009
+004A: E5           push HL
+004B: CD 00 00     db $CD, lo(getw), hi(getw)
+004E: C1           pop BC
+004F: FD E1        pop IY
+0051: DD E1        pop IX
+0053: D1           pop DE
+0054: C1           pop BC
+0055: F1           pop AF
+0056: 22 00 00     db $22, lo(out), hi(out)
+0059: C9           ret
+; func main end
+
+; symbols:
+; label main = $0000
+; var idx = $1000
+; var arr = $1001
+; var out = $1011
+; label getb = $1234
+; label getw = $1240
+; label ping = $1250

--- a/test/fixtures/corpus/golden/basic_control_flow.asm
+++ b/test/fixtures/corpus/golden/basic_control_flow.asm
@@ -1,0 +1,54 @@
+; ZAX lowered .asm trace
+; range: $0000..$0031 (end exclusive)
+
+; func main begin
+main:
+0000: CA 00 00     jp cc, __zax_if_else_1
+0003: 00           nop
+0004: C3 00 00     jp __zax_if_end_2
+__zax_if_else_1:
+0007: 00           nop
+__zax_if_end_2:
+__zax_while_cond_3:
+0008: CA 00 00     jp cc, __zax_while_end_4
+000B: 00           nop
+000C: C3 00 00     jp __zax_while_cond_3
+__zax_repeat_body_5:
+__zax_while_end_4:
+000F: 00           nop
+0010: C2 00 00     jp cc, __zax_repeat_body_5
+0013: C3 00 00     jp __zax_select_dispatch_6
+__zax_case_8:
+0016: 00           nop
+0017: C3 00 00     jp __zax_select_end_7
+__zax_select_else_9:
+001A: 00           nop
+001B: C3 00 00     jp __zax_select_end_7
+__zax_select_dispatch_6:
+001E: E5           push HL
+001F: 26 00        ld H, $0000
+0021: 6F           ld L, A
+0022: 7D           ld a, l
+0023: FE 00        cp imm8
+0025: C2 00 00     jp cc, __zax_select_next_10
+0028: E1           pop HL
+0029: C3 00 00     jp __zax_case_8
+__zax_select_next_10:
+002C: E1           pop HL
+002D: C3 00 00     jp __zax_select_else_9
+__zax_select_end_7:
+0030: C9           ret
+; func main end
+
+; symbols:
+; label main = $0000
+; label __zax_if_else_1 = $0007
+; label __zax_if_end_2 = $0008
+; label __zax_while_cond_3 = $0008
+; label __zax_repeat_body_5 = $000F
+; label __zax_while_end_4 = $000F
+; label __zax_case_8 = $0016
+; label __zax_select_else_9 = $001A
+; label __zax_select_dispatch_6 = $001E
+; label __zax_select_next_10 = $002C
+; label __zax_select_end_7 = $0030

--- a/test/fixtures/corpus/golden/intermediate_indexing.asm
+++ b/test/fixtures/corpus/golden/intermediate_indexing.asm
@@ -1,0 +1,73 @@
+; ZAX lowered .asm trace
+; range: $0000..$0051 (end exclusive)
+
+; func main begin
+main:
+0000: 3A 00 00     db $3A, lo(idx), hi(idx)
+0003: 26 00        ld H, $0000
+0005: 6F           ld L, A
+0006: E5           push HL
+0007: E1           pop HL
+0008: E5           push HL
+0009: 21 00 00     db $21, lo(arr), hi(arr)
+000C: D1           pop DE
+000D: 19           add HL, DE
+000E: E5           push HL
+000F: E1           pop HL
+0010: 7E           ld r, (hl)
+0011: 2A 00 00     db $2A, lo(idxw), hi(idxw)
+0014: E5           push HL
+0015: E1           pop HL
+0016: E5           push HL
+0017: 21 00 00     db $21, lo(arr), hi(arr)
+001A: D1           pop DE
+001B: 19           add HL, DE
+001C: E5           push HL
+001D: E1           pop HL
+001E: 7E           ld r, (hl)
+001F: E5           push HL
+0020: 21 00 00     db $21, lo(arr), hi(arr)
+0023: D1           pop DE
+0024: 19           add HL, DE
+0025: E5           push HL
+0026: E1           pop HL
+0027: 7E           ld r, (hl)
+0028: 7E           ld a, (hl)
+0029: 6F           ld L, A
+002A: 26 00        ld H, $0000
+002C: E5           push HL
+002D: 21 00 00     db $21, lo(arr), hi(arr)
+0030: D1           pop DE
+0031: 19           add HL, DE
+0032: E5           push HL
+0033: E1           pop HL
+0034: 7E           ld r, (hl)
+0035: 21 00 00     ld HL, $0000
+0038: E5           push HL
+0039: 3A 00 00     db $3A, lo(idx), hi(idx)
+003C: 26 00        ld H, $0000
+003E: 6F           ld L, A
+003F: E5           push HL
+0040: E1           pop HL
+0041: 29           add HL, HL
+0042: 29           add HL, HL
+0043: E5           push HL
+0044: 21 00 00     db $21, lo(grid), hi(grid)
+0047: D1           pop DE
+0048: 19           add HL, DE
+0049: E5           push HL
+004A: E1           pop HL
+004B: D1           pop DE
+004C: 19           add HL, DE
+004D: E5           push HL
+004E: E1           pop HL
+004F: 7E           ld r, (hl)
+0050: C9           ret
+; func main end
+
+; symbols:
+; label main = $0000
+; var idx = $1000
+; var idxw = $1001
+; var arr = $1003
+; var grid = $1013

--- a/test/fixtures/corpus/intermediate_indexing.zax
+++ b/test/fixtures/corpus/intermediate_indexing.zax
@@ -1,0 +1,18 @@
+section code at $0000
+section var at $1000
+
+globals
+  idx: byte
+  idxw: word
+  arr: byte[16]
+  grid: byte[4][8]
+
+export func main(): void
+  ld a, arr[idx]
+  ld a, arr[idxw]
+  ld a, arr[hl]
+  ld a, arr[(hl)]
+  ld a, grid[idx][0]
+  ret
+end
+

--- a/test/fixtures/corpus/invalid_runtime_atom_budget.zax
+++ b/test/fixtures/corpus/invalid_runtime_atom_budget.zax
@@ -1,0 +1,13 @@
+section code at $0000
+section var at $1000
+
+globals
+  i: byte
+  j: byte
+  arr: byte[16]
+
+export func main(): void
+  ld a, arr[i + j]
+  ret
+end
+

--- a/test/pr282_tiered_golden_corpus.test.ts
+++ b/test/pr282_tiered_golden_corpus.test.ts
@@ -1,0 +1,87 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { AsmArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+type TierCase = {
+  tier: 'basic' | 'intermediate' | 'advanced';
+  entry: string;
+  golden: string;
+};
+
+const tierCases: TierCase[] = [
+  {
+    tier: 'basic',
+    entry: join(__dirname, 'fixtures', 'corpus', 'basic_control_flow.zax'),
+    golden: join(__dirname, 'fixtures', 'corpus', 'golden', 'basic_control_flow.asm'),
+  },
+  {
+    tier: 'intermediate',
+    entry: join(__dirname, 'fixtures', 'corpus', 'intermediate_indexing.zax'),
+    golden: join(__dirname, 'fixtures', 'corpus', 'golden', 'intermediate_indexing.asm'),
+  },
+  {
+    tier: 'advanced',
+    entry: join(__dirname, 'fixtures', 'corpus', 'advanced_typed_calls.zax'),
+    golden: join(__dirname, 'fixtures', 'corpus', 'golden', 'advanced_typed_calls.asm'),
+  },
+];
+
+describe('PR282: tiered golden corpus for lowering verification', () => {
+  it('matches golden .asm for each tier and stays deterministic', async () => {
+    for (const c of tierCases) {
+      const expected = await readFile(c.golden, 'utf8');
+
+      const first = await compile(
+        c.entry,
+        {
+          emitBin: false,
+          emitHex: false,
+          emitD8m: false,
+          emitListing: false,
+          emitAsm: true,
+        },
+        { formats: defaultFormatWriters },
+      );
+      expect(first.diagnostics, `${c.tier}:diagnostics`).toEqual([]);
+      const asmFirst = first.artifacts.find((a): a is AsmArtifact => a.kind === 'asm');
+      expect(asmFirst, `${c.tier}:asm-artifact`).toBeDefined();
+      expect(asmFirst!.text, `${c.tier}:golden`).toBe(expected);
+
+      const second = await compile(
+        c.entry,
+        {
+          emitBin: false,
+          emitHex: false,
+          emitD8m: false,
+          emitListing: false,
+          emitAsm: true,
+        },
+        { formats: defaultFormatWriters },
+      );
+      expect(second.diagnostics, `${c.tier}:diagnostics-2`).toEqual([]);
+      const asmSecond = second.artifacts.find((a): a is AsmArtifact => a.kind === 'asm');
+      expect(asmSecond, `${c.tier}:asm-artifact-2`).toBeDefined();
+      expect(asmSecond!.text, `${c.tier}:determinism`).toBe(asmFirst!.text);
+    }
+  });
+
+  it('includes a negative runtime-atom-budget rejection case in corpus tests', async () => {
+    const entry = join(__dirname, 'fixtures', 'corpus', 'invalid_runtime_atom_budget.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(true);
+    expect(
+      res.diagnostics.some((d) =>
+        d.message.includes('Source ea expression exceeds runtime-atom budget (max 1; found 2).'),
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Implements #262 by adding a tiered lowering verification corpus with checked-in `.asm` golden outputs, plus a negative runtime-atom-budget corpus case and extension guidance docs.

Primary issue: #262
Tracker: #265

## Scope
- [ ] Docs-only
- [x] Compiler behavior change
- [x] Tests updated

## Acceptance Criteria (from #262)
- [x] Tiered fixture set exists (basic, intermediate, advanced) with explicit intent per case.
- [x] Each fixture has expected emitted `.asm` (or normalized representation) checked in tests.
- [x] Coverage includes `if/while/repeat/select`, array indexing forms, and typed call returns.
- [x] Documentation explains how to add new corpus cases without overfitting.

## What Changed
- Added tiered fixture corpus under `test/fixtures/corpus/`:
  - `basic_control_flow.zax`
  - `intermediate_indexing.zax`
  - `advanced_typed_calls.zax`
  - negative case: `invalid_runtime_atom_budget.zax`
- Added golden `.asm` snapshots:
  - `test/fixtures/corpus/golden/basic_control_flow.asm`
  - `test/fixtures/corpus/golden/intermediate_indexing.asm`
  - `test/fixtures/corpus/golden/advanced_typed_calls.asm`
- Added harness test:
  - `test/pr282_tiered_golden_corpus.test.ts`
  - validates golden match + deterministic rerun + negative atom-budget rejection
- Added corpus maintenance doc:
  - `docs/v02-codegen-golden-corpus.md`
  - linked in `docs/README.md`

## Diagnostics Contract
- Existing diagnostics preserved.
- Negative corpus assertion verifies existing runtime-atom-budget error message.

## Validation
Commands run locally:
- `yarn -s format`
- `yarn -s typecheck`
- `yarn -s test`

Result summary:
- Pass (`226` files / `488` tests)

## Merge Risk Notes
- Golden snapshots intentionally lock current lowering output shape; future lowering refactors will require deliberate golden updates with rationale.

## Out of Scope
- Performance benchmarking.
- New language features.
