### PR TITLE
Add EAW regression: runtime word index to BC

### DIFF
--- a/test/fixtures/pr406_word_index_bc.zax
+++ b/test/fixtures/pr406_word_index_bc.zax
@@ -1,0 +1,7 @@
+data
+  arr_w: word[3] = { $1111, $2222, $3333 }
+
+export func main()
+  ld hl, $0001        ; runtime index
+  ld bc, (arr_w[hl])  ; load word into BC via runtime index
+end

--- a/test/pr406_word_templates_regression.test.ts
+++ b/test/pr406_word_templates_regression.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { AsmArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR406 word templates (runtime index → BC)', () => {
+  it('uses EAW + LW-BC template for reg16 index HL', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr406_word_index_bc.zax');
+    const res = await compile(
+      entry,
+      { emitBin: false, emitHex: false, emitD8m: false, emitListing: false, emitAsm: true },
+      { formats: defaultFormatWriters },
+    );
+
+    expect(res.diagnostics).toEqual([]);
+    const asm = res.artifacts.find((a): a is AsmArtifact => a.kind === 'asm');
+    expect(asm).toBeDefined();
+    const text = asm!.text;
+
+    expect(text).toMatch(/add hl, hl/i); // scale index
+    expect(text).toMatch(/ld de, arr_w/i); // base load
+    expect(text).toMatch(/add hl, de/i); // combine base + offset
+    expect(text).toMatch(/ld e, \(hl\)/i); // word load lo
+    expect(text).toMatch(/ld d, \(hl\)/i); // word load hi
+    expect(text).toMatch(/ld c, l/i);
+    expect(text).toMatch(/ld b, h/i);
+  });
+});


### PR DESCRIPTION
Adds a focused regression fixture for word arrays indexed at runtime (reg16 HL) loading into BC. Asserts the emitted sequence scales the index (add hl,hl), adds base (ld de, arr_w / add hl,de), performs word load, and shuffles into BC. Guards the EAW path wiring for reg16 indexes.

Tests: pr406_word_templates_regression.test.ts