### PR TITLE
docs(v0.2,#274): finalize alias/init normative closure + evidence mapping

### DIFF
--- a/docs/v02-status-snapshot-2026-02-15.md
+++ b/docs/v02-status-snapshot-2026-02-15.md
@@ -176,12 +176,12 @@ Status key:
 
 1. Normative language closure
 
-- `[ ]` Lock alias grammar and semantics in `docs/zax-spec.md`:
+- `[x]` Lock alias grammar and semantics in `docs/zax-spec.md`:
   - alias form is `name = rhs` (inferred type)
   - explicit typed alias form `name: Type = rhs` is invalid
   - keep typed value-init as `name: Type = valueExpr`
-- `[ ]` Define scalar vs non-scalar local initializer policy with unambiguous diagnostics.
-- `[ ]` Align inferred-array policy with alias semantics where applicable.
+- `[x]` Define scalar vs non-scalar local initializer policy with unambiguous diagnostics.
+- `[x]` Align inferred-array policy with alias semantics where applicable.
 
 2. Frontend and semantics closure
 
@@ -221,6 +221,42 @@ Status key:
 - Worked examples compile and match expected lowered `.asm` trace shape.
 - Required coverage includes scalar, alias, composite-addressing, and nested index/address expressions within runtime-atom budget.
 - Reject-path diagnostics are demonstrated for out-of-budget expressions.
+
+### 10.5 Issue #274 Closure Evidence (Normative Text + Test Identification)
+
+Primary issue: [#274](https://github.com/jhlagado/ZAX/issues/274)
+
+Normative text anchors completed in this tranche:
+
+- Alias/value-init grammar and classification:
+  - `docs/zax-spec.md` Section 6.2 (`globals`)
+  - `docs/zax-spec.md` Section 8.1 (function-local `var`)
+- Invalid typed alias and local non-scalar policy:
+  - `docs/zax-spec.md` Section 6.2 rules
+  - `docs/zax-spec.md` Section 8.1 rules
+  - `docs/zax-spec.md` Section 11.3 diagnostics guidance
+
+Acceptance test identification (implemented next in [#275](https://github.com/jhlagado/ZAX/issues/275)):
+
+1. Rule: alias form `name = rhs` is valid (inferred type)
+
+- Positive test target: `test/v02_alias_init_globals_positive.test.ts`
+- Negative test target: `test/v02_typed_alias_invalid_globals_negative.test.ts`
+
+2. Rule: typed value-init `name: Type = valueExpr` is valid
+
+- Positive test target: `test/v02_value_init_globals_locals_positive.test.ts`
+- Negative test target: `test/v02_value_init_invalid_category_negative.test.ts`
+
+3. Rule: explicit typed alias `name: Type = rhs` is invalid
+
+- Positive test target: `test/v02_alias_init_locals_positive.test.ts`
+- Negative test target: `test/v02_typed_alias_invalid_locals_negative.test.ts`
+
+4. Rule: scalar vs non-scalar local initializer policy is explicit
+
+- Positive test target: `test/v02_local_scalar_init_and_alias_positive.test.ts`
+- Negative test target: `test/v02_local_nonscalar_without_alias_negative.test.ts`
 
 ### 10.4 Updated timeline (reopened v0.2)
 

--- a/docs/zax-spec.md
+++ b/docs/zax-spec.md
@@ -601,6 +601,15 @@ Initializer classification and diagnostics (normative):
 - `name = rhs` is alias initialization with inferred type.
 - `name: Type = rhs` is always rejected (typed alias form is not allowed in this scope).
 
+Examples (normative classification):
+
+```zax
+globals
+  table: byte[4] = { 1, 2, 3, 4 } ; valid value-init
+  table_ref = table                ; valid alias-init
+  bad_table: byte[4] = table       ; invalid typed alias form
+```
+
 ### 6.3 `data` (Initialized Storage)
 
 Syntax:
@@ -838,6 +847,21 @@ Function-local `var` invalid forms and rules:
 - typed alias is invalid: `name: Type = rhs`
 - non-scalar local storage declaration without alias init is invalid in this scope
 - non-scalar locals are allowed only via alias form (`name = rhs`) and allocate no frame slot
+
+Examples (normative classification):
+
+```zax
+globals
+  table: byte[4] = { 1, 2, 3, 4 }
+
+func sample(): void
+  var
+    a: word = 0             ; valid scalar value-init
+    b = table               ; valid alias-init
+    bad: byte[4] = table    ; invalid typed alias form
+  end
+end
+```
 
 Function-body block termination (v0.1):
 
@@ -1365,6 +1389,8 @@ next_char
 - Compilers must emit an error when index expressions use unsupported forms for v0.2 grammar/semantics.
 - Compilers should emit diagnostics that distinguish typed-call boundary guarantees from raw Z80 `call` behavior.
 - Compilers may emit warnings when composite storage padding materially increases natural packed size.
+- Compilers must emit an error for typed alias forms (`name: Type = rhs`) in both `globals` and function-local `var`.
+- Compilers must emit an error for non-scalar local storage declarations without alias initialization.
 
 ## 12. Examples (Non-normative)
 


### PR DESCRIPTION
## Primary Issue
Closes #274

## Scope
Single-primary-issue PR for `#274` only (normative closure docs/evidence). No parser/lowering implementation changes (`#275/#276` remain blocked).

## Touched Normative/Support Sections
- `docs/zax-spec.md`
  - Section 6.2 (`globals`) initializer/alias classification examples
  - Section 8.1 (function-local `var`) valid/invalid form examples
  - Section 11.3 diagnostics guidance for typed alias and local non-scalar rejection
- `docs/v02-status-snapshot-2026-02-15.md`
  - Section 10.2 normative closure checklist updated for #274-completed doc closure items
  - New Section 10.5 mapping `#274` acceptance to explicit test identifiers (implemented next in #275)

## Acceptance Criteria Mapping (#274)
- [x] Spec explicitly states alias form is `name = rhs` with inferred type.
- [x] Spec explicitly states typed value-init remains `name: Type = valueExpr`.
- [x] Spec explicitly states explicit typed alias form is invalid.
- [x] Scalar vs non-scalar local initializer policy is explicit with valid/invalid examples.
- [x] At least one positive + one negative test case per rule is identified and linked (recorded in snapshot Section 10.5; implementation vehicle linked to #275).

## Diagnostics Contract
No new diagnostic IDs added in this PR. Normative guidance now explicitly requires diagnostics for:
- typed alias form rejection (`name: Type = rhs`)
- local non-scalar storage declaration without alias initialization

## Validation (scope-relevant only)
- `yarn -s prettier -c docs/v02-status-snapshot-2026-02-15.md docs/zax-spec.md`

## Notes
This PR intentionally does not begin blocked implementation work. Parser/AST/semantic enforcement for these rules is left to `#275` per backlog order.
