### PR TITLE
Extract EA resolution helpers from lowering emitter

### DIFF
--- a/src/lowering/eaResolution.ts
+++ b/src/lowering/eaResolution.ts
@@ -1,0 +1,157 @@
+import type { Diagnostic } from '../diagnostics/types.js';
+import type { EaExprNode, SourceSpan, TypeExprNode } from '../frontend/ast.js';
+import type { CompileEnv } from '../semantics/env.js';
+
+export type EaResolution =
+  | { kind: 'abs'; baseLower: string; addend: number; typeExpr?: TypeExprNode }
+  | { kind: 'stack'; ixDisp: number; typeExpr?: TypeExprNode };
+
+type EaResolutionContext = {
+  env: CompileEnv;
+  diagnostics: Diagnostic[];
+  diagAt: (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
+  stackSlotOffsets: Map<string, number>;
+  stackSlotTypes: Map<string, TypeExprNode>;
+  storageTypes: Map<string, TypeExprNode>;
+  moduleAliasTargets: Map<string, EaExprNode>;
+  getLocalAliasTargets: () => Map<string, EaExprNode>;
+  evalImmExpr: (expr: import('../frontend/ast.js').ImmExprNode) => number | undefined;
+  evalImmNoDiag: (expr: import('../frontend/ast.js').ImmExprNode) => number | undefined;
+  resolveAggregateType: (
+    te: TypeExprNode,
+  ) => { kind: 'record' | 'union'; fields: import('../frontend/ast.js').RecordFieldNode[] } | undefined;
+  resolveEaTypeExpr: (ea: EaExprNode) => TypeExprNode | undefined;
+  sizeOfTypeExpr: (te: TypeExprNode) => number | undefined;
+};
+
+export function createEaResolutionHelpers(ctx: EaResolutionContext) {
+  const resolveAliasTarget = (nameLower: string): EaExprNode | undefined =>
+    ctx.getLocalAliasTargets().get(nameLower) ?? ctx.moduleAliasTargets.get(nameLower);
+
+  const resolveEa = (ea: EaExprNode, span: SourceSpan): EaResolution | undefined => {
+    const go = (expr: EaExprNode, visitingAliases: Set<string>): EaResolution | undefined => {
+      switch (expr.kind) {
+        case 'EaName': {
+          const baseLower = expr.name.toLowerCase();
+          const slotOff = ctx.stackSlotOffsets.get(baseLower);
+          if (slotOff !== undefined) {
+            const slotType = ctx.stackSlotTypes.get(baseLower);
+            return {
+              kind: 'stack',
+              ixDisp: slotOff,
+              ...(slotType ? { typeExpr: slotType } : {}),
+            };
+          }
+          const aliasTarget = resolveAliasTarget(baseLower);
+          if (aliasTarget) {
+            if (visitingAliases.has(baseLower)) return undefined;
+            visitingAliases.add(baseLower);
+            try {
+              return go(aliasTarget, visitingAliases);
+            } finally {
+              visitingAliases.delete(baseLower);
+            }
+          }
+          const typeExpr = ctx.storageTypes.get(baseLower);
+          return { kind: 'abs', baseLower, addend: 0, ...(typeExpr ? { typeExpr } : {}) };
+        }
+        case 'EaAdd':
+        case 'EaSub': {
+          const base = go(expr.base, visitingAliases);
+          if (!base) return undefined;
+          const v = ctx.evalImmNoDiag(expr.offset);
+          if (v === undefined) return undefined;
+          const delta = expr.kind === 'EaAdd' ? v : -v;
+          if (base.kind === 'abs') return { ...base, addend: base.addend + delta };
+          return { ...base, ixDisp: base.ixDisp + delta };
+        }
+        case 'EaField': {
+          const base = go(expr.base, visitingAliases);
+          if (!base) return undefined;
+          if (!base.typeExpr) {
+            ctx.diagAt(ctx.diagnostics, span, `Cannot resolve field "${expr.field}" without a typed base.`);
+            return undefined;
+          }
+          const agg = ctx.resolveAggregateType(base.typeExpr);
+          if (!agg) {
+            ctx.diagAt(
+              ctx.diagnostics,
+              span,
+              `Field access ".${expr.field}" requires a record or union type.`,
+            );
+            return undefined;
+          }
+
+          let off = 0;
+          for (const f of agg.fields) {
+            if (f.name === expr.field) {
+              if (base.kind === 'abs') {
+                return {
+                  kind: 'abs',
+                  baseLower: base.baseLower,
+                  addend: base.addend + off,
+                  typeExpr: f.typeExpr,
+                };
+              }
+              return {
+                kind: 'stack',
+                ixDisp: base.ixDisp + off,
+                typeExpr: f.typeExpr,
+              };
+            }
+            if (agg.kind === 'record') {
+              const sz = ctx.sizeOfTypeExpr(f.typeExpr);
+              if (sz === undefined) return undefined;
+              off += sz;
+            }
+          }
+          const kind = agg.kind === 'union' ? 'union' : 'record';
+          ctx.diagAt(ctx.diagnostics, span, `Unknown ${kind} field "${expr.field}".`);
+          return undefined;
+        }
+        case 'EaIndex': {
+          const base = go(expr.base, visitingAliases);
+          if (!base) return undefined;
+          if (!base.typeExpr) {
+            ctx.diagAt(ctx.diagnostics, span, `Cannot resolve indexing without a typed base.`);
+            return undefined;
+          }
+          if (base.typeExpr.kind !== 'ArrayType') {
+            ctx.diagAt(ctx.diagnostics, span, `Indexing requires an array type.`);
+            return undefined;
+          }
+          const elemSize = ctx.sizeOfTypeExpr(base.typeExpr.element);
+          if (elemSize === undefined) return undefined;
+
+          if (expr.index.kind === 'IndexImm') {
+            const idx = ctx.evalImmExpr(expr.index.value);
+            if (idx === undefined) return undefined;
+            const delta = idx * elemSize;
+            if (base.kind === 'abs') {
+              return {
+                kind: 'abs',
+                baseLower: base.baseLower,
+                addend: base.addend + delta,
+                typeExpr: base.typeExpr.element,
+              };
+            }
+            return {
+              kind: 'stack',
+              ixDisp: base.ixDisp + delta,
+              typeExpr: base.typeExpr.element,
+            };
+          }
+
+          return undefined;
+        }
+      }
+    };
+
+    return go(ea, new Set<string>());
+  };
+
+  return {
+    resolveAliasTarget,
+    resolveEa,
+  };
+}

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -83,6 +83,7 @@ import { sizeOfTypeExpr } from '../semantics/layout.js';
 import { encodeInstruction } from '../z80/encode.js';
 import type { OpStackPolicyMode } from '../pipeline.js';
 import { loadBinInput, loadHexInput } from './inputAssets.js';
+import { createEaResolutionHelpers, type EaResolution } from './eaResolution.js';
 import { createRuntimeAtomBudgetHelpers } from './runtimeAtomBudget.js';
 import {
   alignTo,
@@ -350,10 +351,6 @@ export function emitProgram(
   let spTrackingValid = true;
   let spTrackingInvalidatedByMutation = false;
   let generatedLabelCounter = 0;
-
-  type EaResolution =
-    | { kind: 'abs'; baseLower: string; addend: number; typeExpr?: TypeExprNode }
-    | { kind: 'stack'; ixDisp: number; typeExpr?: TypeExprNode };
 
   const sameSourceTag = (x: SourceSegmentTag, y: SourceSegmentTag): boolean =>
     x.file === y.file &&
@@ -1464,8 +1461,21 @@ export function emitProgram(
     getLocalAliasTargets: () => localAliasTargets,
   });
 
-  const resolveAliasTarget = (nameLower: string): EaExprNode | undefined =>
-    localAliasTargets.get(nameLower) ?? moduleAliasTargets.get(nameLower);
+  const { resolveEa } = createEaResolutionHelpers({
+    env,
+    diagnostics,
+    diagAt,
+    stackSlotOffsets,
+    stackSlotTypes,
+    storageTypes,
+    moduleAliasTargets,
+    getLocalAliasTargets: () => localAliasTargets,
+    evalImmExpr: (expr) => evalImmExpr(expr, env, diagnostics),
+    evalImmNoDiag,
+    resolveAggregateType,
+    resolveEaTypeExpr,
+    sizeOfTypeExpr: (te) => sizeOfTypeExpr(te, env, diagnostics),
+  });
 
   for (const [aliasLower, aliasTarget] of moduleAliasTargets) {
     if (storageTypes.has(aliasLower)) continue;
@@ -1502,130 +1512,6 @@ export function emitProgram(
     stackSlotTypes,
     storageTypes,
   });
-
-  const resolveEa = (ea: EaExprNode, span: SourceSpan): EaResolution | undefined => {
-    const go = (expr: EaExprNode, visitingAliases: Set<string>): EaResolution | undefined => {
-      switch (expr.kind) {
-        case 'EaName': {
-          const baseLower = expr.name.toLowerCase();
-          const slotOff = stackSlotOffsets.get(baseLower);
-          if (slotOff !== undefined) {
-            const slotType = stackSlotTypes.get(baseLower);
-            return {
-              kind: 'stack',
-              ixDisp: slotOff,
-              ...(slotType ? { typeExpr: slotType } : {}),
-            };
-          }
-          const aliasTarget = resolveAliasTarget(baseLower);
-          if (aliasTarget) {
-            if (visitingAliases.has(baseLower)) return undefined;
-            visitingAliases.add(baseLower);
-            try {
-              return go(aliasTarget, visitingAliases);
-            } finally {
-              visitingAliases.delete(baseLower);
-            }
-          }
-          const typeExpr = storageTypes.get(baseLower);
-          return { kind: 'abs', baseLower, addend: 0, ...(typeExpr ? { typeExpr } : {}) };
-        }
-        case 'EaAdd':
-        case 'EaSub': {
-          const base = go(expr.base, visitingAliases);
-          if (!base) return undefined;
-          const v = evalImmNoDiag(expr.offset);
-          if (v === undefined) return undefined;
-          const delta = expr.kind === 'EaAdd' ? v : -v;
-          if (base.kind === 'abs') return { ...base, addend: base.addend + delta };
-          return { ...base, ixDisp: base.ixDisp + delta };
-        }
-        case 'EaField': {
-          const base = go(expr.base, visitingAliases);
-          if (!base) return undefined;
-          if (!base.typeExpr) {
-            diagAt(diagnostics, span, `Cannot resolve field "${expr.field}" without a typed base.`);
-            return undefined;
-          }
-          const agg = resolveAggregateType(base.typeExpr);
-          if (!agg) {
-            diagAt(
-              diagnostics,
-              span,
-              `Field access ".${expr.field}" requires a record or union type.`,
-            );
-            return undefined;
-          }
-
-          let off = 0;
-          for (const f of agg.fields) {
-            if (f.name === expr.field) {
-              if (base.kind === 'abs') {
-                return {
-                  kind: 'abs',
-                  baseLower: base.baseLower,
-                  addend: base.addend + off,
-                  typeExpr: f.typeExpr,
-                };
-              }
-              return {
-                kind: 'stack',
-                ixDisp: base.ixDisp + off,
-                typeExpr: f.typeExpr,
-              };
-            }
-            if (agg.kind === 'record') {
-              const sz = sizeOfTypeExpr(f.typeExpr, env, diagnostics);
-              if (sz === undefined) return undefined;
-              off += sz;
-            }
-          }
-          const kind = agg.kind === 'union' ? 'union' : 'record';
-          diagAt(diagnostics, span, `Unknown ${kind} field "${expr.field}".`);
-          return undefined;
-        }
-        case 'EaIndex': {
-          const base = go(expr.base, visitingAliases);
-          if (!base) return undefined;
-          if (!base.typeExpr) {
-            diagAt(diagnostics, span, `Cannot resolve indexing without a typed base.`);
-            return undefined;
-          }
-          if (base.typeExpr.kind !== 'ArrayType') {
-            diagAt(diagnostics, span, `Indexing requires an array type.`);
-            return undefined;
-          }
-          const elemSize = sizeOfTypeExpr(base.typeExpr.element, env, diagnostics);
-          if (elemSize === undefined) return undefined;
-
-          // Constant index: fold into displacement.
-          if (expr.index.kind === 'IndexImm') {
-            const idx = evalImmExpr(expr.index.value, env, diagnostics);
-            if (idx === undefined) return undefined;
-            const delta = idx * elemSize;
-            if (base.kind === 'abs') {
-              return {
-                kind: 'abs',
-                baseLower: base.baseLower,
-                addend: base.addend + delta,
-                typeExpr: base.typeExpr.element,
-              };
-            }
-            return {
-              kind: 'stack',
-              ixDisp: base.ixDisp + delta,
-              typeExpr: base.typeExpr.element,
-            };
-          }
-
-          // Runtime index: defer to runtime EA construction; resolved EA not available.
-          return undefined;
-        }
-      }
-    };
-
-    return go(ea, new Set<string>());
-  };
 
   const pushEaAddress = (ea: EaExprNode, span: SourceSpan): boolean => {
     const r = resolveEa(ea, span);

--- a/test/pr507_ea_resolution_helpers.test.ts
+++ b/test/pr507_ea_resolution_helpers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR507: extracted EA resolution helpers', () => {
+  it('preserves scalar index value semantics for nested EA resolution', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr260_value_semantics_scalar_index.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics).toEqual([]);
+  });
+
+  it('preserves runtime-affine unsupported-shape diagnostics', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr272_runtime_affine_invalid.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const messages = res.diagnostics.map((d) => d.message);
+
+    expect(messages).toContain(
+      'Runtime array index expression is unsupported. Use a single scalar runtime atom with +, -, *, << and constants (no /, %, &, |, ^, >> on runtime atoms).',
+    );
+    expect(messages).toContain(
+      'Runtime EA offset expression is unsupported. Use a single scalar runtime atom with +, -, *, << and constants (no /, %, &, |, ^, >> on runtime atoms).',
+    );
+  });
+});


### PR DESCRIPTION
## What changed
- extract EA resolution and alias traversal from src/lowering/emit.ts into src/lowering/eaResolution.ts
- keep lowering behavior unchanged and route the existing emitter through the extracted helper boundary
- add focused regression coverage for scalar index value semantics and runtime-affine unsupported-shape diagnostics

## Verification
- npm run typecheck
- npm test -- --run test/pr507_ea_resolution_helpers.test.ts test/pr260_value_semantics_scalar_index.test.ts test/pr272_runtime_affine_index_offset.test.ts test/smoke_language_tour_compile.test.ts