### PR TITLE
[v0.2] #263 hidden-lowering risk matrix evidence hardening

### DIFF
--- a/docs/v02-codegen-verification.md
+++ b/docs/v02-codegen-verification.md
@@ -198,6 +198,21 @@ Anti-overfitting rules:
 | Local/arg/global access in framed functions      | Lowering preserves stack/frame safety while materializing local/arg/global accesses         | `test/pr283_hidden_lowering_risk_matrix.test.ts` (`pr283_local_arg_global_access_matrix.zax`) | `test/pr14_frame_epilogue.test.ts` (untracked SP slot access error case)  |
 | Structured-control + hidden lowering joins       | Unknown/untracked states propagate correctly to ret/fallthrough diagnostics                 | `test/pr221_lowering_op_expansion_retcc_interactions.test.ts`                                 | `test/pr198_lowering_unknown_stack_states.test.ts`                        |
 
+### 6.1 Diagnostics Contract Evidence (Issue #263)
+
+The diagnostics contract tied to hidden-lowering rows is anchored by focused tests that assert stable IDs and category-specific wording where required:
+
+- `test/pr283_hidden_lowering_risk_matrix.test.ts`
+  - `DiagnosticIds.OpStackPolicyRisk` for op-stack-policy escalation (`opStackPolicy: error`)
+  - `DiagnosticIds.RawCallTypedTargetWarning` for raw-to-typed warning path
+  - `DiagnosticIds.EmitError` for stack-delta-at-fallthrough and typed/raw boundary-contract guardrail paths
+- `test/pr275_typed_vs_raw_call_boundary_diagnostics.test.ts`
+  - distinct typed-call vs raw-call boundary diagnostics remain present as separate message forms
+- `test/pr278_raw_call_typed_target_warning.test.ts`
+  - warning-mode toggle behavior and stable warning diagnostic ID
+
+If wording or ID changes are intentional, the owning PR must update this section and the corresponding focused tests in the same change.
+
 ## 7. Completion Gate Before v0.3
 
 All `NORMATIVE-MUST` workstreams (WS1 through WS5) must be complete and linked to passing evidence before declaring v0.2 codegen verification complete.

--- a/docs/v02-status-snapshot-2026-02-15.md
+++ b/docs/v02-status-snapshot-2026-02-15.md
@@ -280,6 +280,35 @@ Acceptance tests:
   - positive fixture: `test/fixtures/pr286_nonscalar_param_compat_positive.zax`
   - negative fixture: `test/fixtures/pr286_nonscalar_param_compat_negative.zax`
 
+### 10.7 Issue #263 Closure Evidence (Hidden-Lowering Risk Matrix)
+
+Primary issue: [#263](https://github.com/jhlagado/ZAX/issues/263)
+
+Normative anchor:
+
+- `docs/zax-spec.md` (hidden lowering responsibilities, call-boundary contract, diagnostics stability expectations)
+
+Verification/evidence anchors:
+
+- `docs/v02-codegen-verification.md` Section 6 (risk matrix rows and focused row-to-test mappings)
+- `docs/v02-codegen-verification.md` Section 6.1 (diagnostics-contract evidence for IDs/message families)
+
+Focused acceptance tests:
+
+- `test/pr283_hidden_lowering_risk_matrix.test.ts`
+  - positive matrix coverage for op expansion attribution, typed-call preservation wrappers, and local/arg/global frame access
+  - negative guardrails for op-stack-policy escalation and non-zero fallthrough stack delta
+- `test/pr14_frame_epilogue.test.ts`
+  - function prologue/epilogue rewrite behavior and untracked-SP slot-access guardrail
+- `test/pr275_typed_vs_raw_call_boundary_diagnostics.test.ts`
+  - typed-call vs raw-call diagnostic separation remains stable
+
+Closeout result for #263:
+
+- hidden-lowering matrix categories are explicitly documented
+- each matrix row is linked to at least one focused positive and one guardrail/negative test
+- matrix/evidence links are now present in active v0.2 closeout planning docs
+
 ### 10.4 Updated timeline (reopened v0.2)
 
 Phase A: normative closure (doc-first)


### PR DESCRIPTION
## Primary issue
- Closes #263

## Scope
- Tighten hidden-lowering risk-matrix evidence and diagnostics-contract assertions
- Keep scope to one active issue only (#263)

## Touched spec/docs sections
- `docs/v02-codegen-verification.md` Section 6 (matrix)
- `docs/v02-codegen-verification.md` Section 6.1 (new diagnostics-contract evidence)
- `docs/v02-status-snapshot-2026-02-15.md` Section 10.7 (new #263 closure evidence)
- Normative authority unchanged: `docs/zax-spec.md`

## Acceptance checklist evidence (#263)
- [x] Risk matrix document lists each hidden-lowering category and expected invariants
  - Evidence: `docs/v02-codegen-verification.md` Section 6
- [x] Tests cover op expansion stack/register discipline interactions at call sites
  - Evidence: `test/pr283_hidden_lowering_risk_matrix.test.ts` (op stack-policy escalation assertions by ID/severity)
- [x] Tests cover function prologue/epilogue behavior for local/arg/global access patterns
  - Evidence: `test/pr283_hidden_lowering_risk_matrix.test.ts` (frame access fixture assertions), `test/pr14_frame_epilogue.test.ts`
- [x] Matrix is linked from active v0.2 closeout planning docs
  - Evidence: `docs/v02-status-snapshot-2026-02-15.md` Section 10.7 links to `docs/v02-codegen-verification.md` Sections 6 and 6.1

## Diagnostics contract evidence
- Added ID-level assertions for hidden-lowering guardrails:
  - `DiagnosticIds.OpStackPolicyRisk`
  - `DiagnosticIds.RawCallTypedTargetWarning`
  - `DiagnosticIds.EmitError` for typed/raw boundary-contract and fallthrough stack-delta guards
- Added explicit diagnostics-contract section documenting update requirements when wording/IDs intentionally change

## Validation (scope-relevant)
- `yarn -s format:check`
- `yarn -s typecheck`
- `yarn -s vitest run test/pr283_hidden_lowering_risk_matrix.test.ts test/pr14_frame_epilogue.test.ts test/pr275_typed_vs_raw_call_boundary_diagnostics.test.ts`
