### PR TITLE
#474 Extract trace and fixup formatting helpers

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -83,6 +83,15 @@ import { sizeOfTypeExpr } from '../semantics/layout.js';
 import { encodeInstruction } from '../z80/encode.js';
 import type { OpStackPolicyMode } from '../pipeline.js';
 import { loadBinInput, loadHexInput } from './inputAssets.js';
+import {
+  formatAbs16FixupAsm,
+  formatAbs16FixupEdAsm,
+  formatAbs16FixupPrefixedAsm,
+  formatAsmInstrForTrace,
+  formatIxDisp,
+  toHexByte,
+  toHexWord,
+} from './traceFormat.js';
 
 function diag(diagnostics: Diagnostic[], file: string, message: string): void {
   diagnostics.push({ id: DiagnosticIds.EmitError, severity: 'error', message, file });
@@ -393,222 +402,6 @@ export function emitProgram(
     codeSourceSegments.push({ ...currentCodeSegmentTag, start, end });
   };
 
-  const toHexByte = (n: number): string =>
-    `$${(n & 0xff).toString(16).toUpperCase().padStart(2, '0')}`;
-  const toHexWord = (n: number): string =>
-    `$${(n & 0xffff).toString(16).toUpperCase().padStart(4, '0')}`;
-
-  const formatImmExprForAsm = (expr: ImmExprNode): string => {
-    switch (expr.kind) {
-      case 'ImmLiteral':
-        return toHexWord(expr.value);
-      case 'ImmName':
-        return expr.name;
-      case 'ImmSizeof':
-        return 'sizeof(...)';
-      case 'ImmOffsetof':
-        return 'offsetof(...)';
-      case 'ImmUnary':
-        return `${expr.op}${formatImmExprForAsm(expr.expr)}`;
-      case 'ImmBinary':
-        return `${formatImmExprForAsm(expr.left)} ${expr.op} ${formatImmExprForAsm(expr.right)}`;
-      default:
-        return 'imm';
-    }
-  };
-
-  const formatEaExprForAsm = (ea: EaExprNode): string => {
-    switch (ea.kind) {
-      case 'EaName':
-        return ea.name;
-      case 'EaField':
-        return `${formatEaExprForAsm(ea.base)}.${ea.field}`;
-      case 'EaAdd':
-        return `${formatEaExprForAsm(ea.base)} + ${formatImmExprForAsm(ea.offset)}`;
-      case 'EaSub':
-        return `${formatEaExprForAsm(ea.base)} - ${formatImmExprForAsm(ea.offset)}`;
-      case 'EaIndex': {
-        let idx = '';
-        switch (ea.index.kind) {
-          case 'IndexImm':
-            idx = formatImmExprForAsm(ea.index.value);
-            break;
-          case 'IndexReg8':
-          case 'IndexReg16':
-            idx = ea.index.reg;
-            break;
-          case 'IndexMemHL':
-            idx = '(HL)';
-            break;
-          case 'IndexMemIxIy':
-            idx = ea.index.disp
-              ? `${ea.index.base}${ea.index.disp.kind === 'ImmUnary' ? '' : '+'}${formatImmExprForAsm(ea.index.disp)}`
-              : ea.index.base;
-            break;
-          case 'IndexEa':
-            idx = formatEaExprForAsm(ea.index.expr);
-            break;
-        }
-        return `${formatEaExprForAsm(ea.base)}[${idx}]`;
-      }
-      default:
-        return 'ea';
-    }
-  };
-
-  const formatAsmOperandForTrace = (operand: AsmOperandNode): string => {
-    switch (operand.kind) {
-      case 'Reg':
-        return operand.name;
-      case 'Imm':
-        return formatImmExprForAsm(operand.expr);
-      case 'Ea':
-        return formatEaExprForAsm(operand.expr);
-      case 'Mem':
-        return `(${formatEaExprForAsm(operand.expr)})`;
-      case 'PortC':
-        return '(C)';
-      case 'PortImm8':
-        return `(${formatImmExprForAsm(operand.expr)})`;
-      default:
-        return '?';
-    }
-  };
-
-  const formatAsmInstrForTrace = (head: string, operands: AsmOperandNode[]): string => {
-    const lowerHead = head.toLowerCase();
-    if (operands.length === 0) return lowerHead;
-    return `${lowerHead} ${operands.map(formatAsmOperandForTrace).join(', ')}`;
-  };
-
-  const formatFixupSymbolExpr = (baseLower: string, addend: number): string => {
-    if (addend === 0) return baseLower;
-    if (addend > 0) return `${baseLower} + ${addend}`;
-    return `${baseLower} - ${Math.abs(addend)}`;
-  };
-
-  const jpCondFromOpcode = (opcode: number): string | undefined => {
-    switch (opcode & 0xff) {
-      case 0xc2:
-        return 'NZ';
-      case 0xca:
-        return 'Z';
-      case 0xd2:
-        return 'NC';
-      case 0xda:
-        return 'C';
-      case 0xe2:
-        return 'PO';
-      case 0xea:
-        return 'PE';
-      case 0xf2:
-        return 'P';
-      case 0xfa:
-        return 'M';
-      default:
-        return undefined;
-    }
-  };
-
-  const callCondFromOpcode = (opcode: number): string | undefined => {
-    switch (opcode & 0xff) {
-      case 0xc4:
-        return 'NZ';
-      case 0xcc:
-        return 'Z';
-      case 0xd4:
-        return 'NC';
-      case 0xdc:
-        return 'C';
-      case 0xe4:
-        return 'PO';
-      case 0xec:
-        return 'PE';
-      case 0xf4:
-        return 'P';
-      case 0xfc:
-        return 'M';
-      default:
-        return undefined;
-    }
-  };
-
-  const formatAbs16FixupAsm = (opcode: number, baseLower: string, addend: number): string => {
-    const sym = formatFixupSymbolExpr(baseLower, addend);
-    switch (opcode & 0xff) {
-      case 0x01:
-        return `ld BC, ${sym}`;
-      case 0x11:
-        return `ld DE, ${sym}`;
-      case 0x21:
-        return `ld HL, ${sym}`;
-      case 0x31:
-        return `ld SP, ${sym}`;
-      case 0x2a:
-        return `ld HL, (${sym})`;
-      case 0x3a:
-        return `ld A, (${sym})`;
-      case 0x22:
-        return `ld (${sym}), HL`;
-      case 0x32:
-        return `ld (${sym}), A`;
-      case 0xc3:
-        return `jp ${sym}`;
-      case 0xcd:
-        return `call ${sym}`;
-      default: {
-        const jpCc = jpCondFromOpcode(opcode);
-        if (jpCc) return `jp ${jpCc}, ${sym}`;
-        const callCc = callCondFromOpcode(opcode);
-        if (callCc) return `call ${callCc}, ${sym}`;
-        return `db ${toHexByte(opcode)}, lo(${baseLower}), hi(${baseLower})`;
-      }
-    }
-  };
-
-  const formatAbs16FixupEdAsm = (opcode2: number, baseLower: string, addend: number): string => {
-    const sym = formatFixupSymbolExpr(baseLower, addend);
-    switch (opcode2 & 0xff) {
-      case 0x4b:
-        return `ld BC, (${sym})`;
-      case 0x5b:
-        return `ld DE, (${sym})`;
-      case 0x7b:
-        return `ld SP, (${sym})`;
-      case 0x43:
-        return `ld (${sym}), BC`;
-      case 0x53:
-        return `ld (${sym}), DE`;
-      case 0x73:
-        return `ld (${sym}), SP`;
-      default:
-        return `db $ED, ${toHexByte(opcode2)}, lo(${baseLower}), hi(${baseLower})`;
-    }
-  };
-
-  const formatAbs16FixupPrefixedAsm = (
-    prefix: number,
-    opcode2: number,
-    baseLower: string,
-    addend: number,
-  ): string => {
-    const sym = formatFixupSymbolExpr(baseLower, addend);
-    const reg16 = prefix === 0xdd ? 'IX' : prefix === 0xfd ? 'IY' : undefined;
-    if (!reg16) {
-      return `db ${toHexByte(prefix)}, ${toHexByte(opcode2)}, lo(${baseLower}), hi(${baseLower})`;
-    }
-    switch (opcode2 & 0xff) {
-      case 0x21:
-        return `ld ${reg16}, ${sym}`;
-      case 0x2a:
-        return `ld ${reg16}, (${sym})`;
-      case 0x22:
-        return `ld (${sym}), ${reg16}`;
-      default:
-        return `db ${toHexByte(prefix)}, ${toHexByte(opcode2)}, lo(${baseLower}), hi(${baseLower})`;
-    }
-  };
-
   const traceInstruction = (offset: number, bytesOut: Uint8Array, text: string): void => {
     if (bytesOut.length === 0) return;
     codeAsmTrace.push({
@@ -810,12 +603,6 @@ export function emitProgram(
       return false;
     }
     return emitInstr('push', [{ kind: 'Reg', span, name: 'HL' }], span);
-  };
-
-  const formatIxDisp = (disp: number): string => {
-    const hex = Math.abs(disp).toString(16).padStart(2, '0');
-    const sign = disp >= 0 ? '+' : '-';
-    return `${sign}$${hex}`;
   };
 
   const emitStepPipeline = (pipe: StepPipeline, span: SourceSpan): boolean => {

--- a/src/lowering/traceFormat.ts
+++ b/src/lowering/traceFormat.ts
@@ -1,0 +1,228 @@
+import type { AsmOperandNode, EaExprNode, ImmExprNode } from '../frontend/ast.js';
+
+export const toHexByte = (n: number): string =>
+  `$${(n & 0xff).toString(16).toUpperCase().padStart(2, '0')}`;
+
+export const toHexWord = (n: number): string =>
+  `$${(n & 0xffff).toString(16).toUpperCase().padStart(4, '0')}`;
+
+export const formatImmExprForAsm = (expr: ImmExprNode): string => {
+  switch (expr.kind) {
+    case 'ImmLiteral':
+      return toHexWord(expr.value);
+    case 'ImmName':
+      return expr.name;
+    case 'ImmSizeof':
+      return 'sizeof(...)';
+    case 'ImmOffsetof':
+      return 'offsetof(...)';
+    case 'ImmUnary':
+      return `${expr.op}${formatImmExprForAsm(expr.expr)}`;
+    case 'ImmBinary':
+      return `${formatImmExprForAsm(expr.left)} ${expr.op} ${formatImmExprForAsm(expr.right)}`;
+    default:
+      return 'imm';
+  }
+};
+
+export const formatEaExprForAsm = (ea: EaExprNode): string => {
+  switch (ea.kind) {
+    case 'EaName':
+      return ea.name;
+    case 'EaField':
+      return `${formatEaExprForAsm(ea.base)}.${ea.field}`;
+    case 'EaAdd':
+      return `${formatEaExprForAsm(ea.base)} + ${formatImmExprForAsm(ea.offset)}`;
+    case 'EaSub':
+      return `${formatEaExprForAsm(ea.base)} - ${formatImmExprForAsm(ea.offset)}`;
+    case 'EaIndex': {
+      let idx = '';
+      switch (ea.index.kind) {
+        case 'IndexImm':
+          idx = formatImmExprForAsm(ea.index.value);
+          break;
+        case 'IndexReg8':
+        case 'IndexReg16':
+          idx = ea.index.reg;
+          break;
+        case 'IndexMemHL':
+          idx = '(HL)';
+          break;
+        case 'IndexMemIxIy':
+          idx = ea.index.disp
+            ? `${ea.index.base}${ea.index.disp.kind === 'ImmUnary' ? '' : '+'}${formatImmExprForAsm(ea.index.disp)}`
+            : ea.index.base;
+          break;
+        case 'IndexEa':
+          idx = formatEaExprForAsm(ea.index.expr);
+          break;
+      }
+      return `${formatEaExprForAsm(ea.base)}[${idx}]`;
+    }
+    default:
+      return 'ea';
+  }
+};
+
+export const formatAsmOperandForTrace = (operand: AsmOperandNode): string => {
+  switch (operand.kind) {
+    case 'Reg':
+      return operand.name;
+    case 'Imm':
+      return formatImmExprForAsm(operand.expr);
+    case 'Ea':
+      return formatEaExprForAsm(operand.expr);
+    case 'Mem':
+      return `(${formatEaExprForAsm(operand.expr)})`;
+    case 'PortC':
+      return '(C)';
+    case 'PortImm8':
+      return `(${formatImmExprForAsm(operand.expr)})`;
+    default:
+      return '?';
+  }
+};
+
+export const formatAsmInstrForTrace = (head: string, operands: AsmOperandNode[]): string => {
+  const lowerHead = head.toLowerCase();
+  if (operands.length === 0) return lowerHead;
+  return `${lowerHead} ${operands.map(formatAsmOperandForTrace).join(', ')}`;
+};
+
+export const formatFixupSymbolExpr = (baseLower: string, addend: number): string => {
+  if (addend === 0) return baseLower;
+  if (addend > 0) return `${baseLower} + ${addend}`;
+  return `${baseLower} - ${Math.abs(addend)}`;
+};
+
+const jpCondFromOpcode = (opcode: number): string | undefined => {
+  switch (opcode & 0xff) {
+    case 0xc2:
+      return 'NZ';
+    case 0xca:
+      return 'Z';
+    case 0xd2:
+      return 'NC';
+    case 0xda:
+      return 'C';
+    case 0xe2:
+      return 'PO';
+    case 0xea:
+      return 'PE';
+    case 0xf2:
+      return 'P';
+    case 0xfa:
+      return 'M';
+    default:
+      return undefined;
+  }
+};
+
+const callCondFromOpcode = (opcode: number): string | undefined => {
+  switch (opcode & 0xff) {
+    case 0xc4:
+      return 'NZ';
+    case 0xcc:
+      return 'Z';
+    case 0xd4:
+      return 'NC';
+    case 0xdc:
+      return 'C';
+    case 0xe4:
+      return 'PO';
+    case 0xec:
+      return 'PE';
+    case 0xf4:
+      return 'P';
+    case 0xfc:
+      return 'M';
+    default:
+      return undefined;
+  }
+};
+
+export const formatAbs16FixupAsm = (opcode: number, baseLower: string, addend: number): string => {
+  const sym = formatFixupSymbolExpr(baseLower, addend);
+  switch (opcode & 0xff) {
+    case 0x01:
+      return `ld BC, ${sym}`;
+    case 0x11:
+      return `ld DE, ${sym}`;
+    case 0x21:
+      return `ld HL, ${sym}`;
+    case 0x31:
+      return `ld SP, ${sym}`;
+    case 0x2a:
+      return `ld HL, (${sym})`;
+    case 0x3a:
+      return `ld A, (${sym})`;
+    case 0x22:
+      return `ld (${sym}), HL`;
+    case 0x32:
+      return `ld (${sym}), A`;
+    case 0xc3:
+      return `jp ${sym}`;
+    case 0xcd:
+      return `call ${sym}`;
+    default: {
+      const jpCc = jpCondFromOpcode(opcode);
+      if (jpCc) return `jp ${jpCc}, ${sym}`;
+      const callCc = callCondFromOpcode(opcode);
+      if (callCc) return `call ${callCc}, ${sym}`;
+      return `db ${toHexByte(opcode)}, lo(${baseLower}), hi(${baseLower})`;
+    }
+  }
+};
+
+export const formatAbs16FixupEdAsm = (
+  opcode2: number,
+  baseLower: string,
+  addend: number,
+): string => {
+  const sym = formatFixupSymbolExpr(baseLower, addend);
+  switch (opcode2 & 0xff) {
+    case 0x4b:
+      return `ld BC, (${sym})`;
+    case 0x5b:
+      return `ld DE, (${sym})`;
+    case 0x7b:
+      return `ld SP, (${sym})`;
+    case 0x43:
+      return `ld (${sym}), BC`;
+    case 0x53:
+      return `ld (${sym}), DE`;
+    case 0x73:
+      return `ld (${sym}), SP`;
+    default:
+      return `db $ED, ${toHexByte(opcode2)}, lo(${baseLower}), hi(${baseLower})`;
+  }
+};
+
+export const formatAbs16FixupPrefixedAsm = (
+  prefix: number,
+  opcode2: number,
+  baseLower: string,
+  addend: number,
+): string => {
+  const sym = formatFixupSymbolExpr(baseLower, addend);
+  const reg16 = prefix === 0xdd ? 'IX' : prefix === 0xfd ? 'IY' : undefined;
+  if (!reg16) {
+    return `db ${toHexByte(prefix)}, ${toHexByte(opcode2)}, lo(${baseLower}), hi(${baseLower})`;
+  }
+  switch (opcode2 & 0xff) {
+    case 0x21:
+      return `ld ${reg16}, ${sym}`;
+    case 0x2a:
+      return `ld ${reg16}, (${sym})`;
+    case 0x22:
+      return `ld (${sym}), ${reg16}`;
+    default:
+      return `db ${toHexByte(prefix)}, ${toHexByte(opcode2)}, lo(${baseLower}), hi(${baseLower})`;
+  }
+};
+
+export const formatIxDisp = (disp: number): string => {
+  const hex = Math.abs(disp).toString(16).padStart(2, '0');
+  const sign = disp >= 0 ? '+' : '-';
+  return `${sign}$${hex}`;
+};

--- a/test/pr474_trace_format_helpers.test.ts
+++ b/test/pr474_trace_format_helpers.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AsmOperandNode, EaExprNode, SourceSpan } from '../src/frontend/ast.js';
+import {
+  formatAbs16FixupAsm,
+  formatAbs16FixupEdAsm,
+  formatAbs16FixupPrefixedAsm,
+  formatAsmInstrForTrace,
+  formatIxDisp,
+} from '../src/lowering/traceFormat.js';
+
+const span: SourceSpan = {
+  file: 'test.zax',
+  start: { offset: 0, line: 1, column: 1 },
+  end: { offset: 0, line: 1, column: 1 },
+};
+
+const eaName = (name: string): EaExprNode => ({ kind: 'EaName', span, name });
+const reg = (name: string): AsmOperandNode => ({ kind: 'Reg', span, name });
+const immName = (name: string): AsmOperandNode => ({
+  kind: 'Imm',
+  span,
+  expr: { kind: 'ImmName', span, name },
+});
+const mem = (name: string): AsmOperandNode => ({ kind: 'Mem', span, expr: eaName(name) });
+
+describe('PR474: trace and fixup formatting helpers', () => {
+  it('formats asm trace operands deterministically', () => {
+    expect(formatAsmInstrForTrace('ld', [reg('A'), mem('glob_b')])).toBe('ld A, (glob_b)');
+    expect(formatAsmInstrForTrace('call', [immName('target')])).toBe('call target');
+  });
+
+  it('formats absolute fixup traces', () => {
+    expect(formatAbs16FixupAsm(0xc2, 'label', 2)).toBe('jp NZ, label + 2');
+    expect(formatAbs16FixupEdAsm(0x53, 'dest', 0)).toBe('ld (dest), DE');
+    expect(formatAbs16FixupPrefixedAsm(0xdd, 0x2a, 'slot', 0)).toBe('ld IX, (slot)');
+  });
+
+  it('formats ix displacements consistently', () => {
+    expect(formatIxDisp(4)).toBe('+$04');
+    expect(formatIxDisp(-4)).toBe('-$04');
+  });
+});


### PR DESCRIPTION
## What this does
- extracts asm trace formatting and fixup trace text helpers from `src/lowering/emit.ts`
- moves the pure formatting logic into `src/lowering/traceFormat.ts`
- keeps `emit.ts` focused on emission state and lowering flow

## Scope
- semantics-preserving extraction only
- no lowering behavior changes
- first #474 slice only (trace/fixup formatting helpers)

## Verification
- `npm run typecheck`
- `npm test -- --run test/pr474_trace_format_helpers.test.ts test/smoke_language_tour_compile.test.ts`
