### PR TITLE
docs: add v0.3 priority queue

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ This directory is intentionally constrained. Every file below has a unique purpo
 - `return-register-policy.md` — preservation/return matrix detail.
 - `arrays.md` — IX + DE/HL lowering guidance and runtime-atom cues.
 - `v03-planning-track.md` — post-v0.2 planning scaffold.
+- `v03-priority-queue.md` — explicit short-form developer order for the current post-v0.2 queue.
 - `github-backlog-workflow.md` — GitHub issue/label/milestone workflow used as the project backlog system.
 
 ## Definitive v0.2 Baseline Set

--- a/docs/v03-priority-queue.md
+++ b/docs/v03-priority-queue.md
@@ -1,0 +1,78 @@
+# v0.3 Priority Queue
+
+This is the explicit current developer work order for post-v0.2 work.
+
+Use this as the short operational queue. The broader rationale remains in
+`docs/v03-planning-track.md`.
+
+## Active order
+
+### 1. `#452` — Fix conditional jump placeholders in `.asm` traces
+
+Why first:
+
+- It is a narrow trace-correctness fix.
+- It directly improves generated `.asm` review quality.
+- It is the cleanest next task because it is a focused correctness issue, not a
+  broader feature expansion.
+
+### 2. `#453` — Define supported codegen-corpus workflow
+
+Why second:
+
+- The corpus should have an explicit supported workflow before it expands further.
+- This is process/tooling cleanup that reduces later ambiguity.
+
+### 3. `#303` — Expand the curated codegen corpus
+
+Why third:
+
+- It should follow the workflow definition in `#453`.
+- Once ownership and regeneration are explicit, the corpus can expand without
+  creating avoidable process drift.
+
+### 4. `#446` — Add virtual 16-bit transfer patterns
+
+Why fourth:
+
+- This is future low-level capability, not a current correctness fix.
+- It is now deliberately narrow:
+  - exhaustive `rp -> rp` transfer definitions
+  - direct non-destructive 8-bit register moves only
+  - no stack traffic
+  - no pair-exchange shortcut standing in for a copy
+
+### 5. `#447` — Support direct IXH/IXL/IYH/IYL forms
+
+Why fifth:
+
+- This is also future low-level capability, but more niche and easier to get
+  wrong than `#446`.
+- It is now deliberately narrow:
+  - exhaustive accepted set for this slice
+  - only directly encodable undocumented Z80 forms that really exist
+  - source-side and destination-side forms where they truly exist
+  - no invented forms
+  - no shuttle-based simulation in this slice
+
+## Parked
+
+These stay open, but they are not current priorities:
+
+- `#376` — `main(): HL` status-return convention
+- `#359` — interrupt function modifier
+
+Do not pull them into active work unless priorities change.
+
+## Closed by triage
+
+These were explicitly reviewed and rejected as current work:
+
+- `#340`
+- `#294` (split into `#452` and `#453`)
+- `#266`
+- `#281`
+- `#282`
+- `#299`
+
+Do not silently reintroduce them as implied backlog.


### PR DESCRIPTION
Closes #456\n\n- add a short-form v0.3 priority queue\n- make the active order explicit\n- mark parked and closed-by-triage items\n- link the new doc from the docs index\n\nDocs only. No code changes.