### PR TITLE
docs: refresh v0.3 roadmap after triage

### DIFF
--- a/docs/v03-planning-track.md
+++ b/docs/v03-planning-track.md
@@ -19,62 +19,41 @@ usability work. It is not unfinished v0.2 verification.
 
 ### Track A. Language surface and core semantics
 
-These are the highest-impact language-facing changes because they affect
-terminology, examples, docs, and downstream implementation decisions.
+These are the language-facing changes that still appear justified after the
+first v0.3 triage pass.
 
-1. `#340` — rename integer widths to `int8` / `int16` / `int32` / `int48`
+There is currently no high-priority language-surface rename or syntax migration
+in active scope. The only remaining language-level items are intentionally
+parked:
 
-- This is the largest surface-level language migration in the current queue.
-- It should land deliberately and in one coordinated pass across spec, grammar,
-  examples, tests, and codegen.
-- Other syntax-facing future work should assume its final naming, not the
-  pre-rename vocabulary.
+- `#376` — `main(): HL` status-return convention (parked)
+- `#359` — interrupt function modifier (parked)
 
-2. `#376` — make `main(): HL` the status-return convention
-
-- This is a policy and examples pass rather than a deep compiler feature.
-- It naturally follows the stabilized return-register model from v0.2.
-- It is lower risk than `#340`, but should be applied after terminology is
-  settled so examples only move once.
-
-3. `#359` — interrupt function modifier
-
-- This adds a real new language feature and codegen path.
-- It should follow the simpler surface-policy updates above.
-- It needs grammar, lowering, and epilogue rewrite coverage.
+They remain plausible future work, but neither is treated as strictly needed
+now.
 
 ### Track B. Tooling, traces, and corpus workflow
 
 These improve inspection quality and long-term maintainability of generated
 artifacts.
 
-1. `#294` — land trace-condition and corpus-workflow changes
+1. `#452` — fix conditional jump placeholders in `.asm` traces
 
-- This is the best first tooling slice because it includes a concrete trace
-  correctness fix (`jp cc, ...` placeholders) plus explicit corpus workflow
-  support.
-- It directly improves the quality of generated `.asm` traces.
+- This is the trace-correctness half of the old bundled `#294` work.
+- It should be treated as a narrow correctness task, not mixed with tooling
+  workflow changes.
 
-2. `#303` — expand the curated codegen corpus
+2. `#453` — define the supported codegen-corpus workflow
 
-- This should follow the workflow cleanup in `#294`.
+- This is the workflow/tooling half of the old bundled `#294` work.
+- It should make ownership, location, and regeneration rules explicit before
+  more corpus growth.
+
+3. `#303` — expand the curated codegen corpus
+
+- This should follow the workflow cleanup in `#453`.
 - Once the workflow is stable, the curated corpus can grow without inventing a
   second process.
-
-3. `#266` — optional external assembler cross-check workflow
-
-- This should stay optional and non-blocking.
-- It is useful after the internal trace/corpus workflow is in better shape.
-
-4. `#282` — cosmetic corpus cleanup for terminal fallthrough returns
-
-- This is intentionally low-risk and non-semantic.
-- Keep it after the heavier corpus and trace work so fixtures do not churn twice.
-
-5. `#281` — CLI artifact flag ergonomics
-
-- This is useful but not on the critical path.
-- It can wait until the corpus and artifact workflow are stable.
 
 ### Track C. Low-level capability expansion
 
@@ -92,37 +71,35 @@ These are explicit future capability additions, not retroactive v0.2 gaps.
   wrong.
 - It should follow the virtual transfer work rather than lead the queue.
 
-## 3. Open item that should not be worked unchanged
+## 3. Closed by v0.3 triage
 
-### `#299` — `@place` diagnostic ticket
+These items were reviewed and explicitly rejected as current work:
 
-This ticket is still open, but it does not fit the current post-v0.2 baseline
-cleanly.
+- `#340` — integer-width rename
+- `#266` — optional external assembler cross-check workflow
+- `#281` — CLI artifact flag ergonomics follow-up
+- `#282` — cosmetic terminal-fallthrough cleanup
+- `#299` — `@place` diagnostic ticket (not relevant while `@place` is not an
+  active planned surface)
 
-- The current v0.2 surface does not treat `@place` as active normative guidance.
-- The issue may still be useful if explicit address-of forms are revived, but it
-  should not be taken as-is without a fresh design decision first.
-
-Current policy:
-
-- leave `#299` open only as a future placeholder
-- do not prioritize it ahead of the concrete v0.3 tracks above
-- rewrite it before active implementation if address-of syntax returns to the
-  planned surface
+They should not be silently reintroduced. If one returns, it should come back as
+a newly justified future issue, not as assumed carry-over work.
 
 ## 4. Ordering rule
 
 Unless priorities change, the practical order is:
 
-1. `#340`
-2. `#294`
+1. `#452`
+2. `#453`
 3. `#303`
-4. one of the lower-risk policy/capability slices (`#376` or `#446`)
-5. then `#359`, `#447`, and the remaining low-priority tooling items
+4. `#446`
+5. `#447`
 
-This order keeps the biggest naming change early, improves trace/corpus
-workflow next, and leaves niche or optional features until the planning base is
-cleaner.
+Leave `#376` and `#359` parked unless priorities change.
+
+This order handles the concrete trace issue first, then the workflow around the
+corpus, then any corpus expansion, and only then the optional low-level
+capability work.
 
 ## 5. Planning rules
 


### PR DESCRIPTION
Closes #454\n\n- update the v0.3 roadmap after explicit feature triage\n- split the old #294 path into the two new active issues\n- mark parked and closed-by-triage items explicitly\n\nDocs only. No code changes.