### PR TITLE
Gate EA/EAW to runtime index cases

### DIFF
--- a/test/pr412_runtime_index_array_word.test.ts
+++ b/test/pr412_runtime_index_array_word.test.ts
@@ -26,7 +26,7 @@ describe('PR412 runtime array indexing (word)', () => {
     expect(text).toMatch(/add hl, hl/i); // scale idx
     expect(text).toMatch(/ld de, arr_w/i); // base load
     expect(text).toMatch(/add hl, de/i); // combine base + scaled idx
-    // Word load via HL address (A/H shuffle acceptable for now)
-    expect(text).toMatch(/ld a, \(hl\)[\s\S]*ld h, \(hl\)/i);
+    // Word load via HL address (any register shuffle is fine)
+    expect(text).toMatch(/ld e, \(hl\)[\s\S]*ld d, \(hl\)/i);
   });
 });


### PR DESCRIPTION
* Gate EA (byte) and EAW (word) builders to real runtime index cases with matching element sizes; scalars stay on folded fast paths.
* Add reg16 HL index handling without reload (uses base+HL directly).
* Import missing step helpers in lowering.
* Update runtime word index test expectation to match emitted load pattern.

Focused tests passing locally: pr412_runtime_index_array_word, pr407_addressing_regression.

Related to #405/#412.