### PR TITLE
Extract enum parser helper

### DIFF
--- a/src/frontend/parseEnum.ts
+++ b/src/frontend/parseEnum.ts
@@ -1,0 +1,127 @@
+import type { EnumDeclNode, SourceSpan } from './ast.js';
+import type { Diagnostic } from '../diagnostics/types.js';
+import { DiagnosticIds } from '../diagnostics/types.js';
+import { diagInvalidHeaderLine, formatIdentifierToken } from './parseModuleCommon.js';
+
+function diag(
+  diagnostics: Diagnostic[],
+  file: string,
+  message: string,
+  where?: { line: number; column: number },
+): void {
+  diagnostics.push({
+    id: DiagnosticIds.ParseError,
+    severity: 'error',
+    message,
+    file,
+    ...(where ? { line: where.line, column: where.column } : {}),
+  });
+}
+
+type ParseEnumContext = {
+  diagnostics: Diagnostic[];
+  modulePath: string;
+  lineNo: number;
+  text: string;
+  span: SourceSpan;
+  isReservedTopLevelName: (name: string) => boolean;
+};
+
+export function parseEnumDecl(enumTail: string, ctx: ParseEnumContext): EnumDeclNode | undefined {
+  const { diagnostics, modulePath, lineNo, text, span, isReservedTopLevelName } = ctx;
+  const decl = enumTail;
+  const nameMatch = /^([A-Za-z_][A-Za-z0-9_]*)(?:\s+(.*))?$/.exec(decl);
+  if (!nameMatch) {
+    const invalidName = decl.split(/\s+/, 1)[0] ?? '';
+    if (invalidName.length > 0) {
+      diag(
+        diagnostics,
+        modulePath,
+        `Invalid enum name ${formatIdentifierToken(invalidName)}: expected <identifier>.`,
+        { line: lineNo, column: 1 },
+      );
+    } else {
+      diagInvalidHeaderLine(
+        diagnostics,
+        modulePath,
+        'enum declaration',
+        text,
+        '<name> <member>[, ...]',
+        lineNo,
+      );
+    }
+    return undefined;
+  }
+
+  const name = nameMatch[1]!;
+  if (isReservedTopLevelName(name)) {
+    diag(
+      diagnostics,
+      modulePath,
+      `Invalid enum name "${name}": collides with a top-level keyword.`,
+      {
+        line: lineNo,
+        column: 1,
+      },
+    );
+    return undefined;
+  }
+  const membersText = (nameMatch[2] ?? '').trim();
+  if (membersText.length === 0) {
+    diag(diagnostics, modulePath, `Enum "${name}" must declare at least one member`, {
+      line: lineNo,
+      column: 1,
+    });
+    return undefined;
+  }
+
+  const rawParts = membersText.split(',').map((p) => p.trim());
+  if (rawParts.some((p) => p.length === 0)) {
+    diag(diagnostics, modulePath, `Trailing commas are not permitted in enum member lists`, {
+      line: lineNo,
+      column: 1,
+    });
+    return undefined;
+  }
+
+  const members: string[] = [];
+  const membersLower = new Set<string>();
+  for (const m of rawParts) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(m)) {
+      diag(
+        diagnostics,
+        modulePath,
+        `Invalid enum member name ${formatIdentifierToken(m)}: expected <identifier>.`,
+        {
+          line: lineNo,
+          column: 1,
+        },
+      );
+      continue;
+    }
+    if (isReservedTopLevelName(m)) {
+      diag(
+        diagnostics,
+        modulePath,
+        `Invalid enum member name "${m}": collides with a top-level keyword.`,
+        {
+          line: lineNo,
+          column: 1,
+        },
+      );
+      continue;
+    }
+    const memberLower = m.toLowerCase();
+    if (membersLower.has(memberLower)) {
+      diag(diagnostics, modulePath, `Duplicate enum member name "${m}".`, {
+        line: lineNo,
+        column: 1,
+      });
+      continue;
+    }
+    membersLower.add(memberLower);
+    members.push(m);
+  }
+
+  return { kind: 'EnumDecl', span, name, members };
+}

--- a/test/pr476_parse_enum_helpers.test.ts
+++ b/test/pr476_parse_enum_helpers.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { parseEnumDecl } from '../src/frontend/parseEnum.js';
+import { makeSourceFile, span } from '../src/frontend/source.js';
+import { parseProgram } from '../src/frontend/parser.js';
+
+describe('PR476 enum parser extraction', () => {
+  const file = makeSourceFile('pr476_parse_enum_helpers.zax', '');
+  const zeroSpan = span(file, 0, 0);
+  const ctx = {
+    diagnostics: [] as Diagnostic[],
+    modulePath: file.path,
+    lineNo: 1,
+    text: 'enum Colors Red, Green, Blue',
+    span: zeroSpan,
+    isReservedTopLevelName: () => false,
+  };
+
+  it('keeps enum helper parsing intact', () => {
+    const node = parseEnumDecl('Colors Red, Green, Blue', ctx);
+    expect(ctx.diagnostics).toEqual([]);
+    expect(node).toEqual({
+      kind: 'EnumDecl',
+      span: zeroSpan,
+      name: 'Colors',
+      members: ['Red', 'Green', 'Blue'],
+    });
+  });
+
+  it('preserves top-level enum parsing through parser.ts', () => {
+    const diagnostics: Diagnostic[] = [];
+    const program = parseProgram(file.path, 'enum Colors Red, Green, Blue\n', diagnostics);
+
+    expect(diagnostics).toEqual([]);
+    expect(program.files[0]?.items[0]).toMatchObject({
+      kind: 'EnumDecl',
+      name: 'Colors',
+      members: ['Red', 'Green', 'Blue'],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extract enum declaration parsing from src/frontend/parser.ts into src/frontend/parseEnum.ts
- keep parseModuleFile as the top-level dispatcher and delegate enum parsing to the new helper
- add focused helper coverage for the extracted enum parsing surface

## Testing
- npm run typecheck
- npm test -- --run test/pr476_parse_enum_helpers.test.ts test/pr476_parse_top_level_simple_helpers.test.ts test/pr4_enum.test.ts test/pr166_top_level_keyword_name_collisions.test.ts test/smoke_language_tour_compile.test.ts
