### PR TITLE
Extract runtime immediate helpers

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -84,6 +84,7 @@ import { encodeInstruction } from '../z80/encode.js';
 import type { OpStackPolicyMode } from '../pipeline.js';
 import { loadBinInput, loadHexInput } from './inputAssets.js';
 import { createEaResolutionHelpers, type EaResolution } from './eaResolution.js';
+import { createRuntimeImmediateHelpers } from './runtimeImmediates.js';
 import { createRuntimeAtomBudgetHelpers } from './runtimeAtomBudget.js';
 import {
   alignTo,
@@ -463,114 +464,10 @@ export function emitProgram(
     return true;
   };
 
-  const pushImm16 = (n: number, span: any): boolean => {
-    if (!loadImm16ToHL(n, span)) return false;
-    return emitInstr('push', [{ kind: 'Reg', span, name: 'HL' }], span);
-  };
-
-  const loadImm16ToHL = (n: number, span: any): boolean => {
-    return emitInstr(
-      'ld',
-      [
-        { kind: 'Reg', span, name: 'HL' },
-        { kind: 'Imm', span, expr: { kind: 'ImmLiteral', span, value: n } },
-      ],
-      span,
-    );
-  };
-
-  const loadImm16ToDE = (n: number, span: any): boolean => {
-    return emitInstr(
-      'ld',
-      [
-        { kind: 'Reg', span, name: 'DE' },
-        { kind: 'Imm', span, expr: { kind: 'ImmLiteral', span, value: n } },
-      ],
-      span,
-    );
-  };
-
-  const negateHL = (span: SourceSpan): boolean => {
-    if (
-      !emitInstr(
-        'ld',
-        [
-          { kind: 'Reg', span, name: 'A' },
-          { kind: 'Reg', span, name: 'H' },
-        ],
-        span,
-      )
-    ) {
-      return false;
-    }
-    if (!emitInstr('cpl', [], span)) return false;
-    if (
-      !emitInstr(
-        'ld',
-        [
-          { kind: 'Reg', span, name: 'H' },
-          { kind: 'Reg', span, name: 'A' },
-        ],
-        span,
-      )
-    ) {
-      return false;
-    }
-    if (
-      !emitInstr(
-        'ld',
-        [
-          { kind: 'Reg', span, name: 'A' },
-          { kind: 'Reg', span, name: 'L' },
-        ],
-        span,
-      )
-    ) {
-      return false;
-    }
-    if (!emitInstr('cpl', [], span)) return false;
-    if (
-      !emitInstr(
-        'ld',
-        [
-          { kind: 'Reg', span, name: 'L' },
-          { kind: 'Reg', span, name: 'A' },
-        ],
-        span,
-      )
-    ) {
-      return false;
-    }
-    return emitInstr('inc', [{ kind: 'Reg', span, name: 'HL' }], span);
-  };
-
-  const pushZeroExtendedReg8 = (r: string, span: any): boolean => {
-    if (
-      !emitInstr(
-        'ld',
-        [
-          { kind: 'Reg', span, name: 'H' },
-          { kind: 'Imm', span, expr: { kind: 'ImmLiteral', span, value: 0 } },
-        ],
-        span,
-      )
-    ) {
-      return false;
-    }
-    if (
-      !emitInstr(
-        'ld',
-        [
-          { kind: 'Reg', span, name: 'L' },
-          { kind: 'Reg', span, name: r },
-        ],
-        span,
-      )
-    ) {
-      return false;
-    }
-    return emitInstr('push', [{ kind: 'Reg', span, name: 'HL' }], span);
-  };
+  const { loadImm16ToDE, loadImm16ToHL, negateHL, pushImm16, pushZeroExtendedReg8 } =
+    createRuntimeImmediateHelpers({
+      emitInstr,
+    });
 
   const emitStepPipeline = (pipe: StepPipeline, span: SourceSpan): boolean => {
     const rpByte = (rp: string, which: 'lo' | 'hi'): string | undefined => {

--- a/src/lowering/runtimeImmediates.ts
+++ b/src/lowering/runtimeImmediates.ts
@@ -1,0 +1,124 @@
+import type { AsmOperandNode, SourceSpan } from '../frontend/ast.js';
+
+type RuntimeImmediateContext = {
+  emitInstr: (head: string, operands: AsmOperandNode[], span: SourceSpan) => boolean;
+};
+
+export function createRuntimeImmediateHelpers(ctx: RuntimeImmediateContext) {
+  const loadImm16ToHL = (n: number, span: SourceSpan): boolean => {
+    return ctx.emitInstr(
+      'ld',
+      [
+        { kind: 'Reg', span, name: 'HL' },
+        { kind: 'Imm', span, expr: { kind: 'ImmLiteral', span, value: n } },
+      ],
+      span,
+    );
+  };
+
+  const loadImm16ToDE = (n: number, span: SourceSpan): boolean => {
+    return ctx.emitInstr(
+      'ld',
+      [
+        { kind: 'Reg', span, name: 'DE' },
+        { kind: 'Imm', span, expr: { kind: 'ImmLiteral', span, value: n } },
+      ],
+      span,
+    );
+  };
+
+  const pushImm16 = (n: number, span: SourceSpan): boolean => {
+    if (!loadImm16ToHL(n, span)) return false;
+    return ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'HL' }], span);
+  };
+
+  const negateHL = (span: SourceSpan): boolean => {
+    if (
+      !ctx.emitInstr(
+        'ld',
+        [
+          { kind: 'Reg', span, name: 'A' },
+          { kind: 'Reg', span, name: 'H' },
+        ],
+        span,
+      )
+    ) {
+      return false;
+    }
+    if (!ctx.emitInstr('cpl', [], span)) return false;
+    if (
+      !ctx.emitInstr(
+        'ld',
+        [
+          { kind: 'Reg', span, name: 'H' },
+          { kind: 'Reg', span, name: 'A' },
+        ],
+        span,
+      )
+    ) {
+      return false;
+    }
+    if (
+      !ctx.emitInstr(
+        'ld',
+        [
+          { kind: 'Reg', span, name: 'A' },
+          { kind: 'Reg', span, name: 'L' },
+        ],
+        span,
+      )
+    ) {
+      return false;
+    }
+    if (!ctx.emitInstr('cpl', [], span)) return false;
+    if (
+      !ctx.emitInstr(
+        'ld',
+        [
+          { kind: 'Reg', span, name: 'L' },
+          { kind: 'Reg', span, name: 'A' },
+        ],
+        span,
+      )
+    ) {
+      return false;
+    }
+    return ctx.emitInstr('inc', [{ kind: 'Reg', span, name: 'HL' }], span);
+  };
+
+  const pushZeroExtendedReg8 = (r: string, span: SourceSpan): boolean => {
+    if (
+      !ctx.emitInstr(
+        'ld',
+        [
+          { kind: 'Reg', span, name: 'H' },
+          { kind: 'Imm', span, expr: { kind: 'ImmLiteral', span, value: 0 } },
+        ],
+        span,
+      )
+    ) {
+      return false;
+    }
+    if (
+      !ctx.emitInstr(
+        'ld',
+        [
+          { kind: 'Reg', span, name: 'L' },
+          { kind: 'Reg', span, name: r },
+        ],
+        span,
+      )
+    ) {
+      return false;
+    }
+    return ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'HL' }], span);
+  };
+
+  return {
+    loadImm16ToDE,
+    loadImm16ToHL,
+    negateHL,
+    pushImm16,
+    pushZeroExtendedReg8,
+  };
+}

--- a/test/pr508_runtime_immediates_helpers.test.ts
+++ b/test/pr508_runtime_immediates_helpers.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR508: extracted runtime-immediate helpers', () => {
+  it('preserves runtime-affine scaling and immediate materialization in lowering', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr272_runtime_affine_valid.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics).toEqual([]);
+  });
+
+  it('preserves byte call-arg zero-extension materialization', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr405_byte_call_scalar_arg.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    const asm = res.artifacts.find((a) => a.kind === 'asm');
+
+    expect(res.diagnostics).toEqual([]);
+    expect(asm?.kind).toBe('asm');
+    expect(asm?.text).toContain('ld H, $0000');
+    expect(asm?.text).toContain('push HL');
+  });
+});


### PR DESCRIPTION
Issue: #508

This slice extracts the runtime-immediate materialization helper cluster from src/lowering/emit.ts into src/lowering/runtimeImmediates.ts.

Scope:
- loadImm16ToHL
- loadImm16ToDE
- pushImm16
- negateHL
- pushZeroExtendedReg8

Verification:
- npm run typecheck
- npm test -- --run test/pr508_runtime_immediates_helpers.test.ts test/pr272_runtime_affine_index_offset.test.ts test/pr405_byte_call_scalar_arg.test.ts test/smoke_language_tour_compile.test.ts