### PR TITLE
[v0.2] #277 harden docs-only CI short-circuit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,33 +18,30 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            docs:
-              - 'docs/**'
-              - '**/*.md'
-              - '.github/ISSUE_TEMPLATE/**'
-            other:
-              - '**'
-              - '!docs/**'
-              - '!**/*.md'
-              - '!.github/ISSUE_TEMPLATE/**'
+      - name: Collect changed files
+        id: changed_files
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+            head_sha="${{ github.event.pull_request.head.sha }}"
+            git diff --name-only "$base_sha" "$head_sha" > changed_files.txt
+          else
+            before_sha="${{ github.event.before }}"
+            head_sha="${{ github.sha }}"
+            if [[ "$before_sha" == "0000000000000000000000000000000000000000" ]]; then
+              git ls-files > changed_files.txt
+            else
+              git diff --name-only "$before_sha" "$head_sha" > changed_files.txt
+            fi
+          fi
+          echo "changed_count=$(wc -l < changed_files.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
 
       - name: Classify change set
         id: classify
         shell: bash
         run: |
-          if [[ "${{ steps.filter.outputs.docs }}" == "true" && "${{ steps.filter.outputs.other }}" != "true" ]]; then
-            echo "docs_only=true" >> "$GITHUB_OUTPUT"
-            echo "run_full=false" >> "$GITHUB_OUTPUT"
-            echo "Change set classified as docs-only."
-          else
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            echo "run_full=true" >> "$GITHUB_OUTPUT"
-            echo "Change set classified as full CI."
-          fi
+          node ./scripts/ci/change-classifier.js < changed_files.txt
 
   docs:
     name: docs (fast)

--- a/docs/github-backlog-workflow.md
+++ b/docs/github-backlog-workflow.md
@@ -77,6 +77,20 @@ Issue close rule:
 
 - close only after merged PR evidence satisfies all acceptance checklist items.
 
+## CI Change Classification Rule
+
+Docs-only PRs are short-circuited in CI and must satisfy this path rule:
+
+- docs-only set: all changed files are in `docs/**`, match `*.md`, or are under `.github/ISSUE_TEMPLATE/**`
+- docs-only result: run `docs (fast)` only, skip full `test (ubuntu/macos/windows)` matrix
+- any non-doc path in the change set: run full matrix
+
+Implementation anchors:
+
+- workflow: `.github/workflows/ci.yml` (`detect-changes` job)
+- classifier script: `scripts/ci/change-classifier.js`
+- classifier tests: `test/pr288_ci_docs_only_classifier.test.ts`
+
 ## Dependency Handling Without Project Views
 
 If GitHub Project access is unavailable (token scope limits), use:

--- a/docs/v02-status-snapshot-2026-02-15.md
+++ b/docs/v02-status-snapshot-2026-02-15.md
@@ -336,6 +336,26 @@ Policy evidence:
 - required CI path: default `test` matrix includes `test/pr287_opcode_verification_workflow.test.ts`
 - optional/non-blocking external cross-check remains in `#266` only
 
+### 10.9 Issue #277 Closure Evidence (Docs-Only CI Short-Circuit Hardening)
+
+Primary issue: [#277](https://github.com/jhlagado/ZAX/issues/277)
+
+Implementation anchors:
+
+- workflow: `.github/workflows/ci.yml` (`detect-changes` job now classifies file sets via script)
+- classifier: `scripts/ci/change-classifier.js`
+- verification tests: `test/pr288_ci_docs_only_classifier.test.ts`
+
+Documented rule anchor:
+
+- `docs/github-backlog-workflow.md` section "CI Change Classification Rule"
+
+Acceptance coverage:
+
+- docs-only sets (`docs/**`, `*.md`, `.github/ISSUE_TEMPLATE/**`) classify to `docs_only=true`, `run_full=false`
+- non-doc and mixed sets classify to `docs_only=false`, `run_full=true`
+- workflow edits are non-doc changes and continue to run full CI
+
 ### 10.4 Updated timeline (reopened v0.2)
 
 Phase A: normative closure (doc-first)

--- a/scripts/ci/change-classifier.d.ts
+++ b/scripts/ci/change-classifier.d.ts
@@ -1,0 +1,9 @@
+export interface ChangeClassification {
+  docsOnly: boolean;
+  runFull: boolean;
+  docsPaths: string[];
+  nonDocPaths: string[];
+}
+
+export function isDocsOnlyPath(path: string): boolean;
+export function classifyChangedPaths(paths: string[]): ChangeClassification;

--- a/scripts/ci/change-classifier.js
+++ b/scripts/ci/change-classifier.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+import { stdin as input, env } from 'node:process';
+import { createInterface } from 'node:readline';
+import { appendFileSync } from 'node:fs';
+
+const DOCS_ONLY_PATH_PATTERNS = [/^docs\//, /\.md$/i, /^\.github\/ISSUE_TEMPLATE\//];
+
+export function isDocsOnlyPath(path) {
+  return DOCS_ONLY_PATH_PATTERNS.some((pattern) => pattern.test(path));
+}
+
+export function classifyChangedPaths(paths) {
+  const cleaned = paths.map((p) => p.trim()).filter((p) => p.length > 0);
+  const docsOnly = cleaned.length > 0 && cleaned.every((p) => isDocsOnlyPath(p));
+  return {
+    docsOnly,
+    runFull: !docsOnly,
+    docsPaths: cleaned.filter((p) => isDocsOnlyPath(p)),
+    nonDocPaths: cleaned.filter((p) => !isDocsOnlyPath(p)),
+  };
+}
+
+async function readPathsFromStdin() {
+  const rl = createInterface({ input, crlfDelay: Infinity });
+  const values = [];
+  for await (const line of rl) {
+    values.push(line);
+  }
+  return values;
+}
+
+function writeGithubOutputs({ docsOnly, runFull }) {
+  const outputFile = env.GITHUB_OUTPUT;
+  if (!outputFile) return;
+  appendFileSync(outputFile, `docs_only=${docsOnly}\n`, 'utf8');
+  appendFileSync(outputFile, `run_full=${runFull}\n`, 'utf8');
+}
+
+async function main() {
+  const paths = await readPathsFromStdin();
+  const result = classifyChangedPaths(paths);
+  writeGithubOutputs(result);
+
+  const summary = [
+    `changed=${result.docsPaths.length + result.nonDocPaths.length}`,
+    `docs_only=${result.docsOnly}`,
+    `run_full=${result.runFull}`,
+  ].join(' ');
+  console.log(`[ci-change-classifier] ${summary}`);
+}
+
+const isExecutedAsScript = import.meta.url === `file://${process.argv[1]}`;
+if (isExecutedAsScript) {
+  await main();
+}

--- a/test/pr288_ci_docs_only_classifier.test.ts
+++ b/test/pr288_ci_docs_only_classifier.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyChangedPaths, isDocsOnlyPath } from '../scripts/ci/change-classifier.js';
+
+describe('PR288: CI docs-only short-circuit classifier', () => {
+  it('classifies docs-only sets for docs, markdown, and issue-template updates', () => {
+    const result = classifyChangedPaths([
+      'docs/v02-codegen-verification.md',
+      'README.md',
+      '.github/ISSUE_TEMPLATE/v02-change-task.yml',
+    ]);
+
+    expect(result.docsOnly).toBe(true);
+    expect(result.runFull).toBe(false);
+    expect(result.nonDocPaths).toEqual([]);
+  });
+
+  it('classifies source changes as full CI', () => {
+    const result = classifyChangedPaths(['src/lowering/emit.ts']);
+
+    expect(result.docsOnly).toBe(false);
+    expect(result.runFull).toBe(true);
+    expect(result.nonDocPaths).toEqual(['src/lowering/emit.ts']);
+  });
+
+  it('classifies mixed docs + source sets as full CI', () => {
+    const result = classifyChangedPaths([
+      'docs/v02-codegen-verification.md',
+      'test/pr1_minimal.test.ts',
+    ]);
+
+    expect(result.docsOnly).toBe(false);
+    expect(result.runFull).toBe(true);
+    expect(result.nonDocPaths).toEqual(['test/pr1_minimal.test.ts']);
+  });
+
+  it('treats workflow edits as non-doc changes', () => {
+    expect(isDocsOnlyPath('.github/workflows/ci.yml')).toBe(false);
+    const result = classifyChangedPaths(['.github/workflows/ci.yml']);
+    expect(result.docsOnly).toBe(false);
+    expect(result.runFull).toBe(true);
+  });
+
+  it('defaults empty change sets to full CI safety mode', () => {
+    const result = classifyChangedPaths([]);
+    expect(result.docsOnly).toBe(false);
+    expect(result.runFull).toBe(true);
+  });
+});


### PR DESCRIPTION
## Primary issue
- Closes #277

## Scope
- Harden docs-only CI change classification and short-circuit behavior
- Keep single-primary-issue scope (#277)

## Touched spec/docs sections
- `.github/workflows/ci.yml` (`detect-changes` job)
- `docs/github-backlog-workflow.md` section `CI Change Classification Rule`
- `docs/v02-status-snapshot-2026-02-15.md` Section 10.9 closure evidence

## Acceptance checklist evidence (#277)
- [x] Docs-only PRs (only `docs/**`, `*.md`, and issue template updates) run `docs (fast)` only
  - Evidence: `scripts/ci/change-classifier.js` emits `docs_only=true` / `run_full=false` only when all changed paths match docs-only set
- [x] Full matrix (`test (ubuntu/macos/windows)`) is skipped for docs-only PRs
  - Evidence: `.github/workflows/ci.yml` gates `test` job on `needs.changes.outputs.run_full == 'true'`; docs-only classification sets `run_full=false`
- [x] Non-doc changes continue to run full CI
  - Evidence: classifier returns `run_full=true` when any path is non-doc
- [x] Rule is documented in contributor/process docs
  - Evidence: `docs/github-backlog-workflow.md` section `CI Change Classification Rule`

## Tests/evidence
- Added: `test/pr288_ci_docs_only_classifier.test.ts`
  - docs-only set => docs_only true / run_full false
  - source-only => run_full true
  - mixed docs+source => run_full true
  - workflow file update => run_full true
  - empty set safety mode => run_full true

## Validation (scope-relevant)
- `printf 'docs/v02-codegen-verification.md\nREADME.md\n' | node ./scripts/ci/change-classifier.js`
- `yarn -s format:check`
- `yarn -s typecheck`
- `yarn -s vitest run test/pr288_ci_docs_only_classifier.test.ts`
