### PR TITLE
Extract scalar word accessor routing

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -88,6 +88,7 @@ import { createEaMaterializationHelpers } from './eaMaterialization.js';
 import { createAddressingPipelineBuilders } from './addressingPipelines.js';
 import { createRuntimeImmediateHelpers } from './runtimeImmediates.js';
 import { createRuntimeAtomBudgetHelpers } from './runtimeAtomBudget.js';
+import { createScalarWordAccessorHelpers } from './scalarWordAccessors.js';
 import {
   alignTo,
   computeWrittenRange,
@@ -2112,49 +2113,16 @@ export function emitProgram(
     evalImmExpr: (expr) => evalImmExpr(expr, env, diagnostics),
   });
 
-  const emitScalarWordLoad = (
-    target: 'HL' | 'DE' | 'BC',
-    resolved: ReturnType<typeof resolveEa>,
-    span: SourceSpan,
-  ): boolean => {
-    if (!resolved) return false;
-    if (resolved.kind === 'abs' && resolved.addend === 0) {
-      return emitStepPipeline(LOAD_RP_GLOB(target, resolved.baseLower), span);
-    }
-    if (resolved.kind === 'stack') {
-      return emitStepPipeline(LOAD_RP_FVAR(target, resolved.ixDisp), span);
-    }
-    return false;
-  };
-
-  const resolvedScalarKind = (
-    resolved: ReturnType<typeof resolveEa>,
-  ): 'byte' | 'word' | 'addr' | undefined =>
-    resolved?.typeExpr ? resolveScalarKind(resolved.typeExpr) : undefined;
-
-  const isWordCompatibleScalarKind = (
-    scalar: 'byte' | 'word' | 'addr' | undefined,
-  ): scalar is 'word' | 'addr' => scalar === 'word' || scalar === 'addr';
-
-  const canUseScalarWordAccessor = (resolved: ReturnType<typeof resolveEa>): boolean =>
-    !!resolved &&
-    isWordCompatibleScalarKind(resolvedScalarKind(resolved)) &&
-    ((resolved.kind === 'abs' && resolved.addend === 0) || resolved.kind === 'stack');
-
-  const emitScalarWordStore = (
-    source: 'HL' | 'DE' | 'BC',
-    resolved: ReturnType<typeof resolveEa>,
-    span: SourceSpan,
-  ): boolean => {
-    if (!resolved) return false;
-    if (resolved.kind === 'abs' && resolved.addend === 0) {
-      return emitStepPipeline(STORE_RP_GLOB(source, resolved.baseLower), span);
-    }
-    if (resolved.kind === 'stack') {
-      return emitStepPipeline(STORE_RP_FVAR(source, resolved.ixDisp), span);
-    }
-    return false;
-  };
+  const {
+    emitScalarWordLoad,
+    emitScalarWordStore,
+    resolvedScalarKind,
+    isWordCompatibleScalarKind,
+    canUseScalarWordAccessor,
+  } = createScalarWordAccessorHelpers({
+    emitStepPipeline,
+    resolveScalarKind,
+  });
 
   const emitLoadWordFromHlAddress = (target: 'HL' | 'DE' | 'BC', span: SourceSpan): boolean => {
     if (target === 'DE') {

--- a/src/lowering/scalarWordAccessors.ts
+++ b/src/lowering/scalarWordAccessors.ts
@@ -1,0 +1,67 @@
+import {
+  LOAD_RP_FVAR,
+  LOAD_RP_GLOB,
+  STORE_RP_FVAR,
+  STORE_RP_GLOB,
+  type StepPipeline,
+} from '../addressing/steps.js';
+import type { SourceSpan, TypeExprNode } from '../frontend/ast.js';
+import type { EaResolution } from './eaResolution.js';
+import type { ScalarKind } from './typeResolution.js';
+
+type ScalarWordAccessorContext = {
+  emitStepPipeline: (pipeline: StepPipeline, span: SourceSpan) => boolean;
+  resolveScalarKind: (typeExpr: TypeExprNode) => ScalarKind | undefined;
+};
+
+export function createScalarWordAccessorHelpers(ctx: ScalarWordAccessorContext) {
+  const resolvedScalarKind = (resolved: EaResolution | undefined): ScalarKind | undefined =>
+    resolved?.typeExpr ? ctx.resolveScalarKind(resolved.typeExpr) : undefined;
+
+  const isWordCompatibleScalarKind = (
+    scalar: ScalarKind | undefined,
+  ): scalar is 'word' | 'addr' => scalar === 'word' || scalar === 'addr';
+
+  const canUseScalarWordAccessor = (resolved: EaResolution | undefined): boolean =>
+    !!resolved &&
+    isWordCompatibleScalarKind(resolvedScalarKind(resolved)) &&
+    ((resolved.kind === 'abs' && resolved.addend === 0) || resolved.kind === 'stack');
+
+  const emitScalarWordLoad = (
+    target: 'HL' | 'DE' | 'BC',
+    resolved: EaResolution | undefined,
+    span: SourceSpan,
+  ): boolean => {
+    if (!resolved) return false;
+    if (resolved.kind === 'abs' && resolved.addend === 0) {
+      return ctx.emitStepPipeline(LOAD_RP_GLOB(target, resolved.baseLower), span);
+    }
+    if (resolved.kind === 'stack') {
+      return ctx.emitStepPipeline(LOAD_RP_FVAR(target, resolved.ixDisp), span);
+    }
+    return false;
+  };
+
+  const emitScalarWordStore = (
+    source: 'HL' | 'DE' | 'BC',
+    resolved: EaResolution | undefined,
+    span: SourceSpan,
+  ): boolean => {
+    if (!resolved) return false;
+    if (resolved.kind === 'abs' && resolved.addend === 0) {
+      return ctx.emitStepPipeline(STORE_RP_GLOB(source, resolved.baseLower), span);
+    }
+    if (resolved.kind === 'stack') {
+      return ctx.emitStepPipeline(STORE_RP_FVAR(source, resolved.ixDisp), span);
+    }
+    return false;
+  };
+
+  return {
+    resolvedScalarKind,
+    isWordCompatibleScalarKind,
+    canUseScalarWordAccessor,
+    emitScalarWordLoad,
+    emitScalarWordStore,
+  };
+}

--- a/test/pr509_scalar_word_accessors.test.ts
+++ b/test/pr509_scalar_word_accessors.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderStepPipeline } from '../src/addressing/steps.js';
+import type { SourceSpan, TypeExprNode } from '../src/frontend/ast.js';
+import { createScalarWordAccessorHelpers } from '../src/lowering/scalarWordAccessors.js';
+import type { EaResolution } from '../src/lowering/eaResolution.js';
+
+const span: SourceSpan = {
+  file: 'test.zax',
+  start: { offset: 0, line: 1, column: 1 },
+  end: { offset: 0, line: 1, column: 1 },
+};
+
+const typeName = (name: string): TypeExprNode => ({ kind: 'TypeName', span, name });
+
+describe('#509 scalar word accessor routing', () => {
+  const emitted: string[][] = [];
+  const helpers = createScalarWordAccessorHelpers({
+    emitStepPipeline: (pipeline) => {
+      emitted.push(renderStepPipeline(pipeline));
+      return true;
+    },
+    resolveScalarKind: (typeExpr) =>
+      typeExpr.kind === 'TypeName' && (typeExpr.name === 'byte' || typeExpr.name === 'word' || typeExpr.name === 'addr')
+        ? typeExpr.name
+        : undefined,
+  });
+
+  const absWord = (): EaResolution => ({
+    kind: 'abs',
+    baseLower: 'globw',
+    addend: 0,
+    typeExpr: typeName('word'),
+  });
+  const stackWord = (): EaResolution => ({
+    kind: 'stack',
+    ixDisp: -4,
+    typeExpr: typeName('word'),
+  });
+  const absByte = (): EaResolution => ({
+    kind: 'abs',
+    baseLower: 'globb',
+    addend: 0,
+    typeExpr: typeName('byte'),
+  });
+  const stackByte = (): EaResolution => ({
+    kind: 'stack',
+    ixDisp: -2,
+    typeExpr: typeName('byte'),
+  });
+
+  it('keeps representative scalar word routing decisions stable', () => {
+    emitted.length = 0;
+
+    expect(helpers.canUseScalarWordAccessor(absWord())).toBe(true);
+    expect(helpers.canUseScalarWordAccessor(stackWord())).toBe(true);
+    expect(helpers.canUseScalarWordAccessor(absByte())).toBe(false);
+    expect(helpers.canUseScalarWordAccessor(stackByte())).toBe(false);
+
+    expect(helpers.emitScalarWordLoad('HL', absWord(), span)).toBe(true);
+    expect(helpers.emitScalarWordLoad('DE', stackWord(), span)).toBe(true);
+
+    expect(helpers.emitScalarWordStore('HL', absWord(), span)).toBe(true);
+    expect(helpers.emitScalarWordStore('DE', stackWord(), span)).toBe(true);
+
+    expect(emitted).toEqual([
+      ['ld hl, (globw)'],
+      ['ld lo(DE), (ix-$04)', 'ld hi(DE), (ix-$03)'],
+      ['ld (globw), HL'],
+      ['ld (ix-$04), lo(DE)', 'ld (ix-$03), hi(DE)'],
+    ]);
+  });
+
+  it('keeps exact scalar-kind gating stable', () => {
+    expect(helpers.resolvedScalarKind(absWord())).toBe('word');
+    expect(helpers.resolvedScalarKind(absByte())).toBe('byte');
+    expect(helpers.isWordCompatibleScalarKind('word')).toBe(true);
+    expect(helpers.isWordCompatibleScalarKind('addr')).toBe(true);
+    expect(helpers.isWordCompatibleScalarKind('byte')).toBe(false);
+    expect(helpers.isWordCompatibleScalarKind(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
Issue: #509

Third narrow slice only.

This extracts the scalar word accessor routing/gating helpers from src/lowering/emit.ts into src/lowering/scalarWordAccessors.ts.

Moved in this slice:
- scalar word accessor gating logic
- scalar word load fast-path routing helper
- scalar word store fast-path routing helper
- tiny scalar-kind helpers used only by that routing

Not moved in this slice:
- lowerLdWithEa(...)
- direct materialization fallback behavior
- emitLoadWordFromHlAddress(...)
- emitStoreWordToHlAddress(...)

Verification:
- npm run typecheck
- npm test -- --run test/pr509_scalar_word_accessors.test.ts test/pr509_ea_materialization_helpers.test.ts test/pr509_addressing_pipeline_builders.test.ts test/pr405_byte_scalar_fast_paths.test.ts test/pr406_word_scalar_accessors.test.ts test/pr407_step_matrix.test.ts test/pr468_typed_step_integration.test.ts test/smoke_language_tour_compile.test.ts