### PR TITLE
Extract addressing pipeline builders

### DIFF
--- a/src/lowering/addressingPipelines.ts
+++ b/src/lowering/addressingPipelines.ts
@@ -1,0 +1,208 @@
+import {
+  CALC_EA,
+  CALC_EA_2,
+  EA_FVAR_CONST,
+  EA_FVAR_FVAR,
+  EA_FVAR_GLOB,
+  EA_FVAR_REG,
+  EA_FVAR_RP,
+  EA_GLOB_CONST,
+  EA_GLOB_FVAR,
+  EA_GLOB_GLOB,
+  EA_GLOB_REG,
+  EA_GLOB_RP,
+  EAW_FVAR_CONST,
+  EAW_FVAR_FVAR,
+  EAW_FVAR_GLOB,
+  EAW_FVAR_REG,
+  EAW_FVAR_RP,
+  EAW_GLOB_CONST,
+  EAW_GLOB_FVAR,
+  EAW_GLOB_GLOB,
+  EAW_GLOB_REG,
+  EAW_GLOB_RP,
+  LOAD_BASE_FVAR,
+  LOAD_BASE_GLOB,
+  type StepPipeline,
+} from '../addressing/steps.js';
+import type { Diagnostic } from '../diagnostics/types.js';
+import type { EaExprNode, ImmExprNode, SourceSpan, TypeExprNode } from '../frontend/ast.js';
+import type { EaResolution } from './eaResolution.js';
+import type { ScalarKind } from './typeResolution.js';
+
+type AddressingPipelineContext = {
+  diagnostics: Diagnostic[];
+  diagAt: (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
+  reg8: ReadonlySet<string>;
+  resolveEa: (ea: EaExprNode, span: SourceSpan) => EaResolution | undefined;
+  resolveEaTypeExpr: (ea: EaExprNode) => TypeExprNode | undefined;
+  resolveScalarBinding: (name: string) => ScalarKind | undefined;
+  resolveScalarKind: (typeExpr: TypeExprNode) => ScalarKind | undefined;
+  sizeOfTypeExpr: (typeExpr: TypeExprNode) => number | undefined;
+  evalImmExpr: (expr: ImmExprNode) => number | undefined;
+};
+
+export function createAddressingPipelineBuilders(ctx: AddressingPipelineContext) {
+  const hasIndex = (expr: EaExprNode): boolean => {
+    switch (expr.kind) {
+      case 'EaIndex':
+        return true;
+      case 'EaAdd':
+      case 'EaSub':
+      case 'EaField':
+        return hasIndex(expr.base);
+      default:
+        return false;
+    }
+  };
+
+  const buildEaBytePipeline = (ea: EaExprNode, span: SourceSpan): StepPipeline | null => {
+    if (ea.kind === 'EaIndex') {
+      const baseResolved = ctx.resolveEa(ea.base, span);
+      const baseType = ctx.resolveEaTypeExpr(ea.base);
+      if (!baseResolved || !baseType || baseType.kind !== 'ArrayType') return null;
+      const elemSize = ctx.sizeOfTypeExpr(baseType.element);
+      if (elemSize !== 1) return null;
+
+      switch (ea.index.kind) {
+        case 'IndexReg8': {
+          const regLower = ea.index.reg.toLowerCase();
+          if (!ctx.reg8.has(regLower.toUpperCase())) return null;
+          return baseResolved.kind === 'abs'
+            ? EA_GLOB_REG(baseResolved.baseLower, regLower)
+            : EA_FVAR_REG(baseResolved.ixDisp, regLower);
+        }
+        case 'IndexReg16': {
+          const rp = ea.index.reg.toUpperCase();
+          if (rp !== 'HL' && rp !== 'DE' && rp !== 'BC') {
+            ctx.diagAt(ctx.diagnostics, span, `Invalid reg16 index "${ea.index.reg}".`);
+            return null;
+          }
+          if (rp === 'HL') {
+            return baseResolved.kind === 'abs'
+              ? [...LOAD_BASE_GLOB(baseResolved.baseLower), ...CALC_EA()]
+              : [...LOAD_BASE_FVAR(baseResolved.ixDisp), ...CALC_EA()];
+          }
+          return baseResolved.kind === 'abs'
+            ? EA_GLOB_RP(baseResolved.baseLower, rp)
+            : EA_FVAR_RP(baseResolved.ixDisp, rp);
+        }
+        case 'IndexEa': {
+          const idxResolved = ctx.resolveEa(ea.index.expr, span);
+          if (!idxResolved) return null;
+          if (idxResolved.kind === 'abs') {
+            return baseResolved.kind === 'abs'
+              ? EA_GLOB_GLOB(baseResolved.baseLower, idxResolved.baseLower)
+              : EA_FVAR_GLOB(baseResolved.ixDisp, idxResolved.baseLower);
+          }
+          if (idxResolved.kind === 'stack') {
+            return baseResolved.kind === 'abs'
+              ? EA_GLOB_FVAR(baseResolved.baseLower, idxResolved.ixDisp)
+              : EA_FVAR_FVAR(baseResolved.ixDisp, idxResolved.ixDisp);
+          }
+          return null;
+        }
+        default:
+          return null;
+      }
+    }
+
+    const resolved = ctx.resolveEa(ea, span);
+    if (!resolved) return null;
+    if (resolved.kind === 'abs') return EA_GLOB_CONST(resolved.baseLower, resolved.addend);
+    if (resolved.kind === 'stack') return EA_FVAR_CONST(resolved.ixDisp, 0);
+    return null;
+  };
+
+  const buildEaWordPipeline = (ea: EaExprNode, span: SourceSpan): StepPipeline | null => {
+    if (!hasIndex(ea)) return null;
+
+    if (ea.kind === 'EaIndex') {
+      const baseResolved = ctx.resolveEa(ea.base, span);
+      const baseType = ctx.resolveEaTypeExpr(ea.base);
+      if (!baseResolved || !baseType || baseType.kind !== 'ArrayType') return null;
+      const elemSize = ctx.sizeOfTypeExpr(baseType.element);
+      if (elemSize !== 2) return null;
+
+      if (ea.index.kind === 'IndexImm') {
+        const imm = ctx.evalImmExpr(ea.index.value);
+        if (imm !== undefined) {
+          return baseResolved.kind === 'abs'
+            ? EAW_GLOB_CONST(baseResolved.baseLower, imm)
+            : EAW_FVAR_CONST(baseResolved.ixDisp, imm);
+        }
+
+        if (ea.index.value.kind === 'ImmName') {
+          const idxScalar = ctx.resolveScalarBinding(ea.index.value.name);
+          if (idxScalar !== 'word' && idxScalar !== 'addr') return null;
+          const idxNameEa: EaExprNode = { kind: 'EaName', span, name: ea.index.value.name };
+          const idxResolved = ctx.resolveEa(idxNameEa, span);
+          if (!idxResolved) return null;
+          if (idxResolved.kind === 'abs') {
+            return baseResolved.kind === 'abs'
+              ? EAW_GLOB_GLOB(baseResolved.baseLower, idxResolved.baseLower)
+              : EAW_FVAR_GLOB(baseResolved.ixDisp, idxResolved.baseLower);
+          }
+          if (idxResolved.kind === 'stack') {
+            return baseResolved.kind === 'abs'
+              ? EAW_GLOB_FVAR(baseResolved.baseLower, idxResolved.ixDisp)
+              : EAW_FVAR_FVAR(baseResolved.ixDisp, idxResolved.ixDisp);
+          }
+        }
+        return null;
+      }
+
+      if (ea.index.kind === 'IndexReg8' || ea.index.kind === 'IndexReg16') {
+        const idxReg = ea.index.reg;
+        const idxUpper = idxReg.toUpperCase();
+
+        if (baseResolved.kind === 'abs') {
+          if (ea.index.kind === 'IndexReg8') {
+            return EAW_GLOB_REG(baseResolved.baseLower, idxReg.toLowerCase());
+          }
+          if (idxUpper === 'HL') return [...LOAD_BASE_GLOB(baseResolved.baseLower), ...CALC_EA_2()];
+          return EAW_GLOB_RP(baseResolved.baseLower, idxUpper);
+        }
+        if (baseResolved.kind === 'stack') {
+          if (ea.index.kind === 'IndexReg8') {
+            return EAW_FVAR_REG(baseResolved.ixDisp, idxReg.toLowerCase());
+          }
+          if (idxUpper === 'HL') return [...LOAD_BASE_FVAR(baseResolved.ixDisp), ...CALC_EA_2()];
+          return EAW_FVAR_RP(baseResolved.ixDisp, idxUpper);
+        }
+        return null;
+      }
+
+      if (ea.index.kind === 'IndexEa') {
+        const idxResolved = ctx.resolveEa(ea.index.expr, span);
+        if (!idxResolved) return null;
+        if (idxResolved.kind === 'abs') {
+          return baseResolved.kind === 'abs'
+            ? EAW_GLOB_GLOB(baseResolved.baseLower, idxResolved.baseLower)
+            : EAW_FVAR_GLOB(baseResolved.ixDisp, idxResolved.baseLower);
+        }
+        if (idxResolved.kind === 'stack') {
+          return baseResolved.kind === 'abs'
+            ? EAW_GLOB_FVAR(baseResolved.baseLower, idxResolved.ixDisp)
+            : EAW_FVAR_FVAR(baseResolved.ixDisp, idxResolved.ixDisp);
+        }
+        return null;
+      }
+    }
+
+    const resolved = ctx.resolveEa(ea, span);
+    if (!resolved) return null;
+    const scalarKind = resolved.typeExpr ? ctx.resolveScalarKind(resolved.typeExpr) : undefined;
+    const elemSize: number | undefined = (resolved as { elemSize?: number }).elemSize ?? 2;
+    if (scalarKind !== 'word' && scalarKind !== 'addr') return null;
+    if (elemSize !== 2) return null;
+    if (resolved.kind === 'abs') return EAW_GLOB_CONST(resolved.baseLower, resolved.addend);
+    if (resolved.kind === 'stack') return EAW_FVAR_CONST(resolved.ixDisp, 0);
+    return null;
+  };
+
+  return {
+    buildEaBytePipeline,
+    buildEaWordPipeline,
+  };
+}

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -84,6 +84,7 @@ import { encodeInstruction } from '../z80/encode.js';
 import type { OpStackPolicyMode } from '../pipeline.js';
 import { loadBinInput, loadHexInput } from './inputAssets.js';
 import { createEaResolutionHelpers, type EaResolution } from './eaResolution.js';
+import { createAddressingPipelineBuilders } from './addressingPipelines.js';
 import { createRuntimeImmediateHelpers } from './runtimeImmediates.js';
 import { createRuntimeAtomBudgetHelpers } from './runtimeAtomBudget.js';
 import {
@@ -2098,168 +2099,17 @@ export function emitProgram(
     return emitInstr('pop', [{ kind: 'Reg', span, name: 'DE' }], span); // restore DE
   };
 
-  const buildEaBytePipeline = (ea: EaExprNode, span: SourceSpan): StepPipeline | null => {
-    // Runtime indexed arrays (byte elements only) use the EA_* matrix.
-    if (ea.kind === 'EaIndex') {
-      const baseResolved = resolveEa(ea.base, span);
-      const baseType = resolveEaTypeExpr(ea.base);
-      if (!baseResolved || !baseType || baseType.kind !== 'ArrayType') return null;
-      const elemSize = sizeOfTypeExpr(baseType.element, env, diagnostics);
-      if (elemSize !== 1) return null; // byte elements only
-
-      switch (ea.index.kind) {
-        case 'IndexReg8': {
-          const reg = (ea.index as any).reg;
-          const regLower = typeof reg === 'string' ? reg.toLowerCase() : undefined;
-          if (!regLower || !reg8.has(regLower.toUpperCase())) return null;
-          return baseResolved.kind === 'abs'
-            ? EA_GLOB_REG(baseResolved.baseLower, regLower)
-            : EA_FVAR_REG(baseResolved.ixDisp, regLower);
-        }
-        case 'IndexReg16': {
-          const rp = (ea.index as any).reg?.toUpperCase();
-          if (!rp || (rp !== 'HL' && rp !== 'DE' && rp !== 'BC')) {
-            diagAt(diagnostics, span, `Invalid reg16 index "${(ea.index as any).reg}".`);
-            return null;
-          }
-          if (rp === 'HL') {
-            return baseResolved.kind === 'abs'
-              ? [...LOAD_BASE_GLOB(baseResolved.baseLower), ...CALC_EA()]
-              : [...LOAD_BASE_FVAR(baseResolved.ixDisp), ...CALC_EA()];
-          }
-          return baseResolved.kind === 'abs'
-            ? EA_GLOB_RP(baseResolved.baseLower, rp)
-            : EA_FVAR_RP(baseResolved.ixDisp, rp);
-        }
-        case 'IndexEa': {
-          const idxResolved = resolveEa(ea.index.expr, span);
-          if (!idxResolved) return null;
-          if (idxResolved.kind === 'abs') {
-            return baseResolved.kind === 'abs'
-              ? EA_GLOB_GLOB(baseResolved.baseLower, idxResolved.baseLower)
-              : EA_FVAR_GLOB(baseResolved.ixDisp, idxResolved.baseLower);
-          }
-          if (idxResolved.kind === 'stack') {
-            return baseResolved.kind === 'abs'
-              ? EA_GLOB_FVAR(baseResolved.baseLower, idxResolved.ixDisp)
-              : EA_FVAR_FVAR(baseResolved.ixDisp, idxResolved.ixDisp);
-          }
-          return null;
-        }
-        default:
-          return null;
-      }
-    }
-
-    // Folded/scalar path: resolveEa already folded const indexes.
-    const r = resolveEa(ea, span);
-    if (!r) return null;
-    if (r.kind === 'abs') return EA_GLOB_CONST(r.baseLower, r.addend);
-    if (r.kind === 'stack') return EA_FVAR_CONST(r.ixDisp, 0);
-    return null;
-  };
-
-  const buildEaWordPipeline = (ea: EaExprNode, span: SourceSpan): StepPipeline | null => {
-    const hasIndex = (expr: EaExprNode): boolean => {
-      switch (expr.kind) {
-        case 'EaIndex':
-          return true;
-        case 'EaAdd':
-        case 'EaSub':
-        case 'EaField':
-          return hasIndex(expr.base);
-        default:
-          return false;
-      }
-    };
-    if (!hasIndex(ea)) return null; // only indexed shapes use EAW
-
-    // Runtime index with reg8/reg16 or Ea → EAW builders
-    if (ea.kind === 'EaIndex') {
-      const baseResolved = resolveEa(ea.base, span);
-      const baseType = resolveEaTypeExpr(ea.base);
-      if (!baseResolved || !baseType || baseType.kind !== 'ArrayType') return null;
-      const elemSize = sizeOfTypeExpr(baseType.element, env, diagnostics);
-      if (elemSize !== 2) return null; // scale-by-2 only
-
-      if (ea.index.kind === 'IndexImm') {
-        const imm = evalImmExpr(ea.index.value, env, diagnostics);
-        if (imm !== undefined) {
-          return baseResolved.kind === 'abs'
-            ? EAW_GLOB_CONST(baseResolved.baseLower, imm)
-            : EAW_FVAR_CONST(baseResolved.ixDisp, imm);
-        }
-
-        if (ea.index.value.kind === 'ImmName') {
-          const idxScalar = resolveScalarBinding(ea.index.value.name);
-          if (idxScalar !== 'word' && idxScalar !== 'addr') return null;
-          const idxNameEa: EaExprNode = { kind: 'EaName', span, name: ea.index.value.name };
-          const idxResolved = resolveEa(idxNameEa, span);
-          if (!idxResolved) return null;
-          if (idxResolved.kind === 'abs') {
-            return baseResolved.kind === 'abs'
-              ? EAW_GLOB_GLOB(baseResolved.baseLower, idxResolved.baseLower)
-              : EAW_FVAR_GLOB(baseResolved.ixDisp, idxResolved.baseLower);
-          }
-          if (idxResolved.kind === 'stack') {
-            return baseResolved.kind === 'abs'
-              ? EAW_GLOB_FVAR(baseResolved.baseLower, idxResolved.ixDisp)
-              : EAW_FVAR_FVAR(baseResolved.ixDisp, idxResolved.ixDisp);
-          }
-        }
-        return null;
-      }
-
-      if (ea.index.kind === 'IndexReg8' || ea.index.kind === 'IndexReg16') {
-        const idxReg = (ea.index as any).reg;
-        if (!idxReg || typeof idxReg !== 'string') return null;
-        const idxUpper = idxReg.toUpperCase();
-
-        if (baseResolved.kind === 'abs') {
-          if (ea.index.kind === 'IndexReg8') {
-            return EAW_GLOB_REG(baseResolved.baseLower, idxReg.toLowerCase());
-          }
-          if (idxUpper === 'HL') return [...LOAD_BASE_GLOB(baseResolved.baseLower), ...CALC_EA_2()];
-          return EAW_GLOB_RP(baseResolved.baseLower, idxUpper);
-        }
-        if (baseResolved.kind === 'stack') {
-          if (ea.index.kind === 'IndexReg8') {
-            return EAW_FVAR_REG(baseResolved.ixDisp, idxReg.toLowerCase());
-          }
-          if (idxUpper === 'HL') return [...LOAD_BASE_FVAR(baseResolved.ixDisp), ...CALC_EA_2()];
-          return EAW_FVAR_RP(baseResolved.ixDisp, idxUpper);
-        }
-        return null;
-      }
-
-      if (ea.index.kind === 'IndexEa') {
-        const idxResolved = resolveEa(ea.index.expr, span);
-        if (!idxResolved) return null;
-        if (idxResolved.kind === 'abs') {
-          return baseResolved.kind === 'abs'
-            ? EAW_GLOB_GLOB(baseResolved.baseLower, idxResolved.baseLower)
-            : EAW_FVAR_GLOB(baseResolved.ixDisp, idxResolved.baseLower);
-        }
-        if (idxResolved.kind === 'stack') {
-          return baseResolved.kind === 'abs'
-            ? EAW_GLOB_FVAR(baseResolved.baseLower, idxResolved.ixDisp)
-            : EAW_FVAR_FVAR(baseResolved.ixDisp, idxResolved.ixDisp);
-        }
-        return null;
-      }
-    }
-
-    // Folded/scalar path: resolveEa may already include addends.
-    const r = resolveEa(ea, span);
-    if (!r) return null;
-    const scalarKind = r.typeExpr ? resolveScalarKind(r.typeExpr) : undefined;
-    const elemSize: number | undefined = (r as any).elemSize ?? 2;
-    if (scalarKind !== 'word' && scalarKind !== 'addr') return null;
-    if (elemSize !== 2) return null;
-    if (r.kind === 'abs') return EAW_GLOB_CONST(r.baseLower, r.addend);
-    if (r.kind === 'stack') return EAW_FVAR_CONST(r.ixDisp, 0);
-    return null;
-  };
+  const { buildEaBytePipeline, buildEaWordPipeline } = createAddressingPipelineBuilders({
+    diagnostics,
+    diagAt,
+    reg8,
+    resolveEa,
+    resolveEaTypeExpr,
+    resolveScalarBinding,
+    resolveScalarKind,
+    sizeOfTypeExpr: (typeExpr) => sizeOfTypeExpr(typeExpr, env, diagnostics),
+    evalImmExpr: (expr) => evalImmExpr(expr, env, diagnostics),
+  });
 
   const emitScalarWordLoad = (
     target: 'HL' | 'DE' | 'BC',

--- a/test/pr509_addressing_pipeline_builders.test.ts
+++ b/test/pr509_addressing_pipeline_builders.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderStepPipeline } from '../src/addressing/steps.js';
+import { DiagnosticIds, type Diagnostic } from '../src/diagnostics/types.js';
+import type { EaExprNode, SourceSpan, TypeExprNode } from '../src/frontend/ast.js';
+import { createAddressingPipelineBuilders } from '../src/lowering/addressingPipelines.js';
+import type { EaResolution } from '../src/lowering/eaResolution.js';
+
+const span: SourceSpan = {
+  file: 'test.zax',
+  start: { offset: 0, line: 1, column: 1 },
+  end: { offset: 0, line: 1, column: 1 },
+};
+
+const typeName = (name: string): TypeExprNode => ({ kind: 'TypeName', span, name });
+const byteArray = (): TypeExprNode => ({ kind: 'ArrayType', span, element: typeName('byte'), length: 4 });
+const wordArray = (): TypeExprNode => ({ kind: 'ArrayType', span, element: typeName('word'), length: 4 });
+const eaName = (name: string): EaExprNode => ({ kind: 'EaName', span, name });
+
+describe('#509 addressing pipeline builders', () => {
+  const diagnostics: Diagnostic[] = [];
+  const reg8 = new Set(['A', 'B', 'C', 'D', 'E', 'H', 'L']);
+
+  const baseResolutions = new Map<string, EaResolution>([
+    ['globb', { kind: 'abs', baseLower: 'globb', addend: 0, typeExpr: byteArray() }],
+    ['frameb', { kind: 'stack', ixDisp: -4, typeExpr: byteArray() }],
+    ['globw', { kind: 'abs', baseLower: 'globw', addend: 0, typeExpr: wordArray() }],
+    ['framew', { kind: 'stack', ixDisp: -8, typeExpr: wordArray() }],
+    ['idxw', { kind: 'abs', baseLower: 'idxw', addend: 0, typeExpr: typeName('word') }],
+  ]);
+
+  const helpers = createAddressingPipelineBuilders({
+    diagnostics,
+    diagAt: (_diagnostics, _span, message) => {
+      diagnostics.push({
+        id: DiagnosticIds.EmitError,
+        severity: 'error',
+        file: span.file,
+        message,
+      });
+    },
+    reg8,
+    resolveEa: (ea, _span) => {
+      if (ea.kind === 'EaName') return baseResolutions.get(ea.name.toLowerCase());
+      return undefined;
+    },
+    resolveEaTypeExpr: (ea) => {
+      if (ea.kind === 'EaName') return baseResolutions.get(ea.name.toLowerCase())?.typeExpr;
+      return undefined;
+    },
+    resolveScalarBinding: (name) => (name.toLowerCase() === 'idxw' ? 'word' : undefined),
+    resolveScalarKind: (typeExpr) =>
+      typeExpr.kind === 'TypeName' && (typeExpr.name === 'word' || typeExpr.name === 'addr')
+        ? typeExpr.name
+        : undefined,
+    sizeOfTypeExpr: (typeExpr) => {
+      if (typeExpr.kind !== 'TypeName') return undefined;
+      if (typeExpr.name === 'byte') return 1;
+      if (typeExpr.name === 'word' || typeExpr.name === 'addr') return 2;
+      return undefined;
+    },
+    evalImmExpr: () => undefined,
+  });
+
+  it('keeps representative byte builder shapes stable', () => {
+    const globPipe = helpers.buildEaBytePipeline(
+      { kind: 'EaIndex', span, base: eaName('globb'), index: { kind: 'IndexReg8', span, reg: 'C' } },
+      span,
+    );
+    const framePipe = helpers.buildEaBytePipeline(
+      { kind: 'EaIndex', span, base: eaName('frameb'), index: { kind: 'IndexReg16', span, reg: 'HL' } },
+      span,
+    );
+
+    expect(renderStepPipeline(globPipe ?? [])).toEqual([
+      'ld de, globb',
+      'ld h, 0',
+      'ld l, c',
+      'add hl, de',
+    ]);
+    expect(renderStepPipeline(framePipe ?? [])).toEqual([
+      'ld e, (ix-$04)',
+      'ld d, (ix-$03)',
+      'add hl, de',
+    ]);
+  });
+
+  it('keeps representative word builder shapes stable', () => {
+    const globPipe = helpers.buildEaWordPipeline(
+      { kind: 'EaIndex', span, base: eaName('globw'), index: { kind: 'IndexReg16', span, reg: 'HL' } },
+      span,
+    );
+    const framePipe = helpers.buildEaWordPipeline(
+      {
+        kind: 'EaIndex',
+        span,
+        base: eaName('framew'),
+        index: { kind: 'IndexImm', span, value: { kind: 'ImmName', span, name: 'idxw' } },
+      },
+      span,
+    );
+
+    expect(renderStepPipeline(globPipe ?? [])).toEqual([
+      'ld de, globw',
+      'add hl, hl',
+      'add hl, de',
+    ]);
+    expect(renderStepPipeline(framePipe ?? [])).toEqual([
+      'ld e, (ix-$08)',
+      'ld d, (ix-$07)',
+      'ld hl, (idxw)',
+      'add hl, hl',
+      'add hl, de',
+    ]);
+  });
+});


### PR DESCRIPTION
Issue: #509

First narrow slice only.

This extracts the addressing-pipeline builder cluster from src/lowering/emit.ts into src/lowering/addressingPipelines.ts.

Moved in this slice:
- buildEaBytePipeline(...)
- buildEaWordPipeline(...)
- the minimal local helper used only by those builders

Not moved in this slice:
- lowerLdWithEa(...)
- materializeEaAddressToHL(...)
- scalar word accessor emission helpers
- direct emission routines tied to emitInstr(...)

Verification:
- npm run typecheck
- npm test -- --run test/pr509_addressing_pipeline_builders.test.ts test/pr405_byte_scalar_fast_paths.test.ts test/pr406_word_scalar_accessors.test.ts test/pr407_step_matrix.test.ts test/pr468_typed_step_integration.test.ts test/smoke_language_tour_compile.test.ts