### PR TITLE
Docs: absolute helper uses const

### DIFF
--- a/docs/addressing-model.md
+++ b/docs/addressing-model.md
@@ -69,12 +69,12 @@ STORE_WORD_FROM_DE   ld (hl),e    ; HL = addr, DE = value
 ### 1.7 Direct absolute / frame helpers
 
 ```
-LOAD_BYTE_ABS sym        ld hl,sym
+LOAD_BYTE_ABS const      ld hl,const
                          ld l,(hl)
-LOAD_WORD_ABS sym        ld hl,(sym)
-STORE_BYTE_ABS sym       ld hl,sym
+LOAD_WORD_ABS const      ld hl,(const)
+STORE_BYTE_ABS const     ld hl,const
                          ld (hl),e
-STORE_WORD_ABS sym       ld (sym),hl
+STORE_WORD_ABS const     ld (const),hl
 
 FRAME_BYTE_LOAD disp     ld l,(ix+disp)
 FRAME_WORD_LOAD disp     push de


### PR DESCRIPTION
## Summary
- rename *_ABS helper parameter from  to  in the addressing step library

Fixes #393.