### PR TITLE
Add addressing mini-suite fixture lock

### DIFF
--- a/examples/language-tour/31_scalar_byte_frame.asm
+++ b/examples/language-tour/31_scalar_byte_frame.asm
@@ -9,53 +9,45 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-ld B, (IX+$04)                 ; 010B: DD 46 04
-push DE                        ; 010E: D5
-push HL                        ; 010F: E5
-ld E, (IX + $0004)             ; 0110: DD 5E 04
-ld D, (IX + $0005)             ; 0113: DD 56 05
-ld HL, $0000                   ; 0116: 21 00 00
-add HL, DE                     ; 0119: 19
-ld (HL), B                     ; 011A: 70
-pop HL                         ; 011B: E1
-pop DE                         ; 011C: D1
-ld H, $0000                    ; 011D: 26 00
-ld L, B                        ; 011F: 68
+ld B, (ix+$04)                 ; 010B: DD 46 04
+ld (ix+$04), B                 ; 010E: DD 70 04
+ld H, $0000                    ; 0111: 26 00
+ld L, B                        ; 0113: 68
 __zax_epilogue_0:
-pop DE                         ; 0120: D1
-pop BC                         ; 0121: C1
-pop AF                         ; 0122: F1
-ld SP, IX                      ; 0123: DD F9
-pop IX                         ; 0125: DD E1
-ret                            ; 0127: C9
+pop DE                         ; 0114: D1
+pop BC                         ; 0115: C1
+pop AF                         ; 0116: F1
+ld SP, IX                      ; 0117: DD F9
+pop IX                         ; 0119: DD E1
+ret                            ; 011B: C9
 ; func main begin
 ; func touch_scalar_byte_frame end
 main:
-push IX                        ; 0128: DD E5
-ld IX, $0000                   ; 012A: DD 21 00 00
-add IX, SP                     ; 012E: DD 39
-push AF                        ; 0130: F5
-push BC                        ; 0131: C5
-push DE                        ; 0132: D5
-push HL                        ; 0133: E5
-ld HL, $0044                   ; 0134: 21 44 00
-push HL                        ; 0137: E5
-call touch_scalar_byte_frame   ; 0138: CD 00 00
-inc SP                         ; 013B: 33
-inc SP                         ; 013C: 33
+push IX                        ; 011C: DD E5
+ld IX, $0000                   ; 011E: DD 21 00 00
+add IX, SP                     ; 0122: DD 39
+push AF                        ; 0124: F5
+push BC                        ; 0125: C5
+push DE                        ; 0126: D5
+push HL                        ; 0127: E5
+ld HL, $0044                   ; 0128: 21 44 00
+push HL                        ; 012B: E5
+call touch_scalar_byte_frame   ; 012C: CD 00 00
+inc SP                         ; 012F: 33
+inc SP                         ; 0130: 33
 __zax_epilogue_1:
-pop HL                         ; 013D: E1
-pop DE                         ; 013E: D1
-pop BC                         ; 013F: C1
-pop AF                         ; 0140: F1
-ld SP, IX                      ; 0141: DD F9
-pop IX                         ; 0143: DD E1
-ret                            ; 0145: C9
+pop HL                         ; 0131: E1
+pop DE                         ; 0132: D1
+pop BC                         ; 0133: C1
+pop AF                         ; 0134: F1
+ld SP, IX                      ; 0135: DD F9
+pop IX                         ; 0137: DD E1
+ret                            ; 0139: C9
 ; func main end
 
 ; symbols:
 ; label touch_scalar_byte_frame = $0100
-; label __zax_epilogue_0 = $0120
-; label main = $0128
-; label __zax_epilogue_1 = $013D
+; label __zax_epilogue_0 = $0114
+; label main = $011C
+; label __zax_epilogue_1 = $0131
 ; data dummy = $2000

--- a/examples/language-tour/31_scalar_byte_frame.d8dbg.json
+++ b/examples/language-tour/31_scalar_byte_frame.d8dbg.json
@@ -16,7 +16,7 @@
         },
         {
           "start": 256,
-          "end": 326,
+          "end": 314,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
@@ -30,49 +30,49 @@
         },
         {
           "start": 270,
-          "end": 285,
+          "end": 273,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 285,
-          "end": 287,
+          "start": 273,
+          "end": 275,
           "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 287,
-          "end": 288,
+          "start": 275,
+          "end": 276,
           "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 288,
-          "end": 296,
+          "start": 276,
+          "end": 284,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 296,
-          "end": 308,
+          "start": 284,
+          "end": 296,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 308,
-          "end": 317,
+          "start": 296,
+          "end": 305,
           "lstLine": 15,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 317,
-          "end": 326,
+          "start": 305,
+          "end": 314,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
@@ -96,21 +96,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 288,
+          "address": 276,
           "line": 7,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 296,
+          "address": 284,
           "line": 14,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 317,
+          "address": 305,
           "line": 14,
           "scope": "local"
         },
@@ -127,7 +127,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 326
+      "end": 314
     },
     {
       "start": 8192,
@@ -149,7 +149,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 288,
+      "address": 276,
       "file": "31_scalar_byte_frame.zax",
       "line": 7,
       "scope": "local"
@@ -157,7 +157,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 296,
+      "address": 284,
       "file": "31_scalar_byte_frame.zax",
       "line": 14,
       "scope": "global"
@@ -165,7 +165,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 317,
+      "address": 305,
       "file": "31_scalar_byte_frame.zax",
       "line": 14,
       "scope": "local"
@@ -182,6 +182,6 @@
   "generator": {
     "tool": "zax",
     "entrySymbol": "main",
-    "entryAddress": 296
+    "entryAddress": 284
   }
 }

--- a/examples/language-tour/35_byte_glob_reg8.asm
+++ b/examples/language-tour/35_byte_glob_reg8.asm
@@ -9,67 +9,69 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-ld e, (ix+$04)                 ; 010B: DD 5E 04
-ld d, (ix+$05)                 ; 010E: DD 56 05
-ex de, hl                      ; 0111: EB
-push HL                        ; 0112: E5
-pop HL                         ; 0113: E1
-push HL                        ; 0114: E5
-ld HL, glob_bytes              ; 0115: 21 00 00
-pop DE                         ; 0118: D1
-add HL, DE                     ; 0119: 19
-push HL                        ; 011A: E5
-pop HL                         ; 011B: E1
-ld B, (hl)                     ; 011C: 46
-ld e, (ix+$04)                 ; 011D: DD 5E 04
-ld d, (ix+$05)                 ; 0120: DD 56 05
-ex de, hl                      ; 0123: EB
-push HL                        ; 0124: E5
-pop HL                         ; 0125: E1
+ex DE, HL                      ; 010B: EB
+ld E, (IX + $0004)             ; 010C: DD 5E 04
+ld D, (IX + $0005)             ; 010F: DD 56 05
+ex DE, HL                      ; 0112: EB
+push HL                        ; 0113: E5
+pop HL                         ; 0114: E1
+push HL                        ; 0115: E5
+ld HL, glob_bytes              ; 0116: 21 00 00
+pop DE                         ; 0119: D1
+add HL, DE                     ; 011A: 19
+push HL                        ; 011B: E5
+pop HL                         ; 011C: E1
+ld B, (hl)                     ; 011D: 46
+ex DE, HL                      ; 011E: EB
+ld E, (IX + $0004)             ; 011F: DD 5E 04
+ld D, (IX + $0005)             ; 0122: DD 56 05
+ex DE, HL                      ; 0125: EB
 push HL                        ; 0126: E5
-ld HL, glob_bytes              ; 0127: 21 00 00
-pop DE                         ; 012A: D1
-add HL, DE                     ; 012B: 19
-push HL                        ; 012C: E5
-pop HL                         ; 012D: E1
-ld (hl), B                     ; 012E: 70
-ld H, $0000                    ; 012F: 26 00
-ld L, B                        ; 0131: 68
+pop HL                         ; 0127: E1
+push HL                        ; 0128: E5
+ld HL, glob_bytes              ; 0129: 21 00 00
+pop DE                         ; 012C: D1
+add HL, DE                     ; 012D: 19
+push HL                        ; 012E: E5
+pop HL                         ; 012F: E1
+ld (hl), B                     ; 0130: 70
+ld H, $0000                    ; 0131: 26 00
+ld L, B                        ; 0133: 68
 __zax_epilogue_0:
-pop DE                         ; 0132: D1
-pop BC                         ; 0133: C1
-pop AF                         ; 0134: F1
-ld SP, IX                      ; 0135: DD F9
-pop IX                         ; 0137: DD E1
-ret                            ; 0139: C9
+pop DE                         ; 0134: D1
+pop BC                         ; 0135: C1
+pop AF                         ; 0136: F1
+ld SP, IX                      ; 0137: DD F9
+pop IX                         ; 0139: DD E1
+ret                            ; 013B: C9
 ; func byte_glob_reg end
 ; func main begin
 main:
-push IX                        ; 013A: DD E5
-ld IX, $0000                   ; 013C: DD 21 00 00
-add IX, SP                     ; 0140: DD 39
-push AF                        ; 0142: F5
-push BC                        ; 0143: C5
-push DE                        ; 0144: D5
-push HL                        ; 0145: E5
-ld HL, $0003                   ; 0146: 21 03 00
-push HL                        ; 0149: E5
-call byte_glob_reg             ; 014A: CD 00 00
-inc SP                         ; 014D: 33
-inc SP                         ; 014E: 33
+push IX                        ; 013C: DD E5
+ld IX, $0000                   ; 013E: DD 21 00 00
+add IX, SP                     ; 0142: DD 39
+push AF                        ; 0144: F5
+push BC                        ; 0145: C5
+push DE                        ; 0146: D5
+push HL                        ; 0147: E5
+ld HL, $0003                   ; 0148: 21 03 00
+push HL                        ; 014B: E5
+call byte_glob_reg             ; 014C: CD 00 00
+inc SP                         ; 014F: 33
+inc SP                         ; 0150: 33
 __zax_epilogue_1:
-pop HL                         ; 014F: E1
-pop DE                         ; 0150: D1
-pop BC                         ; 0151: C1
-pop AF                         ; 0152: F1
-ld SP, IX                      ; 0153: DD F9
-pop IX                         ; 0155: DD E1
-ret                            ; 0157: C9
+pop HL                         ; 0151: E1
+pop DE                         ; 0152: D1
+pop BC                         ; 0153: C1
+pop AF                         ; 0154: F1
+ld SP, IX                      ; 0155: DD F9
+pop IX                         ; 0157: DD E1
+ret                            ; 0159: C9
 ; func main end
 
 ; symbols:
 ; label byte_glob_reg = $0100
-; label __zax_epilogue_0 = $0132
-; label main = $013A
-; label __zax_epilogue_1 = $014F
+; label __zax_epilogue_0 = $0134
+; label main = $013C
+; label __zax_epilogue_1 = $0151
 ; data glob_bytes = $2000

--- a/examples/language-tour/35_byte_glob_reg8.d8dbg.json
+++ b/examples/language-tour/35_byte_glob_reg8.d8dbg.json
@@ -16,63 +16,63 @@
         },
         {
           "start": 256,
-          "end": 344,
+          "end": 346,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
         },
         {
           "start": 267,
-          "end": 285,
+          "end": 286,
           "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 285,
-          "end": 303,
+          "start": 286,
+          "end": 305,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 303,
-          "end": 305,
+          "start": 305,
+          "end": 307,
           "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 305,
-          "end": 306,
+          "start": 307,
+          "end": 308,
           "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 306,
-          "end": 314,
+          "start": 308,
+          "end": 316,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 314,
-          "end": 326,
+          "start": 316,
+          "end": 328,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 326,
-          "end": 335,
+          "start": 328,
+          "end": 337,
           "lstLine": 15,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 335,
-          "end": 344,
+          "start": 337,
+          "end": 346,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
@@ -96,21 +96,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 306,
+          "address": 308,
           "line": 7,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 314,
+          "address": 316,
           "line": 14,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 335,
+          "address": 337,
           "line": 14,
           "scope": "local"
         },
@@ -127,7 +127,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 344
+      "end": 346
     },
     {
       "start": 8192,
@@ -149,7 +149,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 306,
+      "address": 308,
       "file": "35_byte_glob_reg8.zax",
       "line": 7,
       "scope": "local"
@@ -157,7 +157,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 314,
+      "address": 316,
       "file": "35_byte_glob_reg8.zax",
       "line": 14,
       "scope": "global"
@@ -165,7 +165,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 335,
+      "address": 337,
       "file": "35_byte_glob_reg8.zax",
       "line": 14,
       "scope": "local"
@@ -182,6 +182,6 @@
   "generator": {
     "tool": "zax",
     "entrySymbol": "main",
-    "entryAddress": 314
+    "entryAddress": 316
   }
 }

--- a/examples/language-tour/37_byte_fvar_const.asm
+++ b/examples/language-tour/37_byte_fvar_const.asm
@@ -9,54 +9,45 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-ld A, (IX+$06)                 ; 010B: DD 7E 06
-push AF                        ; 010E: F5
-push DE                        ; 010F: D5
-push IX                        ; 0110: DD E5
-pop HL                         ; 0112: E1
-ld DE, $0007                   ; 0113: 11 07 00
-add HL, DE                     ; 0116: 19
-push HL                        ; 0117: E5
-pop DE                         ; 0118: D1
-ld (hl), A                     ; 0119: 77
-pop AF                         ; 011A: F1
-ld H, $0000                    ; 011B: 26 00
-ld L, A                        ; 011D: 6F
+ld A, (ix+$06)                 ; 010B: DD 7E 06
+ld (ix+$07), A                 ; 010E: DD 77 07
+ld H, $0000                    ; 0111: 26 00
+ld L, A                        ; 0113: 6F
 __zax_epilogue_0:
-pop DE                         ; 011E: D1
-pop BC                         ; 011F: C1
-pop AF                         ; 0120: F1
-ld SP, IX                      ; 0121: DD F9
-pop IX                         ; 0123: DD E1
-ret                            ; 0125: C9
+pop DE                         ; 0114: D1
+pop BC                         ; 0115: C1
+pop AF                         ; 0116: F1
+ld SP, IX                      ; 0117: DD F9
+pop IX                         ; 0119: DD E1
+ret                            ; 011B: C9
 ; func byte_fvar_const end
 ; func main begin
 main:
-push IX                        ; 0126: DD E5
-ld IX, $0000                   ; 0128: DD 21 00 00
-add IX, SP                     ; 012C: DD 39
-push AF                        ; 012E: F5
-push BC                        ; 012F: C5
-push DE                        ; 0130: D5
-push HL                        ; 0131: E5
-ld HL, glob_bytes              ; 0132: 21 00 00
-push HL                        ; 0135: E5
-call byte_fvar_const           ; 0136: CD 00 00
-inc SP                         ; 0139: 33
-inc SP                         ; 013A: 33
+push IX                        ; 011C: DD E5
+ld IX, $0000                   ; 011E: DD 21 00 00
+add IX, SP                     ; 0122: DD 39
+push AF                        ; 0124: F5
+push BC                        ; 0125: C5
+push DE                        ; 0126: D5
+push HL                        ; 0127: E5
+ld HL, glob_bytes              ; 0128: 21 00 00
+push HL                        ; 012B: E5
+call byte_fvar_const           ; 012C: CD 00 00
+inc SP                         ; 012F: 33
+inc SP                         ; 0130: 33
 __zax_epilogue_1:
-pop HL                         ; 013B: E1
-pop DE                         ; 013C: D1
-pop BC                         ; 013D: C1
-pop AF                         ; 013E: F1
-ld SP, IX                      ; 013F: DD F9
-pop IX                         ; 0141: DD E1
-ret                            ; 0143: C9
+pop HL                         ; 0131: E1
+pop DE                         ; 0132: D1
+pop BC                         ; 0133: C1
+pop AF                         ; 0134: F1
+ld SP, IX                      ; 0135: DD F9
+pop IX                         ; 0137: DD E1
+ret                            ; 0139: C9
 ; func main end
 
 ; symbols:
 ; label byte_fvar_const = $0100
-; label __zax_epilogue_0 = $011E
-; label main = $0126
-; label __zax_epilogue_1 = $013B
+; label __zax_epilogue_0 = $0114
+; label main = $011C
+; label __zax_epilogue_1 = $0131
 ; data glob_bytes = $2000

--- a/examples/language-tour/37_byte_fvar_const.d8dbg.json
+++ b/examples/language-tour/37_byte_fvar_const.d8dbg.json
@@ -16,7 +16,7 @@
         },
         {
           "start": 256,
-          "end": 324,
+          "end": 314,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
@@ -30,49 +30,49 @@
         },
         {
           "start": 270,
-          "end": 283,
+          "end": 273,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 283,
-          "end": 285,
+          "start": 273,
+          "end": 275,
           "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 285,
-          "end": 286,
+          "start": 275,
+          "end": 276,
           "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 286,
-          "end": 294,
+          "start": 276,
+          "end": 284,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 294,
-          "end": 306,
+          "start": 284,
+          "end": 296,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 306,
-          "end": 315,
+          "start": 296,
+          "end": 305,
           "lstLine": 15,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 315,
-          "end": 324,
+          "start": 305,
+          "end": 314,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
@@ -96,21 +96,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 286,
+          "address": 276,
           "line": 7,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 294,
+          "address": 284,
           "line": 14,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 315,
+          "address": 305,
           "line": 14,
           "scope": "local"
         },
@@ -127,7 +127,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 324
+      "end": 314
     },
     {
       "start": 8192,
@@ -149,7 +149,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 286,
+      "address": 276,
       "file": "37_byte_fvar_const.zax",
       "line": 7,
       "scope": "local"
@@ -157,7 +157,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 294,
+      "address": 284,
       "file": "37_byte_fvar_const.zax",
       "line": 14,
       "scope": "global"
@@ -165,7 +165,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 315,
+      "address": 305,
       "file": "37_byte_fvar_const.zax",
       "line": 14,
       "scope": "local"
@@ -182,6 +182,6 @@
   "generator": {
     "tool": "zax",
     "entrySymbol": "main",
-    "entryAddress": 294
+    "entryAddress": 284
   }
 }

--- a/examples/language-tour/38_byte_fvar_reg8.asm
+++ b/examples/language-tour/38_byte_fvar_reg8.asm
@@ -9,81 +9,83 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-ld e, (ix+$06)                 ; 010B: DD 5E 06
-ld d, (ix+$07)                 ; 010E: DD 56 07
-ex de, hl                      ; 0111: EB
-push HL                        ; 0112: E5
-pop HL                         ; 0113: E1
-push HL                        ; 0114: E5
-push DE                        ; 0115: D5
-push IX                        ; 0116: DD E5
-pop HL                         ; 0118: E1
-ld DE, $0004                   ; 0119: 11 04 00
-add HL, DE                     ; 011C: 19
-pop DE                         ; 011D: D1
+ex DE, HL                      ; 010B: EB
+ld E, (IX + $0006)             ; 010C: DD 5E 06
+ld D, (IX + $0007)             ; 010F: DD 56 07
+ex DE, HL                      ; 0112: EB
+push HL                        ; 0113: E5
+pop HL                         ; 0114: E1
+push HL                        ; 0115: E5
+push DE                        ; 0116: D5
+push IX                        ; 0117: DD E5
+pop HL                         ; 0119: E1
+ld DE, $0004                   ; 011A: 11 04 00
+add HL, DE                     ; 011D: 19
 pop DE                         ; 011E: D1
-add HL, DE                     ; 011F: 19
-push HL                        ; 0120: E5
-pop HL                         ; 0121: E1
-ld B, (hl)                     ; 0122: 46
-ld e, (ix+$06)                 ; 0123: DD 5E 06
-ld d, (ix+$07)                 ; 0126: DD 56 07
-ex de, hl                      ; 0129: EB
-push HL                        ; 012A: E5
-pop HL                         ; 012B: E1
+pop DE                         ; 011F: D1
+add HL, DE                     ; 0120: 19
+push HL                        ; 0121: E5
+pop HL                         ; 0122: E1
+ld B, (hl)                     ; 0123: 46
+ex DE, HL                      ; 0124: EB
+ld E, (IX + $0006)             ; 0125: DD 5E 06
+ld D, (IX + $0007)             ; 0128: DD 56 07
+ex DE, HL                      ; 012B: EB
 push HL                        ; 012C: E5
-push DE                        ; 012D: D5
-push IX                        ; 012E: DD E5
-pop HL                         ; 0130: E1
-ld DE, $0004                   ; 0131: 11 04 00
-add HL, DE                     ; 0134: 19
-pop DE                         ; 0135: D1
-pop DE                         ; 0136: D1
-add HL, DE                     ; 0137: 19
-push HL                        ; 0138: E5
-pop HL                         ; 0139: E1
-ld (hl), B                     ; 013A: 70
-ld H, $0000                    ; 013B: 26 00
-ld L, B                        ; 013D: 68
+pop HL                         ; 012D: E1
+push HL                        ; 012E: E5
+push DE                        ; 012F: D5
+push IX                        ; 0130: DD E5
+pop HL                         ; 0132: E1
+ld DE, $0004                   ; 0133: 11 04 00
+add HL, DE                     ; 0136: 19
+pop DE                         ; 0137: D1
+pop DE                         ; 0138: D1
+add HL, DE                     ; 0139: 19
+push HL                        ; 013A: E5
+pop HL                         ; 013B: E1
+ld (hl), B                     ; 013C: 70
+ld H, $0000                    ; 013D: 26 00
+ld L, B                        ; 013F: 68
 __zax_epilogue_0:
-pop DE                         ; 013E: D1
-pop BC                         ; 013F: C1
-pop AF                         ; 0140: F1
-ld SP, IX                      ; 0141: DD F9
-pop IX                         ; 0143: DD E1
-ret                            ; 0145: C9
+pop DE                         ; 0140: D1
+pop BC                         ; 0141: C1
+pop AF                         ; 0142: F1
+ld SP, IX                      ; 0143: DD F9
+pop IX                         ; 0145: DD E1
+ret                            ; 0147: C9
 ; func byte_fvar_reg end
 ; func main begin
 main:
-push IX                        ; 0146: DD E5
-ld IX, $0000                   ; 0148: DD 21 00 00
-add IX, SP                     ; 014C: DD 39
-push AF                        ; 014E: F5
-push BC                        ; 014F: C5
-push DE                        ; 0150: D5
-push HL                        ; 0151: E5
-ld HL, $0001                   ; 0152: 21 01 00
-push HL                        ; 0155: E5
-ld HL, glob_bytes              ; 0156: 21 00 00
-push HL                        ; 0159: E5
-call byte_fvar_reg             ; 015A: CD 00 00
-inc SP                         ; 015D: 33
-inc SP                         ; 015E: 33
+push IX                        ; 0148: DD E5
+ld IX, $0000                   ; 014A: DD 21 00 00
+add IX, SP                     ; 014E: DD 39
+push AF                        ; 0150: F5
+push BC                        ; 0151: C5
+push DE                        ; 0152: D5
+push HL                        ; 0153: E5
+ld HL, $0001                   ; 0154: 21 01 00
+push HL                        ; 0157: E5
+ld HL, glob_bytes              ; 0158: 21 00 00
+push HL                        ; 015B: E5
+call byte_fvar_reg             ; 015C: CD 00 00
 inc SP                         ; 015F: 33
 inc SP                         ; 0160: 33
+inc SP                         ; 0161: 33
+inc SP                         ; 0162: 33
 __zax_epilogue_1:
-pop HL                         ; 0161: E1
-pop DE                         ; 0162: D1
-pop BC                         ; 0163: C1
-pop AF                         ; 0164: F1
-ld SP, IX                      ; 0165: DD F9
-pop IX                         ; 0167: DD E1
-ret                            ; 0169: C9
+pop HL                         ; 0163: E1
+pop DE                         ; 0164: D1
+pop BC                         ; 0165: C1
+pop AF                         ; 0166: F1
+ld SP, IX                      ; 0167: DD F9
+pop IX                         ; 0169: DD E1
+ret                            ; 016B: C9
 ; func main end
 
 ; symbols:
 ; label byte_fvar_reg = $0100
-; label __zax_epilogue_0 = $013E
-; label main = $0146
-; label __zax_epilogue_1 = $0161
+; label __zax_epilogue_0 = $0140
+; label main = $0148
+; label __zax_epilogue_1 = $0163
 ; data glob_bytes = $2000

--- a/examples/language-tour/38_byte_fvar_reg8.d8dbg.json
+++ b/examples/language-tour/38_byte_fvar_reg8.d8dbg.json
@@ -16,63 +16,63 @@
         },
         {
           "start": 256,
-          "end": 362,
+          "end": 364,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
         },
         {
           "start": 267,
-          "end": 291,
+          "end": 292,
           "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 291,
-          "end": 315,
+          "start": 292,
+          "end": 317,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 315,
-          "end": 317,
+          "start": 317,
+          "end": 319,
           "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 317,
-          "end": 318,
+          "start": 319,
+          "end": 320,
           "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 318,
-          "end": 326,
+          "start": 320,
+          "end": 328,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 326,
-          "end": 338,
+          "start": 328,
+          "end": 340,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 338,
-          "end": 353,
+          "start": 340,
+          "end": 355,
           "lstLine": 15,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 353,
-          "end": 362,
+          "start": 355,
+          "end": 364,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
@@ -96,21 +96,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 318,
+          "address": 320,
           "line": 7,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 326,
+          "address": 328,
           "line": 14,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 353,
+          "address": 355,
           "line": 14,
           "scope": "local"
         },
@@ -127,7 +127,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 362
+      "end": 364
     },
     {
       "start": 8192,
@@ -149,7 +149,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 318,
+      "address": 320,
       "file": "38_byte_fvar_reg8.zax",
       "line": 7,
       "scope": "local"
@@ -157,7 +157,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 326,
+      "address": 328,
       "file": "38_byte_fvar_reg8.zax",
       "line": 14,
       "scope": "global"
@@ -165,7 +165,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 353,
+      "address": 355,
       "file": "38_byte_fvar_reg8.zax",
       "line": 14,
       "scope": "local"
@@ -182,6 +182,6 @@
   "generator": {
     "tool": "zax",
     "entrySymbol": "main",
-    "entryAddress": 326
+    "entryAddress": 328
   }
 }

--- a/examples/language-tour/40_byte_glob_fvar.asm
+++ b/examples/language-tour/40_byte_glob_fvar.asm
@@ -9,69 +9,71 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-ld e, (ix+$04)                 ; 010B: DD 5E 04
-ld d, (ix+$05)                 ; 010E: DD 56 05
-ex de, hl                      ; 0111: EB
-push HL                        ; 0112: E5
-pop HL                         ; 0113: E1
-push HL                        ; 0114: E5
-ld HL, glob_bytes              ; 0115: 21 00 00
-pop DE                         ; 0118: D1
-add HL, DE                     ; 0119: 19
-push HL                        ; 011A: E5
-pop HL                         ; 011B: E1
-ld A, (hl)                     ; 011C: 7E
-push AF                        ; 011D: F5
-ld e, (ix+$04)                 ; 011E: DD 5E 04
-ld d, (ix+$05)                 ; 0121: DD 56 05
-ex de, hl                      ; 0124: EB
-push HL                        ; 0125: E5
-pop HL                         ; 0126: E1
+ex DE, HL                      ; 010B: EB
+ld E, (IX + $0004)             ; 010C: DD 5E 04
+ld D, (IX + $0005)             ; 010F: DD 56 05
+ex DE, HL                      ; 0112: EB
+push HL                        ; 0113: E5
+pop HL                         ; 0114: E1
+push HL                        ; 0115: E5
+ld HL, glob_bytes              ; 0116: 21 00 00
+pop DE                         ; 0119: D1
+add HL, DE                     ; 011A: 19
+push HL                        ; 011B: E5
+pop HL                         ; 011C: E1
+ld A, (hl)                     ; 011D: 7E
+push AF                        ; 011E: F5
+ex DE, HL                      ; 011F: EB
+ld E, (IX + $0004)             ; 0120: DD 5E 04
+ld D, (IX + $0005)             ; 0123: DD 56 05
+ex DE, HL                      ; 0126: EB
 push HL                        ; 0127: E5
-ld HL, glob_bytes              ; 0128: 21 00 00
-pop DE                         ; 012B: D1
-add HL, DE                     ; 012C: 19
-push HL                        ; 012D: E5
-pop HL                         ; 012E: E1
-ld (hl), A                     ; 012F: 77
-pop AF                         ; 0130: F1
-ld H, $0000                    ; 0131: 26 00
-ld L, A                        ; 0133: 6F
+pop HL                         ; 0128: E1
+push HL                        ; 0129: E5
+ld HL, glob_bytes              ; 012A: 21 00 00
+pop DE                         ; 012D: D1
+add HL, DE                     ; 012E: 19
+push HL                        ; 012F: E5
+pop HL                         ; 0130: E1
+ld (hl), A                     ; 0131: 77
+pop AF                         ; 0132: F1
+ld H, $0000                    ; 0133: 26 00
+ld L, A                        ; 0135: 6F
 __zax_epilogue_0:
-pop DE                         ; 0134: D1
-pop BC                         ; 0135: C1
-pop AF                         ; 0136: F1
-ld SP, IX                      ; 0137: DD F9
-pop IX                         ; 0139: DD E1
-ret                            ; 013B: C9
+pop DE                         ; 0136: D1
+pop BC                         ; 0137: C1
+pop AF                         ; 0138: F1
+ld SP, IX                      ; 0139: DD F9
+pop IX                         ; 013B: DD E1
+ret                            ; 013D: C9
 ; func byte_glob_fvar end
 ; func main begin
 main:
-push IX                        ; 013C: DD E5
-ld IX, $0000                   ; 013E: DD 21 00 00
-add IX, SP                     ; 0142: DD 39
-push AF                        ; 0144: F5
-push BC                        ; 0145: C5
-push DE                        ; 0146: D5
-push HL                        ; 0147: E5
-ld HL, $0002                   ; 0148: 21 02 00
-push HL                        ; 014B: E5
-call byte_glob_fvar            ; 014C: CD 00 00
-inc SP                         ; 014F: 33
-inc SP                         ; 0150: 33
+push IX                        ; 013E: DD E5
+ld IX, $0000                   ; 0140: DD 21 00 00
+add IX, SP                     ; 0144: DD 39
+push AF                        ; 0146: F5
+push BC                        ; 0147: C5
+push DE                        ; 0148: D5
+push HL                        ; 0149: E5
+ld HL, $0002                   ; 014A: 21 02 00
+push HL                        ; 014D: E5
+call byte_glob_fvar            ; 014E: CD 00 00
+inc SP                         ; 0151: 33
+inc SP                         ; 0152: 33
 __zax_epilogue_1:
-pop HL                         ; 0151: E1
-pop DE                         ; 0152: D1
-pop BC                         ; 0153: C1
-pop AF                         ; 0154: F1
-ld SP, IX                      ; 0155: DD F9
-pop IX                         ; 0157: DD E1
-ret                            ; 0159: C9
+pop HL                         ; 0153: E1
+pop DE                         ; 0154: D1
+pop BC                         ; 0155: C1
+pop AF                         ; 0156: F1
+ld SP, IX                      ; 0157: DD F9
+pop IX                         ; 0159: DD E1
+ret                            ; 015B: C9
 ; func main end
 
 ; symbols:
 ; label byte_glob_fvar = $0100
-; label __zax_epilogue_0 = $0134
-; label main = $013C
-; label __zax_epilogue_1 = $0151
+; label __zax_epilogue_0 = $0136
+; label main = $013E
+; label __zax_epilogue_1 = $0153
 ; data glob_bytes = $2000

--- a/examples/language-tour/40_byte_glob_fvar.d8dbg.json
+++ b/examples/language-tour/40_byte_glob_fvar.d8dbg.json
@@ -16,63 +16,63 @@
         },
         {
           "start": 256,
-          "end": 346,
+          "end": 348,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
         },
         {
           "start": 267,
-          "end": 285,
+          "end": 286,
           "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 285,
-          "end": 305,
+          "start": 286,
+          "end": 307,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 305,
-          "end": 307,
+          "start": 307,
+          "end": 309,
           "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 307,
-          "end": 308,
+          "start": 309,
+          "end": 310,
           "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 308,
-          "end": 316,
+          "start": 310,
+          "end": 318,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 316,
-          "end": 328,
+          "start": 318,
+          "end": 330,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 328,
-          "end": 337,
+          "start": 330,
+          "end": 339,
           "lstLine": 15,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 337,
-          "end": 346,
+          "start": 339,
+          "end": 348,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
@@ -96,21 +96,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 308,
+          "address": 310,
           "line": 7,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 316,
+          "address": 318,
           "line": 14,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 337,
+          "address": 339,
           "line": 14,
           "scope": "local"
         },
@@ -127,7 +127,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 346
+      "end": 348
     },
     {
       "start": 8192,
@@ -149,7 +149,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 308,
+      "address": 310,
       "file": "40_byte_glob_fvar.zax",
       "line": 7,
       "scope": "local"
@@ -157,7 +157,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 316,
+      "address": 318,
       "file": "40_byte_glob_fvar.zax",
       "line": 14,
       "scope": "global"
@@ -165,7 +165,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 337,
+      "address": 339,
       "file": "40_byte_glob_fvar.zax",
       "line": 14,
       "scope": "local"
@@ -182,6 +182,6 @@
   "generator": {
     "tool": "zax",
     "entrySymbol": "main",
-    "entryAddress": 316
+    "entryAddress": 318
   }
 }

--- a/examples/language-tour/41_byte_fvar_fvar.asm
+++ b/examples/language-tour/41_byte_fvar_fvar.asm
@@ -9,83 +9,85 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-ld e, (ix+$06)                 ; 010B: DD 5E 06
-ld d, (ix+$07)                 ; 010E: DD 56 07
-ex de, hl                      ; 0111: EB
-push HL                        ; 0112: E5
-pop HL                         ; 0113: E1
-push HL                        ; 0114: E5
-push DE                        ; 0115: D5
-push IX                        ; 0116: DD E5
-pop HL                         ; 0118: E1
-ld DE, $0004                   ; 0119: 11 04 00
-add HL, DE                     ; 011C: 19
-pop DE                         ; 011D: D1
+ex DE, HL                      ; 010B: EB
+ld E, (IX + $0006)             ; 010C: DD 5E 06
+ld D, (IX + $0007)             ; 010F: DD 56 07
+ex DE, HL                      ; 0112: EB
+push HL                        ; 0113: E5
+pop HL                         ; 0114: E1
+push HL                        ; 0115: E5
+push DE                        ; 0116: D5
+push IX                        ; 0117: DD E5
+pop HL                         ; 0119: E1
+ld DE, $0004                   ; 011A: 11 04 00
+add HL, DE                     ; 011D: 19
 pop DE                         ; 011E: D1
-add HL, DE                     ; 011F: 19
-push HL                        ; 0120: E5
-pop HL                         ; 0121: E1
-ld A, (hl)                     ; 0122: 7E
-push AF                        ; 0123: F5
-ld e, (ix+$06)                 ; 0124: DD 5E 06
-ld d, (ix+$07)                 ; 0127: DD 56 07
-ex de, hl                      ; 012A: EB
-push HL                        ; 012B: E5
-pop HL                         ; 012C: E1
+pop DE                         ; 011F: D1
+add HL, DE                     ; 0120: 19
+push HL                        ; 0121: E5
+pop HL                         ; 0122: E1
+ld A, (hl)                     ; 0123: 7E
+push AF                        ; 0124: F5
+ex DE, HL                      ; 0125: EB
+ld E, (IX + $0006)             ; 0126: DD 5E 06
+ld D, (IX + $0007)             ; 0129: DD 56 07
+ex DE, HL                      ; 012C: EB
 push HL                        ; 012D: E5
-push DE                        ; 012E: D5
-push IX                        ; 012F: DD E5
-pop HL                         ; 0131: E1
-ld DE, $0004                   ; 0132: 11 04 00
-add HL, DE                     ; 0135: 19
-pop DE                         ; 0136: D1
-pop DE                         ; 0137: D1
-add HL, DE                     ; 0138: 19
-push HL                        ; 0139: E5
-pop HL                         ; 013A: E1
-ld (hl), A                     ; 013B: 77
-pop AF                         ; 013C: F1
-ld H, $0000                    ; 013D: 26 00
-ld L, A                        ; 013F: 6F
+pop HL                         ; 012E: E1
+push HL                        ; 012F: E5
+push DE                        ; 0130: D5
+push IX                        ; 0131: DD E5
+pop HL                         ; 0133: E1
+ld DE, $0004                   ; 0134: 11 04 00
+add HL, DE                     ; 0137: 19
+pop DE                         ; 0138: D1
+pop DE                         ; 0139: D1
+add HL, DE                     ; 013A: 19
+push HL                        ; 013B: E5
+pop HL                         ; 013C: E1
+ld (hl), A                     ; 013D: 77
+pop AF                         ; 013E: F1
+ld H, $0000                    ; 013F: 26 00
+ld L, A                        ; 0141: 6F
 __zax_epilogue_0:
-pop DE                         ; 0140: D1
-pop BC                         ; 0141: C1
-pop AF                         ; 0142: F1
-ld SP, IX                      ; 0143: DD F9
-pop IX                         ; 0145: DD E1
-ret                            ; 0147: C9
+pop DE                         ; 0142: D1
+pop BC                         ; 0143: C1
+pop AF                         ; 0144: F1
+ld SP, IX                      ; 0145: DD F9
+pop IX                         ; 0147: DD E1
+ret                            ; 0149: C9
 ; func byte_fvar_fvar end
 ; func main begin
 main:
-push IX                        ; 0148: DD E5
-ld IX, $0000                   ; 014A: DD 21 00 00
-add IX, SP                     ; 014E: DD 39
-push AF                        ; 0150: F5
-push BC                        ; 0151: C5
-push DE                        ; 0152: D5
-push HL                        ; 0153: E5
-ld HL, $0005                   ; 0154: 21 05 00
-push HL                        ; 0157: E5
-ld HL, glob_bytes              ; 0158: 21 00 00
-push HL                        ; 015B: E5
-call byte_fvar_fvar            ; 015C: CD 00 00
-inc SP                         ; 015F: 33
-inc SP                         ; 0160: 33
+push IX                        ; 014A: DD E5
+ld IX, $0000                   ; 014C: DD 21 00 00
+add IX, SP                     ; 0150: DD 39
+push AF                        ; 0152: F5
+push BC                        ; 0153: C5
+push DE                        ; 0154: D5
+push HL                        ; 0155: E5
+ld HL, $0005                   ; 0156: 21 05 00
+push HL                        ; 0159: E5
+ld HL, glob_bytes              ; 015A: 21 00 00
+push HL                        ; 015D: E5
+call byte_fvar_fvar            ; 015E: CD 00 00
 inc SP                         ; 0161: 33
 inc SP                         ; 0162: 33
+inc SP                         ; 0163: 33
+inc SP                         ; 0164: 33
 __zax_epilogue_1:
-pop HL                         ; 0163: E1
-pop DE                         ; 0164: D1
-pop BC                         ; 0165: C1
-pop AF                         ; 0166: F1
-ld SP, IX                      ; 0167: DD F9
-pop IX                         ; 0169: DD E1
-ret                            ; 016B: C9
+pop HL                         ; 0165: E1
+pop DE                         ; 0166: D1
+pop BC                         ; 0167: C1
+pop AF                         ; 0168: F1
+ld SP, IX                      ; 0169: DD F9
+pop IX                         ; 016B: DD E1
+ret                            ; 016D: C9
 ; func main end
 
 ; symbols:
 ; label byte_fvar_fvar = $0100
-; label __zax_epilogue_0 = $0140
-; label main = $0148
-; label __zax_epilogue_1 = $0163
+; label __zax_epilogue_0 = $0142
+; label main = $014A
+; label __zax_epilogue_1 = $0165
 ; data glob_bytes = $2000

--- a/examples/language-tour/41_byte_fvar_fvar.d8dbg.json
+++ b/examples/language-tour/41_byte_fvar_fvar.d8dbg.json
@@ -16,63 +16,63 @@
         },
         {
           "start": 256,
-          "end": 364,
+          "end": 366,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
         },
         {
           "start": 267,
-          "end": 291,
+          "end": 292,
           "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 291,
-          "end": 317,
+          "start": 292,
+          "end": 319,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 317,
-          "end": 319,
+          "start": 319,
+          "end": 321,
           "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 319,
-          "end": 320,
+          "start": 321,
+          "end": 322,
           "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 320,
-          "end": 328,
+          "start": 322,
+          "end": 330,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 328,
-          "end": 340,
+          "start": 330,
+          "end": 342,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 340,
-          "end": 355,
+          "start": 342,
+          "end": 357,
           "lstLine": 15,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 355,
-          "end": 364,
+          "start": 357,
+          "end": 366,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
@@ -96,21 +96,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 320,
+          "address": 322,
           "line": 7,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 328,
+          "address": 330,
           "line": 14,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 355,
+          "address": 357,
           "line": 14,
           "scope": "local"
         },
@@ -127,7 +127,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 364
+      "end": 366
     },
     {
       "start": 8192,
@@ -149,7 +149,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 320,
+      "address": 322,
       "file": "41_byte_fvar_fvar.zax",
       "line": 7,
       "scope": "local"
@@ -157,7 +157,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 328,
+      "address": 330,
       "file": "41_byte_fvar_fvar.zax",
       "line": 14,
       "scope": "global"
@@ -165,7 +165,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 355,
+      "address": 357,
       "file": "41_byte_fvar_fvar.zax",
       "line": 14,
       "scope": "local"
@@ -182,6 +182,6 @@
   "generator": {
     "tool": "zax",
     "entrySymbol": "main",
-    "entryAddress": 328
+    "entryAddress": 330
   }
 }

--- a/examples/language-tour/60_word_glob_const.asm
+++ b/examples/language-tour/60_word_glob_const.asm
@@ -13,7 +13,7 @@ ld HL, (glob_words + 2)        ; 010B: 2A 00 00
 push DE                        ; 010E: D5
 push HL                        ; 010F: E5
 ld de, glob_words              ; 0110: 11 00 00
-ld HL, $0004                   ; 0113: 21 04 00
+ld HL, $0002                   ; 0113: 21 02 00
 add HL, HL                     ; 0116: 29
 add HL, DE                     ; 0117: 19
 pop DE                         ; 0118: D1

--- a/examples/language-tour/61_word_glob_reg8.asm
+++ b/examples/language-tour/61_word_glob_reg8.asm
@@ -9,76 +9,69 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-ld e, (ix+$04)                 ; 010B: DD 5E 04
-ld d, (ix+$05)                 ; 010E: DD 56 05
-ex de, hl                      ; 0111: EB
-push HL                        ; 0112: E5
-pop HL                         ; 0113: E1
-add HL, HL                     ; 0114: 29
-push HL                        ; 0115: E5
-ld HL, glob_words              ; 0116: 21 00 00
-pop DE                         ; 0119: D1
-add HL, DE                     ; 011A: 19
-push HL                        ; 011B: E5
-pop HL                         ; 011C: E1
-push AF                        ; 011D: F5
-ld A, (HL)                     ; 011E: 7E
-inc HL                         ; 011F: 23
-ld H, (HL)                     ; 0120: 66
-ld L, A                        ; 0121: 6F
-pop AF                         ; 0122: F1
-ld e, (ix+$04)                 ; 0123: DD 5E 04
-ld d, (ix+$05)                 ; 0126: DD 56 05
-ex de, hl                      ; 0129: EB
-push HL                        ; 012A: E5
-pop HL                         ; 012B: E1
+push DE                        ; 010B: D5
+ld de, glob_words              ; 010C: 11 00 00
+ex DE, HL                      ; 010F: EB
+ld E, (IX + $0004)             ; 0110: DD 5E 04
+ld D, (IX + $0005)             ; 0113: DD 56 05
+ex DE, HL                      ; 0116: EB
+add HL, HL                     ; 0117: 29
+add HL, DE                     ; 0118: 19
+ld E, (HL)                     ; 0119: 5E
+inc HL                         ; 011A: 23
+ld D, (HL)                     ; 011B: 56
+ld L, E                        ; 011C: 6B
+ld H, D                        ; 011D: 62
+pop DE                         ; 011E: D1
+push DE                        ; 011F: D5
+push HL                        ; 0120: E5
+ld de, glob_words              ; 0121: 11 00 00
+ex DE, HL                      ; 0124: EB
+ld E, (IX + $0004)             ; 0125: DD 5E 04
+ld D, (IX + $0005)             ; 0128: DD 56 05
+ex DE, HL                      ; 012B: EB
 add HL, HL                     ; 012C: 29
-push HL                        ; 012D: E5
-ld HL, glob_words              ; 012E: 21 00 00
-pop DE                         ; 0131: D1
-add HL, DE                     ; 0132: 19
-push HL                        ; 0133: E5
-pop HL                         ; 0134: E1
-ex DE, HL                      ; 0135: EB
-ld (hl), e                     ; 0136: 73
-inc HL                         ; 0137: 23
-ld (hl), d                     ; 0138: 72
-ex DE, HL                      ; 0139: EB
+add HL, DE                     ; 012D: 19
+pop DE                         ; 012E: D1
+ld (HL), E                     ; 012F: 73
+inc HL                         ; 0130: 23
+ld (HL), D                     ; 0131: 72
+pop DE                         ; 0132: D1
 __zax_epilogue_0:
-pop DE                         ; 013A: D1
-pop BC                         ; 013B: C1
-pop AF                         ; 013C: F1
-ld SP, IX                      ; 013D: DD F9
-pop IX                         ; 013F: DD E1
-ret                            ; 0141: C9
+pop DE                         ; 0133: D1
+pop BC                         ; 0134: C1
+pop AF                         ; 0135: F1
+ld SP, IX                      ; 0136: DD F9
+pop IX                         ; 0138: DD E1
+ret                            ; 013A: C9
 ; func main begin
 ; func word_glob_reg end
 main:
-push IX                        ; 0142: DD E5
-ld IX, $0000                   ; 0144: DD 21 00 00
-add IX, SP                     ; 0148: DD 39
-push AF                        ; 014A: F5
-push BC                        ; 014B: C5
-push DE                        ; 014C: D5
-push HL                        ; 014D: E5
-ld HL, $0003                   ; 014E: 21 03 00
-push HL                        ; 0151: E5
-call word_glob_reg             ; 0152: CD 00 00
-inc SP                         ; 0155: 33
-inc SP                         ; 0156: 33
+push IX                        ; 013B: DD E5
+ld IX, $0000                   ; 013D: DD 21 00 00
+add IX, SP                     ; 0141: DD 39
+push AF                        ; 0143: F5
+push BC                        ; 0144: C5
+push DE                        ; 0145: D5
+push HL                        ; 0146: E5
+ld HL, $0003                   ; 0147: 21 03 00
+push HL                        ; 014A: E5
+call word_glob_reg             ; 014B: CD 00 00
+inc SP                         ; 014E: 33
+inc SP                         ; 014F: 33
 __zax_epilogue_1:
-pop HL                         ; 0157: E1
-pop DE                         ; 0158: D1
-pop BC                         ; 0159: C1
-pop AF                         ; 015A: F1
-ld SP, IX                      ; 015B: DD F9
-pop IX                         ; 015D: DD E1
-ret                            ; 015F: C9
+pop HL                         ; 0150: E1
+pop DE                         ; 0151: D1
+pop BC                         ; 0152: C1
+pop AF                         ; 0153: F1
+ld SP, IX                      ; 0154: DD F9
+pop IX                         ; 0156: DD E1
+ret                            ; 0158: C9
 ; func main end
 
 ; symbols:
 ; label word_glob_reg = $0100
-; label __zax_epilogue_0 = $013A
-; label main = $0142
-; label __zax_epilogue_1 = $0157
+; label __zax_epilogue_0 = $0133
+; label main = $013B
+; label __zax_epilogue_1 = $0150
 ; data glob_words = $2000

--- a/examples/language-tour/61_word_glob_reg8.d8dbg.json
+++ b/examples/language-tour/61_word_glob_reg8.d8dbg.json
@@ -16,49 +16,49 @@
         },
         {
           "start": 256,
-          "end": 352,
+          "end": 345,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
         },
         {
           "start": 267,
-          "end": 291,
+          "end": 287,
           "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 291,
-          "end": 314,
+          "start": 287,
+          "end": 307,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 314,
-          "end": 322,
+          "start": 307,
+          "end": 315,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 322,
-          "end": 334,
+          "start": 315,
+          "end": 327,
           "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 334,
-          "end": 343,
+          "start": 327,
+          "end": 336,
           "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 343,
-          "end": 352,
+          "start": 336,
+          "end": 345,
           "lstLine": 12,
           "kind": "code",
           "confidence": "high"
@@ -82,21 +82,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 314,
+          "address": 307,
           "line": 7,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 322,
+          "address": 315,
           "line": 12,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 343,
+          "address": 336,
           "line": 12,
           "scope": "local"
         },
@@ -113,7 +113,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 352
+      "end": 345
     },
     {
       "start": 8192,
@@ -135,7 +135,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 314,
+      "address": 307,
       "file": "61_word_glob_reg8.zax",
       "line": 7,
       "scope": "local"
@@ -143,7 +143,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 322,
+      "address": 315,
       "file": "61_word_glob_reg8.zax",
       "line": 12,
       "scope": "global"
@@ -151,7 +151,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 343,
+      "address": 336,
       "file": "61_word_glob_reg8.zax",
       "line": 12,
       "scope": "local"
@@ -168,6 +168,6 @@
   "generator": {
     "tool": "zax",
     "entrySymbol": "main",
-    "entryAddress": 322
+    "entryAddress": 315
   }
 }

--- a/examples/language-tour/62_word_glob_reg16.asm
+++ b/examples/language-tour/62_word_glob_reg16.asm
@@ -30,48 +30,46 @@ ld de, glob_words              ; 0122: 11 00 00
 add HL, HL                     ; 0125: 29
 add HL, DE                     ; 0126: 19
 pop DE                         ; 0127: D1
-ld E, E                        ; 0128: 5B
-ld D, D                        ; 0129: 52
-ld (HL), E                     ; 012A: 73
-inc HL                         ; 012B: 23
-ld (HL), D                     ; 012C: 72
-pop HL                         ; 012D: E1
-ex DE, HL                      ; 012E: EB
+ld (HL), E                     ; 0128: 73
+inc HL                         ; 0129: 23
+ld (HL), D                     ; 012A: 72
+pop HL                         ; 012B: E1
+ex DE, HL                      ; 012C: EB
 __zax_epilogue_0:
-pop DE                         ; 012F: D1
-pop BC                         ; 0130: C1
-pop AF                         ; 0131: F1
-ld SP, IX                      ; 0132: DD F9
-pop IX                         ; 0134: DD E1
-ret                            ; 0136: C9
+pop DE                         ; 012D: D1
+pop BC                         ; 012E: C1
+pop AF                         ; 012F: F1
+ld SP, IX                      ; 0130: DD F9
+pop IX                         ; 0132: DD E1
+ret                            ; 0134: C9
 ; func main begin
 ; func word_glob_reg16 end
 main:
-push IX                        ; 0137: DD E5
-ld IX, $0000                   ; 0139: DD 21 00 00
-add IX, SP                     ; 013D: DD 39
-push AF                        ; 013F: F5
-push BC                        ; 0140: C5
-push DE                        ; 0141: D5
-push HL                        ; 0142: E5
-ld HL, $0004                   ; 0143: 21 04 00
-push HL                        ; 0146: E5
-call word_glob_reg16           ; 0147: CD 00 00
-inc SP                         ; 014A: 33
-inc SP                         ; 014B: 33
+push IX                        ; 0135: DD E5
+ld IX, $0000                   ; 0137: DD 21 00 00
+add IX, SP                     ; 013B: DD 39
+push AF                        ; 013D: F5
+push BC                        ; 013E: C5
+push DE                        ; 013F: D5
+push HL                        ; 0140: E5
+ld HL, $0004                   ; 0141: 21 04 00
+push HL                        ; 0144: E5
+call word_glob_reg16           ; 0145: CD 00 00
+inc SP                         ; 0148: 33
+inc SP                         ; 0149: 33
 __zax_epilogue_1:
-pop HL                         ; 014C: E1
-pop DE                         ; 014D: D1
-pop BC                         ; 014E: C1
-pop AF                         ; 014F: F1
-ld SP, IX                      ; 0150: DD F9
-pop IX                         ; 0152: DD E1
-ret                            ; 0154: C9
+pop HL                         ; 014A: E1
+pop DE                         ; 014B: D1
+pop BC                         ; 014C: C1
+pop AF                         ; 014D: F1
+ld SP, IX                      ; 014E: DD F9
+pop IX                         ; 0150: DD E1
+ret                            ; 0152: C9
 ; func main end
 
 ; symbols:
 ; label word_glob_reg16 = $0100
-; label __zax_epilogue_0 = $012F
-; label main = $0137
-; label __zax_epilogue_1 = $014C
+; label __zax_epilogue_0 = $012D
+; label main = $0135
+; label __zax_epilogue_1 = $014A
 ; data glob_words = $2000

--- a/examples/language-tour/62_word_glob_reg16.d8dbg.json
+++ b/examples/language-tour/62_word_glob_reg16.d8dbg.json
@@ -16,7 +16,7 @@
         },
         {
           "start": 256,
-          "end": 341,
+          "end": 339,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
@@ -37,42 +37,42 @@
         },
         {
           "start": 288,
-          "end": 302,
+          "end": 300,
           "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 302,
-          "end": 303,
+          "start": 300,
+          "end": 301,
           "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 303,
-          "end": 311,
+          "start": 301,
+          "end": 309,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 311,
-          "end": 323,
+          "start": 309,
+          "end": 321,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 323,
-          "end": 332,
+          "start": 321,
+          "end": 330,
           "lstLine": 15,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 332,
-          "end": 341,
+          "start": 330,
+          "end": 339,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
@@ -96,21 +96,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 303,
+          "address": 301,
           "line": 7,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 311,
+          "address": 309,
           "line": 14,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 332,
+          "address": 330,
           "line": 14,
           "scope": "local"
         },
@@ -127,7 +127,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 341
+      "end": 339
     },
     {
       "start": 8192,
@@ -149,7 +149,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 303,
+      "address": 301,
       "file": "62_word_glob_reg16.zax",
       "line": 7,
       "scope": "local"
@@ -157,7 +157,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 311,
+      "address": 309,
       "file": "62_word_glob_reg16.zax",
       "line": 14,
       "scope": "global"
@@ -165,7 +165,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 332,
+      "address": 330,
       "file": "62_word_glob_reg16.zax",
       "line": 14,
       "scope": "local"
@@ -182,6 +182,6 @@
   "generator": {
     "tool": "zax",
     "entrySymbol": "main",
-    "entryAddress": 311
+    "entryAddress": 309
   }
 }

--- a/examples/language-tour/64_word_fvar_reg8.asm
+++ b/examples/language-tour/64_word_fvar_reg8.asm
@@ -9,82 +9,77 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-ld e, (ix+$06)                 ; 010B: DD 5E 06
-ld d, (ix+$07)                 ; 010E: DD 56 07
-ex de, hl                      ; 0111: EB
-push HL                        ; 0112: E5
-pop HL                         ; 0113: E1
-add HL, HL                     ; 0114: 29
-push HL                        ; 0115: E5
-push DE                        ; 0116: D5
-push IX                        ; 0117: DD E5
-pop HL                         ; 0119: E1
-ld DE, $0004                   ; 011A: 11 04 00
-add HL, DE                     ; 011D: 19
-pop DE                         ; 011E: D1
-pop DE                         ; 011F: D1
-add HL, DE                     ; 0120: 19
-push HL                        ; 0121: E5
+push HL                        ; 010B: E5
+ld E, (IX + $0004)             ; 010C: DD 5E 04
+ld D, (IX + $0005)             ; 010F: DD 56 05
+ex DE, HL                      ; 0112: EB
+ld E, (IX + $0006)             ; 0113: DD 5E 06
+ld D, (IX + $0007)             ; 0116: DD 56 07
+ex DE, HL                      ; 0119: EB
+add HL, HL                     ; 011A: 29
+add HL, DE                     ; 011B: 19
+ld E, (HL)                     ; 011C: 5E
+inc HL                         ; 011D: 23
+ld D, (HL)                     ; 011E: 56
+ld L, E                        ; 011F: 6B
+ld H, D                        ; 0120: 62
+ex DE, HL                      ; 0121: EB
 pop HL                         ; 0122: E1
-ld a, (hl) ; inc hl ; ld d, (hl) ; ld e, a ; 0123: 7E 23 56 5F
-ld e, (ix+$06)                 ; 0127: DD 5E 06
-ld d, (ix+$07)                 ; 012A: DD 56 07
-ex de, hl                      ; 012D: EB
-push HL                        ; 012E: E5
-pop HL                         ; 012F: E1
-add HL, HL                     ; 0130: 29
-push HL                        ; 0131: E5
-push DE                        ; 0132: D5
-push IX                        ; 0133: DD E5
-pop HL                         ; 0135: E1
-ld DE, $0004                   ; 0136: 11 04 00
-add HL, DE                     ; 0139: 19
-pop DE                         ; 013A: D1
-pop DE                         ; 013B: D1
-add HL, DE                     ; 013C: 19
-push HL                        ; 013D: E5
-pop HL                         ; 013E: E1
-ld (hl), e ; inc hl ; ld (hl), d ; 013F: 73 23 72
-ex DE, HL                      ; 0142: EB
+push HL                        ; 0123: E5
+push DE                        ; 0124: D5
+ld E, (IX + $0004)             ; 0125: DD 5E 04
+ld D, (IX + $0005)             ; 0128: DD 56 05
+ex DE, HL                      ; 012B: EB
+ld E, (IX + $0006)             ; 012C: DD 5E 06
+ld D, (IX + $0007)             ; 012F: DD 56 07
+ex DE, HL                      ; 0132: EB
+add HL, HL                     ; 0133: 29
+add HL, DE                     ; 0134: 19
+pop DE                         ; 0135: D1
+ld (HL), E                     ; 0136: 73
+inc HL                         ; 0137: 23
+ld (HL), D                     ; 0138: 72
+pop HL                         ; 0139: E1
+ex DE, HL                      ; 013A: EB
 __zax_epilogue_0:
-pop DE                         ; 0143: D1
-pop BC                         ; 0144: C1
-pop AF                         ; 0145: F1
-ld SP, IX                      ; 0146: DD F9
-pop IX                         ; 0148: DD E1
-ret                            ; 014A: C9
+pop DE                         ; 013B: D1
+pop BC                         ; 013C: C1
+pop AF                         ; 013D: F1
+ld SP, IX                      ; 013E: DD F9
+pop IX                         ; 0140: DD E1
+ret                            ; 0142: C9
 ; func main begin
 ; func word_fvar_reg end
 main:
-push IX                        ; 014B: DD E5
-ld IX, $0000                   ; 014D: DD 21 00 00
-add IX, SP                     ; 0151: DD 39
-push AF                        ; 0153: F5
-push BC                        ; 0154: C5
-push DE                        ; 0155: D5
+push IX                        ; 0143: DD E5
+ld IX, $0000                   ; 0145: DD 21 00 00
+add IX, SP                     ; 0149: DD 39
+push AF                        ; 014B: F5
+push BC                        ; 014C: C5
+push DE                        ; 014D: D5
+push HL                        ; 014E: E5
+ld HL, $0001                   ; 014F: 21 01 00
+push HL                        ; 0152: E5
+ld HL, glob_words              ; 0153: 21 00 00
 push HL                        ; 0156: E5
-ld HL, $0001                   ; 0157: 21 01 00
-push HL                        ; 015A: E5
-ld HL, glob_words              ; 015B: 21 00 00
-push HL                        ; 015E: E5
-call word_fvar_reg             ; 015F: CD 00 00
-inc SP                         ; 0162: 33
-inc SP                         ; 0163: 33
-inc SP                         ; 0164: 33
-inc SP                         ; 0165: 33
+call word_fvar_reg             ; 0157: CD 00 00
+inc SP                         ; 015A: 33
+inc SP                         ; 015B: 33
+inc SP                         ; 015C: 33
+inc SP                         ; 015D: 33
 __zax_epilogue_1:
-pop HL                         ; 0166: E1
-pop DE                         ; 0167: D1
-pop BC                         ; 0168: C1
-pop AF                         ; 0169: F1
-ld SP, IX                      ; 016A: DD F9
-pop IX                         ; 016C: DD E1
-ret                            ; 016E: C9
+pop HL                         ; 015E: E1
+pop DE                         ; 015F: D1
+pop BC                         ; 0160: C1
+pop AF                         ; 0161: F1
+ld SP, IX                      ; 0162: DD F9
+pop IX                         ; 0164: DD E1
+ret                            ; 0166: C9
 ; func main end
 
 ; symbols:
 ; label word_fvar_reg = $0100
-; label __zax_epilogue_0 = $0143
-; label main = $014B
-; label __zax_epilogue_1 = $0166
+; label __zax_epilogue_0 = $013B
+; label main = $0143
+; label __zax_epilogue_1 = $015E
 ; data glob_words = $2000

--- a/examples/language-tour/64_word_fvar_reg8.d8dbg.json
+++ b/examples/language-tour/64_word_fvar_reg8.d8dbg.json
@@ -16,56 +16,56 @@
         },
         {
           "start": 256,
-          "end": 367,
+          "end": 359,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
         },
         {
           "start": 267,
-          "end": 295,
+          "end": 291,
           "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 295,
-          "end": 322,
+          "start": 291,
+          "end": 314,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 322,
-          "end": 323,
+          "start": 314,
+          "end": 315,
           "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 323,
-          "end": 331,
+          "start": 315,
+          "end": 323,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 331,
-          "end": 343,
+          "start": 323,
+          "end": 335,
           "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 343,
-          "end": 358,
+          "start": 335,
+          "end": 350,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 358,
-          "end": 367,
+          "start": 350,
+          "end": 359,
           "lstLine": 13,
           "kind": "code",
           "confidence": "high"
@@ -89,21 +89,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 323,
+          "address": 315,
           "line": 7,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 331,
+          "address": 323,
           "line": 13,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 358,
+          "address": 350,
           "line": 13,
           "scope": "local"
         },
@@ -120,7 +120,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 367
+      "end": 359
     },
     {
       "start": 8192,
@@ -142,7 +142,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 323,
+      "address": 315,
       "file": "64_word_fvar_reg8.zax",
       "line": 7,
       "scope": "local"
@@ -150,7 +150,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 331,
+      "address": 323,
       "file": "64_word_fvar_reg8.zax",
       "line": 13,
       "scope": "global"
@@ -158,7 +158,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 358,
+      "address": 350,
       "file": "64_word_fvar_reg8.zax",
       "line": 13,
       "scope": "local"
@@ -175,6 +175,6 @@
   "generator": {
     "tool": "zax",
     "entrySymbol": "main",
-    "entryAddress": 331
+    "entryAddress": 323
   }
 }

--- a/examples/language-tour/66_word_glob_fvar.asm
+++ b/examples/language-tour/66_word_glob_fvar.asm
@@ -9,76 +9,69 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-ld e, (ix+$04)                 ; 010B: DD 5E 04
-ld d, (ix+$05)                 ; 010E: DD 56 05
-ex de, hl                      ; 0111: EB
-push HL                        ; 0112: E5
-pop HL                         ; 0113: E1
-add HL, HL                     ; 0114: 29
-push HL                        ; 0115: E5
-ld HL, glob_words              ; 0116: 21 00 00
-pop DE                         ; 0119: D1
-add HL, DE                     ; 011A: 19
-push HL                        ; 011B: E5
-pop HL                         ; 011C: E1
-push AF                        ; 011D: F5
-ld A, (HL)                     ; 011E: 7E
-inc HL                         ; 011F: 23
-ld H, (HL)                     ; 0120: 66
-ld L, A                        ; 0121: 6F
-pop AF                         ; 0122: F1
-ld e, (ix+$04)                 ; 0123: DD 5E 04
-ld d, (ix+$05)                 ; 0126: DD 56 05
-ex de, hl                      ; 0129: EB
-push HL                        ; 012A: E5
-pop HL                         ; 012B: E1
+push DE                        ; 010B: D5
+ld de, glob_words              ; 010C: 11 00 00
+ex DE, HL                      ; 010F: EB
+ld E, (IX + $0004)             ; 0110: DD 5E 04
+ld D, (IX + $0005)             ; 0113: DD 56 05
+ex DE, HL                      ; 0116: EB
+add HL, HL                     ; 0117: 29
+add HL, DE                     ; 0118: 19
+ld E, (HL)                     ; 0119: 5E
+inc HL                         ; 011A: 23
+ld D, (HL)                     ; 011B: 56
+ld L, E                        ; 011C: 6B
+ld H, D                        ; 011D: 62
+pop DE                         ; 011E: D1
+push DE                        ; 011F: D5
+push HL                        ; 0120: E5
+ld de, glob_words              ; 0121: 11 00 00
+ex DE, HL                      ; 0124: EB
+ld E, (IX + $0004)             ; 0125: DD 5E 04
+ld D, (IX + $0005)             ; 0128: DD 56 05
+ex DE, HL                      ; 012B: EB
 add HL, HL                     ; 012C: 29
-push HL                        ; 012D: E5
-ld HL, glob_words              ; 012E: 21 00 00
-pop DE                         ; 0131: D1
-add HL, DE                     ; 0132: 19
-push HL                        ; 0133: E5
-pop HL                         ; 0134: E1
-ex DE, HL                      ; 0135: EB
-ld (hl), e                     ; 0136: 73
-inc HL                         ; 0137: 23
-ld (hl), d                     ; 0138: 72
-ex DE, HL                      ; 0139: EB
+add HL, DE                     ; 012D: 19
+pop DE                         ; 012E: D1
+ld (HL), E                     ; 012F: 73
+inc HL                         ; 0130: 23
+ld (HL), D                     ; 0131: 72
+pop DE                         ; 0132: D1
 __zax_epilogue_0:
-pop DE                         ; 013A: D1
-pop BC                         ; 013B: C1
-pop AF                         ; 013C: F1
-ld SP, IX                      ; 013D: DD F9
-pop IX                         ; 013F: DD E1
-ret                            ; 0141: C9
+pop DE                         ; 0133: D1
+pop BC                         ; 0134: C1
+pop AF                         ; 0135: F1
+ld SP, IX                      ; 0136: DD F9
+pop IX                         ; 0138: DD E1
+ret                            ; 013A: C9
 ; func main begin
 ; func word_glob_fvar end
 main:
-push IX                        ; 0142: DD E5
-ld IX, $0000                   ; 0144: DD 21 00 00
-add IX, SP                     ; 0148: DD 39
-push AF                        ; 014A: F5
-push BC                        ; 014B: C5
-push DE                        ; 014C: D5
-push HL                        ; 014D: E5
-ld HL, $0002                   ; 014E: 21 02 00
-push HL                        ; 0151: E5
-call word_glob_fvar            ; 0152: CD 00 00
-inc SP                         ; 0155: 33
-inc SP                         ; 0156: 33
+push IX                        ; 013B: DD E5
+ld IX, $0000                   ; 013D: DD 21 00 00
+add IX, SP                     ; 0141: DD 39
+push AF                        ; 0143: F5
+push BC                        ; 0144: C5
+push DE                        ; 0145: D5
+push HL                        ; 0146: E5
+ld HL, $0002                   ; 0147: 21 02 00
+push HL                        ; 014A: E5
+call word_glob_fvar            ; 014B: CD 00 00
+inc SP                         ; 014E: 33
+inc SP                         ; 014F: 33
 __zax_epilogue_1:
-pop HL                         ; 0157: E1
-pop DE                         ; 0158: D1
-pop BC                         ; 0159: C1
-pop AF                         ; 015A: F1
-ld SP, IX                      ; 015B: DD F9
-pop IX                         ; 015D: DD E1
-ret                            ; 015F: C9
+pop HL                         ; 0150: E1
+pop DE                         ; 0151: D1
+pop BC                         ; 0152: C1
+pop AF                         ; 0153: F1
+ld SP, IX                      ; 0154: DD F9
+pop IX                         ; 0156: DD E1
+ret                            ; 0158: C9
 ; func main end
 
 ; symbols:
 ; label word_glob_fvar = $0100
-; label __zax_epilogue_0 = $013A
-; label main = $0142
-; label __zax_epilogue_1 = $0157
+; label __zax_epilogue_0 = $0133
+; label main = $013B
+; label __zax_epilogue_1 = $0150
 ; data glob_words = $2000

--- a/examples/language-tour/66_word_glob_fvar.d8dbg.json
+++ b/examples/language-tour/66_word_glob_fvar.d8dbg.json
@@ -16,49 +16,49 @@
         },
         {
           "start": 256,
-          "end": 352,
+          "end": 345,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
         },
         {
           "start": 267,
-          "end": 291,
+          "end": 287,
           "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 291,
-          "end": 314,
+          "start": 287,
+          "end": 307,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 314,
-          "end": 322,
+          "start": 307,
+          "end": 315,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 322,
-          "end": 334,
+          "start": 315,
+          "end": 327,
           "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 334,
-          "end": 343,
+          "start": 327,
+          "end": 336,
           "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 343,
-          "end": 352,
+          "start": 336,
+          "end": 345,
           "lstLine": 12,
           "kind": "code",
           "confidence": "high"
@@ -82,21 +82,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 314,
+          "address": 307,
           "line": 7,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 322,
+          "address": 315,
           "line": 12,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 343,
+          "address": 336,
           "line": 12,
           "scope": "local"
         },
@@ -113,7 +113,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 352
+      "end": 345
     },
     {
       "start": 8192,
@@ -135,7 +135,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 314,
+      "address": 307,
       "file": "66_word_glob_fvar.zax",
       "line": 7,
       "scope": "local"
@@ -143,7 +143,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 322,
+      "address": 315,
       "file": "66_word_glob_fvar.zax",
       "line": 12,
       "scope": "global"
@@ -151,7 +151,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 343,
+      "address": 336,
       "file": "66_word_glob_fvar.zax",
       "line": 12,
       "scope": "local"
@@ -168,6 +168,6 @@
   "generator": {
     "tool": "zax",
     "entrySymbol": "main",
-    "entryAddress": 322
+    "entryAddress": 315
   }
 }

--- a/examples/language-tour/67_word_fvar_fvar.asm
+++ b/examples/language-tour/67_word_fvar_fvar.asm
@@ -9,82 +9,77 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-ld e, (ix+$06)                 ; 010B: DD 5E 06
-ld d, (ix+$07)                 ; 010E: DD 56 07
-ex de, hl                      ; 0111: EB
-push HL                        ; 0112: E5
-pop HL                         ; 0113: E1
-add HL, HL                     ; 0114: 29
-push HL                        ; 0115: E5
-push DE                        ; 0116: D5
-push IX                        ; 0117: DD E5
-pop HL                         ; 0119: E1
-ld DE, $0004                   ; 011A: 11 04 00
-add HL, DE                     ; 011D: 19
-pop DE                         ; 011E: D1
-pop DE                         ; 011F: D1
-add HL, DE                     ; 0120: 19
-push HL                        ; 0121: E5
+push HL                        ; 010B: E5
+ld E, (IX + $0004)             ; 010C: DD 5E 04
+ld D, (IX + $0005)             ; 010F: DD 56 05
+ex DE, HL                      ; 0112: EB
+ld E, (IX + $0006)             ; 0113: DD 5E 06
+ld D, (IX + $0007)             ; 0116: DD 56 07
+ex DE, HL                      ; 0119: EB
+add HL, HL                     ; 011A: 29
+add HL, DE                     ; 011B: 19
+ld E, (HL)                     ; 011C: 5E
+inc HL                         ; 011D: 23
+ld D, (HL)                     ; 011E: 56
+ld L, E                        ; 011F: 6B
+ld H, D                        ; 0120: 62
+ex DE, HL                      ; 0121: EB
 pop HL                         ; 0122: E1
-ld a, (hl) ; inc hl ; ld d, (hl) ; ld e, a ; 0123: 7E 23 56 5F
-ld e, (ix+$06)                 ; 0127: DD 5E 06
-ld d, (ix+$07)                 ; 012A: DD 56 07
-ex de, hl                      ; 012D: EB
-push HL                        ; 012E: E5
-pop HL                         ; 012F: E1
-add HL, HL                     ; 0130: 29
-push HL                        ; 0131: E5
-push DE                        ; 0132: D5
-push IX                        ; 0133: DD E5
-pop HL                         ; 0135: E1
-ld DE, $0004                   ; 0136: 11 04 00
-add HL, DE                     ; 0139: 19
-pop DE                         ; 013A: D1
-pop DE                         ; 013B: D1
-add HL, DE                     ; 013C: 19
-push HL                        ; 013D: E5
-pop HL                         ; 013E: E1
-ld (hl), e ; inc hl ; ld (hl), d ; 013F: 73 23 72
-ex DE, HL                      ; 0142: EB
+push HL                        ; 0123: E5
+push DE                        ; 0124: D5
+ld E, (IX + $0004)             ; 0125: DD 5E 04
+ld D, (IX + $0005)             ; 0128: DD 56 05
+ex DE, HL                      ; 012B: EB
+ld E, (IX + $0006)             ; 012C: DD 5E 06
+ld D, (IX + $0007)             ; 012F: DD 56 07
+ex DE, HL                      ; 0132: EB
+add HL, HL                     ; 0133: 29
+add HL, DE                     ; 0134: 19
+pop DE                         ; 0135: D1
+ld (HL), E                     ; 0136: 73
+inc HL                         ; 0137: 23
+ld (HL), D                     ; 0138: 72
+pop HL                         ; 0139: E1
+ex DE, HL                      ; 013A: EB
 __zax_epilogue_0:
-pop DE                         ; 0143: D1
-pop BC                         ; 0144: C1
-pop AF                         ; 0145: F1
-ld SP, IX                      ; 0146: DD F9
-pop IX                         ; 0148: DD E1
-ret                            ; 014A: C9
+pop DE                         ; 013B: D1
+pop BC                         ; 013C: C1
+pop AF                         ; 013D: F1
+ld SP, IX                      ; 013E: DD F9
+pop IX                         ; 0140: DD E1
+ret                            ; 0142: C9
 ; func main begin
 ; func word_fvar_fvar end
 main:
-push IX                        ; 014B: DD E5
-ld IX, $0000                   ; 014D: DD 21 00 00
-add IX, SP                     ; 0151: DD 39
-push AF                        ; 0153: F5
-push BC                        ; 0154: C5
-push DE                        ; 0155: D5
+push IX                        ; 0143: DD E5
+ld IX, $0000                   ; 0145: DD 21 00 00
+add IX, SP                     ; 0149: DD 39
+push AF                        ; 014B: F5
+push BC                        ; 014C: C5
+push DE                        ; 014D: D5
+push HL                        ; 014E: E5
+ld HL, $0005                   ; 014F: 21 05 00
+push HL                        ; 0152: E5
+ld HL, glob_words              ; 0153: 21 00 00
 push HL                        ; 0156: E5
-ld HL, $0005                   ; 0157: 21 05 00
-push HL                        ; 015A: E5
-ld HL, glob_words              ; 015B: 21 00 00
-push HL                        ; 015E: E5
-call word_fvar_fvar            ; 015F: CD 00 00
-inc SP                         ; 0162: 33
-inc SP                         ; 0163: 33
-inc SP                         ; 0164: 33
-inc SP                         ; 0165: 33
+call word_fvar_fvar            ; 0157: CD 00 00
+inc SP                         ; 015A: 33
+inc SP                         ; 015B: 33
+inc SP                         ; 015C: 33
+inc SP                         ; 015D: 33
 __zax_epilogue_1:
-pop HL                         ; 0166: E1
-pop DE                         ; 0167: D1
-pop BC                         ; 0168: C1
-pop AF                         ; 0169: F1
-ld SP, IX                      ; 016A: DD F9
-pop IX                         ; 016C: DD E1
-ret                            ; 016E: C9
+pop HL                         ; 015E: E1
+pop DE                         ; 015F: D1
+pop BC                         ; 0160: C1
+pop AF                         ; 0161: F1
+ld SP, IX                      ; 0162: DD F9
+pop IX                         ; 0164: DD E1
+ret                            ; 0166: C9
 ; func main end
 
 ; symbols:
 ; label word_fvar_fvar = $0100
-; label __zax_epilogue_0 = $0143
-; label main = $014B
-; label __zax_epilogue_1 = $0166
+; label __zax_epilogue_0 = $013B
+; label main = $0143
+; label __zax_epilogue_1 = $015E
 ; data glob_words = $2000

--- a/examples/language-tour/67_word_fvar_fvar.d8dbg.json
+++ b/examples/language-tour/67_word_fvar_fvar.d8dbg.json
@@ -16,56 +16,56 @@
         },
         {
           "start": 256,
-          "end": 367,
+          "end": 359,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
         },
         {
           "start": 267,
-          "end": 295,
+          "end": 291,
           "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 295,
-          "end": 322,
+          "start": 291,
+          "end": 314,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 322,
-          "end": 323,
+          "start": 314,
+          "end": 315,
           "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 323,
-          "end": 331,
+          "start": 315,
+          "end": 323,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 331,
-          "end": 343,
+          "start": 323,
+          "end": 335,
           "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 343,
-          "end": 358,
+          "start": 335,
+          "end": 350,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 358,
-          "end": 367,
+          "start": 350,
+          "end": 359,
           "lstLine": 13,
           "kind": "code",
           "confidence": "high"
@@ -89,21 +89,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 323,
+          "address": 315,
           "line": 7,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 331,
+          "address": 323,
           "line": 13,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 358,
+          "address": 350,
           "line": 13,
           "scope": "local"
         },
@@ -120,7 +120,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 367
+      "end": 359
     },
     {
       "start": 8192,
@@ -142,7 +142,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 323,
+      "address": 315,
       "file": "67_word_fvar_fvar.zax",
       "line": 7,
       "scope": "local"
@@ -150,7 +150,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 331,
+      "address": 323,
       "file": "67_word_fvar_fvar.zax",
       "line": 13,
       "scope": "global"
@@ -158,7 +158,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 358,
+      "address": 350,
       "file": "67_word_fvar_fvar.zax",
       "line": 13,
       "scope": "local"
@@ -175,6 +175,6 @@
   "generator": {
     "tool": "zax",
     "entrySymbol": "main",
-    "entryAddress": 331
+    "entryAddress": 323
   }
 }

--- a/examples/language-tour/68_word_fvar_glob.asm
+++ b/examples/language-tour/68_word_fvar_glob.asm
@@ -9,83 +9,66 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-ld HL, (glob_idx_word)         ; 010B: 2A 00 00
-push HL                        ; 010E: E5
-pop HL                         ; 010F: E1
-add HL, HL                     ; 0110: 29
-push HL                        ; 0111: E5
-push DE                        ; 0112: D5
-push IX                        ; 0113: DD E5
-pop HL                         ; 0115: E1
-ld DE, $0004                   ; 0116: 11 04 00
-add HL, DE                     ; 0119: 19
-pop DE                         ; 011A: D1
-pop DE                         ; 011B: D1
-add HL, DE                     ; 011C: 19
-push HL                        ; 011D: E5
-pop HL                         ; 011E: E1
-push AF                        ; 011F: F5
-ld A, (HL)                     ; 0120: 7E
-inc HL                         ; 0121: 23
-ld H, (HL)                     ; 0122: 66
-ld L, A                        ; 0123: 6F
-pop AF                         ; 0124: F1
-ld HL, (glob_idx_word)         ; 0125: 2A 00 00
-push HL                        ; 0128: E5
-pop HL                         ; 0129: E1
-add HL, HL                     ; 012A: 29
-push HL                        ; 012B: E5
-push DE                        ; 012C: D5
-push IX                        ; 012D: DD E5
-pop HL                         ; 012F: E1
-ld DE, $0004                   ; 0130: 11 04 00
-add HL, DE                     ; 0133: 19
-pop DE                         ; 0134: D1
-pop DE                         ; 0135: D1
-add HL, DE                     ; 0136: 19
-push HL                        ; 0137: E5
-pop HL                         ; 0138: E1
-ex DE, HL                      ; 0139: EB
-ld (hl), e                     ; 013A: 73
-inc HL                         ; 013B: 23
-ld (hl), d                     ; 013C: 72
-ex DE, HL                      ; 013D: EB
+push DE                        ; 010B: D5
+ld E, (IX + $0004)             ; 010C: DD 5E 04
+ld D, (IX + $0005)             ; 010F: DD 56 05
+ld hl, (glob_idx_word)         ; 0112: 2A 00 00
+add HL, HL                     ; 0115: 29
+add HL, DE                     ; 0116: 19
+ld E, (HL)                     ; 0117: 5E
+inc HL                         ; 0118: 23
+ld D, (HL)                     ; 0119: 56
+ld L, E                        ; 011A: 6B
+ld H, D                        ; 011B: 62
+pop DE                         ; 011C: D1
+push DE                        ; 011D: D5
+push HL                        ; 011E: E5
+ld E, (IX + $0004)             ; 011F: DD 5E 04
+ld D, (IX + $0005)             ; 0122: DD 56 05
+ld hl, (glob_idx_word)         ; 0125: 2A 00 00
+add HL, HL                     ; 0128: 29
+add HL, DE                     ; 0129: 19
+pop DE                         ; 012A: D1
+ld (HL), E                     ; 012B: 73
+inc HL                         ; 012C: 23
+ld (HL), D                     ; 012D: 72
+pop DE                         ; 012E: D1
 __zax_epilogue_0:
-pop DE                         ; 013E: D1
-pop BC                         ; 013F: C1
-pop AF                         ; 0140: F1
-ld SP, IX                      ; 0141: DD F9
-pop IX                         ; 0143: DD E1
-ret                            ; 0145: C9
+pop DE                         ; 012F: D1
+pop BC                         ; 0130: C1
+pop AF                         ; 0131: F1
+ld SP, IX                      ; 0132: DD F9
+pop IX                         ; 0134: DD E1
+ret                            ; 0136: C9
 ; func main begin
 ; func word_fvar_glob end
 main:
-push IX                        ; 0146: DD E5
-ld IX, $0000                   ; 0148: DD 21 00 00
-add IX, SP                     ; 014C: DD 39
-push AF                        ; 014E: F5
-push BC                        ; 014F: C5
-push DE                        ; 0150: D5
-push HL                        ; 0151: E5
-ld HL, glob_words              ; 0152: 21 00 00
-push HL                        ; 0155: E5
-call word_fvar_glob            ; 0156: CD 00 00
-inc SP                         ; 0159: 33
-inc SP                         ; 015A: 33
+push IX                        ; 0137: DD E5
+ld IX, $0000                   ; 0139: DD 21 00 00
+add IX, SP                     ; 013D: DD 39
+push AF                        ; 013F: F5
+push BC                        ; 0140: C5
+push DE                        ; 0141: D5
+push HL                        ; 0142: E5
+ld HL, glob_words              ; 0143: 21 00 00
+push HL                        ; 0146: E5
+call word_fvar_glob            ; 0147: CD 00 00
+inc SP                         ; 014A: 33
+inc SP                         ; 014B: 33
 __zax_epilogue_1:
-pop HL                         ; 015B: E1
-pop DE                         ; 015C: D1
-pop BC                         ; 015D: C1
-pop AF                         ; 015E: F1
-ld SP, IX                      ; 015F: DD F9
-pop IX                         ; 0161: DD E1
-ret                            ; 0163: C9
+pop HL                         ; 014C: E1
+pop DE                         ; 014D: D1
+pop BC                         ; 014E: C1
+pop AF                         ; 014F: F1
+ld SP, IX                      ; 0150: DD F9
+pop IX                         ; 0152: DD E1
+ret                            ; 0154: C9
 ; func main end
 
 ; symbols:
 ; label word_fvar_glob = $0100
-; label __zax_epilogue_0 = $013E
-; label main = $0146
-; label __zax_epilogue_1 = $015B
+; label __zax_epilogue_0 = $012F
+; label main = $0137
+; label __zax_epilogue_1 = $014C
 ; data glob_words = $2000
 ; data glob_idx_word = $2010

--- a/examples/language-tour/68_word_fvar_glob.d8dbg.json
+++ b/examples/language-tour/68_word_fvar_glob.d8dbg.json
@@ -16,49 +16,49 @@
         },
         {
           "start": 256,
-          "end": 356,
+          "end": 341,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
         },
         {
           "start": 267,
-          "end": 293,
+          "end": 285,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 293,
-          "end": 318,
+          "start": 285,
+          "end": 303,
           "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 318,
-          "end": 326,
+          "start": 303,
+          "end": 311,
           "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 326,
-          "end": 338,
+          "start": 311,
+          "end": 323,
           "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 338,
-          "end": 347,
+          "start": 323,
+          "end": 332,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 347,
-          "end": 356,
+          "start": 332,
+          "end": 341,
           "lstLine": 13,
           "kind": "code",
           "confidence": "high"
@@ -82,21 +82,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 318,
+          "address": 303,
           "line": 8,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 326,
+          "address": 311,
           "line": 13,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 347,
+          "address": 332,
           "line": 13,
           "scope": "local"
         },
@@ -120,7 +120,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 356
+      "end": 341
     },
     {
       "start": 8192,
@@ -142,7 +142,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 318,
+      "address": 303,
       "file": "68_word_fvar_glob.zax",
       "line": 8,
       "scope": "local"
@@ -150,7 +150,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 326,
+      "address": 311,
       "file": "68_word_fvar_glob.zax",
       "line": 13,
       "scope": "global"
@@ -158,7 +158,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 347,
+      "address": 332,
       "file": "68_word_fvar_glob.zax",
       "line": 13,
       "scope": "local"
@@ -183,6 +183,6 @@
   "generator": {
     "tool": "zax",
     "entrySymbol": "main",
-    "entryAddress": 326
+    "entryAddress": 311
   }
 }

--- a/examples/language-tour/69_word_glob_glob.asm
+++ b/examples/language-tour/69_word_glob_glob.asm
@@ -9,69 +9,60 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-ld HL, (glob_idx_word)         ; 010B: 2A 00 00
-push HL                        ; 010E: E5
-pop HL                         ; 010F: E1
-add HL, HL                     ; 0110: 29
-push HL                        ; 0111: E5
-ld HL, glob_words              ; 0112: 21 00 00
-pop DE                         ; 0115: D1
-add HL, DE                     ; 0116: 19
-push HL                        ; 0117: E5
-pop HL                         ; 0118: E1
-push AF                        ; 0119: F5
-ld A, (HL)                     ; 011A: 7E
-inc HL                         ; 011B: 23
-ld H, (HL)                     ; 011C: 66
-ld L, A                        ; 011D: 6F
-pop AF                         ; 011E: F1
-ld HL, (glob_idx_word)         ; 011F: 2A 00 00
-push HL                        ; 0122: E5
-pop HL                         ; 0123: E1
-add HL, HL                     ; 0124: 29
-push HL                        ; 0125: E5
-ld HL, glob_words              ; 0126: 21 00 00
-pop DE                         ; 0129: D1
-add HL, DE                     ; 012A: 19
-push HL                        ; 012B: E5
-pop HL                         ; 012C: E1
-ex DE, HL                      ; 012D: EB
-ld (hl), e                     ; 012E: 73
-inc HL                         ; 012F: 23
-ld (hl), d                     ; 0130: 72
-ex DE, HL                      ; 0131: EB
+push DE                        ; 010B: D5
+ld de, glob_words              ; 010C: 11 00 00
+ld hl, (glob_idx_word)         ; 010F: 2A 00 00
+add HL, HL                     ; 0112: 29
+add HL, DE                     ; 0113: 19
+ld E, (HL)                     ; 0114: 5E
+inc HL                         ; 0115: 23
+ld D, (HL)                     ; 0116: 56
+ld L, E                        ; 0117: 6B
+ld H, D                        ; 0118: 62
+pop DE                         ; 0119: D1
+push DE                        ; 011A: D5
+push HL                        ; 011B: E5
+ld de, glob_words              ; 011C: 11 00 00
+ld hl, (glob_idx_word)         ; 011F: 2A 00 00
+add HL, HL                     ; 0122: 29
+add HL, DE                     ; 0123: 19
+pop DE                         ; 0124: D1
+ld (HL), E                     ; 0125: 73
+inc HL                         ; 0126: 23
+ld (HL), D                     ; 0127: 72
+pop DE                         ; 0128: D1
 __zax_epilogue_0:
-pop DE                         ; 0132: D1
-pop BC                         ; 0133: C1
-pop AF                         ; 0134: F1
-ld SP, IX                      ; 0135: DD F9
-pop IX                         ; 0137: DD E1
-ret                            ; 0139: C9
+pop DE                         ; 0129: D1
+pop BC                         ; 012A: C1
+pop AF                         ; 012B: F1
+ld SP, IX                      ; 012C: DD F9
+pop IX                         ; 012E: DD E1
+ret                            ; 0130: C9
 ; func main begin
 ; func word_glob_glob end
 main:
-push IX                        ; 013A: DD E5
-ld IX, $0000                   ; 013C: DD 21 00 00
-add IX, SP                     ; 0140: DD 39
-push AF                        ; 0142: F5
-push BC                        ; 0143: C5
-push DE                        ; 0144: D5
-push HL                        ; 0145: E5
-call word_glob_glob            ; 0146: CD 00 00
+push IX                        ; 0131: DD E5
+ld IX, $0000                   ; 0133: DD 21 00 00
+add IX, SP                     ; 0137: DD 39
+push AF                        ; 0139: F5
+push BC                        ; 013A: C5
+push DE                        ; 013B: D5
+push HL                        ; 013C: E5
+call word_glob_glob            ; 013D: CD 00 00
 __zax_epilogue_1:
-pop HL                         ; 0149: E1
-pop DE                         ; 014A: D1
-pop BC                         ; 014B: C1
-pop AF                         ; 014C: F1
-ld SP, IX                      ; 014D: DD F9
-pop IX                         ; 014F: DD E1
-ret                            ; 0151: C9
+pop HL                         ; 0140: E1
+pop DE                         ; 0141: D1
+pop BC                         ; 0142: C1
+pop AF                         ; 0143: F1
+ld SP, IX                      ; 0144: DD F9
+pop IX                         ; 0146: DD E1
+ret                            ; 0148: C9
 ; func main end
 
 ; symbols:
 ; label word_glob_glob = $0100
-; label __zax_epilogue_0 = $0132
-; label main = $013A
-; label __zax_epilogue_1 = $0149
+; label __zax_epilogue_0 = $0129
+; label main = $0131
+; label __zax_epilogue_1 = $0140
 ; data glob_words = $2000
 ; data glob_idx_word = $2010

--- a/examples/language-tour/69_word_glob_glob.d8dbg.json
+++ b/examples/language-tour/69_word_glob_glob.d8dbg.json
@@ -16,49 +16,49 @@
         },
         {
           "start": 256,
-          "end": 338,
+          "end": 329,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
         },
         {
           "start": 267,
-          "end": 287,
+          "end": 282,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 287,
-          "end": 306,
+          "start": 282,
+          "end": 297,
           "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 306,
-          "end": 314,
+          "start": 297,
+          "end": 305,
           "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 314,
-          "end": 326,
+          "start": 305,
+          "end": 317,
           "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 326,
-          "end": 329,
+          "start": 317,
+          "end": 320,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 329,
-          "end": 338,
+          "start": 320,
+          "end": 329,
           "lstLine": 13,
           "kind": "code",
           "confidence": "high"
@@ -82,21 +82,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 306,
+          "address": 297,
           "line": 8,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 314,
+          "address": 305,
           "line": 13,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 329,
+          "address": 320,
           "line": 13,
           "scope": "local"
         },
@@ -120,7 +120,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 338
+      "end": 329
     },
     {
       "start": 8192,
@@ -142,7 +142,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 306,
+      "address": 297,
       "file": "69_word_glob_glob.zax",
       "line": 8,
       "scope": "local"
@@ -150,7 +150,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 314,
+      "address": 305,
       "file": "69_word_glob_glob.zax",
       "line": 13,
       "scope": "global"
@@ -158,7 +158,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 329,
+      "address": 320,
       "file": "69_word_glob_glob.zax",
       "line": 13,
       "scope": "local"
@@ -183,6 +183,6 @@
   "generator": {
     "tool": "zax",
     "entrySymbol": "main",
-    "entryAddress": 314
+    "entryAddress": 305
   }
 }

--- a/test/pr374_addressing_modes_mini_suite.test.ts
+++ b/test/pr374_addressing_modes_mini_suite.test.ts
@@ -1,0 +1,118 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { AsmArtifact, D8mArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const byteMiniSuite = [
+  '30_scalar_byte_glob',
+  '31_scalar_byte_frame',
+  '34_byte_glob_const',
+  '35_byte_glob_reg8',
+  '36_byte_glob_reg16',
+  '37_byte_fvar_const',
+  '38_byte_fvar_reg8',
+  '39_byte_fvar_reg16',
+  '40_byte_glob_fvar',
+  '41_byte_fvar_fvar',
+  '42_byte_fvar_glob',
+  '43_byte_glob_glob',
+] as const;
+
+const wordMiniSuite = [
+  '32_scalar_word_glob',
+  '33_scalar_word_frame',
+  '60_word_glob_const',
+  '61_word_glob_reg8',
+  '62_word_glob_reg16',
+  '63_word_fvar_const',
+  '64_word_fvar_reg8',
+  '65_word_fvar_reg16',
+  '66_word_glob_fvar',
+  '67_word_fvar_fvar',
+  '68_word_fvar_glob',
+  '69_word_glob_glob',
+] as const;
+
+const miniSuite = [...byteMiniSuite, ...wordMiniSuite];
+
+function canonicalProgramAsm(text: string): string {
+  const out: string[] = [];
+  const canonicalizeIxIyDisp = (input: string): string =>
+    input.replace(
+      /\(\s*(IX|IY)\s*([+-])\s*\$([0-9A-F]{1,4})\s*\)/gi,
+      (_m, base: string, sign: string, hex: string) => {
+        const value = Number.parseInt(hex, 16) & 0xff;
+        return `(${base.toUpperCase()}${sign}$${value.toString(16).toUpperCase().padStart(2, '0')})`;
+      },
+    );
+
+  for (const rawLine of text.replace(/\r\n/g, '\n').split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (line.startsWith(';')) continue;
+    if (line.toLowerCase() === '; symbols:') continue;
+    if (/^; (label|var|data|constant)\b/i.test(line)) continue;
+    if (line.endsWith(':')) {
+      out.push(line.toUpperCase());
+      continue;
+    }
+    const noTraceComment = line.replace(/\s*;\s*[0-9A-F]{4}:\s+[0-9A-F ]+\s*$/i, '');
+    const noInlineComment = noTraceComment.replace(/\s*;.*/, '');
+    const normalized = canonicalizeIxIyDisp(noInlineComment.replace(/\s+/g, ' ').trim());
+    if (!normalized) continue;
+    out.push(normalized.toUpperCase());
+  }
+
+  return out.join('\n');
+}
+
+describe('PR374: addressing mini-suite fixtures stay locked', () => {
+  for (const stem of miniSuite) {
+    it(`${stem} matches checked-in asm and d8dbg fixtures`, async () => {
+      const entry = join(__dirname, '..', 'examples', 'language-tour', `${stem}.zax`);
+      const asmPath = join(__dirname, '..', 'examples', 'language-tour', `${stem}.asm`);
+      const d8Path = join(__dirname, '..', 'examples', 'language-tour', `${stem}.d8dbg.json`);
+
+      const [expectedAsm, expectedD8Text] = await Promise.all([
+        readFile(asmPath, 'utf8'),
+        readFile(d8Path, 'utf8'),
+      ]);
+
+      const result = await compile(
+        entry,
+        {
+          emitBin: false,
+          emitHex: false,
+          emitD8m: true,
+          emitListing: false,
+          emitAsm: true,
+          defaultCodeBase: 0x0100,
+        },
+        { formats: defaultFormatWriters },
+      );
+
+      expect(result.diagnostics).toEqual([]);
+
+      const asm = result.artifacts.find((a): a is AsmArtifact => a.kind === 'asm');
+      const d8m = result.artifacts.find((a): a is D8mArtifact => a.kind === 'd8m');
+
+      expect(asm).toBeDefined();
+      expect(d8m).toBeDefined();
+      expect(canonicalProgramAsm(asm!.text)).toBe(canonicalProgramAsm(expectedAsm));
+      expect(d8m!.json).toEqual(JSON.parse(expectedD8Text));
+
+      const upper = asm!.text.toUpperCase();
+      expect(upper).not.toMatch(/LD\s+H,\s+\(IX/i);
+      expect(upper).not.toMatch(/LD\s+L,\s+\(IX/i);
+      expect(upper).not.toMatch(/LD\s+\(IX[^\n]*,\s+H/i);
+      expect(upper).not.toMatch(/LD\s+\(IX[^\n]*,\s+L/i);
+    });
+  }
+});


### PR DESCRIPTION
## What this does
- adds a focused regression harness for the addressing mini-suite (30-43, 60-69)
- compares compiled `.asm` and `.d8dbg.json` against the checked-in language-tour artifacts
- refreshes the stale checked-in artifacts that had drifted from current lowering

## Why
Issue #374 is about locking down representative addressing-mode examples. The examples already existed, but several checked-in `.asm` / `.d8dbg.json` fixtures were stale. This PR makes them executable regression inputs instead of passive samples.

## Fail-before / pass-after
- Before: `test/pr374_addressing_modes_mini_suite.test.ts` failed on 14 stale fixtures (`31`, `35`, `37`, `38`, `40`, `41`, `60`, `61`, `62`, `64`, `66`, `67`, `68`, `69`).
- After: the same test passes with all 24 fixtures locked.

## Verification
- `npm test -- --run test/pr374_addressing_modes_mini_suite.test.ts test/smoke_language_tour_compile.test.ts`
