### PR TITLE
Extract type-resolution helpers from lowering emitter

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -71,7 +71,6 @@ import type {
   OpMatcherNode,
   ParamNode,
   ProgramNode,
-  RecordFieldNode,
   SectionDirectiveNode,
   SourceSpan,
   TypeExprNode,
@@ -100,6 +99,7 @@ import {
   toHexByte,
   toHexWord,
 } from './traceFormat.js';
+import { createTypeResolutionHelpers } from './typeResolution.js';
 
 function diag(diagnostics: Diagnostic[], file: string, message: string): void {
   diagnostics.push({ id: DiagnosticIds.EmitError, severity: 'error', message, file });
@@ -359,22 +359,6 @@ export function emitProgram(
       : { kind: 'known', delta, hasUntrackedSpMutation };
     opStackSummaryCache.set(decl, out);
     return out;
-  };
-
-  const resolveScalarKind = (
-    typeExpr: TypeExprNode,
-    seen: Set<string> = new Set(),
-  ): 'byte' | 'word' | 'addr' | undefined => {
-    if (typeExpr.kind !== 'TypeName') return undefined;
-    const lower = typeExpr.name.toLowerCase();
-    if (lower === 'byte' || lower === 'word' || lower === 'addr') return lower;
-    if (lower === 'ptr') return 'addr';
-    if (seen.has(lower)) return undefined;
-    seen.add(lower);
-    const decl = env.types.get(typeExpr.name);
-    if (!decl) return undefined;
-    if (decl.kind !== 'TypeDecl') return undefined;
-    return resolveScalarKind(decl.typeExpr, seen);
   };
 
   const storageTypes = new Map<string, TypeExprNode>();
@@ -1483,187 +1467,27 @@ export function emitProgram(
     }
   };
 
-  type AggregateType = { kind: 'record' | 'union'; fields: RecordFieldNode[] };
-
-  const resolveAggregateType = (te: TypeExprNode): AggregateType | undefined => {
-    if (te.kind === 'RecordType') return { kind: 'record', fields: te.fields };
-    if (te.kind === 'TypeName') {
-      const decl = env.types.get(te.name);
-      if (!decl) return undefined;
-      if (decl.kind === 'UnionDecl') return { kind: 'union', fields: decl.fields };
-      if (decl.typeExpr.kind === 'RecordType')
-        return { kind: 'record', fields: decl.typeExpr.fields };
-    }
-    return undefined;
-  };
-
-  const resolveArrayElementType = (te: TypeExprNode): TypeExprNode | undefined => {
-    if (te.kind === 'ArrayType') return te.element;
-    if (te.kind === 'TypeName') {
-      const decl = env.types.get(te.name);
-      if (decl?.kind === 'TypeDecl' && decl.typeExpr.kind === 'ArrayType') {
-        return decl.typeExpr.element;
-      }
-    }
-    return undefined;
-  };
-
-  const unwrapTypeAlias = (
-    te: TypeExprNode,
-    seen = new Set<string>(),
-  ): TypeExprNode | undefined => {
-    if (te.kind !== 'TypeName') return te;
-    const scalar = resolveScalarKind(te);
-    if (scalar)
-      return { kind: 'TypeName', span: te.span, name: scalar === 'addr' ? 'addr' : scalar };
-    const lower = te.name.toLowerCase();
-    if (seen.has(lower)) return undefined;
-    seen.add(lower);
-    const decl = env.types.get(te.name);
-    if (!decl || decl.kind !== 'TypeDecl') return te;
-    return unwrapTypeAlias(decl.typeExpr, seen);
-  };
-
-  const resolveArrayType = (
-    te: TypeExprNode,
-  ): { element: TypeExprNode; length?: number } | undefined => {
-    const resolved = unwrapTypeAlias(te);
-    if (!resolved || resolved.kind !== 'ArrayType') return undefined;
-    return resolved.length === undefined
-      ? { element: resolved.element }
-      : { element: resolved.element, length: resolved.length };
-  };
-
-  const typeDisplay = (te: TypeExprNode): string => {
-    const render = (x: TypeExprNode): string => {
-      if (x.kind === 'TypeName') return x.name;
-      if (x.kind === 'ArrayType') {
-        const inner = render(x.element);
-        return `${inner}[${x.length === undefined ? '' : x.length}]`;
-      }
-      if (x.kind === 'RecordType') {
-        return `record{${x.fields.map((f) => `${f.name}:${render(f.typeExpr)}`).join(',')}}`;
-      }
-      return 'type';
-    };
-    return render(te);
-  };
-
-  const sameTypeShape = (left: TypeExprNode, right: TypeExprNode): boolean => {
-    const l = unwrapTypeAlias(left);
-    const r = unwrapTypeAlias(right);
-    if (!l || !r) return false;
-    if (l.kind !== r.kind) return false;
-    switch (l.kind) {
-      case 'TypeName':
-        return r.kind === 'TypeName' && l.name.toLowerCase() === r.name.toLowerCase();
-      case 'ArrayType':
-        if (r.kind !== 'ArrayType') return false;
-        if (l.length !== r.length) return false;
-        return sameTypeShape(l.element, r.element);
-      case 'RecordType':
-        if (r.kind !== 'RecordType') return false;
-        if (l.fields.length !== r.fields.length) return false;
-        for (let i = 0; i < l.fields.length; i++) {
-          const lf = l.fields[i]!;
-          const rf = r.fields[i]!;
-          if (lf.name !== rf.name || !sameTypeShape(lf.typeExpr, rf.typeExpr)) return false;
-        }
-        return true;
-    }
-  };
-
-  const resolveEaBaseName = (ea: EaExprNode): string | undefined => {
-    switch (ea.kind) {
-      case 'EaName':
-        return ea.name;
-      case 'EaField':
-      case 'EaIndex':
-      case 'EaAdd':
-      case 'EaSub':
-        return resolveEaBaseName(ea.base);
-    }
-  };
+  const {
+    resolveAggregateType,
+    resolveArrayType,
+    resolveEaTypeExpr,
+    resolveScalarBinding,
+    resolveScalarKind,
+    resolveScalarTypeForEa,
+    resolveScalarTypeForLd,
+    sameTypeShape,
+    typeDisplay,
+  } = createTypeResolutionHelpers({
+    env,
+    storageTypes,
+    stackSlotTypes,
+    rawAddressSymbols,
+    moduleAliasTargets,
+    getLocalAliasTargets: () => localAliasTargets,
+  });
 
   const resolveAliasTarget = (nameLower: string): EaExprNode | undefined =>
     localAliasTargets.get(nameLower) ?? moduleAliasTargets.get(nameLower);
-
-  const resolveEaTypeExprInternal = (
-    ea: EaExprNode,
-    visitingAliases: Set<string>,
-  ): TypeExprNode | undefined => {
-    switch (ea.kind) {
-      case 'EaName': {
-        const lower = ea.name.toLowerCase();
-        const direct = stackSlotTypes.get(lower) ?? storageTypes.get(lower);
-        if (direct) return direct;
-        const aliasTarget = resolveAliasTarget(lower);
-        if (!aliasTarget) return undefined;
-        if (visitingAliases.has(lower)) return undefined;
-        visitingAliases.add(lower);
-        try {
-          return resolveEaTypeExprInternal(aliasTarget, visitingAliases);
-        } finally {
-          visitingAliases.delete(lower);
-        }
-      }
-      case 'EaAdd':
-      case 'EaSub':
-        return resolveEaTypeExprInternal(ea.base, visitingAliases);
-      case 'EaField': {
-        const baseType = resolveEaTypeExprInternal(ea.base, visitingAliases);
-        if (!baseType) return undefined;
-        const agg = resolveAggregateType(baseType);
-        if (!agg) return undefined;
-        for (const f of agg.fields) {
-          if (f.name === ea.field) return f.typeExpr;
-        }
-        return undefined;
-      }
-      case 'EaIndex': {
-        const baseType = resolveEaTypeExprInternal(ea.base, visitingAliases);
-        if (!baseType) return undefined;
-        return resolveArrayElementType(baseType);
-      }
-    }
-  };
-
-  const resolveEaTypeExpr = (ea: EaExprNode): TypeExprNode | undefined =>
-    resolveEaTypeExprInternal(ea, new Set<string>());
-
-  const resolveScalarBinding = (name: string): 'byte' | 'word' | 'addr' | undefined => {
-    const lower = name.toLowerCase();
-    if (rawAddressSymbols.has(lower)) return undefined;
-    const typeExpr =
-      stackSlotTypes.get(lower) ??
-      storageTypes.get(lower) ??
-      (() => {
-        const aliasTarget = resolveAliasTarget(lower);
-        if (!aliasTarget) return undefined;
-        return resolveEaTypeExpr(aliasTarget);
-      })();
-    if (!typeExpr) return undefined;
-    return resolveScalarKind(typeExpr);
-  };
-
-  const resolveScalarTypeForEa = (ea: EaExprNode): 'byte' | 'word' | 'addr' | undefined => {
-    const base = resolveEaBaseName(ea);
-    if (base && rawAddressSymbols.has(base.toLowerCase())) return undefined;
-    const typeExpr = resolveEaTypeExpr(ea);
-    if (!typeExpr) return undefined;
-    return resolveScalarKind(typeExpr);
-  };
-
-  // Version for ld/st lowering that allows indexed/field access to data arrays.
-  // For ld instructions, indexed access to data arrays should use value semantics.
-  const resolveScalarTypeForLd = (ea: EaExprNode): 'byte' | 'word' | 'addr' | undefined => {
-    // Only reject scalar resolution for direct name access to rawAddressSymbols.
-    // Indexed/field access (even to data arrays) should resolve to scalar element types.
-    if (ea.kind === 'EaName' && rawAddressSymbols.has(ea.name.toLowerCase())) return undefined;
-    const typeExpr = resolveEaTypeExpr(ea);
-    if (!typeExpr) return undefined;
-    return resolveScalarKind(typeExpr);
-  };
 
   for (const [aliasLower, aliasTarget] of moduleAliasTargets) {
     if (storageTypes.has(aliasLower)) continue;

--- a/src/lowering/typeResolution.ts
+++ b/src/lowering/typeResolution.ts
@@ -1,0 +1,225 @@
+import type {
+  EaExprNode,
+  RecordFieldNode,
+  TypeExprNode,
+} from '../frontend/ast.js';
+import type { CompileEnv } from '../semantics/env.js';
+
+export type ScalarKind = 'byte' | 'word' | 'addr';
+export type AggregateType = { kind: 'record' | 'union'; fields: RecordFieldNode[] };
+
+type TypeResolutionContext = {
+  env: CompileEnv;
+  storageTypes: Map<string, TypeExprNode>;
+  stackSlotTypes: Map<string, TypeExprNode>;
+  rawAddressSymbols: Set<string>;
+  moduleAliasTargets: Map<string, EaExprNode>;
+  getLocalAliasTargets: () => Map<string, EaExprNode>;
+};
+
+export function createTypeResolutionHelpers(ctx: TypeResolutionContext) {
+  const resolveScalarKind = (
+    typeExpr: TypeExprNode,
+    seen: Set<string> = new Set(),
+  ): ScalarKind | undefined => {
+    if (typeExpr.kind !== 'TypeName') return undefined;
+    const lower = typeExpr.name.toLowerCase();
+    if (lower === 'byte' || lower === 'word' || lower === 'addr') return lower;
+    if (lower === 'ptr') return 'addr';
+    if (seen.has(lower)) return undefined;
+    seen.add(lower);
+    const decl = ctx.env.types.get(typeExpr.name);
+    if (!decl || decl.kind !== 'TypeDecl') return undefined;
+    return resolveScalarKind(decl.typeExpr, seen);
+  };
+
+  const resolveAggregateType = (te: TypeExprNode): AggregateType | undefined => {
+    if (te.kind === 'RecordType') return { kind: 'record', fields: te.fields };
+    if (te.kind === 'TypeName') {
+      const decl = ctx.env.types.get(te.name);
+      if (!decl) return undefined;
+      if (decl.kind === 'UnionDecl') return { kind: 'union', fields: decl.fields };
+      if (decl.typeExpr.kind === 'RecordType') {
+        return { kind: 'record', fields: decl.typeExpr.fields };
+      }
+    }
+    return undefined;
+  };
+
+  const resolveArrayElementType = (te: TypeExprNode): TypeExprNode | undefined => {
+    if (te.kind === 'ArrayType') return te.element;
+    if (te.kind === 'TypeName') {
+      const decl = ctx.env.types.get(te.name);
+      if (decl?.kind === 'TypeDecl' && decl.typeExpr.kind === 'ArrayType') {
+        return decl.typeExpr.element;
+      }
+    }
+    return undefined;
+  };
+
+  const unwrapTypeAlias = (
+    te: TypeExprNode,
+    seen: Set<string> = new Set(),
+  ): TypeExprNode | undefined => {
+    if (te.kind !== 'TypeName') return te;
+    const scalar = resolveScalarKind(te);
+    if (scalar) {
+      return { kind: 'TypeName', span: te.span, name: scalar === 'addr' ? 'addr' : scalar };
+    }
+    const lower = te.name.toLowerCase();
+    if (seen.has(lower)) return undefined;
+    seen.add(lower);
+    const decl = ctx.env.types.get(te.name);
+    if (!decl || decl.kind !== 'TypeDecl') return te;
+    return unwrapTypeAlias(decl.typeExpr, seen);
+  };
+
+  const resolveArrayType = (
+    te: TypeExprNode,
+  ): { element: TypeExprNode; length?: number } | undefined => {
+    const resolved = unwrapTypeAlias(te);
+    if (!resolved || resolved.kind !== 'ArrayType') return undefined;
+    return resolved.length === undefined
+      ? { element: resolved.element }
+      : { element: resolved.element, length: resolved.length };
+  };
+
+  const typeDisplay = (te: TypeExprNode): string => {
+    const render = (x: TypeExprNode): string => {
+      if (x.kind === 'TypeName') return x.name;
+      if (x.kind === 'ArrayType') {
+        const inner = render(x.element);
+        return `${inner}[${x.length === undefined ? '' : x.length}]`;
+      }
+      if (x.kind === 'RecordType') {
+        return `record{${x.fields.map((f) => `${f.name}:${render(f.typeExpr)}`).join(',')}}`;
+      }
+      return 'type';
+    };
+    return render(te);
+  };
+
+  const sameTypeShape = (left: TypeExprNode, right: TypeExprNode): boolean => {
+    const l = unwrapTypeAlias(left);
+    const r = unwrapTypeAlias(right);
+    if (!l || !r) return false;
+    if (l.kind !== r.kind) return false;
+    switch (l.kind) {
+      case 'TypeName':
+        return r.kind === 'TypeName' && l.name.toLowerCase() === r.name.toLowerCase();
+      case 'ArrayType':
+        if (r.kind !== 'ArrayType') return false;
+        if (l.length !== r.length) return false;
+        return sameTypeShape(l.element, r.element);
+      case 'RecordType':
+        if (r.kind !== 'RecordType') return false;
+        if (l.fields.length !== r.fields.length) return false;
+        for (let i = 0; i < l.fields.length; i++) {
+          const lf = l.fields[i]!;
+          const rf = r.fields[i]!;
+          if (lf.name !== rf.name || !sameTypeShape(lf.typeExpr, rf.typeExpr)) return false;
+        }
+        return true;
+    }
+  };
+
+  const resolveEaBaseName = (ea: EaExprNode): string | undefined => {
+    switch (ea.kind) {
+      case 'EaName':
+        return ea.name;
+      case 'EaField':
+      case 'EaIndex':
+      case 'EaAdd':
+      case 'EaSub':
+        return resolveEaBaseName(ea.base);
+    }
+  };
+
+  const resolveAliasTarget = (nameLower: string): EaExprNode | undefined =>
+    ctx.getLocalAliasTargets().get(nameLower) ?? ctx.moduleAliasTargets.get(nameLower);
+
+  const resolveEaTypeExprInternal = (
+    ea: EaExprNode,
+    visitingAliases: Set<string>,
+  ): TypeExprNode | undefined => {
+    switch (ea.kind) {
+      case 'EaName': {
+        const lower = ea.name.toLowerCase();
+        const direct = ctx.stackSlotTypes.get(lower) ?? ctx.storageTypes.get(lower);
+        if (direct) return direct;
+        const aliasTarget = resolveAliasTarget(lower);
+        if (!aliasTarget) return undefined;
+        if (visitingAliases.has(lower)) return undefined;
+        visitingAliases.add(lower);
+        try {
+          return resolveEaTypeExprInternal(aliasTarget, visitingAliases);
+        } finally {
+          visitingAliases.delete(lower);
+        }
+      }
+      case 'EaAdd':
+      case 'EaSub':
+        return resolveEaTypeExprInternal(ea.base, visitingAliases);
+      case 'EaField': {
+        const baseType = resolveEaTypeExprInternal(ea.base, visitingAliases);
+        if (!baseType) return undefined;
+        const agg = resolveAggregateType(baseType);
+        if (!agg) return undefined;
+        for (const f of agg.fields) {
+          if (f.name === ea.field) return f.typeExpr;
+        }
+        return undefined;
+      }
+      case 'EaIndex': {
+        const baseType = resolveEaTypeExprInternal(ea.base, visitingAliases);
+        if (!baseType) return undefined;
+        return resolveArrayElementType(baseType);
+      }
+    }
+  };
+
+  const resolveEaTypeExpr = (ea: EaExprNode): TypeExprNode | undefined =>
+    resolveEaTypeExprInternal(ea, new Set<string>());
+
+  const resolveScalarBinding = (name: string): ScalarKind | undefined => {
+    const lower = name.toLowerCase();
+    if (ctx.rawAddressSymbols.has(lower)) return undefined;
+    const typeExpr =
+      ctx.stackSlotTypes.get(lower) ??
+      ctx.storageTypes.get(lower) ??
+      (() => {
+        const aliasTarget = resolveAliasTarget(lower);
+        if (!aliasTarget) return undefined;
+        return resolveEaTypeExpr(aliasTarget);
+      })();
+    if (!typeExpr) return undefined;
+    return resolveScalarKind(typeExpr);
+  };
+
+  const resolveScalarTypeForEa = (ea: EaExprNode): ScalarKind | undefined => {
+    const base = resolveEaBaseName(ea);
+    if (base && ctx.rawAddressSymbols.has(base.toLowerCase())) return undefined;
+    const typeExpr = resolveEaTypeExpr(ea);
+    if (!typeExpr) return undefined;
+    return resolveScalarKind(typeExpr);
+  };
+
+  const resolveScalarTypeForLd = (ea: EaExprNode): ScalarKind | undefined => {
+    if (ea.kind === 'EaName' && ctx.rawAddressSymbols.has(ea.name.toLowerCase())) return undefined;
+    const typeExpr = resolveEaTypeExpr(ea);
+    if (!typeExpr) return undefined;
+    return resolveScalarKind(typeExpr);
+  };
+
+  return {
+    resolveScalarKind,
+    resolveAggregateType,
+    resolveArrayType,
+    resolveEaTypeExpr,
+    resolveScalarBinding,
+    resolveScalarTypeForEa,
+    resolveScalarTypeForLd,
+    sameTypeShape,
+    typeDisplay,
+  };
+}

--- a/test/pr505_type_resolution_helpers.test.ts
+++ b/test/pr505_type_resolution_helpers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR505: extracted type-resolution helpers', () => {
+  it('preserves scalar index value semantics for ld lowering', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr260_value_semantics_scalar_index.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics).toEqual([]);
+  });
+
+  it('preserves non-scalar typed-call compatibility diagnostics', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr286_nonscalar_param_compat_negative.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(messages).toContain(
+      'Incompatible non-scalar argument for parameter "values": expected byte[10], got byte[] (exact length proof required).',
+    );
+    expect(messages).toContain(
+      'Incompatible non-scalar argument for parameter "values": expected element type byte, got word.',
+    );
+  });
+});


### PR DESCRIPTION
## What changed
- extract type-resolution and scalar-kind helper cluster from src/lowering/emit.ts into src/lowering/typeResolution.ts
- keep emitter behavior unchanged and wire the existing lowering path through the extracted helpers
- add focused regression coverage for scalar index value semantics and non-scalar typed-call compatibility

## Verification
- npm run typecheck
- npm test -- --run test/pr505_type_resolution_helpers.test.ts test/pr260_value_semantics_scalar_index.test.ts test/pr286_nonscalar_param_compat_matrix.test.ts test/smoke_language_tour_compile.test.ts