### PR TITLE
Add Windows npm CLI smoke to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,13 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Windows npm CLI smoke
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          npm run build
+          node dist/src/cli.js --version
+
       - name: Format check
         if: ${{ env.SKIP_LANGUAGE_TOUR != '1' }}
         run: npm run format:check


### PR DESCRIPTION
Closes #333\n\nThis updates CI to explicitly exercise the documented Windows npm-only CLI path in the full matrix.\n\nWhat changed:\n- added a Windows-only CI step that runs 
> zax@0.0.0 build
> tsc -p tsconfig.json and then 0.0.0\n- docs-only gating and the full matrix were already present; this fills the missing explicit Windows smoke check\n\nVerification:\n- npm test -- --run test/cli_zax_smoke.test.ts test/pr288_ci_docs_only_classifier.test.ts test/ci_change_classifier.test.ts\n- npm run build\n- node dist/src/cli.js --version