### PR TITLE
Extract func parser helper

### DIFF
--- a/src/frontend/parseFunc.ts
+++ b/src/frontend/parseFunc.ts
@@ -1,0 +1,447 @@
+import type {
+  AsmBlockNode,
+  AsmItemNode,
+  AsmLabelNode,
+  FuncDeclNode,
+  ParamNode,
+  SourceSpan,
+  VarBlockNode,
+  VarDeclNode,
+} from './ast.js';
+import type { SourceFile } from './source.js';
+import { span } from './source.js';
+import type { Diagnostic } from '../diagnostics/types.js';
+import { DiagnosticIds } from '../diagnostics/types.js';
+import {
+  appendParsedAsmStatement,
+  isRecoverOnlyControlFrame,
+  parseAsmStatement,
+  type AsmControlFrame,
+} from './parseAsmStatements.js';
+import {
+  diagInvalidBlockLine,
+  diagInvalidHeaderLine,
+  formatIdentifierToken,
+  looksLikeKeywordBodyDeclLine,
+  parseReturnRegsFromText,
+  parseVarDeclLine,
+  topLevelStartKeyword,
+} from './parseModuleCommon.js';
+import type { ParseParamsContext } from './parseParams.js';
+
+function diag(
+  diagnostics: Diagnostic[],
+  file: string,
+  message: string,
+  where?: { line: number; column: number },
+): void {
+  diagnostics.push({
+    id: DiagnosticIds.ParseError,
+    severity: 'error',
+    message,
+    file,
+    ...(where ? { line: where.line, column: where.column } : {}),
+  });
+}
+
+function stripComment(line: string): string {
+  const semi = line.indexOf(';');
+  return semi >= 0 ? line.slice(0, semi) : line;
+}
+
+type RawLine = {
+  raw: string;
+  startOffset: number;
+  endOffset: number;
+};
+
+type ParseFuncContext = {
+  file: SourceFile;
+  lineCount: number;
+  diagnostics: Diagnostic[];
+  modulePath: string;
+  getRawLine: (lineIndex: number) => RawLine;
+  parseParamsFromText: (
+    filePath: string,
+    paramsText: string,
+    paramsSpan: SourceSpan,
+    diagnostics: Diagnostic[],
+    ctx: ParseParamsContext,
+  ) => ParamNode[] | undefined;
+} & ParseParamsContext;
+
+type ParsedFuncDecl = {
+  node?: FuncDeclNode;
+  nextIndex: number;
+};
+
+export function parseTopLevelFuncDecl(
+  funcTail: string,
+  stmtText: string,
+  stmtSpan: SourceSpan,
+  lineNo: number,
+  startIndex: number,
+  exported: boolean,
+  ctx: ParseFuncContext,
+): ParsedFuncDecl {
+  const {
+    file,
+    lineCount,
+    diagnostics,
+    modulePath,
+    getRawLine,
+    isReservedTopLevelName,
+    parseParamsFromText,
+  } = ctx;
+  const header = funcTail;
+  const openParen = header.indexOf('(');
+  const closeParen = header.lastIndexOf(')');
+  if (openParen < 0 || closeParen < openParen) {
+    diagInvalidHeaderLine(
+      diagnostics,
+      modulePath,
+      'func header',
+      stmtText,
+      '<name>(...): <retType>',
+      lineNo,
+    );
+    return { nextIndex: startIndex + 1 };
+  }
+
+  const name = header.slice(0, openParen).trim();
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    diag(
+      diagnostics,
+      modulePath,
+      `Invalid func name ${formatIdentifierToken(name)}: expected <identifier>.`,
+      { line: lineNo, column: 1 },
+    );
+    return { nextIndex: startIndex + 1 };
+  }
+  if (isReservedTopLevelName(name)) {
+    diag(
+      diagnostics,
+      modulePath,
+      `Invalid func name "${name}": collides with a top-level keyword.`,
+      {
+        line: lineNo,
+        column: 1,
+      },
+    );
+    return { nextIndex: startIndex + 1 };
+  }
+
+  const funcStartOffset = stmtSpan.start.offset;
+  const afterClose = header.slice(closeParen + 1).trimStart();
+  let returnRegs: string[] | undefined;
+  if (afterClose.length === 0) {
+    returnRegs = [];
+  } else {
+    const retMatch = /^:\s*(.+)$/.exec(afterClose);
+    if (!retMatch) {
+      diag(diagnostics, modulePath, `Invalid func header: expected ": <return registers>"`, {
+        line: lineNo,
+        column: 1,
+      });
+      return { nextIndex: startIndex + 1 };
+    }
+    const parsedRegs = parseReturnRegsFromText(
+      retMatch[1]!.trim(),
+      stmtSpan,
+      lineNo,
+      diagnostics,
+      modulePath,
+    );
+    if (!parsedRegs) return { nextIndex: startIndex + 1 };
+    returnRegs = parsedRegs.regs;
+  }
+
+  const paramsText = header.slice(openParen + 1, closeParen);
+  const params = parseParamsFromText(modulePath, paramsText, stmtSpan, diagnostics, {
+    isReservedTopLevelName,
+  });
+  if (!params) return { nextIndex: startIndex + 1 };
+
+  let index = startIndex + 1;
+
+  let locals: VarBlockNode | undefined;
+  let asmStartOffset: number | undefined;
+  let interruptedBeforeBodyKeyword: string | undefined;
+  let interruptedBeforeBodyLine: number | undefined;
+  while (index < lineCount) {
+    const { raw: raw2, startOffset: so2 } = getRawLine(index);
+    const t2 = stripComment(raw2).trim();
+    const t2Lower = t2.toLowerCase();
+    if (t2.length === 0) {
+      index++;
+      continue;
+    }
+    const t2TopKeyword = topLevelStartKeyword(t2);
+    if (t2TopKeyword !== undefined && t2Lower !== 'var') {
+      interruptedBeforeBodyKeyword = t2TopKeyword;
+      interruptedBeforeBodyLine = index + 1;
+      break;
+    }
+
+    if (t2Lower === 'var') {
+      const varStart = so2;
+      index++;
+      const decls: VarDeclNode[] = [];
+      const declNamesLower = new Set<string>();
+      let varTerminated = false;
+
+      while (index < lineCount) {
+        const { raw: rawDecl, startOffset: soDecl, endOffset: eoDecl } = getRawLine(index);
+        const tDecl = stripComment(rawDecl).trim();
+        const tDeclLower = tDecl.toLowerCase();
+        if (tDecl.length === 0) {
+          index++;
+          continue;
+        }
+        if (tDeclLower === 'end') {
+          locals = {
+            kind: 'VarBlock',
+            span: span(file, varStart, eoDecl),
+            scope: 'function',
+            decls,
+          };
+          index++;
+          varTerminated = true;
+          break;
+        }
+        if (tDeclLower === 'asm') {
+          diag(
+            diagnostics,
+            modulePath,
+            `Function-local var block must end with "end" before function body`,
+            { line: index + 1, column: 1 },
+          );
+          locals = {
+            kind: 'VarBlock',
+            span: span(file, varStart, soDecl),
+            scope: 'function',
+            decls,
+          };
+          index++;
+          varTerminated = true;
+          break;
+        }
+        const tDeclTopKeyword = topLevelStartKeyword(tDecl);
+        if (tDeclTopKeyword !== undefined) {
+          if (looksLikeKeywordBodyDeclLine(tDecl)) {
+            diagInvalidBlockLine(
+              diagnostics,
+              modulePath,
+              'var declaration',
+              tDecl,
+              '<name>: <type>',
+              index + 1,
+            );
+            index++;
+            continue;
+          }
+          interruptedBeforeBodyKeyword = tDeclTopKeyword;
+          interruptedBeforeBodyLine = index + 1;
+          locals = {
+            kind: 'VarBlock',
+            span: span(file, varStart, soDecl),
+            scope: 'function',
+            decls,
+          };
+          break;
+        }
+
+        const declSpan = span(file, soDecl, eoDecl);
+        const parsed = parseVarDeclLine(tDecl, declSpan, index + 1, 'var', {
+          diagnostics,
+          modulePath,
+          isReservedTopLevelName,
+        });
+        if (!parsed) {
+          index++;
+          continue;
+        }
+        const localNameLower = parsed.name.toLowerCase();
+        if (declNamesLower.has(localNameLower)) {
+          diag(diagnostics, modulePath, `Duplicate var declaration name "${parsed.name}".`, {
+            line: index + 1,
+            column: 1,
+          });
+          index++;
+          continue;
+        }
+        declNamesLower.add(localNameLower);
+        decls.push(parsed);
+        index++;
+      }
+      if (interruptedBeforeBodyKeyword !== undefined) break;
+      if (!varTerminated) {
+        diag(
+          diagnostics,
+          modulePath,
+          `Unterminated func "${name}": expected "end" to terminate var block`,
+          {
+            line: lineNo,
+            column: 1,
+          },
+        );
+        return { nextIndex: index };
+      }
+      continue;
+    }
+
+    if (t2Lower === 'end') {
+      asmStartOffset = so2;
+      break;
+    }
+    asmStartOffset = so2;
+    break;
+  }
+
+  if (asmStartOffset === undefined) {
+    if (interruptedBeforeBodyKeyword !== undefined && interruptedBeforeBodyLine !== undefined) {
+      diag(
+        diagnostics,
+        modulePath,
+        `Unterminated func "${name}": expected function body before "${interruptedBeforeBodyKeyword}"`,
+        { line: interruptedBeforeBodyLine, column: 1 },
+      );
+      return { nextIndex: index };
+    }
+    diag(diagnostics, modulePath, `Unterminated func "${name}": expected function body`, {
+      line: lineNo,
+      column: 1,
+    });
+    return { nextIndex: lineCount };
+  }
+
+  const asmItems: AsmItemNode[] = [];
+  const asmControlStack: AsmControlFrame[] = [];
+  let terminated = false;
+  let interruptedByKeyword: string | undefined;
+  let interruptedByLine: number | undefined;
+  while (index < lineCount) {
+    const { raw: rawLine, startOffset: lineOffset, endOffset } = getRawLine(index);
+    const withoutComment = stripComment(rawLine);
+    const content = withoutComment.trim();
+    const contentLower = content.toLowerCase();
+    if (content.length === 0) {
+      index++;
+      continue;
+    }
+    if (contentLower === 'asm' && asmControlStack.length === 0 && asmItems.length === 0) {
+      diag(
+        diagnostics,
+        modulePath,
+        `Unexpected "asm" in function body (function bodies are implicit)`,
+        { line: index + 1, column: 1 },
+      );
+      index++;
+      continue;
+    }
+
+    if (contentLower === 'end' && asmControlStack.length === 0) {
+      terminated = true;
+      const funcEndOffset = endOffset;
+      const funcSpan = span(file, funcStartOffset, funcEndOffset);
+      const asmSpan = span(file, asmStartOffset, funcEndOffset);
+      const asm: AsmBlockNode = { kind: 'AsmBlock', span: asmSpan, items: asmItems };
+
+      return {
+        node: {
+          kind: 'FuncDecl',
+          span: funcSpan,
+          name,
+          exported,
+          params,
+          ...(returnRegs ? { returnRegs } : {}),
+          ...(locals ? { locals } : {}),
+          asm,
+        },
+        nextIndex: index + 1,
+      };
+    }
+    const topKeyword = topLevelStartKeyword(content);
+    if (topKeyword !== undefined) {
+      interruptedByKeyword = topKeyword;
+      interruptedByLine = index + 1;
+      break;
+    }
+
+    const fullSpan = span(file, lineOffset, endOffset);
+    const contentStart = withoutComment.indexOf(content);
+    const contentSpan =
+      contentStart >= 0
+        ? span(file, lineOffset + contentStart, lineOffset + withoutComment.length)
+        : fullSpan;
+
+    const labelMatch = /^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.*)$/.exec(content);
+    if (labelMatch) {
+      const label = labelMatch[1]!;
+      const remainder = labelMatch[2] ?? '';
+      const labelNode: AsmLabelNode = { kind: 'AsmLabel', span: fullSpan, name: label };
+      asmItems.push(labelNode);
+      if (remainder.trim().length > 0) {
+        const stmtNode = parseAsmStatement(
+          modulePath,
+          remainder,
+          contentSpan,
+          diagnostics,
+          asmControlStack,
+        );
+        appendParsedAsmStatement(asmItems, stmtNode);
+      }
+      index++;
+      continue;
+    }
+
+    const stmtNode = parseAsmStatement(
+      modulePath,
+      content,
+      contentSpan,
+      diagnostics,
+      asmControlStack,
+    );
+    appendParsedAsmStatement(asmItems, stmtNode);
+    index++;
+  }
+
+  if (interruptedByKeyword !== undefined && interruptedByLine !== undefined) {
+    for (const frame of asmControlStack) {
+      if (isRecoverOnlyControlFrame(frame)) continue;
+      const frameSpan = frame.openSpan;
+      const msg =
+        frame.kind === 'Repeat'
+          ? `"repeat" without matching "until <cc>"`
+          : `"${frame.kind.toLowerCase()}" without matching "end"`;
+      diag(diagnostics, modulePath, msg, {
+        line: frameSpan.start.line,
+        column: frameSpan.start.column,
+      });
+    }
+    diag(
+      diagnostics,
+      modulePath,
+      `Unterminated func "${name}": expected "end" before "${interruptedByKeyword}"`,
+      { line: interruptedByLine, column: 1 },
+    );
+    return { nextIndex: index };
+  }
+  for (const frame of asmControlStack) {
+    if (isRecoverOnlyControlFrame(frame)) continue;
+    const frameSpan = frame.openSpan;
+    const msg =
+      frame.kind === 'Repeat'
+        ? `"repeat" without matching "until <cc>"`
+        : `"${frame.kind.toLowerCase()}" without matching "end"`;
+    diag(diagnostics, modulePath, msg, {
+      line: frameSpan.start.line,
+      column: frameSpan.start.column,
+    });
+  }
+  diag(diagnostics, modulePath, `Unterminated func "${name}": missing "end"`, {
+    line: lineNo,
+    column: 1,
+  });
+  return { nextIndex: lineCount };
+}

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -7,7 +7,6 @@ import type {
   BinDeclNode,
   ConstDeclNode,
   EnumDeclNode,
-  FuncDeclNode,
   HexDeclNode,
   ImmExprNode,
   ModuleFileNode,
@@ -59,6 +58,7 @@ import {
 } from './parseModuleCommon.js';
 import { parseTopLevelExternDecl } from './parseExternBlock.js';
 import { parseEnumDecl } from './parseEnum.js';
+import { parseTopLevelFuncDecl } from './parseFunc.js';
 import { parseGlobalsBlock } from './parseGlobals.js';
 import { parseOpParamsFromText, parseParamsFromText } from './parseParams.js';
 import { parseTypeDecl, parseUnionDecl } from './parseTypes.js';
@@ -308,366 +308,25 @@ export function parseModuleFile(
 
     const funcTail = consumeTopKeyword(rest, 'func');
     if (funcTail !== undefined) {
-      const exported = hasExportPrefix;
-      const header = funcTail;
-      const openParen = header.indexOf('(');
-      const closeParen = header.lastIndexOf(')');
-      if (openParen < 0 || closeParen < openParen) {
-        diagInvalidHeaderLine(
+      const parsedFunc = parseTopLevelFuncDecl(
+        funcTail,
+        text,
+        span(file, lineStartOffset, lineEndOffset),
+        lineNo,
+        i,
+        hasExportPrefix,
+        {
+          file,
+          lineCount,
           diagnostics,
           modulePath,
-          'func header',
-          text,
-          '<name>(...): <retType>',
-          lineNo,
-        );
-        i++;
-        continue;
-      }
-
-      const name = header.slice(0, openParen).trim();
-      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
-        diag(
-          diagnostics,
-          modulePath,
-          `Invalid func name ${formatIdentifierToken(name)}: expected <identifier>.`,
-          { line: lineNo, column: 1 },
-        );
-        i++;
-        continue;
-      }
-      if (isReservedTopLevelName(name)) {
-        diag(
-          diagnostics,
-          modulePath,
-          `Invalid func name "${name}": collides with a top-level keyword.`,
-          { line: lineNo, column: 1 },
-        );
-        i++;
-        continue;
-      }
-
-      const funcStartOffset = lineStartOffset;
-      const headerSpan = span(file, lineStartOffset, lineEndOffset);
-      const afterClose = header.slice(closeParen + 1).trimStart();
-      let returnRegs: string[] | undefined;
-      if (afterClose.length === 0) {
-        returnRegs = [];
-      } else {
-        const retMatch = /^:\s*(.+)$/.exec(afterClose);
-        if (!retMatch) {
-          diag(diagnostics, modulePath, `Invalid func header: expected ": <return registers>"`, {
-            line: lineNo,
-            column: 1,
-          });
-          i++;
-          continue;
-        }
-        const parsedRegs = parseReturnRegsFromText(
-          retMatch[1]!.trim(),
-          headerSpan,
-          lineNo,
-          diagnostics,
-          modulePath,
-        );
-        if (!parsedRegs) {
-          i++;
-          continue;
-        }
-        returnRegs = parsedRegs.regs;
-      }
-
-      const paramsText = header.slice(openParen + 1, closeParen);
-      const params = parseParamsFromText(modulePath, paramsText, headerSpan, diagnostics, {
-        isReservedTopLevelName,
-      });
-      if (!params) {
-        i++;
-        continue;
-      }
-
-      i++;
-
-      // Optional function-local `var` block; function instruction body is parsed
-      // as an implicit instruction stream.
-      let locals: VarBlockNode | undefined;
-      let asmStartOffset: number | undefined;
-      let interruptedBeforeBodyKeyword: string | undefined;
-      let interruptedBeforeBodyLine: number | undefined;
-      while (i < lineCount) {
-        const { raw: raw2, startOffset: so2 } = getRawLine(i);
-        const t2 = stripComment(raw2).trim();
-        const t2Lower = t2.toLowerCase();
-        if (t2.length === 0) {
-          i++;
-          continue;
-        }
-        const t2TopKeyword = topLevelStartKeyword(t2);
-        if (t2TopKeyword !== undefined && t2Lower !== 'var') {
-          interruptedBeforeBodyKeyword = t2TopKeyword;
-          interruptedBeforeBodyLine = i + 1;
-          break;
-        }
-
-        if (t2Lower === 'var') {
-          const varStart = so2;
-          i++;
-          const decls: VarDeclNode[] = [];
-          const declNamesLower = new Set<string>();
-          let varTerminated = false;
-
-          while (i < lineCount) {
-            const { raw: rawDecl, startOffset: soDecl, endOffset: eoDecl } = getRawLine(i);
-            const tDecl = stripComment(rawDecl).trim();
-            const tDeclLower = tDecl.toLowerCase();
-            if (tDecl.length === 0) {
-              i++;
-              continue;
-            }
-            if (tDeclLower === 'end') {
-              locals = {
-                kind: 'VarBlock',
-                span: span(file, varStart, eoDecl),
-                scope: 'function',
-                decls,
-              };
-              i++; // consume var-terminating end
-              varTerminated = true;
-              break;
-            }
-            if (tDeclLower === 'asm') {
-              diag(
-                diagnostics,
-                modulePath,
-                `Function-local var block must end with "end" before function body`,
-                { line: i + 1, column: 1 },
-              );
-              locals = {
-                kind: 'VarBlock',
-                span: span(file, varStart, soDecl),
-                scope: 'function',
-                decls,
-              };
-              i++; // consume asm so body parsing can continue
-              varTerminated = true;
-              break;
-            }
-            const tDeclTopKeyword = topLevelStartKeyword(tDecl);
-            if (tDeclTopKeyword !== undefined) {
-              if (looksLikeKeywordBodyDeclLine(tDecl)) {
-                diagInvalidBlockLine(
-                  diagnostics,
-                  modulePath,
-                  'var declaration',
-                  tDecl,
-                  '<name>: <type>',
-                  i + 1,
-                );
-                i++;
-                continue;
-              }
-              interruptedBeforeBodyKeyword = tDeclTopKeyword;
-              interruptedBeforeBodyLine = i + 1;
-              locals = {
-                kind: 'VarBlock',
-                span: span(file, varStart, soDecl),
-                scope: 'function',
-                decls,
-              };
-              break;
-            }
-
-            const declSpan = span(file, soDecl, eoDecl);
-            const parsed = parseVarDeclLine(tDecl, declSpan, i + 1, 'var', {
-              diagnostics,
-              modulePath,
-              isReservedTopLevelName,
-            });
-            if (!parsed) {
-              i++;
-              continue;
-            }
-            const localNameLower = parsed.name.toLowerCase();
-            if (declNamesLower.has(localNameLower)) {
-              diag(diagnostics, modulePath, `Duplicate var declaration name "${parsed.name}".`, {
-                line: i + 1,
-                column: 1,
-              });
-              i++;
-              continue;
-            }
-            declNamesLower.add(localNameLower);
-            decls.push(parsed);
-            i++;
-          }
-          if (interruptedBeforeBodyKeyword !== undefined) break;
-          if (!varTerminated) {
-            diag(
-              diagnostics,
-              modulePath,
-              `Unterminated func "${name}": expected "end" to terminate var block`,
-              { line: lineNo, column: 1 },
-            );
-            break;
-          }
-          continue;
-        }
-
-        if (t2Lower === 'end') {
-          asmStartOffset = so2;
-          break;
-        }
-        asmStartOffset = so2;
-        break;
-      }
-
-      if (asmStartOffset === undefined) {
-        if (interruptedBeforeBodyKeyword !== undefined && interruptedBeforeBodyLine !== undefined) {
-          diag(
-            diagnostics,
-            modulePath,
-            `Unterminated func "${name}": expected function body before "${interruptedBeforeBodyKeyword}"`,
-            { line: interruptedBeforeBodyLine, column: 1 },
-          );
-          continue;
-        }
-        diag(diagnostics, modulePath, `Unterminated func "${name}": expected function body`, {
-          line: lineNo,
-          column: 1,
-        });
-        break;
-      }
-
-      const asmItems: AsmItemNode[] = [];
-      const asmControlStack: AsmControlFrame[] = [];
-      let terminated = false;
-      let interruptedByKeyword: string | undefined;
-      let interruptedByLine: number | undefined;
-      while (i < lineCount) {
-        const { raw: rawLine, startOffset: lineOffset, endOffset } = getRawLine(i);
-        const withoutComment = stripComment(rawLine);
-        const content = withoutComment.trim();
-        const contentLower = content.toLowerCase();
-        if (content.length === 0) {
-          i++;
-          continue;
-        }
-        if (contentLower === 'asm' && asmControlStack.length === 0 && asmItems.length === 0) {
-          diag(
-            diagnostics,
-            modulePath,
-            `Unexpected "asm" in function body (function bodies are implicit)`,
-            { line: i + 1, column: 1 },
-          );
-          i++;
-          continue;
-        }
-
-        if (contentLower === 'end' && asmControlStack.length === 0) {
-          terminated = true;
-          const funcEndOffset = endOffset;
-          const funcSpan = span(file, funcStartOffset, funcEndOffset);
-          const asmSpan = span(file, asmStartOffset, funcEndOffset);
-          const asm: AsmBlockNode = { kind: 'AsmBlock', span: asmSpan, items: asmItems };
-
-          const funcNode: FuncDeclNode = {
-            kind: 'FuncDecl',
-            span: funcSpan,
-            name,
-            exported,
-            params,
-            ...(returnRegs ? { returnRegs } : {}),
-            ...(locals ? { locals } : {}),
-            asm,
-          };
-          items.push(funcNode);
-          i++;
-          break;
-        }
-        const topKeyword = topLevelStartKeyword(content);
-        if (topKeyword !== undefined) {
-          interruptedByKeyword = topKeyword;
-          interruptedByLine = i + 1;
-          break;
-        }
-
-        const fullSpan = span(file, lineOffset, endOffset);
-        const contentStart = withoutComment.indexOf(content);
-        const contentSpan =
-          contentStart >= 0
-            ? span(file, lineOffset + contentStart, lineOffset + withoutComment.length)
-            : fullSpan;
-
-        /* label: */
-        const labelMatch = /^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.*)$/.exec(content);
-        if (labelMatch) {
-          const label = labelMatch[1]!;
-          const remainder = labelMatch[2] ?? '';
-          const labelNode: AsmLabelNode = { kind: 'AsmLabel', span: fullSpan, name: label };
-          asmItems.push(labelNode);
-          if (remainder.trim().length > 0) {
-            const stmtNode = parseAsmStatement(
-              modulePath,
-              remainder,
-              contentSpan,
-              diagnostics,
-              asmControlStack,
-            );
-            appendParsedAsmStatement(asmItems, stmtNode);
-          }
-          i++;
-          continue;
-        }
-
-        const stmtNode = parseAsmStatement(
-          modulePath,
-          content,
-          contentSpan,
-          diagnostics,
-          asmControlStack,
-        );
-        appendParsedAsmStatement(asmItems, stmtNode);
-        i++;
-      }
-
-      if (!terminated) {
-        if (interruptedByKeyword !== undefined && interruptedByLine !== undefined) {
-          for (const frame of asmControlStack) {
-            if (isRecoverOnlyControlFrame(frame)) continue;
-            const frameSpan = frame.openSpan;
-            const msg =
-              frame.kind === 'Repeat'
-                ? `"repeat" without matching "until <cc>"`
-                : `"${frame.kind.toLowerCase()}" without matching "end"`;
-            diag(diagnostics, modulePath, msg, {
-              line: frameSpan.start.line,
-              column: frameSpan.start.column,
-            });
-          }
-          diag(
-            diagnostics,
-            modulePath,
-            `Unterminated func "${name}": expected "end" before "${interruptedByKeyword}"`,
-            { line: interruptedByLine, column: 1 },
-          );
-          continue;
-        }
-        for (const frame of asmControlStack) {
-          if (isRecoverOnlyControlFrame(frame)) continue;
-          const span = frame.openSpan;
-          const msg =
-            frame.kind === 'Repeat'
-              ? `"repeat" without matching "until <cc>"`
-              : `"${frame.kind.toLowerCase()}" without matching "end"`;
-          diag(diagnostics, modulePath, msg, { line: span.start.line, column: span.start.column });
-        }
-        diag(diagnostics, modulePath, `Unterminated func "${name}": missing "end"`, {
-          line: lineNo,
-          column: 1,
-        });
-        break;
-      }
-
+          getRawLine,
+          isReservedTopLevelName,
+          parseParamsFromText,
+        },
+      );
+      if (parsedFunc.node) items.push(parsedFunc.node);
+      i = parsedFunc.nextIndex;
       continue;
     }
 

--- a/test/pr476_parse_func_helpers.test.ts
+++ b/test/pr476_parse_func_helpers.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { parseTopLevelFuncDecl } from '../src/frontend/parseFunc.js';
+import { parseParamsFromText } from '../src/frontend/parseParams.js';
+import { parseProgram } from '../src/frontend/parser.js';
+import { makeSourceFile, span } from '../src/frontend/source.js';
+
+describe('PR476 func parser extraction', () => {
+  it('keeps top-level func parsing intact', () => {
+    const sourceText = [
+      'func add(lhs: word, rhs: word): HL',
+      'var',
+      'temp: word = $1234',
+      'end',
+      'ld hl, lhs',
+      'add hl, rhs',
+      'end',
+      'const DONE = 1',
+      '',
+    ].join('\n');
+    const file = makeSourceFile('pr476_parse_func_helpers.zax', sourceText);
+    const diagnostics: Diagnostic[] = [];
+
+    function getRawLine(lineIndex: number): {
+      raw: string;
+      startOffset: number;
+      endOffset: number;
+    } {
+      const startOffset = file.lineStarts[lineIndex] ?? 0;
+      const nextStart = file.lineStarts[lineIndex + 1] ?? file.text.length;
+      let rawWithEol = file.text.slice(startOffset, nextStart);
+      if (rawWithEol.endsWith('\n')) rawWithEol = rawWithEol.slice(0, -1);
+      if (rawWithEol.endsWith('\r')) rawWithEol = rawWithEol.slice(0, -1);
+      return { raw: rawWithEol, startOffset, endOffset: startOffset + rawWithEol.length };
+    }
+
+    const parsed = parseTopLevelFuncDecl(
+      'add(lhs: word, rhs: word): HL',
+      'func add(lhs: word, rhs: word): HL',
+      span(file, 0, 31),
+      1,
+      0,
+      false,
+      {
+        file,
+        lineCount: file.lineStarts.length,
+        diagnostics,
+        modulePath: file.path,
+        getRawLine,
+        isReservedTopLevelName: () => false,
+        parseParamsFromText,
+      },
+    );
+
+    expect(diagnostics).toEqual([]);
+    expect(parsed.nextIndex).toBe(7);
+    expect(parsed.node).toMatchObject({
+      kind: 'FuncDecl',
+      name: 'add',
+      returnRegs: ['HL'],
+      params: [{ name: 'lhs' }, { name: 'rhs' }],
+      locals: {
+        kind: 'VarBlock',
+        decls: [{ name: 'temp' }],
+      },
+      asm: { kind: 'AsmBlock' },
+    });
+  });
+
+  it('preserves func parsing through parser.ts', () => {
+    const diagnostics: Diagnostic[] = [];
+    const program = parseProgram(
+      'pr476_parse_func_helpers.zax',
+      [
+        'func add(lhs: word, rhs: word): HL',
+        'var',
+        'temp: word = $1234',
+        'end',
+        'ld hl, lhs',
+        'add hl, rhs',
+        'end',
+        '',
+      ].join('\n'),
+      diagnostics,
+    );
+
+    expect(diagnostics).toEqual([]);
+    expect(program.files[0]?.items[0]).toMatchObject({
+      kind: 'FuncDecl',
+      name: 'add',
+      returnRegs: ['HL'],
+      params: [{ name: 'lhs' }, { name: 'rhs' }],
+      locals: { kind: 'VarBlock', decls: [{ name: 'temp' }] },
+    });
+  });
+});


### PR DESCRIPTION
## What changed
- extract top-level func declaration parsing from src/frontend/parser.ts into src/frontend/parseFunc.ts
- keep parseModuleFile as the dispatcher and delegate only the func branch
- add focused helper coverage for the extracted func parser

## Verification
- npm run typecheck
- npm test -- --run test/pr476_parse_func_helpers.test.ts test/pr476_parse_extern_block_helpers.test.ts test/pr476_parse_params_helpers.test.ts test/pr196_parser_control_interruption_matrix.test.ts test/pr170_block_termination_recovery_matrix.test.ts test/smoke_language_tour_compile.test.ts

## Scope
- semantics-preserving parser extraction only
- no syntax changes
- no broader dispatcher rewrite