### PR TITLE
Extract globals parser helper

### DIFF
--- a/src/frontend/parseGlobals.ts
+++ b/src/frontend/parseGlobals.ts
@@ -1,0 +1,166 @@
+import type { VarBlockNode, VarDeclNode } from './ast.js';
+import type { SourceFile } from './source.js';
+import { span } from './source.js';
+import type { Diagnostic } from '../diagnostics/types.js';
+import { DiagnosticIds } from '../diagnostics/types.js';
+import {
+  TOP_LEVEL_KEYWORDS,
+  diagInvalidBlockLine,
+  isTopLevelStart,
+  looksLikeKeywordBodyDeclLine,
+  parseVarDeclLine,
+} from './parseModuleCommon.js';
+
+function diag(
+  diagnostics: Diagnostic[],
+  file: string,
+  message: string,
+  where?: { line: number; column: number },
+): void {
+  diagnostics.push({
+    id: DiagnosticIds.ParseError,
+    severity: 'error',
+    message,
+    file,
+    ...(where ? { line: where.line, column: where.column } : {}),
+  });
+}
+
+function stripComment(line: string): string {
+  const semi = line.indexOf(';');
+  return semi >= 0 ? line.slice(0, semi) : line;
+}
+
+type RawLine = {
+  raw: string;
+  startOffset: number;
+  endOffset: number;
+};
+
+type ParseGlobalsContext = {
+  file: SourceFile;
+  lineCount: number;
+  diagnostics: Diagnostic[];
+  modulePath: string;
+  getRawLine: (lineIndex: number) => RawLine;
+  isReservedTopLevelName: (name: string) => boolean;
+};
+
+type ParsedGlobalsBlock = {
+  varBlock: VarBlockNode;
+  nextIndex: number;
+};
+
+export function parseGlobalsBlock(
+  storageHeader: 'var' | 'globals',
+  startIndex: number,
+  lineNo: number,
+  ctx: ParseGlobalsContext,
+): ParsedGlobalsBlock {
+  const { file, lineCount, diagnostics, modulePath, getRawLine, isReservedTopLevelName } = ctx;
+  if (storageHeader === 'var') {
+    diag(diagnostics, modulePath, `Top-level "var" block has been renamed to "globals".`, {
+      line: lineNo,
+      column: 1,
+    });
+  }
+
+  const blockDeclKind = 'globals declaration';
+  const blockHeaderExpected = 'globals';
+  const blockStart = getRawLine(startIndex).startOffset;
+  let index = startIndex + 1;
+  const decls: VarDeclNode[] = [];
+  const declNamesLower = new Set<string>();
+
+  while (index < lineCount) {
+    const { raw: rawDecl, startOffset: so, endOffset: eo } = getRawLine(index);
+    const t = stripComment(rawDecl).trim();
+    if (t.length === 0) {
+      index++;
+      continue;
+    }
+    if (isTopLevelStart(t)) {
+      const m = /^([A-Za-z_][A-Za-z0-9_]*)\s*[:=]\s*(.+)$/.exec(t);
+      if (m && TOP_LEVEL_KEYWORDS.has(m[1]!)) {
+        diag(
+          diagnostics,
+          modulePath,
+          `Invalid globals declaration name "${m[1]!}": collides with a top-level keyword.`,
+          { line: index + 1, column: 1 },
+        );
+        index++;
+        continue;
+      }
+      if (looksLikeKeywordBodyDeclLine(t)) {
+        diagInvalidBlockLine(
+          diagnostics,
+          modulePath,
+          blockDeclKind,
+          t,
+          '<name>: <type>',
+          index + 1,
+        );
+        index++;
+        continue;
+      }
+      break;
+    }
+    const declSpan = span(file, so, eo);
+    const parsed = parseVarDeclLine(t, declSpan, index + 1, 'globals', {
+      diagnostics,
+      modulePath,
+      isReservedTopLevelName,
+    });
+    if (!parsed) {
+      if (/^globals\b/i.test(t)) {
+        diagInvalidBlockLine(
+          diagnostics,
+          modulePath,
+          blockDeclKind,
+          t,
+          blockHeaderExpected,
+          index + 1,
+        );
+      }
+      index++;
+      continue;
+    }
+    const nameLower = parsed.name.toLowerCase();
+    if (declNamesLower.has(nameLower)) {
+      diag(diagnostics, modulePath, `Duplicate globals declaration name "${parsed.name}".`, {
+        line: index + 1,
+        column: 1,
+      });
+      index++;
+      continue;
+    }
+    if (nameLower === 'globals') {
+      diag(
+        diagnostics,
+        modulePath,
+        `Invalid globals declaration name "${parsed.name}": collides with a top-level keyword.`,
+        {
+          line: index + 1,
+          column: 1,
+        },
+      );
+      index++;
+      continue;
+    }
+    declNamesLower.add(nameLower);
+    decls.push(parsed);
+    index++;
+  }
+
+  const blockEnd =
+    index < lineCount ? (getRawLine(index).startOffset ?? blockStart) : file.text.length;
+  return {
+    varBlock: {
+      kind: 'VarBlock',
+      span: span(file, blockStart, blockEnd),
+      scope: 'module',
+      decls,
+    },
+    nextIndex: index,
+  };
+}

--- a/test/pr476_parse_globals_helpers.test.ts
+++ b/test/pr476_parse_globals_helpers.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { parseGlobalsBlock } from '../src/frontend/parseGlobals.js';
+import { parseProgram } from '../src/frontend/parser.js';
+import { makeSourceFile } from '../src/frontend/source.js';
+
+describe('PR476 globals parser extraction', () => {
+  it('keeps globals block parsing intact', () => {
+    const sourceText = ['globals', 'foo: byte', 'bar: word = $1234', 'func main()', 'end'].join(
+      '\n',
+    );
+    const file = makeSourceFile('pr476_parse_globals_helpers.zax', sourceText);
+    const diagnostics: Diagnostic[] = [];
+
+    function getRawLine(lineIndex: number): {
+      raw: string;
+      startOffset: number;
+      endOffset: number;
+    } {
+      const startOffset = file.lineStarts[lineIndex] ?? 0;
+      const nextStart = file.lineStarts[lineIndex + 1] ?? file.text.length;
+      let rawWithEol = file.text.slice(startOffset, nextStart);
+      if (rawWithEol.endsWith('\n')) rawWithEol = rawWithEol.slice(0, -1);
+      if (rawWithEol.endsWith('\r')) rawWithEol = rawWithEol.slice(0, -1);
+      return { raw: rawWithEol, startOffset, endOffset: startOffset + rawWithEol.length };
+    }
+
+    const parsed = parseGlobalsBlock('globals', 0, 1, {
+      file,
+      lineCount: file.lineStarts.length,
+      diagnostics,
+      modulePath: file.path,
+      getRawLine,
+      isReservedTopLevelName: () => false,
+    });
+
+    expect(diagnostics).toEqual([]);
+    expect(parsed.nextIndex).toBe(3);
+    expect(parsed.varBlock).toMatchObject({
+      kind: 'VarBlock',
+      scope: 'module',
+      decls: [
+        { name: 'foo', typeExpr: { kind: 'TypeName', name: 'byte' } },
+        {
+          name: 'bar',
+          typeExpr: { kind: 'TypeName', name: 'word' },
+          initializer: { kind: 'VarInitValue', expr: { kind: 'ImmLiteral', value: 0x1234 } },
+        },
+      ],
+    });
+  });
+
+  it('preserves globals parsing through parser.ts', () => {
+    const diagnostics: Diagnostic[] = [];
+    const program = parseProgram(
+      'pr476_parse_globals_helpers.zax',
+      ['globals', 'foo: byte', 'bar: word = $1234', 'func main()', 'end', ''].join('\n'),
+      diagnostics,
+    );
+
+    expect(diagnostics).toEqual([]);
+    expect(program.files[0]?.items[0]).toMatchObject({
+      kind: 'VarBlock',
+      scope: 'module',
+      decls: [
+        { name: 'foo', typeExpr: { kind: 'TypeName', name: 'byte' } },
+        {
+          name: 'bar',
+          typeExpr: { kind: 'TypeName', name: 'word' },
+        },
+      ],
+    });
+    expect(program.files[0]?.items[1]).toMatchObject({ kind: 'FuncDecl', name: 'main' });
+  });
+});


### PR DESCRIPTION
## What changed
- extract top-level globals/legacy var block parsing from src/frontend/parser.ts into src/frontend/parseGlobals.ts
- keep parseModuleFile as the dispatcher and delegate only the globals branch
- add focused helper coverage for the extracted globals block parser

## Verification
- npm run typecheck
- npm test -- --run test/pr476_parse_globals_helpers.test.ts test/pr476_parse_enum_helpers.test.ts test/pr476_parse_top_level_simple_helpers.test.ts test/pr289_place_expression_contexts.test.ts test/smoke_language_tour_compile.test.ts

## Scope
- semantics-preserving parser extraction only
- no syntax changes
- no dispatcher rewrite outside the globals branch