### PR TITLE
#475 Replace string-based addressing steps with typed ops

### DIFF
--- a/test/addressing_model_steps.test.ts
+++ b/test/addressing_model_steps.test.ts
@@ -19,9 +19,10 @@ import {
   CALC_EA,
   LOAD_RP_FVAR,
   STORE_RP_FVAR,
+  renderStepPipeline,
 } from '../src/addressing/steps';
 
-const asm = (pipeline: { asm: string }[]) => pipeline.map((s) => s.asm);
+const asm = renderStepPipeline;
 
 describe('addressing-model step library', () => {
   it('EA_GLOB_CONST matches doc (byte)', () => {

--- a/test/pr407_step_matrix.test.ts
+++ b/test/pr407_step_matrix.test.ts
@@ -33,21 +33,23 @@ import {
   LOAD_BASE_GLOB,
   LOAD_IDX_CONST,
   CALC_EA,
+  renderStepPipeline,
+  type StepPipeline,
 } from '../src/addressing/steps';
 
-const asm = (pipeline: { asm: string }[]) => pipeline.map((s) => s.asm);
+const asm = renderStepPipeline;
 
-const assertSingleInstr = (name: string, pipeline: { asm: string }[]) => {
+const assertSingleInstr = (name: string, pipeline: StepPipeline) => {
   expect(pipeline.length, `${name} should not be empty`).toBeGreaterThan(0);
-  for (const step of pipeline) {
-    expect(step.asm.includes('\n'), `${name} contains newline in ${step.asm}`).toBe(false);
-    expect(step.asm.includes(';'), `${name} contains multi-op/comment in ${step.asm}`).toBe(false);
+  for (const text of renderStepPipeline(pipeline)) {
+    expect(text.includes('\n'), `${name} contains newline in ${text}`).toBe(false);
+    expect(text.includes(';'), `${name} contains multi-op/comment in ${text}`).toBe(false);
   }
 };
 
 describe('PR407 addressing-model coverage: step pipelines stay single-instruction', () => {
   it('EA and EAW builders emit single-op steps', () => {
-    const builders: [string, { asm: string }[]][] = [
+    const builders: [string, StepPipeline][] = [
       ['EA_GLOB_CONST', EA_GLOB_CONST('glob_b', 1)],
       ['EA_GLOB_REG', EA_GLOB_REG('glob_b', 'c')],
       ['EA_GLOB_RP', EA_GLOB_RP('glob_b', 'de')],
@@ -77,7 +79,7 @@ describe('PR407 addressing-model coverage: step pipelines stay single-instructio
 
   it('templates keep one-instruction steps around EA', () => {
     const sampleEA = [...LOAD_BASE_GLOB('glob_b'), ...LOAD_IDX_CONST(0), ...CALC_EA()];
-    const templates: [string, { asm: string }[]][] = [
+    const templates: [string, StepPipeline][] = [
       ['TEMPLATE_L_ABC', TEMPLATE_L_ABC('a', sampleEA)],
       ['TEMPLATE_L_HL', TEMPLATE_L_HL('H', sampleEA)],
       ['TEMPLATE_L_DE', TEMPLATE_L_DE('D', sampleEA)],


### PR DESCRIPTION
## What this does
- replaces the addressing step DSL in `src/addressing/steps.ts` with a typed step model
- removes regex-based pseudo-assembly parsing from `emitStepPipeline(...)` in `src/lowering/emit.ts`
- keeps the existing step surface and behavior, with rendering retained only for tests/document checks

## Scope
- semantics-preserving refactor only
- no new addressing features
- no docs changes

## Verification
- `npm run typecheck`
- `npm test -- --run test/addressing_model_steps.test.ts test/pr407_step_matrix.test.ts test/smoke_language_tour_compile.test.ts`
- `npm test -- --run test/pr405_byte_scalar_fast_paths.test.ts test/pr406_word_scalar_accessors.test.ts test/pr407_emission_guard.test.ts`
