### PR TITLE
[v0.3] #289 place-expression field/element context semantics

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -1052,7 +1052,7 @@ export function emitProgram(
         return v !== undefined && fitsImm16(v);
       }
       case 'MatcherEa':
-        return operand.kind === 'Ea' || operand.kind === 'Mem';
+        return operand.kind === 'Ea';
       case 'MatcherMem8': {
         if (operand.kind !== 'Mem') return false;
         const width = inferMemWidth(operand);
@@ -1347,7 +1347,7 @@ export function emitProgram(
         return `expects imm16, got ${got}`;
       }
       case 'MatcherEa':
-        return `expects ea or (ea), got ${got}`;
+        return `expects ea, got ${got}`;
       case 'MatcherMem8': {
         if (operand.kind !== 'Mem') return `expects mem8 dereference, got ${got}`;
         const width = inferMemWidth(operand);

--- a/test/fixtures/pr289_place_expression_contexts_negative.zax
+++ b/test/fixtures/pr289_place_expression_contexts_negative.zax
@@ -1,0 +1,22 @@
+section code at $0000
+section var at $1000
+
+type Pair
+  lo: byte
+  hi: byte
+end
+
+globals
+  p: Pair = 0
+  idx: byte = 0
+  arr: byte[8]
+
+op readAddr(addr: ea)
+  ld a, (addr)
+end
+
+export func main(): void
+  readAddr (p.lo)
+  readAddr (arr[idx])
+  ret
+end

--- a/test/fixtures/pr289_place_expression_contexts_positive.zax
+++ b/test/fixtures/pr289_place_expression_contexts_positive.zax
@@ -1,0 +1,32 @@
+section code at $0000
+section var at $1000
+
+type Pair
+  lo: byte
+  hi: byte
+end
+
+globals
+  p: Pair = 0
+  idx: byte = 0
+  arr: byte[8]
+
+op readAddr(addr: ea)
+  ld a, (addr)
+end
+
+export func main(): void
+  ld a, p.lo
+  ld p.lo, a
+  ld a, arr[idx]
+  ld arr[idx], a
+
+  ld a, (p.lo)
+  ld (p.lo), a
+  ld a, (arr[idx])
+  ld (arr[idx]), a
+
+  readAddr p.lo
+  readAddr arr[idx]
+  ret
+end

--- a/test/pr289_place_expression_contexts.test.ts
+++ b/test/pr289_place_expression_contexts.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnostics/types.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { AsmArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR289: place-expression semantics for field/element operands', () => {
+  it('applies value/store contexts for scalar place expressions and address contexts for ea params', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr289_place_expression_contexts_positive.zax');
+    const res = await compile(
+      entry,
+      {
+        emitBin: false,
+        emitHex: false,
+        emitD8m: false,
+        emitListing: false,
+        emitAsm: true,
+      },
+      { formats: defaultFormatWriters },
+    );
+
+    expect(res.diagnostics).toEqual([]);
+    const asm = res.artifacts.find((a): a is AsmArtifact => a.kind === 'asm');
+    expect(asm).toBeDefined();
+
+    // Field place-expression in value/store contexts.
+    expect(asm!.text).toContain('ld A, (p)');
+    expect(asm!.text).toContain('ld (p), A');
+
+    // Array element place-expression in value/store contexts.
+    expect(asm!.text).toContain('ld A, (hl)');
+    expect(asm!.text).toContain('ld (hl), A');
+
+    // Explicit (ea) forms remain valid and compile in parallel with implicit place forms.
+    expect(asm!.text).toContain('; func main begin');
+    expect(asm!.text).toContain('; func main end');
+  });
+
+  it('rejects passing dereference forms to ea-typed parameters', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr289_place_expression_contexts_negative.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics.some((d) => d.id === DiagnosticIds.OpNoMatchingOverload)).toBe(true);
+    expect(res.diagnostics.some((d) => d.message.includes('No matching op overload'))).toBe(true);
+    expect(res.diagnostics.some((d) => d.message.includes('expects ea, got (p.lo)'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Primary issue
- Closes #289

## Scope
Implement place-expression context behavior for field/element operands in lowering/op matching:
- `LD A, rec.field` / `LD A, arr[idx]` => scalar value read
- `LD rec.field, A` / `LD arr[idx], A` => scalar value write
- `ea`-typed matcher/parameter sites consume place expressions as addresses (not dereference operands)

## Touched spec/docs sections
- No normative docs changed in this PR.
- Behavioral target referenced from existing docs:
  - `docs/zax-spec.md` §7.2 value semantics note
  - `docs/ZAX-quick-guide.md` Chapter 3 place-expression bullets
  - `docs/v02-codegen-worked-examples.md` §11.2a

## Acceptance criteria -> evidence mapping (#289)
1. `LD A, rec.field` reads scalar value
- Evidence:
  - `test/pr289_place_expression_contexts.test.ts` (`applies value/store contexts...`)
  - fixture: `test/fixtures/pr289_place_expression_contexts_positive.zax`

2. `LD rec.field, A` writes scalar value
- Evidence:
  - `test/pr289_place_expression_contexts.test.ts` asserts store lowering in asm trace
  - fixture: `test/fixtures/pr289_place_expression_contexts_positive.zax`

3. `ea`-typed matcher/parameter sites consume `rec.field` / `arr[idx]` as addresses
- Evidence:
  - positive: `test/pr289_place_expression_contexts.test.ts` with `readAddr(addr: ea)` and calls `readAddr p.lo`, `readAddr arr[idx]`
  - implementation: `src/lowering/emit.ts` matcher update (`MatcherEa` now matches `ea` operands only)

4. No regression for explicit `(ea)` forms
- Evidence:
  - positive fixture keeps explicit `(p.lo)` / `(arr[idx])` `LD` forms compiling in parallel with implicit place forms
  - asserted by `test/pr289_place_expression_contexts.test.ts`

5. Tests cover field and array-element variants in value/store/address contexts
- Evidence:
  - `test/pr289_place_expression_contexts.test.ts`
  - fixtures: `test/fixtures/pr289_place_expression_contexts_positive.zax`, `test/fixtures/pr289_place_expression_contexts_negative.zax`

## Diagnostics contract
- `ea` matcher no longer accepts dereference operands; passing `(ea)` where `ea` is required now resolves to stable no-match diagnostics.
- Added negative test asserts:
  - `DiagnosticIds.OpNoMatchingOverload`
  - message includes `expects ea, got (p.lo)`

## Validation (scope-relevant)
- `yarn -s format:check`
- `yarn -s typecheck`
- `yarn -s vitest run test/pr289_place_expression_contexts.test.ts test/pr16_ops.test.ts test/pr273_call_scalar_value_runtime_index.test.ts`
