### PR TITLE
Extract runtime-atom budget helpers from lowering emitter

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -83,6 +83,7 @@ import { sizeOfTypeExpr } from '../semantics/layout.js';
 import { encodeInstruction } from '../z80/encode.js';
 import type { OpStackPolicyMode } from '../pipeline.js';
 import { loadBinInput, loadHexInput } from './inputAssets.js';
+import { createRuntimeAtomBudgetHelpers } from './runtimeAtomBudget.js';
 import {
   alignTo,
   computeWrittenRange,
@@ -238,29 +239,6 @@ export function emitProgram(
 
   const reg8 = new Set(['A', 'B', 'C', 'D', 'E', 'H', 'L']);
   const reg16 = new Set(['BC', 'DE', 'HL']);
-  const runtimeAtomRegisterNames = new Set([
-    'A',
-    'B',
-    'C',
-    'D',
-    'E',
-    'H',
-    'L',
-    'HL',
-    'DE',
-    'BC',
-    'SP',
-    'IX',
-    'IY',
-    'IXH',
-    'IXL',
-    'IYH',
-    'IYL',
-    'AF',
-    "AF'",
-    'I',
-    'R',
-  ]);
   const reg8Code = new Map([
     ['B', 0],
     ['C', 1],
@@ -1513,113 +1491,17 @@ export function emitProgram(
     storageTypes.set(aliasLower, inferred);
   }
 
-  const countRuntimeAtomsInImmExpr = (expr: ImmExprNode): number => {
-    switch (expr.kind) {
-      case 'ImmLiteral':
-      case 'ImmSizeof':
-        return 0;
-      case 'ImmOffsetof':
-        return expr.path.steps.reduce(
-          (acc, step) =>
-            acc + (step.kind === 'OffsetofIndex' ? countRuntimeAtomsInImmExpr(step.expr) : 0),
-          0,
-        );
-      case 'ImmName':
-        return resolveScalarBinding(expr.name) ? 1 : 0;
-      case 'ImmUnary':
-        return countRuntimeAtomsInImmExpr(expr.expr);
-      case 'ImmBinary':
-        return countRuntimeAtomsInImmExpr(expr.left) + countRuntimeAtomsInImmExpr(expr.right);
-    }
-  };
-
-  const countRuntimeAtomsInEaExpr = (ea: EaExprNode): number => {
-    switch (ea.kind) {
-      case 'EaName':
-        return resolveScalarBinding(ea.name) || runtimeAtomRegisterNames.has(ea.name.toUpperCase())
-          ? 1
-          : 0;
-      case 'EaField':
-        return countRuntimeAtomsInEaExpr(ea.base);
-      case 'EaAdd':
-      case 'EaSub':
-        return countRuntimeAtomsInEaExpr(ea.base) + countRuntimeAtomsInImmExpr(ea.offset);
-      case 'EaIndex': {
-        const baseAtoms = countRuntimeAtomsInEaExpr(ea.base);
-        switch (ea.index.kind) {
-          case 'IndexImm':
-            return baseAtoms + countRuntimeAtomsInImmExpr(ea.index.value);
-          case 'IndexReg8':
-          case 'IndexReg16':
-          case 'IndexMemHL':
-            return baseAtoms + 1;
-          case 'IndexMemIxIy':
-            return baseAtoms + 1 + (ea.index.disp ? countRuntimeAtomsInImmExpr(ea.index.disp) : 0);
-          case 'IndexEa':
-            return baseAtoms + Math.max(1, countRuntimeAtomsInEaExpr(ea.index.expr));
-        }
-      }
-    }
-  };
-
-  const enforceEaRuntimeAtomBudget = (operand: AsmOperandNode, context: string): boolean => {
-    if (operand.kind !== 'Ea' && operand.kind !== 'Mem') return true;
-    const atoms = countRuntimeAtomsInEaExpr(operand.expr);
-    if (atoms <= 1) return true;
-    diagAt(
-      diagnostics,
-      operand.span,
-      `${context} exceeds runtime-atom budget (max 1; found ${atoms}).`,
-    );
-    return false;
-  };
-
-  const countRuntimeAtomsForDirectCallSiteEa = (ea: EaExprNode): number => {
-    switch (ea.kind) {
-      case 'EaName': {
-        const lower = ea.name.toLowerCase();
-        const isBoundStorageName =
-          stackSlotOffsets.has(lower) || stackSlotTypes.has(lower) || storageTypes.has(lower);
-        if (isBoundStorageName) return 0;
-        return runtimeAtomRegisterNames.has(ea.name.toUpperCase()) ? 1 : 0;
-      }
-      case 'EaField':
-        return countRuntimeAtomsForDirectCallSiteEa(ea.base);
-      case 'EaAdd':
-      case 'EaSub':
-        return (
-          countRuntimeAtomsForDirectCallSiteEa(ea.base) + countRuntimeAtomsInImmExpr(ea.offset)
-        );
-      case 'EaIndex': {
-        const baseAtoms = countRuntimeAtomsForDirectCallSiteEa(ea.base);
-        switch (ea.index.kind) {
-          case 'IndexImm':
-            return baseAtoms + countRuntimeAtomsInImmExpr(ea.index.value);
-          case 'IndexReg8':
-          case 'IndexReg16':
-          case 'IndexMemHL':
-            return baseAtoms + 1;
-          case 'IndexMemIxIy':
-            return baseAtoms + 1 + (ea.index.disp ? countRuntimeAtomsInImmExpr(ea.index.disp) : 0);
-          case 'IndexEa':
-            return baseAtoms + Math.max(1, countRuntimeAtomsForDirectCallSiteEa(ea.index.expr));
-        }
-      }
-    }
-  };
-
-  const enforceDirectCallSiteEaBudget = (operand: AsmOperandNode, calleeName: string): boolean => {
-    if (operand.kind !== 'Ea' && operand.kind !== 'Mem') return true;
-    const atoms = countRuntimeAtomsForDirectCallSiteEa(operand.expr);
-    if (atoms === 0) return true;
-    const form = operand.kind === 'Mem' ? '(ea)' : 'ea';
-    diagAt(
-      diagnostics,
-      operand.span,
-      `Direct call-site ${form} argument for "${calleeName}" must be runtime-atom-free in v0.2 (found ${atoms}). Stage dynamic addressing in prior instructions and pass a register or precomputed slot value.`,
-    );
-    return false;
-  };
+  const {
+    enforceDirectCallSiteEaBudget,
+    enforceEaRuntimeAtomBudget,
+  } = createRuntimeAtomBudgetHelpers({
+    diagnostics,
+    diagAt,
+    resolveScalarBinding,
+    stackSlotOffsets,
+    stackSlotTypes,
+    storageTypes,
+  });
 
   const resolveEa = (ea: EaExprNode, span: SourceSpan): EaResolution | undefined => {
     const go = (expr: EaExprNode, visitingAliases: Set<string>): EaResolution | undefined => {

--- a/src/lowering/runtimeAtomBudget.ts
+++ b/src/lowering/runtimeAtomBudget.ts
@@ -1,0 +1,155 @@
+import type { Diagnostic } from '../diagnostics/types.js';
+import type { AsmOperandNode, EaExprNode, ImmExprNode, SourceSpan } from '../frontend/ast.js';
+
+type RuntimeAtomBudgetContext = {
+  diagnostics: Diagnostic[];
+  diagAt: (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
+  resolveScalarBinding: (name: string) => 'byte' | 'word' | 'addr' | undefined;
+  stackSlotOffsets: Map<string, number>;
+  stackSlotTypes: Map<string, unknown>;
+  storageTypes: Map<string, unknown>;
+};
+
+const runtimeAtomRegisterNames = new Set([
+  'A',
+  'B',
+  'C',
+  'D',
+  'E',
+  'H',
+  'L',
+  'HL',
+  'DE',
+  'BC',
+  'SP',
+  'IX',
+  'IY',
+  'IXH',
+  'IXL',
+  'IYH',
+  'IYL',
+  'AF',
+  "AF'",
+  'I',
+  'R',
+]);
+
+export function createRuntimeAtomBudgetHelpers(ctx: RuntimeAtomBudgetContext) {
+  const countRuntimeAtomsInImmExpr = (expr: ImmExprNode): number => {
+    switch (expr.kind) {
+      case 'ImmLiteral':
+      case 'ImmSizeof':
+        return 0;
+      case 'ImmOffsetof':
+        return expr.path.steps.reduce(
+          (acc, step) =>
+            acc + (step.kind === 'OffsetofIndex' ? countRuntimeAtomsInImmExpr(step.expr) : 0),
+          0,
+        );
+      case 'ImmName':
+        return ctx.resolveScalarBinding(expr.name) ? 1 : 0;
+      case 'ImmUnary':
+        return countRuntimeAtomsInImmExpr(expr.expr);
+      case 'ImmBinary':
+        return countRuntimeAtomsInImmExpr(expr.left) + countRuntimeAtomsInImmExpr(expr.right);
+    }
+  };
+
+  const countRuntimeAtomsInEaExpr = (ea: EaExprNode): number => {
+    switch (ea.kind) {
+      case 'EaName':
+        return ctx.resolveScalarBinding(ea.name) || runtimeAtomRegisterNames.has(ea.name.toUpperCase())
+          ? 1
+          : 0;
+      case 'EaField':
+        return countRuntimeAtomsInEaExpr(ea.base);
+      case 'EaAdd':
+      case 'EaSub':
+        return countRuntimeAtomsInEaExpr(ea.base) + countRuntimeAtomsInImmExpr(ea.offset);
+      case 'EaIndex': {
+        const baseAtoms = countRuntimeAtomsInEaExpr(ea.base);
+        switch (ea.index.kind) {
+          case 'IndexImm':
+            return baseAtoms + countRuntimeAtomsInImmExpr(ea.index.value);
+          case 'IndexReg8':
+          case 'IndexReg16':
+          case 'IndexMemHL':
+            return baseAtoms + 1;
+          case 'IndexMemIxIy':
+            return baseAtoms + 1 + (ea.index.disp ? countRuntimeAtomsInImmExpr(ea.index.disp) : 0);
+          case 'IndexEa':
+            return baseAtoms + Math.max(1, countRuntimeAtomsInEaExpr(ea.index.expr));
+        }
+      }
+    }
+  };
+
+  const enforceEaRuntimeAtomBudget = (operand: AsmOperandNode, context: string): boolean => {
+    if (operand.kind !== 'Ea' && operand.kind !== 'Mem') return true;
+    const atoms = countRuntimeAtomsInEaExpr(operand.expr);
+    if (atoms <= 1) return true;
+    ctx.diagAt(
+      ctx.diagnostics,
+      operand.span,
+      `${context} exceeds runtime-atom budget (max 1; found ${atoms}).`,
+    );
+    return false;
+  };
+
+  const countRuntimeAtomsForDirectCallSiteEa = (ea: EaExprNode): number => {
+    switch (ea.kind) {
+      case 'EaName': {
+        const lower = ea.name.toLowerCase();
+        const isBoundStorageName =
+          ctx.stackSlotOffsets.has(lower) ||
+          ctx.stackSlotTypes.has(lower) ||
+          ctx.storageTypes.has(lower);
+        if (isBoundStorageName) return 0;
+        return runtimeAtomRegisterNames.has(ea.name.toUpperCase()) ? 1 : 0;
+      }
+      case 'EaField':
+        return countRuntimeAtomsForDirectCallSiteEa(ea.base);
+      case 'EaAdd':
+      case 'EaSub':
+        return (
+          countRuntimeAtomsForDirectCallSiteEa(ea.base) + countRuntimeAtomsInImmExpr(ea.offset)
+        );
+      case 'EaIndex': {
+        const baseAtoms = countRuntimeAtomsForDirectCallSiteEa(ea.base);
+        switch (ea.index.kind) {
+          case 'IndexImm':
+            return baseAtoms + countRuntimeAtomsInImmExpr(ea.index.value);
+          case 'IndexReg8':
+          case 'IndexReg16':
+          case 'IndexMemHL':
+            return baseAtoms + 1;
+          case 'IndexMemIxIy':
+            return baseAtoms + 1 + (ea.index.disp ? countRuntimeAtomsInImmExpr(ea.index.disp) : 0);
+          case 'IndexEa':
+            return baseAtoms + Math.max(1, countRuntimeAtomsForDirectCallSiteEa(ea.index.expr));
+        }
+      }
+    }
+  };
+
+  const enforceDirectCallSiteEaBudget = (operand: AsmOperandNode, calleeName: string): boolean => {
+    if (operand.kind !== 'Ea' && operand.kind !== 'Mem') return true;
+    const atoms = countRuntimeAtomsForDirectCallSiteEa(operand.expr);
+    if (atoms === 0) return true;
+    const form = operand.kind === 'Mem' ? '(ea)' : 'ea';
+    ctx.diagAt(
+      ctx.diagnostics,
+      operand.span,
+      `Direct call-site ${form} argument for "${calleeName}" must be runtime-atom-free in v0.2 (found ${atoms}). Stage dynamic addressing in prior instructions and pass a register or precomputed slot value.`,
+    );
+    return false;
+  };
+
+  return {
+    countRuntimeAtomsForDirectCallSiteEa,
+    countRuntimeAtomsInEaExpr,
+    countRuntimeAtomsInImmExpr,
+    enforceDirectCallSiteEaBudget,
+    enforceEaRuntimeAtomBudget,
+  };
+}

--- a/test/pr506_runtime_atom_budget_helpers.test.ts
+++ b/test/pr506_runtime_atom_budget_helpers.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR506: extracted runtime-atom budget helpers', () => {
+  it('preserves source ea runtime-atom budget diagnostics', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr264_runtime_atom_budget_invalid.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(messages).toContain('Source ea expression exceeds runtime-atom budget (max 1; found 2).');
+  });
+
+  it('preserves direct call-site ea runtime-atom budget diagnostics', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr273_call_address_runtime_index_reject.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(messages.some((m) => m.includes('Direct call-site ea argument for "takeAddr"'))).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## What changed
- extract runtime-atom budget counting and enforcement from src/lowering/emit.ts into src/lowering/runtimeAtomBudget.ts
- keep lowering behavior unchanged and route existing checks through the extracted helpers
- add focused regression coverage for source ea and direct call-site runtime-atom diagnostics

## Verification
- npm run typecheck
- npm test -- --run test/pr506_runtime_atom_budget_helpers.test.ts test/pr264_runtime_atom_budget_matrix.test.ts test/pr273_call_scalar_value_runtime_index.test.ts test/smoke_language_tour_compile.test.ts