### PR TITLE
Extract EA materialization helper

### DIFF
--- a/src/lowering/eaMaterialization.ts
+++ b/src/lowering/eaMaterialization.ts
@@ -1,0 +1,51 @@
+import type { AsmOperandNode, EaExprNode, SourceSpan } from '../frontend/ast.js';
+import type { EaResolution } from './eaResolution.js';
+
+type EaMaterializationContext = {
+  resolveEa: (ea: EaExprNode, span: SourceSpan) => EaResolution | undefined;
+  pushEaAddress: (ea: EaExprNode, span: SourceSpan) => boolean;
+  emitInstr: (head: string, operands: AsmOperandNode[], span: SourceSpan) => boolean;
+  emitAbs16Fixup: (opcode: number, target: string, addend: number, span: SourceSpan) => void;
+  loadImm16ToDE: (value: number, span: SourceSpan) => boolean;
+};
+
+export function createEaMaterializationHelpers(ctx: EaMaterializationContext) {
+  const materializeEaAddressToHL = (ea: EaExprNode, span: SourceSpan): boolean => {
+    const resolved = ctx.resolveEa(ea, span);
+    if (!resolved) {
+      if (!ctx.pushEaAddress(ea, span)) return false;
+      return ctx.emitInstr('pop', [{ kind: 'Reg', span, name: 'HL' }], span);
+    }
+
+    if (resolved.kind === 'abs') {
+      ctx.emitAbs16Fixup(0x21, resolved.baseLower, resolved.addend, span);
+      return true;
+    }
+
+    const disp = resolved.ixDisp & 0xffff;
+    if (!ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'DE' }], span)) return false;
+    if (!ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'IX' }], span)) return false;
+    if (!ctx.emitInstr('pop', [{ kind: 'Reg', span, name: 'HL' }], span)) return false;
+    if (disp !== 0) {
+      if (!ctx.loadImm16ToDE(disp, span)) return false;
+      if (
+        !ctx.emitInstr(
+          'add',
+          [
+            { kind: 'Reg', span, name: 'HL' },
+            { kind: 'Reg', span, name: 'DE' },
+          ],
+          span,
+        )
+      ) {
+        return false;
+      }
+    }
+    if (!ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'HL' }], span)) return false;
+    return ctx.emitInstr('pop', [{ kind: 'Reg', span, name: 'DE' }], span);
+  };
+
+  return {
+    materializeEaAddressToHL,
+  };
+}

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -84,6 +84,7 @@ import { encodeInstruction } from '../z80/encode.js';
 import type { OpStackPolicyMode } from '../pipeline.js';
 import { loadBinInput, loadHexInput } from './inputAssets.js';
 import { createEaResolutionHelpers, type EaResolution } from './eaResolution.js';
+import { createEaMaterializationHelpers } from './eaMaterialization.js';
 import { createAddressingPipelineBuilders } from './addressingPipelines.js';
 import { createRuntimeImmediateHelpers } from './runtimeImmediates.js';
 import { createRuntimeAtomBudgetHelpers } from './runtimeAtomBudget.js';
@@ -2229,39 +2230,13 @@ export function emitProgram(
     return emitStepPipeline(templated, span) && pushZeroExtendedReg8('A', span);
   };
 
-  const materializeEaAddressToHL = (ea: EaExprNode, span: SourceSpan): boolean => {
-    const r = resolveEa(ea, span);
-    if (!r) {
-      if (!pushEaAddress(ea, span)) return false;
-      return emitInstr('pop', [{ kind: 'Reg', span, name: 'HL' }], span);
-    }
-    if (r.kind === 'abs') {
-      emitAbs16Fixup(0x21, r.baseLower, r.addend, span); // ld hl, nn
-      return true;
-    }
-    // Stack slot: use DE shuttle, avoid mutating IX or using HL address math.
-    const disp = r.ixDisp & 0xffff;
-    if (!emitInstr('push', [{ kind: 'Reg', span, name: 'DE' }], span)) return false; // save DE
-    if (!emitInstr('push', [{ kind: 'Reg', span, name: 'IX' }], span)) return false; // IX -> stack
-    if (!emitInstr('pop', [{ kind: 'Reg', span, name: 'HL' }], span)) return false; // HL = IX
-    if (disp !== 0) {
-      if (!loadImm16ToDE(disp, span)) return false;
-      if (
-        !emitInstr(
-          'add',
-          [
-            { kind: 'Reg', span, name: 'HL' },
-            { kind: 'Reg', span, name: 'DE' },
-          ],
-          span,
-        )
-      ) {
-        return false;
-      }
-    }
-    if (!emitInstr('push', [{ kind: 'Reg', span, name: 'HL' }], span)) return false; // address -> stack
-    return emitInstr('pop', [{ kind: 'Reg', span, name: 'DE' }], span); // restore DE
-  };
+  const { materializeEaAddressToHL } = createEaMaterializationHelpers({
+    resolveEa,
+    pushEaAddress,
+    emitInstr,
+    emitAbs16Fixup,
+    loadImm16ToDE,
+  });
 
   const lowerLdWithEa = (inst: AsmInstructionNode): boolean => {
     if (inst.head.toLowerCase() !== 'ld' || inst.operands.length !== 2) return false;

--- a/test/pr509_ea_materialization_helpers.test.ts
+++ b/test/pr509_ea_materialization_helpers.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AsmOperandNode, EaExprNode, SourceSpan } from '../src/frontend/ast.js';
+import { createEaMaterializationHelpers } from '../src/lowering/eaMaterialization.js';
+import type { EaResolution } from '../src/lowering/eaResolution.js';
+
+const span: SourceSpan = {
+  file: 'test.zax',
+  start: { offset: 0, line: 1, column: 1 },
+  end: { offset: 0, line: 1, column: 1 },
+};
+
+const eaName = (name: string): EaExprNode => ({ kind: 'EaName', span, name });
+
+describe('#509 ea materialization helpers', () => {
+  it('keeps absolute and frame-slot materialization shapes stable', () => {
+    const emitted: string[] = [];
+    const fixups: string[] = [];
+    const resolutions = new Map<string, EaResolution>([
+      ['globw', { kind: 'abs', baseLower: 'globw', addend: 2 }],
+      ['slotw', { kind: 'stack', ixDisp: -4 }],
+    ]);
+
+    const emitInstr = (head: string, operands: AsmOperandNode[]): boolean => {
+      const rendered = operands
+        .map((operand) => {
+          if (operand.kind !== 'Reg') return operand.kind;
+          return operand.name;
+        })
+        .join(', ');
+      emitted.push(rendered ? `${head} ${rendered}` : head);
+      return true;
+    };
+
+    const helpers = createEaMaterializationHelpers({
+      resolveEa: (ea) => (ea.kind === 'EaName' ? resolutions.get(ea.name.toLowerCase()) : undefined),
+      pushEaAddress: () => {
+        emitted.push('pushEaAddress');
+        return true;
+      },
+      emitInstr,
+      emitAbs16Fixup: (_opcode, target, addend) => {
+        fixups.push(`${target}+${addend}`);
+      },
+      loadImm16ToDE: (value) => {
+        emitted.push(`loadImm16ToDE ${value}`);
+        return true;
+      },
+    });
+
+    expect(helpers.materializeEaAddressToHL(eaName('globw'), span)).toBe(true);
+    expect(helpers.materializeEaAddressToHL(eaName('slotw'), span)).toBe(true);
+
+    expect(fixups).toEqual(['globw+2']);
+    expect(emitted).toEqual([
+      'push DE',
+      'push IX',
+      'pop HL',
+      'loadImm16ToDE 65532',
+      'add HL, DE',
+      'push HL',
+      'pop DE',
+    ]);
+  });
+});


### PR DESCRIPTION
Issue: #509

Second narrow slice only.

This extracts materializeEaAddressToHL(...) from src/lowering/emit.ts into src/lowering/eaMaterialization.ts.

Moved in this slice:
- materializeEaAddressToHL(...)

Not moved in this slice:
- lowerLdWithEa(...)
- scalar word accessor emission helpers
- direct emission routines tied to emitInstr(...) beyond this helper boundary

Verification:
- npm run typecheck
- npm test -- --run test/pr509_ea_materialization_helpers.test.ts test/pr509_addressing_pipeline_builders.test.ts test/pr405_byte_scalar_fast_paths.test.ts test/pr406_word_scalar_accessors.test.ts test/pr407_step_matrix.test.ts test/pr468_typed_step_integration.test.ts test/smoke_language_tour_compile.test.ts