### PR TITLE
[v0.2] Implement #276 non-scalar call compatibility semantics

### DIFF
--- a/docs/v02-codegen-worked-examples.md
+++ b/docs/v02-codegen-worked-examples.md
@@ -518,6 +518,14 @@ Lowering note:
 - Call lowering still pushes one 16-bit argument slot for non-scalar args.
 - The non-scalar "by-reference" meaning is semantic/type-level, not a different stack width.
 
+Implementation evidence:
+
+- `test/pr286_nonscalar_param_compat_matrix.test.ts` covers:
+  - `T[N] -> T[]` acceptance
+  - exact `T[N] -> T[N]` acceptance
+  - `T[] -> T[N]` rejection without exact-length proof
+  - element-type mismatch rejection (`byte[]` vs `word[]`)
+
 ## 12. Codegen Acceptance Matrix (Must-Complete for v0.2)
 
 Each row requires:

--- a/docs/v02-status-snapshot-2026-02-15.md
+++ b/docs/v02-status-snapshot-2026-02-15.md
@@ -258,6 +258,28 @@ Acceptance test identification (implemented in [#275](https://github.com/jhlagad
 - Positive test target: `test/pr285_alias_init_parser_semantics_matrix.test.ts` (`accepts globals/local value-init and inferred alias-init forms`)
 - Negative test target: `test/pr285_alias_init_parser_semantics_matrix.test.ts` (`rejects non-scalar local storage declarations without alias form`)
 
+### 10.6 Issue #276 Progress Evidence (Non-Scalar Call Compatibility)
+
+Primary issue: [#276](https://github.com/jhlagado/ZAX/issues/276)
+
+Spec/example anchors exercised by implementation/tests:
+
+- `docs/zax-spec.md` Section 8.2 (non-scalar argument contract)
+- `docs/v02-codegen-worked-examples.md` Section 11.3 (`[]` vs `[N]` compatibility)
+
+Implemented compatibility checks:
+
+- `T[N] -> T[]` accepted
+- exact `T[N] -> T[N]` accepted
+- `T[] -> T[N]` rejected without exact-length proof
+- element-type mismatch rejected
+
+Acceptance tests:
+
+- `test/pr286_nonscalar_param_compat_matrix.test.ts`
+  - positive fixture: `test/fixtures/pr286_nonscalar_param_compat_positive.zax`
+  - negative fixture: `test/fixtures/pr286_nonscalar_param_compat_negative.zax`
+
 ### 10.4 Updated timeline (reopened v0.2)
 
 Phase A: normative closure (doc-first)

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -1215,16 +1215,9 @@ function parseParamsFromText(
     seen.add(lower);
     const typeText = m[2]!.trim();
     const typeExpr = parseTypeExprFromText(typeText, paramsSpan, {
-      allowInferredArrayLength: false,
+      allowInferredArrayLength: true,
     });
     if (!typeExpr) {
-      if (
-        diagIfInferredArrayLengthNotAllowed(diagnostics, filePath, typeText, {
-          line: paramsSpan.start.line,
-          column: paramsSpan.start.column,
-        })
-      )
-        return undefined;
       diag(diagnostics, filePath, `Invalid parameter type "${typeText}": expected <type>`, {
         line: paramsSpan.start.line,
         column: paramsSpan.start.column,

--- a/test/fixtures/pr286_nonscalar_param_compat_negative.zax
+++ b/test/fixtures/pr286_nonscalar_param_compat_negative.zax
@@ -1,0 +1,23 @@
+section code at $0000
+section var at $1000
+
+globals
+  bytes10: byte[10]
+  words10: word[10]
+
+data
+  unknown_len: byte[] = [1, 2, 3]
+
+func take_ten(values: byte[10]): void
+  ret
+end
+
+func take_any(values: byte[]): void
+  ret
+end
+
+export func main(): void
+  take_ten unknown_len
+  take_any words10
+  ret
+end

--- a/test/fixtures/pr286_nonscalar_param_compat_positive.zax
+++ b/test/fixtures/pr286_nonscalar_param_compat_positive.zax
@@ -1,0 +1,28 @@
+section code at $0000
+section var at $1000
+
+globals
+  bytes10: byte[10]
+
+func take_any(values: byte[]): void
+  ret
+end
+
+func take_ten(values: byte[10]): void
+  ret
+end
+
+func relay_alias(): void
+  var
+    alias = bytes10
+  end
+  take_any alias
+  ret
+end
+
+export func main(): void
+  take_any bytes10
+  take_ten bytes10
+  relay_alias
+  ret
+end

--- a/test/pr286_nonscalar_param_compat_matrix.test.ts
+++ b/test/pr286_nonscalar_param_compat_matrix.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR286: non-scalar typed-call parameter compatibility', () => {
+  it('accepts T[N] -> T[] and exact T[N] -> T[N] non-scalar arguments', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr286_nonscalar_param_compat_positive.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+  });
+
+  it('rejects T[] -> T[N] without proof and rejects element-type mismatches', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr286_nonscalar_param_compat_negative.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(messages).toContain(
+      'Incompatible non-scalar argument for parameter "values": expected byte[10], got byte[] (exact length proof required).',
+    );
+    expect(messages).toContain(
+      'Incompatible non-scalar argument for parameter "values": expected element type byte, got word.',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Implements issue #276 non-scalar call compatibility semantics in typed calls, with parser support for `T[]` parameters and compatibility diagnostics for `[]` vs `[N]` rules.

Closes #276

## Scope
- Parser/AST
- Lowering/Codegen
- Diagnostics
- Tests
- Docs evidence

## Spec/Docs Anchors
- `docs/zax-spec.md` Section 8.2 (non-scalar argument contract)
- `docs/v02-codegen-worked-examples.md` Section 11.3 (`[]` vs `[N]` policy)
- `docs/v02-status-snapshot-2026-02-15.md` Section 10.6 (#276 progress evidence)

## Acceptance Checklist Mapping (#276)
- [x] Spec/examples define non-scalar alias behavior for globals, args, and locals.
  - Anchors retained + implementation evidence added in `docs/v02-codegen-worked-examples.md`.
- [x] Array argument compatibility policy (`[]` vs `[N]`) is explicit and tested.
  - `src/lowering/emit.ts` adds compatibility checks:
    - `T[N] -> T[]` allowed
    - exact `T[N] -> T[N]` allowed
    - `T[] -> T[N]` rejected without proof
    - element-type mismatch rejected
- [x] Worked examples include non-scalar alias use and expected lowering shape.
  - `test/fixtures/pr286_nonscalar_param_compat_positive.zax` includes local alias and typed calls.
- [x] Golden/example checks validate behavior under runtime-atom budget rules.
  - Existing call-site runtime-atom enforcement remains active; this change integrates non-scalar compatibility without relaxing those checks.

## Key Changes
- `src/frontend/parser.ts`
  - Function/extern parameter parser now accepts `T[]` in parameter position.
- `src/lowering/emit.ts`
  - Removed scalar-only parameter rejection.
  - Added non-scalar parameter compatibility checks with stable diagnostics.
  - Added non-scalar argument address push path for typed calls.
- `test/pr286_nonscalar_param_compat_matrix.test.ts`
  - Positive and negative compatibility matrix coverage.
- Docs updates:
  - `docs/v02-codegen-worked-examples.md`
  - `docs/v02-status-snapshot-2026-02-15.md`

## Validation
Ran locally before push:
- `yarn -s format:check`
- `yarn -s typecheck`
- `yarn -s test`

All passed.
