### PR TITLE
#465 Audit lowering behavior and fix pr447 typecheck

### DIFF
--- a/test/pr447_direct_index_high_low.test.ts
+++ b/test/pr447_direct_index_high_low.test.ts
@@ -13,6 +13,8 @@ type IndexedFamily = {
   regs: readonly string[];
 };
 
+type IndexedLane = 'IXH' | 'IXL' | 'IYH' | 'IYL';
+
 const indexedFamilies: readonly IndexedFamily[] = [
   { prefix: 0xdd, lanes: ['IXH', 'IXL'], regs: ['A', 'B', 'C', 'D', 'E', 'IXH', 'IXL'] },
   { prefix: 0xfd, lanes: ['IYH', 'IYL'], regs: ['A', 'B', 'C', 'D', 'E', 'IYH', 'IYL'] },
@@ -53,11 +55,11 @@ describe('PR447: direct IXH/IXL/IYH/IYL forms', () => {
     const expected: number[] = [];
 
     for (const family of indexedFamilies) {
+      const familyLanes = new Set<IndexedLane>(family.lanes);
       for (const dst of family.regs) {
         for (const src of family.regs) {
           const touchesLane =
-            family.lanes.includes(dst as 'IXH' | 'IXL' | 'IYH' | 'IYL') ||
-            family.lanes.includes(src as 'IXH' | 'IXL' | 'IYH' | 'IYL');
+            familyLanes.has(dst as IndexedLane) || familyLanes.has(src as IndexedLane);
           if (!touchesLane) continue;
 
           lines.push(`ld ${dst.toLowerCase()}, ${src.toLowerCase()}`);


### PR DESCRIPTION
## What this does
- fixes the current typecheck break in `test/pr447_direct_index_high_low.test.ts`
- captures the v0.4 lowering audit in issue #465 comments

## Scope
- no lowering refactor
- no semantic changes
- no feature work

## Audit output
- audit comments are on #465:
  - https://github.com/jhlagado/ZAX/issues/465#issuecomment-3980028315
  - https://github.com/jhlagado/ZAX/issues/465#issuecomment-3980048891

## Verification
- `npm run typecheck`
- `npm test -- --run test/pr447_direct_index_high_low.test.ts`

Closes none. This is the understanding pass only.
