### PR TITLE
Addressing-model: byte templating groundwork

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -2588,7 +2588,16 @@ export function emitProgram(
         ) {
           return false;
         }
-        if (!emitInstr('ld', [{ kind: 'Reg', span, name: 'L' }, { kind: 'Reg', span, name: r8 }], span)) {
+        if (
+          !emitInstr(
+            'ld',
+            [
+              { kind: 'Reg', span, name: 'L' },
+              { kind: 'Reg', span, name: r8 },
+            ],
+            span,
+          )
+        ) {
           return false;
         }
       } else if (ea.index.kind === 'IndexMemHL' || ea.index.kind === 'IndexMemIxIy') {


### PR DESCRIPTION
## Summary
- route byte loads/stores (including mem→mem) through the addressing step templates when EAs resolve
- leave word templating infra present but keep EAW pipelines disabled (type-aware scaling pending) to preserve baselines
- no baseline behavior change; full test suite passing

## Testing
- tsc --noEmit
- npx vitest run
