### PR TITLE
docs: define v0.4 quality workstreams

### DIFF
--- a/docs/v04-planning-track.md
+++ b/docs/v04-planning-track.md
@@ -15,13 +15,105 @@ future-work planning layer only.
 
 ## 2. Current v0.4 stance
 
-There is no committed active v0.4 feature queue yet.
+v0.4 is a code-quality release line.
 
-The immediate v0.4 job is to decide which future changes are actually justified
-before reopening feature work. New work should therefore start from explicit
-justification, not from assumed backlog carry-over.
+Its purpose is to improve the quality, maintainability, and inspectability of
+the existing compiler rather than to add new language surface.
 
-## 3. Planning rules for v0.4
+The main concerns driving v0.4 are:
+
+- the codebase has grown through rapid iterative changes
+- the spec has evolved while implementation details accumulated
+- some code paths are likely stale, duplicated, overly coupled, or poorly
+  understood
+- large files, especially `src/lowering/emit.ts`, need structural cleanup
+
+v0.4 therefore focuses on:
+
+- refactoring
+- modularization
+- dead-code and duplication audits
+- documentation consolidation
+- coverage improvement in weakly tested areas
+
+v0.4 does **not** start as a feature-expansion cycle. New syntax or new surface
+capability should stay out of scope until the compiler internals are in better
+shape and the existing implementation is better understood.
+
+## 3. Active workstreams
+
+### Track A. Codebase audit and understanding
+
+The first job is to understand what the compiler is actually doing now:
+
+- identify stale lowering paths
+- identify duplicated logic
+- identify paths that no longer match the current spec
+- identify areas where behavior is poorly explained by the current structure
+
+This is especially important in:
+
+- `src/lowering/emit.ts`
+- encoding / parsing boundaries where old and new behavior may overlap
+
+Primary issue:
+
+- `#465` — audit current lowering behavior in `src/lowering/emit.ts`
+
+### Track B. Refactoring and modularization
+
+Once the current behavior is understood, refactor for structure without changing
+intended semantics:
+
+- break oversized files into clearer modules
+- isolate reusable lowering helpers
+- reduce ad hoc branching where explicit helper layers would be clearer
+- keep behavior-preserving refactors separate from functional changes wherever
+  possible
+
+Primary issue:
+
+- `#466` — refactor the lowering emitter into smaller modules without semantic drift
+
+### Track C. Documentation consolidation
+
+The current docs set has accumulated over time. v0.4 should reduce sprawl:
+
+- merge overlapping guidance into fewer, clearer docs
+- keep one authoritative place per topic
+- remove or archive stale supporting notes when their content is absorbed
+- keep normative vs non-normative boundaries explicit
+
+Primary issue:
+
+- `#467` — consolidate documentation and reduce overlapping support docs
+
+### Track D. Coverage and regression hardening
+
+v0.4 should increase confidence in the current compiler before new feature work:
+
+- identify low-coverage areas
+- add focused regression tests around poorly covered lowering paths
+- improve confidence in emitted output for existing supported behavior
+- treat test additions as a way to lock current behavior before deeper refactors
+
+Primary issue:
+
+- `#468` — audit coverage gaps and add targeted regression tests for weak areas
+
+## 4. Explicitly out of scope at the start of v0.4
+
+These are not the focus of the initial v0.4 cycle:
+
+- new syntax
+- new language-level features
+- speculative capability expansion
+- broad semantic redesign
+
+After the code-quality work is complete, syntax sharpening can be reconsidered
+from a stronger codebase position.
+
+## 5. Planning rules for v0.4
 
 - Start from a fresh justification for each proposed feature.
 - Prefer small, explicit slices with one issue per PR.
@@ -29,8 +121,10 @@ justification, not from assumed backlog carry-over.
   reissued as current v0.4 work.
 - Do not silently convert completed v0.3 work into continuing “phase two” work
   without a new scope decision.
+- Prefer semantics-preserving cleanup first; functional changes should be
+  justified separately.
 
-## 4. How to activate a v0.4 item
+## 6. How to activate a v0.4 item
 
 Before a feature enters the active queue:
 

--- a/docs/v04-priority-queue.md
+++ b/docs/v04-priority-queue.md
@@ -2,20 +2,77 @@
 
 This is the active short-form developer queue for the v0.4 era.
 
-At the start of v0.4 planning, there is no active implementation queue yet.
+v0.4 is focused on code quality and maintainability only.
 
 ## Active order
 
-- No active v0.4 items are scheduled yet.
+### 1. Codebase audit of current compiler behavior
+
+Issue:
+
+- `#465`
+
+Why first:
+
+- the current implementation needs to be understood before it is restructured
+- stale, duplicated, or obsolete paths need to be identified before refactors
+- this is the foundation for all later v0.4 cleanup
+
+Priority focus:
+
+- `src/lowering/emit.ts`
+- places where spec evolution may have left old behavior behind
+
+### 2. Refactoring and modularization of high-risk areas
+
+Issue:
+
+- `#466`
+
+Why second:
+
+- once current behavior is mapped, large files can be broken down safely
+- refactoring should follow understanding, not precede it
+- the main target is better structure without semantic drift
+
+### 3. Documentation consolidation
+
+Issue:
+
+- `#467`
+
+Why third:
+
+- the docs should reflect the cleaned-up implementation structure
+- overlapping docs should be merged or clarified while the code is being
+  understood and reorganized
+
+### 4. Coverage gap audit and targeted test expansion
+
+Issue:
+
+- `#468`
+
+Why fourth:
+
+- test gaps should be closed around the areas identified during the audit
+- stronger regression coverage makes deeper cleanup safer
+
+### 5. Reassess future syntax work only after the code-quality pass
+
+Why last:
+
+- syntax changes are intentionally deferred until the compiler internals are in
+  better shape
+- this is a reassessment gate, not active feature work yet
 
 ## Activation rule
 
-- Add an item here only after it has been justified and scoped in the v0.4
-  planning process.
-- Each new item should be listed in the intended execution order.
+- Break each queue item into explicit issues before developer implementation.
+- Prefer one narrowly scoped cleanup/refactor issue per PR.
+- Keep behavior-preserving cleanup separate from intended semantic changes.
 
 ## Boundary
 
 - v0.3 is complete and closed out in `docs/v03-closeout-and-followups.md`.
-- This queue should not inherit old work automatically; new entries must be
-  explicitly chosen.
+- v0.4 starts as a code-quality cycle, not a feature-expansion cycle.


### PR DESCRIPTION
Closes #469\n\n## What changed\n- define v0.4 explicitly as a code-quality cycle\n- add concrete v0.4 issue numbers to the active workstreams\n- set the short operational queue to the quality-first order\n\n## Why\n- v0.3 is closed\n- v0.4 needs a concrete quality roadmap before developer work starts