### PR TITLE
Lock runtime array indexing coverage

### DIFF
--- a/test/fixtures/pr412_runtime_index_byte_matrix.zax
+++ b/test/fixtures/pr412_runtime_index_byte_matrix.zax
@@ -1,0 +1,11 @@
+section data at $2000
+
+data
+  arr_b: byte[8] = { $01,$02,$03,$04,$05,$06,$07,$08 }
+
+export func main(): AF, BC, DE, HL
+  ld a, $03
+  ld b, arr_b[a]
+  ld hl, $0002
+  ld c, arr_b[hl]
+end

--- a/test/pr412_runtime_index_matrix.test.ts
+++ b/test/pr412_runtime_index_matrix.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { AsmArtifact } from '../src/formats/types.js';
+
+describe('PR412: runtime array indexing matrix', () => {
+  it('supports runtime byte indexing via reg8 and reg16', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr412_runtime_index_byte_matrix.zax');
+    const res = await compile(
+      entry,
+      { emitAsm: true, emitBin: false, emitHex: false, emitListing: false, emitD8m: false },
+      { formats: defaultFormatWriters },
+    );
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const asm = res.artifacts.find((a): a is AsmArtifact => a.kind === 'asm');
+    expect(asm).toBeDefined();
+    const text = asm!.text.toUpperCase();
+
+    expect(text).toContain('LD H, $0000');
+    expect(text).toContain('LD L, A');
+    expect(text).toContain('LD DE, ARR_B');
+    expect(text).toContain('ADD HL, DE');
+    expect(text).toContain('LD B, (HL)');
+
+    expect(text).toContain('LD HL, $0002');
+    expect(text).toContain('LD C, (HL)');
+  });
+
+  it('keeps runtime word indexing via HL on the scaled EAW path', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr412_runtime_index_word.zax');
+    const res = await compile(
+      entry,
+      { emitAsm: true, emitBin: false, emitHex: false, emitListing: false, emitD8m: false },
+      { formats: defaultFormatWriters },
+    );
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const asm = res.artifacts.find((a): a is AsmArtifact => a.kind === 'asm');
+    expect(asm).toBeDefined();
+    const text = asm!.text.toUpperCase();
+
+    expect(text).toContain('ADD HL, HL');
+    expect(text).toContain('LD DE, ARR_W');
+    expect(text).toContain('ADD HL, DE');
+    expect(text).toContain('LD E, (HL)');
+    expect(text).toContain('LD D, (HL)');
+    expect(text).not.toContain('LD A, (HL)');
+  });
+});


### PR DESCRIPTION
Closes #412

Current `main` already supports the runtime array indexing shapes introduced by the addressing-model work, but #412 still lacked direct regression coverage for the accepted forms. This PR locks that behavior down.

What changed
- add `test/fixtures/pr412_runtime_index_byte_matrix.zax` covering runtime byte indexing through reg8 (`A`) and reg16 (`HL`)
- add `test/pr412_runtime_index_matrix.test.ts`
- keep existing `test/pr412_runtime_index_array_word.test.ts` and extend the explicit coverage surface for the issue acceptance

What the new tests assert
- byte runtime indexing via reg8 zero-extends into HL, loads base into DE, and combines with `add hl, de`
- byte runtime indexing via HL works without diagnostics
- word runtime indexing via HL stays on the scaled EAW path (`add hl, hl`, `ld de, arr_w`, `add hl, de`)

Verification
- `npm test -- --run test/pr412_runtime_index_matrix.test.ts test/pr412_runtime_index_array_word.test.ts test/smoke_language_tour_compile.test.ts`
