### PR TITLE
ci: guard format when SKIP_LANGUAGE_TOUR=1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         run: npm ci
 
       - name: Format check
-        if: env.SKIP_LANGUAGE_TOUR != '1'
+        if: ${{ env.SKIP_LANGUAGE_TOUR != '1' }}
         run: npm run format:check
 
       - name: Typecheck


### PR DESCRIPTION
Skip the format check step when SKIP_LANGUAGE_TOUR=1 so language-tour files don't block CI in the interim. Tests already gate on the env; this aligns format check with the same flag.