### PR TITLE
v0.3 #286: named-field record aggregate initializers

### DIFF
--- a/docs/ZAX-quick-guide.md
+++ b/docs/ZAX-quick-guide.md
@@ -166,6 +166,13 @@ globals
 
 Aggregate record initializer syntax for `globals` (positional or named-field) is deferred beyond v0.2.
 
+For `data` record declarations, both aggregate forms are supported:
+
+- positional: `pair: Pair = { 1, 2 }`
+- named-field: `pair: Pair = { lo: 1, hi: 2 }`
+
+Named-field aggregates must cover every field exactly once (no unknown, duplicate, or missing fields).
+
 ## Chapter 3 - Addressing and Indexing
 
 ### 3.1 Core Forms

--- a/docs/zax-spec.md
+++ b/docs/zax-spec.md
@@ -650,8 +650,14 @@ Type vs initializer (v0.1):
   - Example: `banner: byte[] = "HELLO"` is equivalent to `banner: byte[5] = "HELLO"`.
   - Example: `table: word[] = { 1, 2, 3 }` is equivalent to `table: word[3] = { 1, 2, 3 }`.
 - A bare scalar type without `[]` or `[n]` is not an array; `table: word = { 1, 2, 3 }` is a compile error.
-- Record initializers must supply field values in field order; for arrays of records, initializers are flattened in element order.
-- Named-field aggregate syntax is not part of v0.2 (`{ lo: 0, hi: 0 }` is unsupported in this version).
+- Record initializers support two forms:
+  - positional aggregate: `pair: Pair = { 1, 2 }` (field-order mapping)
+  - named-field aggregate: `pair: Pair = { lo: 1, hi: 2 }`
+- Named-field aggregate rules:
+  - unknown field names are compile errors
+  - duplicate field names are compile errors
+  - missing required fields are compile errors
+  - mixing positional and named entries in one aggregate is a compile error
 
 Nested record initializer example (v0.1):
 

--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -188,7 +188,14 @@ export interface DataDeclNode extends BaseNode {
  */
 export type DataInitializerNode =
   | { kind: 'InitArray'; span: SourceSpan; elements: ImmExprNode[] }
-  | { kind: 'InitString'; span: SourceSpan; value: string };
+  | { kind: 'InitString'; span: SourceSpan; value: string }
+  | { kind: 'InitRecordNamed'; span: SourceSpan; fields: DataRecordFieldInitNode[] };
+
+export interface DataRecordFieldInitNode extends BaseNode {
+  kind: 'DataRecordFieldInit';
+  name: string;
+  value: ImmExprNode;
+}
 
 /**
  * `bin` declaration: include raw bytes from an external file into a section.

--- a/test/fixtures/pr286_record_named_init_mixed_negative.zax
+++ b/test/fixtures/pr286_record_named_init_mixed_negative.zax
@@ -1,0 +1,10 @@
+type Pair
+  lo: byte
+  hi: byte
+end
+
+data
+  bad_mixed: Pair = { lo: 1, 2 }
+
+export func main(): void
+end

--- a/test/fixtures/pr286_record_named_init_negative.zax
+++ b/test/fixtures/pr286_record_named_init_negative.zax
@@ -1,0 +1,13 @@
+type Pair
+  lo: byte
+  hi: byte
+end
+
+data
+  bad_unknown: Pair = { lo: 1, xx: 2 }
+  bad_duplicate: Pair = { lo: 1, lo: 2, hi: 3 }
+  bad_missing: Pair = { lo: 1 }
+  bad_shape: byte[2] = { lo: 1, hi: 2 }
+
+export func main(): void
+end

--- a/test/fixtures/pr286_record_named_init_positive.zax
+++ b/test/fixtures/pr286_record_named_init_positive.zax
@@ -1,0 +1,11 @@
+type Pair
+  lo: byte
+  hi: byte
+end
+
+data
+  named: Pair = { hi: $12, lo: $34 }
+  positional: Pair = { $56, $78 }
+
+export func main(): void
+end

--- a/test/fixtures/pr4_data_unsupported_type.zax
+++ b/test/fixtures/pr4_data_unsupported_type.zax
@@ -4,8 +4,7 @@ type Point
 end
 
 data
-  p: Point = [0]
+  p: Point[1] = [0]
 
 export func main(): void
 end
-

--- a/test/pr286_record_named_field_initializers.test.ts
+++ b/test/pr286_record_named_field_initializers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact, D8mArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR286 data record initializers: positional + named-field forms', () => {
+  it('emits deterministic bytes for named-field and positional record aggregates', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr286_record_named_init_positive.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    const d8m = res.artifacts.find((a): a is D8mArtifact => a.kind === 'd8m');
+    expect(bin).toBeDefined();
+    expect(d8m).toBeDefined();
+
+    expect(bin!.bytes).toEqual(Uint8Array.of(0xc9, 0x00, 0x34, 0x12, 0x56, 0x78));
+
+    const symbols = d8m!.json['symbols'] as Array<{ name: string; kind: string; address?: number }>;
+    const byName = new Map(symbols.map((s) => [s.name, s]));
+    expect(byName.get('named')).toMatchObject({ kind: 'data', address: 2 });
+    expect(byName.get('positional')).toMatchObject({ kind: 'data', address: 4 });
+  });
+
+  it('keeps stable diagnostics for unknown/duplicate/missing/shape errors', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr286_record_named_init_negative.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(messages).toContain('Unknown record field "xx" in initializer for "bad_unknown".');
+    expect(messages).toContain('Duplicate record field "lo" in initializer for "bad_duplicate".');
+    expect(messages).toContain('Missing record field "hi" in initializer for "bad_missing".');
+    expect(messages).toContain(
+      'Named-field aggregate initializer requires a record type for "bad_shape".',
+    );
+  });
+
+  it('rejects mixed positional + named aggregate entries in one initializer', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr286_record_named_init_mixed_negative.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(messages).toContain(
+      'Mixed positional and named aggregate initializer entries are not allowed for "bad_mixed".',
+    );
+  });
+});


### PR DESCRIPTION
Closes #286

## Primary Issue
- #286 (single primary scope)

## What changed
- Added parser support for brace aggregate initializers in `data` declarations with:
  - positional record form: `{ 1, 2 }`
  - named-field record form: `{ lo: 1, hi: 2 }`
- Added a dedicated AST initializer kind for named-field record aggregates.
- Implemented data-lowering support for record initializers:
  - positional mapping by record field order
  - named-field mapping with validation
- Added stable diagnostics for:
  - unknown record fields
  - duplicate named fields
  - missing required fields
  - mixed positional + named forms
  - named-field aggregate used on non-record types
- Kept scalar/array data initializer behavior and existing positional pathways intact.

## Acceptance criteria -> evidence
- [x] Parser supports named-field aggregate initializer syntax for records.
  - Evidence: `test/fixtures/pr286_record_named_init_positive.zax`, `test/pr286_record_named_field_initializers.test.ts`.
- [x] Semantic/lowering checks enforce full/valid field coverage rules.
  - Evidence: `test/fixtures/pr286_record_named_init_negative.zax`, `test/pr286_record_named_field_initializers.test.ts` (unknown/duplicate/missing/shape diagnostics).
- [x] Positional and named forms are both documented with compatibility notes.
  - Evidence: `docs/zax-spec.md` section 6.3 and `docs/ZAX-quick-guide.md` section 2.5 updates.
- [x] Existing positional behavior remains supported.
  - Evidence: positional record aggregate in positive fixture and existing const/data suites remain green.

## Touched spec/docs sections
- `docs/zax-spec.md` (section 6.3 `data` initializer rules)
- `docs/ZAX-quick-guide.md` (section 2.5 storage/initializer guidance)

## Validation run (scope-relevant)
- `yarn -s format:check`
- `yarn -s typecheck`
- `yarn -s vitest run test/pr286_record_named_field_initializers.test.ts test/pr4_negative.test.ts test/pr2_const_data.test.ts test/pr215_const_data_followups_matrix.test.ts`
- `yarn -s vitest run test/pr51_data_inferred_array_len.test.ts test/pr54_inferred_array_len_invalid.test.ts`

## Diagnostics behavior
- Added stable record-aggregate diagnostics without changing unrelated diagnostic IDs/severities.
- Updated `test/fixtures/pr4_data_unsupported_type.zax` to keep the legacy unsupported-type negative surface valid after adding record initializer support.
