### PR TITLE
v0.3 #287: add explicit @place address-of operator

### DIFF
--- a/docs/ZAX-quick-guide.md
+++ b/docs/ZAX-quick-guide.md
@@ -186,6 +186,9 @@ arr[(HL)]
 - `rec.field` and `arr[idx]` are place expressions:
   - value/store contexts use implicit scalar read/write lowering (`LD A, rec.field`, `LD rec.field, A`)
   - `ea`-typed contexts pass addresses (for example `touch rec.field` when `touch(addr: ea)`)
+- `@place` is explicit address-of for place expressions:
+  - examples: `@rec.field`, `@arr[idx]`, `@symbol`
+  - use `@place` when you want address intent to be explicit in source
 
 ### 3.3 Runtime Atom Rule
 

--- a/docs/v02-codegen-worked-examples.md
+++ b/docs/v02-codegen-worked-examples.md
@@ -491,7 +491,7 @@ Context rule:
 - `rec.field` and `arr[idx]` are place expressions.
 - In value/store instruction contexts, scalar places are read/written as values.
 - When a matcher/parameter requires `ea`, place expressions are passed as addresses.
-- Explicit address-of operator syntax (for example `@p.lo`) is deferred to v0.3.
+- Explicit address-of is available via `@place` (for example `@p.lo`) when address intent should be explicit.
 
 ### 11.3 Non-Scalar Function Arguments: `[]` vs `[N]` (Design Target)
 

--- a/docs/zax-spec.md
+++ b/docs/zax-spec.md
@@ -808,7 +808,8 @@ Value semantics note (v0.2):
 - `rec.field` and `arr[idx]` are place expressions (addressable locations).
 - In scalar value/store instruction contexts (for example `LD A, rec.field`, `LD rec.field, A`), the compiler inserts required load/store lowering.
 - In explicit address contexts (for example `ea`-typed matchers/parameters), the same place expression is used as an address value.
-- Explicit address-of syntax (for example `@rec.field`) is deferred to v0.3; v0.2 uses context to disambiguate.
+- Explicit address-of syntax is supported as `@place` (for example `@rec.field`, `@arr[idx]`, `@symbol`).
+  Use `@place` to force address intent in source even when the surrounding context could otherwise infer value semantics.
 
 Precedence (v0.1):
 

--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -339,7 +339,7 @@ export type AsmControlNode =
 export type AsmOperandNode =
   | { kind: 'Reg'; span: SourceSpan; /** Canonical upper-case register token. */ name: string }
   | { kind: 'Imm'; span: SourceSpan; expr: ImmExprNode }
-  | { kind: 'Ea'; span: SourceSpan; expr: EaExprNode }
+  | { kind: 'Ea'; span: SourceSpan; expr: EaExprNode; explicitAddressOf?: boolean }
   | { kind: 'Mem'; span: SourceSpan; expr: EaExprNode }
   | { kind: 'PortC'; span: SourceSpan }
   | { kind: 'PortImm8'; span: SourceSpan; expr: ImmExprNode };

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -644,6 +644,24 @@ function parseAsmOperand(
   const t = operandText.trim();
   if (t.length === 0) return undefined;
 
+  if (t.startsWith('@')) {
+    const placeText = t.slice(1).trim();
+    if (placeText.length === 0) {
+      diag(diagnostics, filePath, `Invalid address-of target "${t}": expected @<place>.`, {
+        line: operandSpan.start.line,
+        column: operandSpan.start.column,
+      });
+      return undefined;
+    }
+    const ea = parseEaExprFromText(filePath, placeText, operandSpan, diagnostics);
+    if (ea) return { kind: 'Ea', span: operandSpan, expr: ea, explicitAddressOf: true };
+    diag(diagnostics, filePath, `Invalid address-of target "${t}": expected @<place>.`, {
+      line: operandSpan.start.line,
+      column: operandSpan.start.column,
+    });
+    return undefined;
+  }
+
   if (/^(A|B|C|D|E|H|L|IXH|IXL|IYH|IYL|HL|DE|BC|SP|IX|IY|AF|AF'|I|R)$/i.test(t)) {
     return { kind: 'Reg', span: operandSpan, name: canonicalRegisterToken(t) };
   }

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -2427,6 +2427,7 @@ export function emitProgram(
         }
       }
       if (op.kind === 'Ea') {
+        if (op.explicitAddressOf) return op;
         const scalar = resolveScalarTypeForEa(op.expr);
         if (scalar) return { kind: 'Mem', span: op.span, expr: op.expr };
       }
@@ -4088,7 +4089,9 @@ export function emitProgram(
                       pushedArgWords++;
                       continue;
                     }
-                    ok = pushArgValueFromEa(arg.expr, 'byte');
+                    ok = arg.explicitAddressOf
+                      ? pushEaAddress(arg.expr, asmItem.span)
+                      : pushArgValueFromEa(arg.expr, 'byte');
                     if (!ok) break;
                     pushedArgWords++;
                     continue;
@@ -4153,7 +4156,9 @@ export function emitProgram(
                       pushedArgWords++;
                       continue;
                     }
-                    ok = pushArgValueFromEa(arg.expr, 'word');
+                    ok = arg.explicitAddressOf
+                      ? pushEaAddress(arg.expr, asmItem.span)
+                      : pushArgValueFromEa(arg.expr, 'word');
                     if (!ok) break;
                     pushedArgWords++;
                     continue;

--- a/test/fixtures/pr287_address_of_invalid_targets_negative.zax
+++ b/test/fixtures/pr287_address_of_invalid_targets_negative.zax
@@ -1,0 +1,8 @@
+section code at $0000
+
+export func main(): void
+  ld hl, @
+  ld hl, @(3 + 2)
+  ld hl, @3
+  ret
+end

--- a/test/fixtures/pr287_address_of_positive.zax
+++ b/test/fixtures/pr287_address_of_positive.zax
@@ -1,0 +1,14 @@
+section code at $0000
+section var at $1000
+
+globals
+  b: byte
+
+func accept(v: word): void
+  ret
+end
+
+export func main(): void
+  accept @b
+  ret
+end

--- a/test/pr287_address_of_operator.test.ts
+++ b/test/pr287_address_of_operator.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { AsmArtifact } from '../src/formats/types.js';
+
+type MaybeAsm = AsmArtifact | undefined;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR287 explicit address-of operator (@place)', () => {
+  it('accepts @place and preserves explicit address intent in lowering', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr287_address_of_positive.zax');
+    const res = await compile(
+      entry,
+      { emitBin: false, emitHex: false, emitD8m: false, emitListing: false, emitAsm: true },
+      { formats: defaultFormatWriters },
+    );
+
+    const errors = res.diagnostics.filter((d) => d.severity === 'error');
+    expect(errors).toEqual([]);
+
+    const asm = res.artifacts.find((a): a is AsmArtifact => a.kind === 'asm') as MaybeAsm;
+    expect(asm).toBeDefined();
+
+    const text = asm!.text;
+    expect(text).toContain('call accept');
+    expect(text).toContain('ld HL, b');
+    expect(text).not.toContain('ld A, (b)');
+  });
+
+  it('rejects invalid @ targets with stable diagnostics', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr287_address_of_invalid_targets_negative.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(messages.filter((m) => m.includes('Invalid address-of target')).length).toBe(3);
+    expect(messages).toContain('Invalid address-of target "@": expected @<place>.');
+    expect(messages).toContain('Invalid address-of target "@(3 + 2)": expected @<place>.');
+    expect(messages).toContain('Invalid address-of target "@3": expected @<place>.');
+  });
+});


### PR DESCRIPTION
Closes #287

## Primary Issue
- #287 (single primary scope)

## What changed
- Added explicit address-of operand syntax `@place` in asm parsing.
- `@place` parses to `Ea` with explicit-address intent metadata.
- Lowering now preserves explicit address intent in value-typed call argument lowering (avoids implicit scalar load coercion).
- Added positive/negative tests for `@place` and invalid targets.
- Updated spec/guide/examples text to document `@place` usage and migration from implicit address contexts.

## Acceptance criteria -> evidence
- [x] Grammar accepts `@place` where `place` is symbol/field/element path.
  - Evidence: `test/fixtures/pr287_address_of_positive.zax` and `test/pr287_address_of_operator.test.ts`.
- [x] Lowering emits equivalent address behavior in `ea`/address contexts.
  - Evidence: positive test asserts `accept @b` lowers to address load path (`ld HL, b`) and not scalar value load (`ld A, (b)`).
- [x] Invalid usage produces stable diagnostics.
  - Evidence: `test/fixtures/pr287_address_of_invalid_targets_negative.zax` and `test/pr287_address_of_operator.test.ts` assert stable `Invalid address-of target ... expected @<place>.` diagnostics.
- [x] Docs/examples include migration guidance.
  - Evidence: updated `docs/zax-spec.md`, `docs/ZAX-quick-guide.md`, `docs/v02-codegen-worked-examples.md`.

## Touched spec/docs sections
- `docs/zax-spec.md` section `7.2 ea (Effective Address) Expressions`
- `docs/ZAX-quick-guide.md` chapter `3.2 Critical v0.2 Semantics`
- `docs/v02-codegen-worked-examples.md` section `11.2a Place Expressions vs Address Context`

## Validation run (scope-relevant)
- `yarn -s format:check`
- `yarn -s typecheck`
- `yarn -s vitest run test/pr287_address_of_operator.test.ts test/pr289_place_expression_contexts.test.ts test/pr292_local_var_initializer_enforcement.test.ts`
