### PR TITLE
Add virtual 16-bit transfer patterns

### DIFF
--- a/test/fixtures/pr446_virtual_reg16_transfers.zax
+++ b/test/fixtures/pr446_virtual_reg16_transfers.zax
@@ -1,0 +1,8 @@
+export func main(): AF, BC, DE, HL
+  ld bc, de
+  ld de, bc
+  ld bc, hl
+  ld hl, bc
+  ld de, hl
+  ld hl, de
+end

--- a/test/pr446_virtual_reg16_transfers.test.ts
+++ b/test/pr446_virtual_reg16_transfers.test.ts
@@ -1,0 +1,42 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { AsmArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR446: virtual 16-bit transfer patterns', () => {
+  it('lowers BC/DE/HL pair transfers with direct byte moves only', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr446_virtual_reg16_transfers.zax');
+    const res = await compile(
+      entry,
+      { emitAsm: true, emitBin: false, emitHex: false, emitListing: false, emitD8m: false },
+      { formats: defaultFormatWriters },
+    );
+
+    expect(res.diagnostics).toEqual([]);
+    const asm = res.artifacts.find((a): a is AsmArtifact => a.kind === 'asm');
+    expect(asm).toBeDefined();
+
+    const text = asm!.text.toUpperCase();
+    expect(text).toContain('LD B, D');
+    expect(text).toContain('LD C, E');
+    expect(text).toContain('LD D, B');
+    expect(text).toContain('LD E, C');
+    expect(text).toContain('LD B, H');
+    expect(text).toContain('LD C, L');
+    expect(text).toContain('LD H, B');
+    expect(text).toContain('LD L, C');
+    expect(text).toContain('LD D, H');
+    expect(text).toContain('LD E, L');
+    expect(text).toContain('LD H, D');
+    expect(text).toContain('LD L, E');
+    expect(text).not.toContain('PUSH ');
+    expect(text).not.toContain('POP ');
+    expect(text).not.toContain('EX DE, HL');
+  });
+});


### PR DESCRIPTION
## What this does
- adds the first explicit virtual `rp -> rp` transfer set for `BC`, `DE`, and `HL`
- lowers the six supported cross-pair copies into direct 8-bit register moves
- keeps the feature non-destructive outside the destination pair
- uses no stack traffic and no exchange-as-copy shortcut
- adds focused regression coverage

## Supported set in this slice
- `ld bc, de` -> `ld b, d` / `ld c, e`
- `ld de, bc` -> `ld d, b` / `ld e, c`
- `ld bc, hl` -> `ld b, h` / `ld c, l`
- `ld hl, bc` -> `ld h, b` / `ld l, c`
- `ld de, hl` -> `ld d, h` / `ld e, l`
- `ld hl, de` -> `ld h, d` / `ld l, e`

## Scope
This is #446 only. It does not widen into a general pseudo-instruction system.

## Verification
- `npm test -- --run test/pr446_virtual_reg16_transfers.test.ts test/smoke_language_tour_compile.test.ts`
