### PR TITLE
Extract extern block parser helper

### DIFF
--- a/src/frontend/parseExternBlock.ts
+++ b/src/frontend/parseExternBlock.ts
@@ -1,0 +1,298 @@
+import type { ExternDeclNode, ExternFuncNode, ParamNode, SourceSpan } from './ast.js';
+import type { SourceFile } from './source.js';
+import { span } from './source.js';
+import type { Diagnostic } from '../diagnostics/types.js';
+import { DiagnosticIds } from '../diagnostics/types.js';
+import { consumeKeywordPrefix } from './parseModuleCommon.js';
+import {
+  diagInvalidBlockLine,
+  diagInvalidHeaderLine,
+  formatIdentifierToken,
+  looksLikeKeywordBodyDeclLine,
+  topLevelStartKeyword,
+} from './parseModuleCommon.js';
+import { parseExternFuncFromTail } from './parseExtern.js';
+import type { ParseParamsContext } from './parseParams.js';
+
+function diag(
+  diagnostics: Diagnostic[],
+  file: string,
+  message: string,
+  where?: { line: number; column: number },
+): void {
+  diagnostics.push({
+    id: DiagnosticIds.ParseError,
+    severity: 'error',
+    message,
+    file,
+    ...(where ? { line: where.line, column: where.column } : {}),
+  });
+}
+
+function stripComment(line: string): string {
+  const semi = line.indexOf(';');
+  return semi >= 0 ? line.slice(0, semi) : line;
+}
+
+type RawLine = {
+  raw: string;
+  startOffset: number;
+  endOffset: number;
+};
+
+type ParseExternBlockContext = {
+  file: SourceFile;
+  lineCount: number;
+  diagnostics: Diagnostic[];
+  modulePath: string;
+  getRawLine: (lineIndex: number) => RawLine;
+  parseParamsFromText: (
+    filePath: string,
+    paramsText: string,
+    paramsSpan: SourceSpan,
+    diagnostics: Diagnostic[],
+    ctx: ParseParamsContext,
+  ) => ParamNode[] | undefined;
+} & ParseParamsContext;
+
+type ParsedExternDecl = {
+  node?: ExternDeclNode;
+  nextIndex: number;
+};
+
+function consumeInvalidExternBlock(startIndex: number, ctx: ParseExternBlockContext): number {
+  const { lineCount, getRawLine } = ctx;
+  let previewIndex = startIndex + 1;
+  while (previewIndex < lineCount) {
+    const { raw } = getRawLine(previewIndex);
+    const t = stripComment(raw).trim();
+    if (t.length === 0) {
+      previewIndex++;
+      continue;
+    }
+    const looksLikeBodyStart =
+      t.toLowerCase() === 'end' ||
+      consumeKeywordPrefix(t, 'func') !== undefined ||
+      looksLikeKeywordBodyDeclLine(t);
+    if (!looksLikeBodyStart) return startIndex + 1;
+    break;
+  }
+  if (previewIndex >= lineCount) return startIndex + 1;
+
+  let index = previewIndex;
+  while (index < lineCount) {
+    const { raw } = getRawLine(index);
+    const t = stripComment(raw).trim();
+    const tLower = t.toLowerCase();
+    if (t.length === 0) {
+      index++;
+      continue;
+    }
+    if (tLower === 'end') return index + 1;
+    const topKeyword = topLevelStartKeyword(t);
+    if (
+      topKeyword !== undefined &&
+      consumeKeywordPrefix(t, 'func') === undefined &&
+      !looksLikeKeywordBodyDeclLine(t)
+    ) {
+      return index;
+    }
+    index++;
+  }
+  return lineCount;
+}
+
+export function parseTopLevelExternDecl(
+  externTail: string,
+  stmtText: string,
+  stmtSpan: SourceSpan,
+  lineNo: number,
+  startIndex: number,
+  ctx: ParseExternBlockContext,
+): ParsedExternDecl {
+  const {
+    file,
+    lineCount,
+    diagnostics,
+    modulePath,
+    getRawLine,
+    isReservedTopLevelName,
+    parseParamsFromText,
+  } = ctx;
+  const decl = externTail.trim();
+  const externFuncTail = consumeKeywordPrefix(decl, 'func');
+  if (externFuncTail !== undefined) {
+    const externFunc = parseExternFuncFromTail(externFuncTail, stmtSpan, lineNo, {
+      diagnostics,
+      modulePath,
+      isReservedTopLevelName,
+      parseParamsFromText,
+    });
+    return {
+      ...(externFunc
+        ? {
+            node: {
+              kind: 'ExternDecl',
+              span: stmtSpan,
+              funcs: [externFunc],
+            } as ExternDeclNode,
+          }
+        : {}),
+      nextIndex: startIndex + 1,
+    };
+  }
+
+  if (decl.length > 0) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(decl)) {
+      diag(
+        diagnostics,
+        modulePath,
+        `Invalid extern base name ${formatIdentifierToken(decl)}: expected <identifier>.`,
+        { line: lineNo, column: 1 },
+      );
+      return { nextIndex: consumeInvalidExternBlock(startIndex, ctx) };
+    }
+    if (isReservedTopLevelName(decl)) {
+      diag(
+        diagnostics,
+        modulePath,
+        `Invalid extern base name "${decl}": collides with a top-level keyword.`,
+        { line: lineNo, column: 1 },
+      );
+      return { nextIndex: consumeInvalidExternBlock(startIndex, ctx) };
+    }
+  }
+
+  let preview = startIndex + 1;
+  let previewText: string | undefined;
+  while (preview < lineCount) {
+    const { raw: rawPreview } = getRawLine(preview);
+    const t = stripComment(rawPreview).trim();
+    if (t.length === 0) {
+      preview++;
+      continue;
+    }
+    previewText = t;
+    break;
+  }
+  const previewKeyword = previewText ? topLevelStartKeyword(previewText) : undefined;
+  const previewLooksLikeExternBodyDecl =
+    previewText !== undefined &&
+    previewKeyword !== undefined &&
+    looksLikeKeywordBodyDeclLine(previewText);
+  if (
+    previewText === undefined ||
+    (previewText.toLowerCase() !== 'end' &&
+      consumeKeywordPrefix(previewText, 'func') === undefined &&
+      !previewLooksLikeExternBodyDecl)
+  ) {
+    diagInvalidHeaderLine(
+      diagnostics,
+      modulePath,
+      'extern declaration',
+      stmtText,
+      '[<baseName>] or func <name>(...): <retType> at <imm16>',
+      lineNo,
+    );
+    return { nextIndex: startIndex + 1 };
+  }
+
+  const blockStart = stmtSpan.start.offset;
+  const funcs: ExternFuncNode[] = [];
+  const base = decl.length > 0 ? decl : undefined;
+  let terminated = false;
+  let interruptedByKeyword: string | undefined;
+  let interruptedByLine: number | undefined;
+  let blockEndOffset = file.text.length;
+  let index = startIndex + 1;
+
+  while (index < lineCount) {
+    const { raw: rawDecl, startOffset: so, endOffset: eo } = getRawLine(index);
+    const t = stripComment(rawDecl).trim();
+    const tLower = t.toLowerCase();
+    if (t.length === 0) {
+      index++;
+      continue;
+    }
+    if (tLower === 'end') {
+      terminated = true;
+      blockEndOffset = eo;
+      index++;
+      break;
+    }
+    const topKeyword = topLevelStartKeyword(t);
+    if (topKeyword !== undefined && consumeKeywordPrefix(t, 'func') === undefined) {
+      if (looksLikeKeywordBodyDeclLine(t)) {
+        diagInvalidBlockLine(
+          diagnostics,
+          modulePath,
+          'extern func declaration',
+          t,
+          'func <name>(...): <retType> at <imm16>',
+          index + 1,
+        );
+        index++;
+        continue;
+      }
+      interruptedByKeyword = topKeyword;
+      interruptedByLine = index + 1;
+      break;
+    }
+
+    const funcTail = consumeKeywordPrefix(t, 'func');
+    if (funcTail === undefined) {
+      diagInvalidBlockLine(
+        diagnostics,
+        modulePath,
+        'extern func declaration',
+        t,
+        'func <name>(...): <retType> at <imm16>',
+        index + 1,
+      );
+      index++;
+      continue;
+    }
+
+    const fn = parseExternFuncFromTail(funcTail, span(file, so, eo), index + 1, {
+      diagnostics,
+      modulePath,
+      isReservedTopLevelName,
+      parseParamsFromText,
+    });
+    if (fn) funcs.push(fn);
+    index++;
+  }
+
+  if (!terminated) {
+    const namePart = base ? ` "${base}"` : '';
+    if (interruptedByKeyword !== undefined && interruptedByLine !== undefined) {
+      diag(
+        diagnostics,
+        modulePath,
+        `Unterminated extern${namePart}: expected "end" before "${interruptedByKeyword}"`,
+        { line: interruptedByLine, column: 1 },
+      );
+    } else {
+      diag(diagnostics, modulePath, `Unterminated extern${namePart}: missing "end"`, {
+        line: lineNo,
+        column: 1,
+      });
+    }
+  }
+  if (funcs.length === 0) {
+    diag(diagnostics, modulePath, `extern block must contain at least one func declaration`, {
+      line: lineNo,
+      column: 1,
+    });
+  }
+
+  return {
+    node: {
+      kind: 'ExternDecl',
+      span: span(file, blockStart, terminated ? blockEndOffset : file.text.length),
+      ...(base ? { base } : {}),
+      funcs,
+    },
+    nextIndex: index,
+  };
+}

--- a/test/pr476_parse_extern_block_helpers.test.ts
+++ b/test/pr476_parse_extern_block_helpers.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { parseTopLevelExternDecl } from '../src/frontend/parseExternBlock.js';
+import { parseParamsFromText } from '../src/frontend/parseParams.js';
+import { parseProgram } from '../src/frontend/parser.js';
+import { makeSourceFile, span } from '../src/frontend/source.js';
+
+describe('PR476 extern block parser extraction', () => {
+  it('keeps extern block parsing intact', () => {
+    const sourceText = [
+      'extern Math',
+      'func add(lhs: word, rhs: word): HL at $1234',
+      'end',
+      'func main()',
+      'end',
+      '',
+    ].join('\n');
+    const file = makeSourceFile('pr476_parse_extern_block_helpers.zax', sourceText);
+    const diagnostics: Diagnostic[] = [];
+
+    function getRawLine(lineIndex: number): {
+      raw: string;
+      startOffset: number;
+      endOffset: number;
+    } {
+      const startOffset = file.lineStarts[lineIndex] ?? 0;
+      const nextStart = file.lineStarts[lineIndex + 1] ?? file.text.length;
+      let rawWithEol = file.text.slice(startOffset, nextStart);
+      if (rawWithEol.endsWith('\n')) rawWithEol = rawWithEol.slice(0, -1);
+      if (rawWithEol.endsWith('\r')) rawWithEol = rawWithEol.slice(0, -1);
+      return { raw: rawWithEol, startOffset, endOffset: startOffset + rawWithEol.length };
+    }
+
+    const parsed = parseTopLevelExternDecl('Math', 'extern Math', span(file, 0, 11), 1, 0, {
+      file,
+      lineCount: file.lineStarts.length,
+      diagnostics,
+      modulePath: file.path,
+      getRawLine,
+      isReservedTopLevelName: () => false,
+      parseParamsFromText,
+    });
+
+    expect(diagnostics).toEqual([]);
+    expect(parsed.nextIndex).toBe(3);
+    expect(parsed.node).toMatchObject({
+      kind: 'ExternDecl',
+      base: 'Math',
+      funcs: [{ name: 'add', returnRegs: ['HL'] }],
+    });
+  });
+
+  it('preserves extern parsing through parser.ts', () => {
+    const diagnostics: Diagnostic[] = [];
+    const program = parseProgram(
+      'pr476_parse_extern_block_helpers.zax',
+      [
+        'extern Math',
+        'func add(lhs: word, rhs: word): HL at $1234',
+        'end',
+        'extern func sub(lhs: word, rhs: word): HL at $2345',
+        '',
+      ].join('\n'),
+      diagnostics,
+    );
+
+    expect(diagnostics).toEqual([]);
+    expect(program.files[0]?.items[0]).toMatchObject({
+      kind: 'ExternDecl',
+      base: 'Math',
+      funcs: [{ name: 'add' }],
+    });
+    expect(program.files[0]?.items[1]).toMatchObject({
+      kind: 'ExternDecl',
+      funcs: [{ name: 'sub' }],
+    });
+  });
+});


### PR DESCRIPTION
## What changed
- extract top-level extern declaration parsing, including extern block recovery, from src/frontend/parser.ts into src/frontend/parseExternBlock.ts
- keep parseModuleFile as the dispatcher and delegate only the extern branch
- add focused helper coverage for the extracted extern-block parser

## Verification
- npm run typecheck
- npm test -- --run test/pr476_parse_extern_block_helpers.test.ts test/pr476_parse_extern_helpers.test.ts test/pr476_parse_params_helpers.test.ts test/pr184_func_extern_param_return_diag_matrix.test.ts test/pr175_func_op_extern_malformed_header_matrix.test.ts test/pr164_extern_missing_end_recovery.test.ts test/smoke_language_tour_compile.test.ts

## Scope
- semantics-preserving parser extraction only
- no syntax changes
- no broader dispatcher rewrite