### PR TITLE
Elide no-op self-moves in word store helpers

### DIFF
--- a/src/addressing/steps.ts
+++ b/src/addressing/steps.ts
@@ -107,8 +107,7 @@ export const LOAD_RP_EA = (rp: string): StepPipeline => [
 ];
 
 export const STORE_RP_EA = (rp: string): StepPipeline => [
-  instr(`ld e, lo(${rp})`),
-  instr(`ld d, hi(${rp})`),
+  ...(rp.toUpperCase() === 'DE' ? [] : [instr(`ld e, lo(${rp})`), instr(`ld d, hi(${rp})`)]),
   instr('ld (hl), e'),
   instr('inc hl'),
   instr('ld (hl), d'),
@@ -351,22 +350,8 @@ export const TEMPLATE_LW_BC = (ea: StepPipeline): StepPipeline => [
 // ---------------------------------------------------------------------------
 export const TEMPLATE_SW_DEBC = (vpair: 'DE' | 'BC', ea: StepPipeline): StepPipeline =>
   vpair === 'DE'
-    ? [
-        ...SAVE_HL(),
-        ...SAVE_DE(),
-        ...ea,
-        ...RESTORE_DE(),
-        ...STORE_RP_EA('DE'),
-        ...RESTORE_HL(),
-      ]
-    : [
-        ...SAVE_DE(),
-        ...SAVE_HL(),
-        ...ea,
-        ...STORE_RP_EA('BC'),
-        ...RESTORE_HL(),
-        ...RESTORE_DE(),
-      ];
+    ? [...SAVE_HL(), ...SAVE_DE(), ...ea, ...RESTORE_DE(), ...STORE_RP_EA('DE'), ...RESTORE_HL()]
+    : [...SAVE_DE(), ...SAVE_HL(), ...ea, ...STORE_RP_EA('BC'), ...RESTORE_HL(), ...RESTORE_DE()];
 
 export const TEMPLATE_SW_HL = (ea: StepPipeline): StepPipeline => [
   ...SAVE_DE(),

--- a/test/addressing_model_steps.test.ts
+++ b/test/addressing_model_steps.test.ts
@@ -13,6 +13,7 @@ import {
   TEMPLATE_LW_HL,
   LOAD_REG_GLOB,
   STORE_REG_GLOB,
+  STORE_RP_EA,
   LOAD_BASE_GLOB,
   LOAD_IDX_CONST,
   CALC_EA,
@@ -104,6 +105,17 @@ describe('addressing-model step library', () => {
       'ld lo(HL), e',
       'ld hi(HL), d',
       'pop de',
+    ]);
+  });
+
+  it('STORE_RP_EA omits self-moves for DE', () => {
+    expect(asm(STORE_RP_EA('DE'))).toEqual(['ld (hl), e', 'inc hl', 'ld (hl), d']);
+    expect(asm(STORE_RP_EA('BC'))).toEqual([
+      'ld e, lo(BC)',
+      'ld d, hi(BC)',
+      'ld (hl), e',
+      'inc hl',
+      'ld (hl), d',
     ]);
   });
 

--- a/test/pr406_word_edge_cases.test.ts
+++ b/test/pr406_word_edge_cases.test.ts
@@ -45,6 +45,8 @@ describe('PR406: word edge cases', () => {
     expect(text).toContain('LD DE, (SRC_W)');
     expect(text).toContain('ADD HL, HL');
     expect(text).toContain('LD DE, ARR_W');
+    expect(text).not.toContain('LD E, E');
+    expect(text).not.toContain('LD D, D');
     expect(text).not.toContain('LD HL, SRC_W');
   });
 


### PR DESCRIPTION
Closes #436

This is a narrow code-shape cleanup follow-up to the word pipeline work.

What changed
- `STORE_RP_EA('DE')` now omits redundant self-moves (`ld e, e` / `ld d, d`)
- non-`DE` paths (for example `BC`) still emit the expected register-byte moves
- tightened regressions to assert the no-op moves stay gone in the mixed word mem->mem case

Verification
- `npm test -- --run test/addressing_model_steps.test.ts test/pr406_word_edge_cases.test.ts test/pr406_word_scalar_accessors.test.ts test/smoke_language_tour_compile.test.ts`

No behavior change is intended; this is an output-shape cleanup only.
