### PR TITLE
[v0.2] Close #275 parser/AST alias-init vs value-init

### DIFF
--- a/docs/v02-status-snapshot-2026-02-15.md
+++ b/docs/v02-status-snapshot-2026-02-15.md
@@ -185,9 +185,9 @@ Status key:
 
 2. Frontend and semantics closure
 
-- `[ ]` AST update plan documented and implemented for var/global initializer split (value-init vs alias-init).
-- `[ ]` Parser grammar matrices updated for `globals` and function-local `var`.
-- `[ ]` Semantics/type-compatibility rules documented for alias binding compatibility and inference.
+- `[x]` AST update plan documented and implemented for var/global initializer split (value-init vs alias-init).
+- `[x]` Parser grammar matrices updated for `globals` and function-local `var`.
+- `[x]` Semantics/type-compatibility rules documented for alias binding compatibility and inference.
 
 3. Codegen and lowering closure
 
@@ -236,27 +236,27 @@ Normative text anchors completed in this tranche:
   - `docs/zax-spec.md` Section 8.1 rules
   - `docs/zax-spec.md` Section 11.3 diagnostics guidance
 
-Acceptance test identification (implemented next in [#275](https://github.com/jhlagado/ZAX/issues/275)):
+Acceptance test identification (implemented in [#275](https://github.com/jhlagado/ZAX/issues/275)):
 
 1. Rule: alias form `name = rhs` is valid (inferred type)
 
-- Positive test target: `test/v02_alias_init_globals_positive.test.ts`
-- Negative test target: `test/v02_typed_alias_invalid_globals_negative.test.ts`
+- Positive test target: `test/pr285_alias_init_parser_semantics_matrix.test.ts` (`accepts globals/local value-init and inferred alias-init forms`)
+- Negative test target: `test/pr285_alias_init_parser_semantics_matrix.test.ts` (`rejects typed alias form in globals and function-local var blocks`)
 
 2. Rule: typed value-init `name: Type = valueExpr` is valid
 
-- Positive test target: `test/v02_value_init_globals_locals_positive.test.ts`
-- Negative test target: `test/v02_value_init_invalid_category_negative.test.ts`
+- Positive test target: `test/pr285_alias_init_parser_semantics_matrix.test.ts` (`accepts globals/local value-init and inferred alias-init forms`)
+- Negative test target: `test/pr285_alias_init_parser_semantics_matrix.test.ts` (`rejects inferred alias declarations when rhs is not an address expression`)
 
 3. Rule: explicit typed alias `name: Type = rhs` is invalid
 
-- Positive test target: `test/v02_alias_init_locals_positive.test.ts`
-- Negative test target: `test/v02_typed_alias_invalid_locals_negative.test.ts`
+- Positive test target: `test/pr285_alias_init_parser_semantics_matrix.test.ts` (`accepts globals/local value-init and inferred alias-init forms`)
+- Negative test target: `test/pr285_alias_init_parser_semantics_matrix.test.ts` (`rejects typed alias form in globals and function-local var blocks`)
 
 4. Rule: scalar vs non-scalar local initializer policy is explicit
 
-- Positive test target: `test/v02_local_scalar_init_and_alias_positive.test.ts`
-- Negative test target: `test/v02_local_nonscalar_without_alias_negative.test.ts`
+- Positive test target: `test/pr285_alias_init_parser_semantics_matrix.test.ts` (`accepts globals/local value-init and inferred alias-init forms`)
+- Negative test target: `test/pr285_alias_init_parser_semantics_matrix.test.ts` (`rejects non-scalar local storage declarations without alias form`)
 
 ### 10.4 Updated timeline (reopened v0.2)
 

--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -157,8 +157,13 @@ export interface VarBlockNode extends BaseNode {
 export interface VarDeclNode extends BaseNode {
   kind: 'VarDecl';
   name: string;
-  typeExpr: TypeExprNode;
+  typeExpr?: TypeExprNode;
+  initializer?: VarDeclInitializerNode;
 }
+
+export type VarDeclInitializerNode =
+  | { kind: 'VarInitValue'; span: SourceSpan; expr: ImmExprNode }
+  | { kind: 'VarInitAlias'; span: SourceSpan; expr: EaExprNode };
 
 /**
  * Data storage block (`data`) with initializers.
@@ -437,4 +442,5 @@ export type Node =
   | OffsetofPathNode
   | OffsetofPathStepNode
   | DataInitializerNode
+  | VarDeclInitializerNode
   | OpMatcherNode;

--- a/test/fixtures/pr285_alias_init_globals_locals_positive.zax
+++ b/test/fixtures/pr285_alias_init_globals_locals_positive.zax
@@ -1,0 +1,18 @@
+section code at $0000
+section var at $1000
+
+globals
+  base: word
+  count: word = 7
+  global_ref = base
+
+export func main(): void
+  var
+    tmp: word = 1
+    local_ref = global_ref
+  end
+  ld hl, local_ref
+  ld (base), hl
+  ld hl, global_ref
+  ret
+end

--- a/test/fixtures/pr285_incompatible_inferred_alias_matrix.zax
+++ b/test/fixtures/pr285_incompatible_inferred_alias_matrix.zax
@@ -1,0 +1,10 @@
+globals
+  base: word
+  bad_global = 1
+
+func main(): void
+  var
+    bad_local = 2 + 3
+  end
+  ret
+end

--- a/test/fixtures/pr285_local_nonscalar_without_alias_negative.zax
+++ b/test/fixtures/pr285_local_nonscalar_without_alias_negative.zax
@@ -1,0 +1,10 @@
+globals
+  arr: byte[4]
+
+func main(): void
+  var
+    local_arr: byte[4]
+  end
+  ld a, arr[0]
+  ret
+end

--- a/test/fixtures/pr285_typed_alias_invalid_matrix.zax
+++ b/test/fixtures/pr285_typed_alias_invalid_matrix.zax
@@ -1,0 +1,10 @@
+globals
+  base: word
+  bad_global: word = base
+
+func main(): void
+  var
+    bad_local: word = base
+  end
+  ret
+end

--- a/test/pr285_alias_init_parser_semantics_matrix.test.ts
+++ b/test/pr285_alias_init_parser_semantics_matrix.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR285 parser/AST closure: alias-init vs value-init', () => {
+  it('accepts globals/local value-init and inferred alias-init forms', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr285_alias_init_globals_locals_positive.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    const errors = res.diagnostics.filter((d) => d.severity === 'error');
+    expect(errors).toEqual([]);
+  });
+
+  it('rejects typed alias form in globals and function-local var blocks', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr285_typed_alias_invalid_matrix.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(messages).toContain(
+      'Unsupported typed alias form for "bad_global": use "bad_global = base" for alias initialization.',
+    );
+    expect(messages).toContain(
+      'Unsupported typed alias form for "bad_local": use "bad_local = base" for alias initialization.',
+    );
+  });
+
+  it('rejects inferred alias declarations when rhs is not an address expression', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr285_incompatible_inferred_alias_matrix.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(messages).toContain(
+      'Incompatible inferred alias binding for "bad_global": expected address expression on right-hand side.',
+    );
+    expect(messages).toContain(
+      'Incompatible inferred alias binding for "bad_local": expected address expression on right-hand side.',
+    );
+  });
+
+  it('rejects non-scalar local storage declarations without alias form', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr285_local_nonscalar_without_alias_negative.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(messages).toContain(
+      'Non-scalar local storage declaration "local_arr" requires alias form ("local_arr = rhs").',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Implements v0.2 issue #275 by closing parser/AST semantics for `globals` and function-local `var` declaration split between:
- typed storage/value-init: `name: Type` and `name: Type = valueExpr`
- inferred alias-init: `name = rhs`

Primary issue: Closes #275

## Scope
- Parser/AST
- Diagnostics
- Semantics/type-compatibility checks (alias inference + local non-scalar rule)
- Tests
- Docs evidence updates

## Spec/Docs Anchors
- `docs/zax-spec.md` Section 6.2 (`globals` forms and typed-alias rejection)
- `docs/zax-spec.md` Section 8.1 (function-local `var` forms and non-scalar local rule)
- `docs/zax-spec.md` Section 11.3 (diagnostics expectations)
- `docs/v02-status-snapshot-2026-02-15.md` Section 10.2 and 10.5 (gate + evidence mapping)

## Acceptance Checklist Mapping (#275)
- [x] AST can represent value-init and alias-init distinctly.
  - `src/frontend/ast.ts`: `VarDeclNode.typeExpr?` + `VarDeclInitializerNode` (`VarInitValue` / `VarInitAlias`).
- [x] Parser accepts valid alias/value-init grammar and rejects invalid forms.
  - `src/frontend/parser.ts`: unified `parseVarDeclLine` for globals/local var.
  - Rejected with stable diagnostics:
    - typed alias form `name: Type = rhs`
    - non-address rhs in inferred alias `name = rhs`
- [x] Semantic/type-compatibility checks enforce inferred alias behavior.
  - `src/lowering/emit.ts`:
    - module/local alias target maps
    - inferred alias type resolution across alias chains
    - diagnostics for non-inferable alias bindings
    - non-scalar local typed storage rejection unless alias form
- [x] Tests cover globals and local-var forms, including negative cases.
  - `test/pr285_alias_init_parser_semantics_matrix.test.ts`
  - Fixtures:
    - `test/fixtures/pr285_alias_init_globals_locals_positive.zax`
    - `test/fixtures/pr285_typed_alias_invalid_matrix.zax`
    - `test/fixtures/pr285_incompatible_inferred_alias_matrix.zax`
    - `test/fixtures/pr285_local_nonscalar_without_alias_negative.zax`
- [x] Docs updated with grammar matrices/examples matching behavior.
  - `docs/v02-status-snapshot-2026-02-15.md` updated gate state + concrete test mapping.

## Validation
Ran locally before push:
- `yarn -s format:check`
- `yarn -s typecheck`
- `yarn -s test`

All passed.
