### PR TITLE
Extract op parser helper

### DIFF
--- a/src/frontend/parseOp.ts
+++ b/src/frontend/parseOp.ts
@@ -1,0 +1,249 @@
+import type { AsmBlockNode, AsmItemNode, OpDeclNode, OpParamNode, SourceSpan } from './ast.js';
+import type { SourceFile } from './source.js';
+import { span } from './source.js';
+import type { Diagnostic } from '../diagnostics/types.js';
+import { DiagnosticIds } from '../diagnostics/types.js';
+import {
+  appendParsedAsmStatement,
+  isRecoverOnlyControlFrame,
+  parseAsmStatement,
+  type AsmControlFrame,
+} from './parseAsmStatements.js';
+import {
+  diagInvalidHeaderLine,
+  formatIdentifierToken,
+  parseReturnRegsFromText,
+  topLevelStartKeyword,
+} from './parseModuleCommon.js';
+import type { ParseParamsContext } from './parseParams.js';
+
+function diag(
+  diagnostics: Diagnostic[],
+  file: string,
+  message: string,
+  where?: { line: number; column: number },
+): void {
+  diagnostics.push({
+    id: DiagnosticIds.ParseError,
+    severity: 'error',
+    message,
+    file,
+    ...(where ? { line: where.line, column: where.column } : {}),
+  });
+}
+
+function stripComment(line: string): string {
+  const semi = line.indexOf(';');
+  return semi >= 0 ? line.slice(0, semi) : line;
+}
+
+type RawLine = {
+  raw: string;
+  startOffset: number;
+  endOffset: number;
+};
+
+type ParseOpContext = {
+  file: SourceFile;
+  lineCount: number;
+  diagnostics: Diagnostic[];
+  modulePath: string;
+  getRawLine: (lineIndex: number) => RawLine;
+  parseOpParamsFromText: (
+    filePath: string,
+    paramsText: string,
+    paramsSpan: SourceSpan,
+    diagnostics: Diagnostic[],
+    ctx: ParseParamsContext,
+  ) => OpParamNode[] | undefined;
+} & ParseParamsContext;
+
+type ParsedOpDecl = {
+  node: OpDeclNode;
+  nextIndex: number;
+};
+
+export function parseTopLevelOpDecl(
+  opTail: string,
+  stmtText: string,
+  stmtSpan: SourceSpan,
+  lineNo: number,
+  startIndex: number,
+  exported: boolean,
+  ctx: ParseOpContext,
+): ParsedOpDecl | undefined {
+  const {
+    file,
+    lineCount,
+    diagnostics,
+    modulePath,
+    getRawLine,
+    isReservedTopLevelName,
+    parseOpParamsFromText,
+  } = ctx;
+  const header = opTail;
+  const openParen = header.indexOf('(');
+  const closeParen = header.lastIndexOf(')');
+  if (openParen < 0 || closeParen < openParen) {
+    diagInvalidHeaderLine(diagnostics, modulePath, 'op header', stmtText, '<name>(...)', lineNo);
+    return undefined;
+  }
+
+  const name = header.slice(0, openParen).trim();
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    diag(
+      diagnostics,
+      modulePath,
+      `Invalid op name ${formatIdentifierToken(name)}: expected <identifier>.`,
+      { line: lineNo, column: 1 },
+    );
+    return undefined;
+  }
+  if (isReservedTopLevelName(name)) {
+    diag(diagnostics, modulePath, `Invalid op name "${name}": collides with a top-level keyword.`, {
+      line: lineNo,
+      column: 1,
+    });
+    return undefined;
+  }
+
+  const trailing = header.slice(closeParen + 1).trim();
+  if (trailing.length > 0) {
+    diag(diagnostics, modulePath, `Invalid op header: unexpected trailing tokens`, {
+      line: lineNo,
+      column: 1,
+    });
+    return undefined;
+  }
+
+  const opStartOffset = stmtSpan.start.offset;
+  const paramsText = header.slice(openParen + 1, closeParen);
+  const params = parseOpParamsFromText(modulePath, paramsText, stmtSpan, diagnostics, {
+    isReservedTopLevelName,
+  });
+  if (!params) return undefined;
+
+  let index = startIndex + 1;
+  const bodyItems: AsmItemNode[] = [];
+  const controlStack: AsmControlFrame[] = [];
+  let terminated = false;
+  let interruptedByKeyword: string | undefined;
+  let interruptedByLine: number | undefined;
+  let opEndOffset = file.text.length;
+  while (index < lineCount) {
+    const { raw: rawLine, startOffset: so, endOffset: eo } = getRawLine(index);
+    const rawNoComment = stripComment(rawLine);
+    const content = rawNoComment.trim();
+    const contentLower = content.toLowerCase();
+    if (content.length === 0) {
+      index++;
+      continue;
+    }
+    if (bodyItems.length === 0 && controlStack.length === 0 && contentLower === 'asm') {
+      diag(diagnostics, modulePath, `Unexpected "asm" in op body (op bodies are implicit)`, {
+        line: index + 1,
+        column: 1,
+      });
+      index++;
+      continue;
+    }
+    if (contentLower === 'end' && controlStack.length === 0) {
+      terminated = true;
+      opEndOffset = eo;
+      index++;
+      break;
+    }
+    const topKeyword = topLevelStartKeyword(content);
+    if (topKeyword !== undefined) {
+      interruptedByKeyword = topKeyword;
+      interruptedByLine = index + 1;
+      break;
+    }
+
+    const fullSpan = span(file, so, eo);
+    const contentStart = rawNoComment.indexOf(content);
+    const contentSpan =
+      contentStart >= 0 ? span(file, so + contentStart, so + rawNoComment.length) : fullSpan;
+    const labelMatch = /^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.*)$/.exec(content);
+    if (labelMatch) {
+      const label = labelMatch[1]!;
+      const remainder = labelMatch[2] ?? '';
+      bodyItems.push({ kind: 'AsmLabel', span: fullSpan, name: label });
+      if (remainder.trim().length > 0) {
+        const stmt = parseAsmStatement(
+          modulePath,
+          remainder,
+          contentSpan,
+          diagnostics,
+          controlStack,
+        );
+        appendParsedAsmStatement(bodyItems, stmt);
+      }
+      index++;
+      continue;
+    }
+
+    const stmt = parseAsmStatement(modulePath, content, contentSpan, diagnostics, controlStack);
+    appendParsedAsmStatement(bodyItems, stmt);
+    index++;
+  }
+
+  if (!terminated) {
+    if (interruptedByKeyword !== undefined && interruptedByLine !== undefined) {
+      for (const frame of controlStack) {
+        if (isRecoverOnlyControlFrame(frame)) continue;
+        const frameSpan = frame.openSpan;
+        const msg =
+          frame.kind === 'Repeat'
+            ? `"repeat" without matching "until <cc>"`
+            : `"${frame.kind.toLowerCase()}" without matching "end"`;
+        diag(diagnostics, modulePath, msg, {
+          line: frameSpan.start.line,
+          column: frameSpan.start.column,
+        });
+      }
+      diag(
+        diagnostics,
+        modulePath,
+        `Unterminated op "${name}": expected "end" before "${interruptedByKeyword}"`,
+        {
+          line: interruptedByLine,
+          column: 1,
+        },
+      );
+    } else {
+      for (const frame of controlStack) {
+        if (isRecoverOnlyControlFrame(frame)) continue;
+        const frameSpan = frame.openSpan;
+        const msg =
+          frame.kind === 'Repeat'
+            ? `"repeat" without matching "until <cc>"`
+            : `"${frame.kind.toLowerCase()}" without matching "end"`;
+        diag(diagnostics, modulePath, msg, {
+          line: frameSpan.start.line,
+          column: frameSpan.start.column,
+        });
+      }
+      diag(diagnostics, modulePath, `Unterminated op "${name}": missing "end"`, {
+        line: lineNo,
+        column: 1,
+      });
+    }
+  }
+
+  return {
+    node: {
+      kind: 'OpDecl',
+      span: span(file, opStartOffset, opEndOffset),
+      name,
+      exported,
+      params,
+      body: {
+        kind: 'AsmBlock',
+        span: span(file, opStartOffset, opEndOffset),
+        items: bodyItems,
+      } as AsmBlockNode,
+    },
+    nextIndex: index,
+  };
+}

--- a/test/pr476_parse_op_helpers.test.ts
+++ b/test/pr476_parse_op_helpers.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { parseTopLevelOpDecl } from '../src/frontend/parseOp.js';
+import { parseOpParamsFromText } from '../src/frontend/parseParams.js';
+import { parseProgram } from '../src/frontend/parser.js';
+import { makeSourceFile, span } from '../src/frontend/source.js';
+
+describe('PR476 op parser extraction', () => {
+  it('keeps top-level op parsing intact', () => {
+    const sourceText = [
+      'op add(lhs: word, rhs: word)',
+      'ld hl, lhs',
+      'add hl, rhs',
+      'end',
+      'const DONE = 1',
+      '',
+    ].join('\n');
+    const file = makeSourceFile('pr476_parse_op_helpers.zax', sourceText);
+    const diagnostics: Diagnostic[] = [];
+
+    function getRawLine(lineIndex: number): {
+      raw: string;
+      startOffset: number;
+      endOffset: number;
+    } {
+      const startOffset = file.lineStarts[lineIndex] ?? 0;
+      const nextStart = file.lineStarts[lineIndex + 1] ?? file.text.length;
+      let rawWithEol = file.text.slice(startOffset, nextStart);
+      if (rawWithEol.endsWith('\n')) rawWithEol = rawWithEol.slice(0, -1);
+      if (rawWithEol.endsWith('\r')) rawWithEol = rawWithEol.slice(0, -1);
+      return { raw: rawWithEol, startOffset, endOffset: startOffset + rawWithEol.length };
+    }
+
+    const parsed = parseTopLevelOpDecl(
+      'add(lhs: word, rhs: word)',
+      'op add(lhs: word, rhs: word)',
+      span(file, 0, 27),
+      1,
+      0,
+      false,
+      {
+        file,
+        lineCount: file.lineStarts.length,
+        diagnostics,
+        modulePath: file.path,
+        getRawLine,
+        isReservedTopLevelName: () => false,
+        parseOpParamsFromText,
+      },
+    );
+
+    expect(diagnostics).toEqual([]);
+    expect(parsed?.nextIndex).toBe(4);
+    expect(parsed?.node).toMatchObject({
+      kind: 'OpDecl',
+      name: 'add',
+      params: [{ name: 'lhs' }, { name: 'rhs' }],
+      body: { kind: 'AsmBlock' },
+    });
+  });
+
+  it('preserves op parsing through parser.ts', () => {
+    const diagnostics: Diagnostic[] = [];
+    const program = parseProgram(
+      'pr476_parse_op_helpers.zax',
+      ['op add(lhs: word, rhs: word)', 'ld hl, lhs', 'add hl, rhs', 'end', ''].join('\n'),
+      diagnostics,
+    );
+
+    expect(diagnostics).toEqual([]);
+    expect(program.files[0]?.items[0]).toMatchObject({
+      kind: 'OpDecl',
+      name: 'add',
+      params: [{ name: 'lhs' }, { name: 'rhs' }],
+    });
+  });
+});


### PR DESCRIPTION
## What changed
- extract top-level op declaration parsing from src/frontend/parser.ts into src/frontend/parseOp.ts
- keep parseModuleFile as the dispatcher and delegate only the op branch
- add focused helper coverage for the extracted op parser

## Verification
- npm run typecheck
- npm test -- --run test/pr476_parse_op_helpers.test.ts test/pr476_parse_func_helpers.test.ts test/pr476_parse_extern_block_helpers.test.ts test/pr196_parser_control_interruption_matrix.test.ts test/pr170_block_termination_recovery_matrix.test.ts test/smoke_language_tour_compile.test.ts

## Scope
- semantics-preserving parser extraction only
- no syntax changes
- no broader dispatcher rewrite