### PR TITLE
Fix conditional jump placeholders in asm traces

### DIFF
--- a/examples/codegen-corpus/basic_control_flow.asm
+++ b/examples/codegen-corpus/basic_control_flow.asm
@@ -3,20 +3,20 @@
 
 ; func main begin
 main:
-jp cc, __zax_if_else_1         ; 0000: CA 00 00
+jp z, __zax_if_else_1          ; 0000: CA 00 00
 nop                            ; 0003: 00
 jp __zax_if_end_2              ; 0004: C3 00 00
 __zax_if_else_1:
 nop                            ; 0007: 00
 __zax_if_end_2:
 __zax_while_cond_3:
-jp cc, __zax_while_end_4       ; 0008: CA 00 00
+jp z, __zax_while_end_4        ; 0008: CA 00 00
 nop                            ; 000B: 00
 jp __zax_while_cond_3          ; 000C: C3 00 00
 __zax_repeat_body_5:
 __zax_while_end_4:
 nop                            ; 000F: 00
-jp cc, __zax_repeat_body_5     ; 0010: C2 00 00
+jp nz, __zax_repeat_body_5     ; 0010: C2 00 00
 jp __zax_select_dispatch_6     ; 0013: C3 00 00
 __zax_case_8:
 nop                            ; 0016: 00
@@ -30,7 +30,7 @@ ld H, $0000                    ; 001F: 26 00
 ld L, A                        ; 0021: 6F
 ld a, l                        ; 0022: 7D
 cp imm8                        ; 0023: FE 00
-jp cc, __zax_select_next_10    ; 0025: C2 00 00
+jp nz, __zax_select_next_10    ; 0025: C2 00 00
 pop HL                         ; 0028: E1
 jp __zax_case_8                ; 0029: C3 00 00
 __zax_select_next_10:

--- a/examples/codegen-corpus/pr222_locals_retcc_and_ret.asm
+++ b/examples/codegen-corpus/pr222_locals_retcc_and_ret.asm
@@ -4,7 +4,7 @@
 ; func main begin
 main:
 push BC                        ; 0100: C5
-jp cc, __zax_epilogue_0        ; 0101: CA 00 00
+jp z, __zax_epilogue_0         ; 0101: CA 00 00
 jp __zax_epilogue_0            ; 0104: C3 00 00
 __zax_epilogue_0:
 pop BC                         ; 0107: C1

--- a/examples/codegen-corpus/pr258_op_cc_matcher.asm
+++ b/examples/codegen-corpus/pr258_op_cc_matcher.asm
@@ -3,13 +3,13 @@
 
 ; func main begin
 main:
-jp cc, __zax_if_else_1         ; 0100: CA 00 00
+jp z, __zax_if_else_1          ; 0100: CA 00 00
 nop                            ; 0103: 00
 __zax_if_else_1:
-jp cc, __zax_if_else_3         ; 0104: C2 00 00
+jp nz, __zax_if_else_3         ; 0104: C2 00 00
 nop                            ; 0107: 00
 __zax_if_else_3:
-jp cc, __zax_if_else_5         ; 0108: D2 00 00
+jp nc, __zax_if_else_5         ; 0108: D2 00 00
 nop                            ; 010B: 00
 __zax_if_else_5:
 ret                            ; 010C: C9

--- a/test/fixtures/corpus/golden/basic_control_flow.asm
+++ b/test/fixtures/corpus/golden/basic_control_flow.asm
@@ -3,20 +3,20 @@
 
 ; func main begin
 main:
-jp cc, __zax_if_else_1         ; 0000: CA 00 00
+jp z, __zax_if_else_1          ; 0000: CA 00 00
 nop                            ; 0003: 00
 jp __zax_if_end_2              ; 0004: C3 00 00
 __zax_if_else_1:
 nop                            ; 0007: 00
 __zax_if_end_2:
 __zax_while_cond_3:
-jp cc, __zax_while_end_4       ; 0008: CA 00 00
+jp z, __zax_while_end_4        ; 0008: CA 00 00
 nop                            ; 000B: 00
 jp __zax_while_cond_3          ; 000C: C3 00 00
 __zax_repeat_body_5:
 __zax_while_end_4:
 nop                            ; 000F: 00
-jp cc, __zax_repeat_body_5     ; 0010: C2 00 00
+jp nz, __zax_repeat_body_5     ; 0010: C2 00 00
 jp __zax_select_dispatch_6     ; 0013: C3 00 00
 __zax_case_8:
 nop                            ; 0016: 00
@@ -30,7 +30,7 @@ ld H, $0000                    ; 001F: 26 00
 ld L, A                        ; 0021: 6F
 ld a, l                        ; 0022: 7D
 cp imm8                        ; 0023: FE 00
-jp cc, __zax_select_next_10    ; 0025: C2 00 00
+jp nz, __zax_select_next_10    ; 0025: C2 00 00
 pop HL                         ; 0028: E1
 jp __zax_case_8                ; 0029: C3 00 00
 __zax_select_next_10:

--- a/test/pr452_conditional_jump_trace_placeholders.test.ts
+++ b/test/pr452_conditional_jump_trace_placeholders.test.ts
@@ -1,0 +1,55 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { AsmArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR452: conditional jump trace placeholders', () => {
+  it('emits concrete condition names in structured-control traces', async () => {
+    const entries = [
+      join(__dirname, '..', 'examples', 'codegen-corpus', 'basic_control_flow.zax'),
+      join(__dirname, '..', 'examples', 'codegen-corpus', 'pr222_locals_retcc_and_ret.zax'),
+      join(__dirname, '..', 'examples', 'codegen-corpus', 'pr258_op_cc_matcher.zax'),
+    ];
+
+    const asmTexts: string[] = [];
+    for (const entry of entries) {
+      const res = await compile(
+        entry,
+        { emitAsm: true, emitBin: false, emitHex: false, emitListing: false, emitD8m: false },
+        { formats: defaultFormatWriters },
+      );
+
+      expect(res.diagnostics).toEqual([]);
+      const asm = res.artifacts.find((a): a is AsmArtifact => a.kind === 'asm');
+      expect(asm).toBeDefined();
+      asmTexts.push(asm!.text.toUpperCase());
+    }
+
+    const combined = asmTexts.join('\n');
+    expect(combined).not.toContain('JP CC,');
+    expect(combined).toContain('JP Z,');
+    expect(combined).toContain('JP NZ,');
+    expect(combined).toContain('JP NC,');
+  });
+
+  it('removes jp cc placeholders from the touched checked-in traces', async () => {
+    const traces = [
+      join(__dirname, '..', 'examples', 'codegen-corpus', 'basic_control_flow.asm'),
+      join(__dirname, '..', 'examples', 'codegen-corpus', 'pr222_locals_retcc_and_ret.asm'),
+      join(__dirname, '..', 'examples', 'codegen-corpus', 'pr258_op_cc_matcher.asm'),
+      join(__dirname, '..', 'test', 'fixtures', 'corpus', 'golden', 'basic_control_flow.asm'),
+    ];
+
+    for (const trace of traces) {
+      const text = (await readFile(trace, 'utf8')).toUpperCase();
+      expect(text).not.toContain('JP CC,');
+    }
+  });
+});


### PR DESCRIPTION
## What this does
- replaces stale `jp cc, ...` placeholder text in the touched structured-control `.asm` traces with concrete condition names
- adds a focused regression test that rejects `jp cc,` in current structured-control lowering
- adds a guard that the touched checked-in traces no longer contain the placeholder form

## Scope
This is the narrow trace-correctness slice for #452 only. It does not change corpus workflow or expansion policy.

## Why this is the right fix
The current compiler already emits concrete condition names (`jp z`, `jp nz`, `jp nc`). The stale placeholder remained only in checked-in `.asm` traces. This PR brings those traces back in line with current lowering and locks the behavior.

## Verification
- `npm test -- --run test/pr452_conditional_jump_trace_placeholders.test.ts`
