### PR TITLE
#474 Extract section layout helpers

### DIFF
--- a/src/lowering/sectionLayout.ts
+++ b/src/lowering/sectionLayout.ts
@@ -1,0 +1,65 @@
+import type { AddressRange, EmittedAsmTraceEntry, EmittedSourceSegment } from '../formats/types.js';
+
+type LayoutDiag = (message: string) => void;
+
+export function alignTo(n: number, alignment: number): number {
+  return alignment <= 0 ? n : Math.ceil(n / alignment) * alignment;
+}
+
+export function writeSection(
+  base: number,
+  section: Map<number, number>,
+  bytes: Map<number, number>,
+  report: LayoutDiag,
+): void {
+  for (const [offset, value] of section) {
+    const addr = base + offset;
+    if (addr < 0 || addr > 0xffff) {
+      report(`Emitted byte address out of range: ${addr}.`);
+      continue;
+    }
+    if (bytes.has(addr)) {
+      report(`Byte overlap at address ${addr}.`);
+      continue;
+    }
+    bytes.set(addr, value);
+  }
+}
+
+export function computeWrittenRange(bytes: Map<number, number>): AddressRange {
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+
+  for (const addr of bytes.keys()) {
+    min = Math.min(min, addr);
+    max = Math.max(max, addr);
+  }
+
+  return Number.isFinite(min) && Number.isFinite(max)
+    ? { start: min, end: max + 1 }
+    : { start: 0, end: 0 };
+}
+
+export function rebaseCodeSourceSegments(
+  codeBase: number,
+  segments: EmittedSourceSegment[],
+): EmittedSourceSegment[] {
+  return segments
+    .map((segment) => ({
+      ...segment,
+      start: codeBase + segment.start,
+      end: codeBase + segment.end,
+    }))
+    .filter(
+      (segment) => segment.start >= 0 && segment.end <= 0x10000 && segment.end > segment.start,
+    );
+}
+
+export function rebaseAsmTrace(
+  codeBase: number,
+  asmTrace: EmittedAsmTraceEntry[],
+): EmittedAsmTraceEntry[] {
+  return asmTrace
+    .map((entry) => ({ ...entry, offset: codeBase + entry.offset }))
+    .filter((entry) => entry.offset >= 0 && entry.offset <= 0xffff);
+}

--- a/test/pr474_section_layout_helpers.test.ts
+++ b/test/pr474_section_layout_helpers.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import type { EmittedAsmTraceEntry, EmittedSourceSegment } from '../src/formats/types.js';
+import {
+  alignTo,
+  computeWrittenRange,
+  rebaseAsmTrace,
+  rebaseCodeSourceSegments,
+  writeSection,
+} from '../src/lowering/sectionLayout.js';
+
+describe('PR474: section layout helpers', () => {
+  it('aligns offsets and computes written ranges deterministically', () => {
+    expect(alignTo(3, 2)).toBe(4);
+    expect(alignTo(4, 2)).toBe(4);
+    expect(alignTo(5, 0)).toBe(5);
+
+    const bytes = new Map<number, number>([
+      [0x10, 0xaa],
+      [0x12, 0xbb],
+    ]);
+    expect(computeWrittenRange(bytes)).toEqual({ start: 0x10, end: 0x13 });
+    expect(computeWrittenRange(new Map())).toEqual({ start: 0, end: 0 });
+  });
+
+  it('writes sections with overlap and range diagnostics', () => {
+    const bytes = new Map<number, number>([[0x20, 0xff]]);
+    const diagnostics: string[] = [];
+
+    writeSection(
+      0x20,
+      new Map<number, number>([
+        [0, 0xaa],
+        [1, 0xbb],
+      ]),
+      bytes,
+      (message) => diagnostics.push(message),
+    );
+
+    expect(bytes.get(0x20)).toBe(0xff);
+    expect(bytes.get(0x21)).toBe(0xbb);
+    expect(diagnostics).toEqual(['Byte overlap at address 32.']);
+  });
+
+  it('rebases source segments and asm trace entries', () => {
+    const segments: EmittedSourceSegment[] = [
+      {
+        start: 0,
+        end: 2,
+        file: 'a.zax',
+        line: 1,
+        column: 1,
+        kind: 'code',
+        confidence: 'high',
+      },
+      {
+        start: -0x300,
+        end: -0x2ff,
+        file: 'b.zax',
+        line: 2,
+        column: 1,
+        kind: 'code',
+        confidence: 'low',
+      },
+    ];
+    const trace: EmittedAsmTraceEntry[] = [
+      { kind: 'label', offset: 0, name: 'main' },
+      { kind: 'comment', offset: -0x101, text: 'bad' },
+    ];
+
+    expect(rebaseCodeSourceSegments(0x100, segments)).toEqual([
+      {
+        ...segments[0]!,
+        start: 0x100,
+        end: 0x102,
+      },
+    ]);
+    expect(rebaseAsmTrace(0x100, trace)).toEqual([{ kind: 'label', offset: 0x100, name: 'main' }]);
+  });
+});


### PR DESCRIPTION
## What this does
- extracts section layout and finalization helpers from `src/lowering/emit.ts`
- moves alignment, section writes, written-range computation, and trace/source rebasing into `src/lowering/sectionLayout.ts`
- keeps emitter behavior unchanged while reducing non-lowering responsibility in `emit.ts`

## Scope
- semantics-preserving extraction only
- second #474 slice
- no changes to core lowering semantics

## Verification
- `npm run typecheck`
- `npm test -- --run test/pr474_trace_format_helpers.test.ts test/pr474_section_layout_helpers.test.ts test/smoke_language_tour_compile.test.ts`
