### PR TITLE
codex/addressing eaw callout

### DIFF
--- a/docs/addressing-model.md
+++ b/docs/addressing-model.md
@@ -530,6 +530,15 @@ ex de,hl
 pop de
 ```
 
+> **Routing rule:** use the simplest path that matches the source shape. If there is **no `[]` index**, stay on the A-series scalar paths (direct glob/frame accessors). If the index is a **constant**, fold it into the frame displacement and use the B-series constant-index paths. Only use the indexed pipelines (C/D/E) when a runtime index is present. Do not send scalars through the indexed pipelines—they will add unnecessary base+index math and save/restore traffic.
+
+| Access shape             | Path to use          |
+| ---                      | ---                  |
+| glob / frame var (no []) | A-series (scalar)    |
+| glob / frame[var+const]  | B-series (const idx) |
+| glob / frame[r8]         | C-series             |
+| glob / frame[word index] | D/E-series           |
+
 ### C. Indexed by register (8-bit index in `r8`)
 
 #### C1 load byte: global[r]


### PR DESCRIPTION
- **docs: update addressing model for consistency and clarity in load/store operations**
- **docs: align section1 byte/word accessors**
- **docs: update IDX_FRAME references to use frame instead of local**
- **docs: refine addressing model for global and frame access, correcting register usage and improving clarity**
- **docs: streamline STORE_WORD and FRAME_WORD operations by removing unnecessary push/pop of DE**
- **docs: update FRAME_WORD_LOAD to improve clarity and consistency in global access**
- **docs: update load instructions to use register A instead of E for frame and global byte access**
- **docs: update accessor functions for byte and word operations, improving clarity and consistency in global and frame access**
- **Refactor addressing model documentation for clarity and consistency**
- **docs: improve clarity and consistency in addressing model documentation**
- **docs: update addressing model to improve clarity and consistency in indexed word operations**
- **docs: update addressing model section numbers for consistency in load/store operations**
- **docs: improve section headings for clarity in addressing model**
- **docs: add load and store templates for 8-bit addressing in the addressing model**
- **docs: clarify load/store templates for 8-bit addressing in the addressing model**
- **docs: escape underscores in addressing model for clarity**
- **docs: update load/store templates for 16-bit addressing in the addressing model**
- **docs: update load/store templates to use EAW_* for clarity in addressing model**
- **docs: refine load/store templates for clarity and consistency in addressing model**
- **docs: add scalar fast path examples for direct symbol access in addressing model**
- **docs: refine store templates for clarity and consistency in addressing model**
- **docs: enhance addressing model documentation with scalar accessors and examples**
- **docs: simplify LOAD_RP_GLOB and STORE_RP_GLOB operations for clarity in addressing model**
- **docs: clarify SW-DEBC operation to emphasize preservation of source value in SAVE_DE**
- **docs: remove redundant STORE_REG_GLOB example and add section for 16-bit load templates**
- **docs: standardize terminology and enhance load/store templates for clarity**
- **Add addressing step library and EA/EAW builders**
- **Wire step pipelines through emitter for byte loads**
- **Route LD r,(ea) fallback through step templates**
- **Restrict byte store templating to reg8 sources**
- **Use step templates for reg8 stores when EA is resolvable**
- **Tighten reg8 store templating and drop duplicate fallback**
- **Use templates for byte mem-to-mem when both EAs resolve**
- **Use templates for byte mem-to-mem; add word EA pipeline helper**
- **Start word-path templating: use EAW pipeline for loads and HL stores**
- **Template word paths when EAW available (loads, HL/DE/BC stores)**
- **Use word templates for reg16 call args when EA resolves**
- **Disable EAW pipelines until type-aware scaling is ready**
- **Addressing-model: byte templating groundwork (EAW gated)**
- **docs: call out scalar vs indexed EA paths**
