### PR TITLE
v0.3 #292: enforce local var initializer lowering + diagnostics

### DIFF
--- a/test/fixtures/pr292_local_nonscalar_value_init_negative.zax
+++ b/test/fixtures/pr292_local_nonscalar_value_init_negative.zax
@@ -1,0 +1,8 @@
+section code at $0000
+
+export func main(): void
+  var
+    arr: byte[4] = 1
+  end
+  ret
+end

--- a/test/fixtures/pr292_local_scalar_init_and_alias_positive.zax
+++ b/test/fixtures/pr292_local_scalar_init_and_alias_positive.zax
@@ -1,0 +1,15 @@
+section code at $0000
+section var at $1000
+
+globals
+  base: word
+
+export func main(): void
+  var
+    tmp: word = $1234
+    local_ref = base
+  end
+  ld hl, tmp
+  ld (local_ref), hl
+  ret
+end

--- a/test/pr292_local_var_initializer_enforcement.test.ts
+++ b/test/pr292_local_var_initializer_enforcement.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { AsmArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR292 local var initializer completeness', () => {
+  it('lowers local scalar value-init at function entry and keeps alias locals slot-free', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr292_local_scalar_init_and_alias_positive.zax');
+    const res = await compile(
+      entry,
+      { emitBin: false, emitHex: false, emitD8m: false, emitListing: false, emitAsm: true },
+      { formats: defaultFormatWriters },
+    );
+
+    const errors = res.diagnostics.filter((d) => d.severity === 'error');
+    expect(errors).toEqual([]);
+
+    const asm = res.artifacts.find((a): a is AsmArtifact => a.kind === 'asm');
+    expect(asm).toBeDefined();
+    const text = asm!.text;
+
+    expect(text).toContain('push BC');
+    expect((text.match(/\bpush BC\b/g) ?? []).length).toBe(1);
+    expect(text).toContain('ld HL, $0000');
+    expect(text).toContain('add HL, SP');
+    expect(text).toContain('ld (HL), $0034');
+    expect(text).toContain('ld (HL), $0012');
+  });
+
+  it('rejects non-scalar local value-init declarations with stable diagnostics', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr292_local_nonscalar_value_init_negative.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(messages).toContain(
+      'Non-scalar local storage declaration "arr" requires alias form ("arr = rhs").',
+    );
+  });
+});


### PR DESCRIPTION
Closes #292

## Primary Issue
- #292 (single primary scope)

## What changed
- Lowering now emits function-entry stores for local scalar value initializers (`name: Type = valueExpr`).
- Non-scalar typed local declarations now hard-stop frame allocation and keep stable rejection diagnostics (`requires alias form`).
- Added focused tests/fixtures for positive lowering and negative diagnostic behavior.

## Acceptance criteria -> evidence
- [x] Local scalar value-init is fully supported and lowered at function entry.
  - Evidence: `test/pr292_local_var_initializer_enforcement.test.ts` (`lowers local scalar value-init...`) and fixture `test/fixtures/pr292_local_scalar_init_and_alias_positive.zax` asserting emitted entry-store sequence.
- [x] Local alias-init (`name = rhs`) is supported with inferred type and no local slot allocation.
  - Evidence: same positive test asserts single local-slot prologue allocation (`push BC` count remains `1`) while alias local is used successfully.
- [x] Typed alias form (`name: Type = rhs`) is rejected with stable diagnostic.
  - Evidence: existing parser diagnostic test remains green: `test/pr285_alias_init_parser_semantics_matrix.test.ts`.
- [x] Non-scalar local value-init declarations are rejected with stable diagnostics.
  - Evidence: `test/pr292_local_var_initializer_enforcement.test.ts` (`rejects non-scalar local value-init...`) with fixture `test/fixtures/pr292_local_nonscalar_value_init_negative.zax`.
- [x] Spec/guide/examples remain aligned with compiler behavior for this scope.
  - Evidence: no normative docs changed in this PR; behavior now matches existing declared rule for local scalar slots vs alias-only non-scalars.

## Touched normative/docs sections (reference only)
- `docs/zax-spec.md` (function-local `var` declaration forms)
- `docs/ZAX-quick-guide.md` (initializer guidance)
- `docs/v02-codegen-worked-examples.md` (local initializer examples, non-normative)

## Validation run (scope-relevant)
- `yarn -s format:check`
- `yarn -s typecheck`
- `yarn -s vitest run test/pr292_local_var_initializer_enforcement.test.ts test/pr285_alias_init_parser_semantics_matrix.test.ts test/pr14_frame_epilogue.test.ts test/pr23_lowering_safety.test.ts test/pr52_ptr_scalar_slots.test.ts`

## Diagnostics behavior
- Preserved existing parser diagnostic for typed alias form rejection.
- Preserved stable non-scalar local rejection wording (`requires alias form ("name = rhs")`).
