### PR TITLE
docs: close out v0.3 and start v0.4 planning

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,10 +22,15 @@ This directory is intentionally constrained. Every file below has a unique purpo
 - `v02-codegen-reference.md` — single-stop v0.2 codegen reference (what to read, invariants).
 - `v02-codegen-worked-examples.md` — worked `.zax` → `.asm` examples for frame/call behavior.
 - `v02-closeout-and-followups.md` — records v0.2 closeout state and pushes future capability work into post-v0.2 tickets.
+- `v03-closeout-and-followups.md` — records v0.3 closeout and the transition boundary into v0.4 planning.
+- `v04-planning-track.md` — active v0.4 planning view.
+- `v04-priority-queue.md` — active short-form v0.4 queue.
 - `return-register-policy.md` — preservation/return matrix detail.
 - `arrays.md` — IX + DE/HL lowering guidance and runtime-atom cues.
-- `v03-planning-track.md` — post-v0.2 planning scaffold.
-- `v03-priority-queue.md` — explicit short-form developer order for the current post-v0.2 queue.
+- `codegen-corpus-workflow.md` — supported workflow and ownership rules for the curated codegen corpus.
+- `virtual-reg16-transfer-patterns.md` — supported `rp -> rp` virtual transfer patterns for the current low-level convenience slice.
+- `v03-planning-track.md` — historical v0.3 planning record.
+- `v03-priority-queue.md` — historical v0.3 short-form queue.
 - `github-backlog-workflow.md` — GitHub issue/label/milestone workflow used as the project backlog system.
 
 ## Definitive v0.2 Baseline Set

--- a/docs/v03-closeout-and-followups.md
+++ b/docs/v03-closeout-and-followups.md
@@ -1,0 +1,36 @@
+# v0.3 Closeout And Follow-ups
+
+v0.3 implementation work is complete.
+
+This note records the project state at closeout and marks the transition from
+the v0.3 planning/implementation cycle into v0.4 planning.
+
+## v0.3 closeout status
+
+- The v0.3 queue is treated as complete.
+- The v0.3 additions now considered landed are:
+  - `docs/codegen-corpus-workflow.md`
+  - `docs/virtual-reg16-transfer-patterns.md`
+- The v0.3 planning docs remain as historical planning references:
+  - `docs/v03-planning-track.md`
+  - `docs/v03-priority-queue.md`
+
+## Boundary rule
+
+- `v0.3.0` marks the end of the v0.3 line.
+- Work after that tag is v0.4-era work unless it is a true regression fix on the
+  released v0.3 surface.
+
+## Follow-on policy
+
+- Do not reopen completed v0.3 tickets as implicit carry-over work.
+- If a v0.3 behavior needs to change, create a new v0.4-scoped issue with the
+  updated rationale.
+- Keep the shipped v0.3 behavior stable unless a new planned change explicitly
+  replaces it.
+
+## Next planning state
+
+- Active planning moves to:
+  - `docs/v04-planning-track.md`
+  - `docs/v04-priority-queue.md`

--- a/docs/v03-planning-track.md
+++ b/docs/v03-planning-track.md
@@ -1,5 +1,8 @@
 # ZAX v0.3 Planning Track
 
+This file is now a historical planning record. Active planning has moved to
+`docs/v04-planning-track.md`.
+
 This document is the current post-v0.2 roadmap.
 
 Normative language behavior for shipped versions remains in `docs/zax-spec.md`.

--- a/docs/v03-priority-queue.md
+++ b/docs/v03-priority-queue.md
@@ -1,5 +1,8 @@
 # v0.3 Priority Queue
 
+This file is now a historical queue record. Active planning has moved to
+`docs/v04-priority-queue.md`.
+
 This is the explicit current developer work order for post-v0.2 work.
 
 Use this as the short operational queue. The broader rationale remains in

--- a/docs/v04-planning-track.md
+++ b/docs/v04-planning-track.md
@@ -1,0 +1,43 @@
+# ZAX v0.4 Planning Track
+
+This document is the active planning view after v0.3 closeout.
+
+Normative shipped behavior remains in `docs/zax-spec.md`. This file is the
+future-work planning layer only.
+
+## 1. Starting point after v0.3
+
+- v0.3 implementation is treated as complete.
+- v0.3 closeout note: `docs/v03-closeout-and-followups.md`
+- v0.3 workflow additions now part of the established project surface:
+  - `docs/codegen-corpus-workflow.md`
+  - `docs/virtual-reg16-transfer-patterns.md`
+
+## 2. Current v0.4 stance
+
+There is no committed active v0.4 feature queue yet.
+
+The immediate v0.4 job is to decide which future changes are actually justified
+before reopening feature work. New work should therefore start from explicit
+justification, not from assumed backlog carry-over.
+
+## 3. Planning rules for v0.4
+
+- Start from a fresh justification for each proposed feature.
+- Prefer small, explicit slices with one issue per PR.
+- Treat old plans as historical context only unless they are deliberately
+  reissued as current v0.4 work.
+- Do not silently convert completed v0.3 work into continuing “phase two” work
+  without a new scope decision.
+
+## 4. How to activate a v0.4 item
+
+Before a feature enters the active queue:
+
+1. define the user-facing value
+2. define the exact supported scope
+3. define what remains explicitly unsupported
+4. define the acceptance checks
+5. add it to `docs/v04-priority-queue.md`
+
+Until then, it is only a candidate idea, not active implementation work.

--- a/docs/v04-priority-queue.md
+++ b/docs/v04-priority-queue.md
@@ -1,0 +1,21 @@
+# v0.4 Priority Queue
+
+This is the active short-form developer queue for the v0.4 era.
+
+At the start of v0.4 planning, there is no active implementation queue yet.
+
+## Active order
+
+- No active v0.4 items are scheduled yet.
+
+## Activation rule
+
+- Add an item here only after it has been justified and scoped in the v0.4
+  planning process.
+- Each new item should be listed in the intended execution order.
+
+## Boundary
+
+- v0.3 is complete and closed out in `docs/v03-closeout-and-followups.md`.
+- This queue should not inherit old work automatically; new entries must be
+  explicitly chosen.


### PR DESCRIPTION
Closes #463\n\n## What changed\n- add a v0.3 closeout note\n- mark v0.3 planning docs as historical records\n- add the initial v0.4 planning track and empty v0.4 priority queue\n- update the docs index for the new boundary\n\n## Why\n- v0.3 is treated as complete\n- the next planning cycle needs an explicit v0.3 -> v0.4 boundary before new work is queued