### PR TITLE
Addressing: word EAW index support and template wiring

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -2889,22 +2889,24 @@ export function emitProgram(
         const idxReg = (ea.index as any).reg;
         if (!idxReg || typeof idxReg !== 'string') return null;
         const idxUpper = idxReg.toUpperCase();
+
+        // HL as index: HL already holds idx. Just load base to DE and scale/add.
+        const hlIndexAbs = baseResolved.kind === 'abs'
+          ? [...LOAD_BASE_GLOB(baseResolved.baseLower), ...CALC_EA_2()]
+          : [...LOAD_BASE_FVAR(baseResolved.ixDisp), ...CALC_EA_2()];
+
         if (baseResolved.kind === 'abs') {
           if (ea.index.kind === 'IndexReg8') {
             return EAW_GLOB_REG(baseResolved.baseLower, idxReg.toLowerCase());
           }
-          if (idxUpper === 'HL') {
-            return [...LOAD_BASE_GLOB(baseResolved.baseLower), ...CALC_EA_2()];
-          }
+          if (idxUpper === 'HL') return hlIndexAbs;
           return EAW_GLOB_RP(baseResolved.baseLower, idxUpper);
         }
         if (baseResolved.kind === 'stack') {
           if (ea.index.kind === 'IndexReg8') {
             return EAW_FVAR_REG(baseResolved.ixDisp, idxReg.toLowerCase());
           }
-          if (idxUpper === 'HL') {
-            return [...LOAD_BASE_FVAR(baseResolved.ixDisp), ...CALC_EA_2()];
-          }
+          if (idxUpper === 'HL') return hlIndexAbs;
           return EAW_FVAR_RP(baseResolved.ixDisp, idxUpper);
         }
         return null;


### PR DESCRIPTION
- Expand word EA builders to handle reg8/reg16/Ea indexes for glob/fvar bases (EAW matrix).
- Route word load/store paths through LW-HL/DE/BC and SW-DEBC/SW-HL templates when available; simplify fallback gating.
- No new fixtures yet; existing tests pass locally (typecheck, step library).