### PR TITLE
Extract op substitution helpers

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -90,6 +90,7 @@ import { createRuntimeImmediateHelpers } from './runtimeImmediates.js';
 import { createRuntimeAtomBudgetHelpers } from './runtimeAtomBudget.js';
 import { createScalarWordAccessorHelpers } from './scalarWordAccessors.js';
 import { createLdLoweringHelpers } from './ldLowering.js';
+import { createOpSubstitutionHelpers } from './opSubstitution.js';
 import {
   alignTo,
   computeWrittenRange,
@@ -3649,80 +3650,24 @@ export function emitProgram(
               for (let idx = 0; idx < opDecl.params.length; idx++) {
                 bindings.set(opDecl.params[idx]!.name.toLowerCase(), asmItem.operands[idx]!);
               }
-
-              const bindingAsImmExpr = (
-                bound: AsmOperandNode | undefined,
-                span: SourceSpan,
-              ): ImmExprNode | undefined => {
-                if (!bound) return undefined;
-                if (bound.kind === 'Imm') return cloneImmExpr(bound.expr);
-                if (bound.kind !== 'Ea') return undefined;
-                const name = flattenEaDottedName(bound.expr);
-                if (!name || !env.enums.has(name)) return undefined;
-                return { kind: 'ImmName', span, name };
-              };
-
-              const substituteImm = (expr: ImmExprNode): ImmExprNode => {
-                const substituteOffsetofPath = (path: any): any => ({
-                  ...path,
-                  steps: path.steps.map((step: any) =>
-                    step.kind === 'OffsetofIndex'
-                      ? { ...step, expr: substituteImm(step.expr) }
-                      : { ...step },
-                  ),
-                });
-                if (expr.kind === 'ImmName') {
-                  const bound = bindings.get(expr.name.toLowerCase());
-                  const immBound = bindingAsImmExpr(bound, expr.span);
-                  if (immBound) return immBound;
-                  return { ...expr };
-                }
-                if (expr.kind === 'ImmOffsetof') {
-                  return { ...expr, path: substituteOffsetofPath(expr.path) as typeof expr.path };
-                }
-                if (expr.kind === 'ImmUnary') return { ...expr, expr: substituteImm(expr.expr) };
-                if (expr.kind === 'ImmBinary') {
-                  return {
-                    ...expr,
-                    left: substituteImm(expr.left),
-                    right: substituteImm(expr.right),
-                  };
-                }
-                return { ...expr };
-              };
-
-              const substituteOperand = (operand: AsmOperandNode): AsmOperandNode => {
-                if (operand.kind === 'Imm' && operand.expr.kind === 'ImmName') {
-                  const bound = bindings.get(operand.expr.name.toLowerCase());
-                  const immBound = bindingAsImmExpr(bound, operand.span);
-                  if (immBound) return { kind: 'Imm', span: operand.span, expr: immBound };
-                  if (bound) return cloneOperand(bound);
-                  return { ...operand, expr: substituteImm(operand.expr) };
-                }
-                if (operand.kind === 'Imm')
-                  return { ...operand, expr: substituteImm(operand.expr) };
-                if (
-                  (operand.kind === 'Ea' || operand.kind === 'Mem') &&
-                  operand.expr.kind === 'EaName'
-                ) {
-                  const bound = bindings.get(operand.expr.name.toLowerCase());
-                  if (bound?.kind === 'Ea') return cloneOperand(bound);
-                  if (bound?.kind === 'Reg') {
-                    return {
-                      ...operand,
-                      expr: { kind: 'EaName', span: operand.expr.span, name: bound.name },
-                    };
-                  }
-                  if (bound?.kind === 'Imm' && bound.expr.kind === 'ImmName') {
-                    return {
-                      ...operand,
-                      expr: { kind: 'EaName', span: operand.expr.span, name: bound.expr.name },
-                    };
-                  }
-                  return cloneOperand(operand);
-                }
-                return cloneOperand(operand);
-              };
+              const {
+                substituteImm,
+                substituteOperand,
+                substituteImmWithOpLabels,
+                substituteOperandWithOpLabels,
+                substituteConditionWithOpLabels,
+              } = createOpSubstitutionHelpers({
+                bindings,
+                env,
+                diagnostics,
+                diagAt,
+                cloneImmExpr,
+                cloneEaExpr,
+                cloneOperand,
+                flattenEaDottedName,
+                normalizeFixedToken,
+                inverseConditionName,
+              });
 
               opExpansionStack.push({
                 key: opKey,
@@ -3743,121 +3688,15 @@ export function emitProgram(
                   }
                 }
 
-                const substituteImmWithOpLabels = (expr: ImmExprNode): ImmExprNode => {
-                  const substituteOffsetofPath = (path: any): any => ({
-                    ...path,
-                    steps: path.steps.map((step: any) =>
-                      step.kind === 'OffsetofIndex'
-                        ? { ...step, expr: substituteImmWithOpLabels(step.expr) }
-                        : { ...step },
-                    ),
-                  });
-                  if (expr.kind === 'ImmName') {
-                    const bound = bindings.get(expr.name.toLowerCase());
-                    const immBound = bindingAsImmExpr(bound, expr.span);
-                    if (immBound) return immBound;
-                    const mapped = localLabelMap.get(expr.name.toLowerCase());
-                    if (mapped) return { kind: 'ImmName', span: expr.span, name: mapped };
-                    return { ...expr };
-                  }
-                  if (expr.kind === 'ImmOffsetof') {
-                    return { ...expr, path: substituteOffsetofPath(expr.path) as typeof expr.path };
-                  }
-                  if (expr.kind === 'ImmUnary') {
-                    return { ...expr, expr: substituteImmWithOpLabels(expr.expr) };
-                  }
-                  if (expr.kind === 'ImmBinary') {
-                    return {
-                      ...expr,
-                      left: substituteImmWithOpLabels(expr.left),
-                      right: substituteImmWithOpLabels(expr.right),
-                    };
-                  }
-                  return { ...expr };
-                };
-
-                const substituteOperandWithOpLabels = (operand: AsmOperandNode): AsmOperandNode => {
-                  const substituteEaWithOpLabels = (ea: EaExprNode): EaExprNode => {
-                    if (ea.kind === 'EaName') {
-                      const bound = bindings.get(ea.name.toLowerCase());
-                      if (bound?.kind === 'Ea') return cloneEaExpr(bound.expr);
-                      if (bound?.kind === 'Reg') {
-                        return { kind: 'EaName', span: ea.span, name: bound.name };
-                      }
-                      if (bound?.kind === 'Imm' && bound.expr.kind === 'ImmName') {
-                        return { kind: 'EaName', span: ea.span, name: bound.expr.name };
-                      }
-                      const mapped = localLabelMap.get(ea.name.toLowerCase());
-                      if (mapped) return { kind: 'EaName', span: ea.span, name: mapped };
-                      return { ...ea };
-                    }
-                    if (ea.kind === 'EaField') {
-                      return { ...ea, base: substituteEaWithOpLabels(ea.base) };
-                    }
-                    if (ea.kind === 'EaIndex') {
-                      const index =
-                        ea.index.kind === 'IndexEa'
-                          ? { ...ea.index, expr: substituteEaWithOpLabels(ea.index.expr) }
-                          : ea.index.kind === 'IndexImm'
-                            ? { ...ea.index, value: substituteImmWithOpLabels(ea.index.value) }
-                            : ea.index.kind === 'IndexMemIxIy' && ea.index.disp
-                              ? { ...ea.index, disp: substituteImmWithOpLabels(ea.index.disp) }
-                              : { ...ea.index };
-                      return { ...ea, base: substituteEaWithOpLabels(ea.base), index };
-                    }
-                    if (ea.kind === 'EaAdd' || ea.kind === 'EaSub') {
-                      return {
-                        ...ea,
-                        base: substituteEaWithOpLabels(ea.base),
-                        offset: substituteImmWithOpLabels(ea.offset),
-                      };
-                    }
-                    return cloneEaExpr(ea);
-                  };
-
-                  if (operand.kind === 'Imm') {
-                    if (operand.expr.kind === 'ImmName') {
-                      const bound = bindings.get(operand.expr.name.toLowerCase());
-                      const immBound = bindingAsImmExpr(bound, operand.span);
-                      if (immBound) return { kind: 'Imm', span: operand.span, expr: immBound };
-                      if (bound) return cloneOperand(bound);
-                    }
-                    return { ...operand, expr: substituteImmWithOpLabels(operand.expr) };
-                  }
-                  if (operand.kind === 'Ea' || operand.kind === 'Mem') {
-                    return {
-                      ...operand,
-                      expr: substituteEaWithOpLabels(operand.expr),
-                    };
-                  }
-                  return substituteOperand(operand);
-                };
-
-                const substituteConditionWithOpLabels = (
-                  condition: string,
-                  span: SourceSpan,
-                ): string => {
-                  const bound = bindings.get(condition.toLowerCase());
-                  if (!bound) return condition;
-                  const token = normalizeFixedToken(bound);
-                  if (!token || inverseConditionName(token) === undefined) {
-                    diagAt(
-                      diagnostics,
-                      span,
-                      `op "${opDecl.name}" condition parameter "${condition}" must bind to a condition token (NZ/Z/NC/C/PO/PE/P/M).`,
-                    );
-                    return condition;
-                  }
-                  return token;
-                };
-
                 const expandedItems: AsmItemNode[] = opDecl.body.items.map((bodyItem) => {
                   if (bodyItem.kind === 'AsmInstruction') {
                     return {
                       kind: 'AsmInstruction',
                       span: bodyItem.span,
                       head: bodyItem.head,
-                      operands: bodyItem.operands.map((o) => substituteOperandWithOpLabels(o)),
+                      operands: bodyItem.operands.map((o) =>
+                        substituteOperandWithOpLabels(o, localLabelMap),
+                      ),
                     };
                   }
                   if (bodyItem.kind === 'AsmLabel') {
@@ -3871,14 +3710,14 @@ export function emitProgram(
                     return {
                       kind: 'Select',
                       span: bodyItem.span,
-                      selector: substituteOperandWithOpLabels(bodyItem.selector),
+                      selector: substituteOperandWithOpLabels(bodyItem.selector, localLabelMap),
                     };
                   }
                   if (bodyItem.kind === 'Case') {
                     return {
                       kind: 'Case',
                       span: bodyItem.span,
-                      value: substituteImmWithOpLabels(bodyItem.value),
+                      value: substituteImmWithOpLabels(bodyItem.value, localLabelMap),
                     };
                   }
                   if (
@@ -3888,7 +3727,7 @@ export function emitProgram(
                   ) {
                     return {
                       ...bodyItem,
-                      cc: substituteConditionWithOpLabels(bodyItem.cc, bodyItem.span),
+                      cc: substituteConditionWithOpLabels(bodyItem.cc, bodyItem.span, opDecl.name),
                     };
                   }
                   return { ...bodyItem };

--- a/src/lowering/opSubstitution.ts
+++ b/src/lowering/opSubstitution.ts
@@ -1,0 +1,212 @@
+import type { Diagnostic } from '../diagnostics/types.js';
+import type { AsmOperandNode, EaExprNode, ImmExprNode, SourceSpan } from '../frontend/ast.js';
+import type { CompileEnv } from '../semantics/env.js';
+
+type OpSubstitutionContext = {
+  bindings: Map<string, AsmOperandNode>;
+  env: CompileEnv;
+  diagnostics: Diagnostic[];
+  diagAt: (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
+  cloneImmExpr: (expr: ImmExprNode) => ImmExprNode;
+  cloneEaExpr: (ea: EaExprNode) => EaExprNode;
+  cloneOperand: (operand: AsmOperandNode) => AsmOperandNode;
+  flattenEaDottedName: (ea: EaExprNode) => string | undefined;
+  normalizeFixedToken: (operand: AsmOperandNode) => string | undefined;
+  inverseConditionName: (name: string) => string | undefined;
+};
+
+export function createOpSubstitutionHelpers(ctx: OpSubstitutionContext) {
+  const bindingAsImmExpr = (
+    bound: AsmOperandNode | undefined,
+    span: SourceSpan,
+  ): ImmExprNode | undefined => {
+    if (!bound) return undefined;
+    if (bound.kind === 'Imm') return ctx.cloneImmExpr(bound.expr);
+    if (bound.kind !== 'Ea') return undefined;
+    const name = ctx.flattenEaDottedName(bound.expr);
+    if (!name || !ctx.env.enums.has(name)) return undefined;
+    return { kind: 'ImmName', span, name };
+  };
+
+  const substituteImm = (expr: ImmExprNode): ImmExprNode => {
+    const substituteOffsetofPath = (path: any): any => ({
+      ...path,
+      steps: path.steps.map((step: any) =>
+        step.kind === 'OffsetofIndex'
+          ? { ...step, expr: substituteImm(step.expr) }
+          : { ...step },
+      ),
+    });
+    if (expr.kind === 'ImmName') {
+      const bound = ctx.bindings.get(expr.name.toLowerCase());
+      const immBound = bindingAsImmExpr(bound, expr.span);
+      if (immBound) return immBound;
+      return { ...expr };
+    }
+    if (expr.kind === 'ImmOffsetof') {
+      return { ...expr, path: substituteOffsetofPath(expr.path) as typeof expr.path };
+    }
+    if (expr.kind === 'ImmUnary') return { ...expr, expr: substituteImm(expr.expr) };
+    if (expr.kind === 'ImmBinary') {
+      return {
+        ...expr,
+        left: substituteImm(expr.left),
+        right: substituteImm(expr.right),
+      };
+    }
+    return { ...expr };
+  };
+
+  const substituteOperand = (operand: AsmOperandNode): AsmOperandNode => {
+    if (operand.kind === 'Imm' && operand.expr.kind === 'ImmName') {
+      const bound = ctx.bindings.get(operand.expr.name.toLowerCase());
+      const immBound = bindingAsImmExpr(bound, operand.span);
+      if (immBound) return { kind: 'Imm', span: operand.span, expr: immBound };
+      if (bound) return ctx.cloneOperand(bound);
+      return { ...operand, expr: substituteImm(operand.expr) };
+    }
+    if (operand.kind === 'Imm') return { ...operand, expr: substituteImm(operand.expr) };
+    if ((operand.kind === 'Ea' || operand.kind === 'Mem') && operand.expr.kind === 'EaName') {
+      const bound = ctx.bindings.get(operand.expr.name.toLowerCase());
+      if (bound?.kind === 'Ea') return ctx.cloneOperand(bound);
+      if (bound?.kind === 'Reg') {
+        return {
+          ...operand,
+          expr: { kind: 'EaName', span: operand.expr.span, name: bound.name },
+        };
+      }
+      if (bound?.kind === 'Imm' && bound.expr.kind === 'ImmName') {
+        return {
+          ...operand,
+          expr: { kind: 'EaName', span: operand.expr.span, name: bound.expr.name },
+        };
+      }
+      return ctx.cloneOperand(operand);
+    }
+    return ctx.cloneOperand(operand);
+  };
+
+  const substituteImmWithOpLabels = (
+    expr: ImmExprNode,
+    localLabelMap: Map<string, string>,
+  ): ImmExprNode => {
+    const substituteOffsetofPath = (path: any): any => ({
+      ...path,
+      steps: path.steps.map((step: any) =>
+        step.kind === 'OffsetofIndex'
+          ? { ...step, expr: substituteImmWithOpLabels(step.expr, localLabelMap) }
+          : { ...step },
+      ),
+    });
+    if (expr.kind === 'ImmName') {
+      const bound = ctx.bindings.get(expr.name.toLowerCase());
+      const immBound = bindingAsImmExpr(bound, expr.span);
+      if (immBound) return immBound;
+      const mapped = localLabelMap.get(expr.name.toLowerCase());
+      if (mapped) return { kind: 'ImmName', span: expr.span, name: mapped };
+      return { ...expr };
+    }
+    if (expr.kind === 'ImmOffsetof') {
+      return { ...expr, path: substituteOffsetofPath(expr.path) as typeof expr.path };
+    }
+    if (expr.kind === 'ImmUnary') {
+      return { ...expr, expr: substituteImmWithOpLabels(expr.expr, localLabelMap) };
+    }
+    if (expr.kind === 'ImmBinary') {
+      return {
+        ...expr,
+        left: substituteImmWithOpLabels(expr.left, localLabelMap),
+        right: substituteImmWithOpLabels(expr.right, localLabelMap),
+      };
+    }
+    return { ...expr };
+  };
+
+  const substituteOperandWithOpLabels = (
+    operand: AsmOperandNode,
+    localLabelMap: Map<string, string>,
+  ): AsmOperandNode => {
+    const substituteEaWithOpLabels = (ea: EaExprNode): EaExprNode => {
+      if (ea.kind === 'EaName') {
+        const bound = ctx.bindings.get(ea.name.toLowerCase());
+        if (bound?.kind === 'Ea') return ctx.cloneEaExpr(bound.expr);
+        if (bound?.kind === 'Reg') {
+          return { kind: 'EaName', span: ea.span, name: bound.name };
+        }
+        if (bound?.kind === 'Imm' && bound.expr.kind === 'ImmName') {
+          return { kind: 'EaName', span: ea.span, name: bound.expr.name };
+        }
+        const mapped = localLabelMap.get(ea.name.toLowerCase());
+        if (mapped) return { kind: 'EaName', span: ea.span, name: mapped };
+        return { ...ea };
+      }
+      if (ea.kind === 'EaField') {
+        return { ...ea, base: substituteEaWithOpLabels(ea.base) };
+      }
+      if (ea.kind === 'EaIndex') {
+        const index =
+          ea.index.kind === 'IndexEa'
+            ? { ...ea.index, expr: substituteEaWithOpLabels(ea.index.expr) }
+            : ea.index.kind === 'IndexImm'
+              ? { ...ea.index, value: substituteImmWithOpLabels(ea.index.value, localLabelMap) }
+              : ea.index.kind === 'IndexMemIxIy' && ea.index.disp
+                ? { ...ea.index, disp: substituteImmWithOpLabels(ea.index.disp, localLabelMap) }
+                : { ...ea.index };
+        return { ...ea, base: substituteEaWithOpLabels(ea.base), index };
+      }
+      if (ea.kind === 'EaAdd' || ea.kind === 'EaSub') {
+        return {
+          ...ea,
+          base: substituteEaWithOpLabels(ea.base),
+          offset: substituteImmWithOpLabels(ea.offset, localLabelMap),
+        };
+      }
+      return ctx.cloneEaExpr(ea);
+    };
+
+    if (operand.kind === 'Imm') {
+      if (operand.expr.kind === 'ImmName') {
+        const bound = ctx.bindings.get(operand.expr.name.toLowerCase());
+        const immBound = bindingAsImmExpr(bound, operand.span);
+        if (immBound) return { kind: 'Imm', span: operand.span, expr: immBound };
+        if (bound) return ctx.cloneOperand(bound);
+      }
+      return { ...operand, expr: substituteImmWithOpLabels(operand.expr, localLabelMap) };
+    }
+    if (operand.kind === 'Ea' || operand.kind === 'Mem') {
+      return {
+        ...operand,
+        expr: substituteEaWithOpLabels(operand.expr),
+      };
+    }
+    return substituteOperand(operand);
+  };
+
+  const substituteConditionWithOpLabels = (
+    condition: string,
+    span: SourceSpan,
+    opName: string,
+  ): string => {
+    const bound = ctx.bindings.get(condition.toLowerCase());
+    if (!bound) return condition;
+    const token = ctx.normalizeFixedToken(bound);
+    if (!token || ctx.inverseConditionName(token) === undefined) {
+      ctx.diagAt(
+        ctx.diagnostics,
+        span,
+        `op "${opName}" condition parameter "${condition}" must bind to a condition token (NZ/Z/NC/C/PO/PE/P/M).`,
+      );
+      return condition;
+    }
+    return token;
+  };
+
+  return {
+    bindingAsImmExpr,
+    substituteImm,
+    substituteOperand,
+    substituteImmWithOpLabels,
+    substituteOperandWithOpLabels,
+    substituteConditionWithOpLabels,
+  };
+}

--- a/test/pr510_op_substitution_helpers.test.ts
+++ b/test/pr510_op_substitution_helpers.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { DiagnosticIds, type Diagnostic } from '../src/diagnostics/types.js';
+import type { AsmOperandNode, EaExprNode, ImmExprNode, SourceSpan } from '../src/frontend/ast.js';
+import { createOpSubstitutionHelpers } from '../src/lowering/opSubstitution.js';
+
+const span: SourceSpan = {
+  file: 'test.zax',
+  start: { offset: 0, line: 1, column: 1 },
+  end: { offset: 0, line: 1, column: 1 },
+};
+
+const cloneImmExpr = (expr: ImmExprNode): ImmExprNode => JSON.parse(JSON.stringify(expr));
+const cloneEaExpr = (ea: EaExprNode): EaExprNode => JSON.parse(JSON.stringify(ea));
+const cloneOperand = (operand: AsmOperandNode): AsmOperandNode => JSON.parse(JSON.stringify(operand));
+const immName = (name: string): ImmExprNode => ({ kind: 'ImmName', span, name });
+const immOperand = (name: string): AsmOperandNode => ({ kind: 'Imm', span, expr: immName(name) });
+const regOperand = (name: string): AsmOperandNode => ({ kind: 'Reg', span, name });
+const memOperand = (name: string): AsmOperandNode => ({
+  kind: 'Mem',
+  span,
+  expr: { kind: 'EaName', span, name },
+});
+
+describe('#510 op substitution helpers', () => {
+  it('keeps substitution behavior stable for bindings and local labels', () => {
+    const diagnostics: Diagnostic[] = [];
+    const bindings = new Map<string, AsmOperandNode>([
+      ['arg', regOperand('B')],
+      ['immarg', immOperand('ENUM_ONE')],
+      ['cond', immOperand('NZ')],
+    ]);
+    const localLabelMap = new Map<string, string>([['loop', '__hidden_loop_0']]);
+
+    const helpers = createOpSubstitutionHelpers({
+      bindings,
+      env: { enums: new Map([['ENUM_ONE', {} as never]]) } as never,
+      diagnostics,
+      diagAt: (list, sourceSpan, message) => {
+        list.push({
+          id: DiagnosticIds.EmitError,
+          severity: 'error',
+          file: sourceSpan.file,
+          message,
+        });
+      },
+      cloneImmExpr,
+      cloneEaExpr,
+      cloneOperand,
+      flattenEaDottedName: (ea) => (ea.kind === 'EaName' ? ea.name : undefined),
+      normalizeFixedToken: (operand) =>
+        operand.kind === 'Imm' && operand.expr.kind === 'ImmName' ? operand.expr.name.toUpperCase() : undefined,
+      inverseConditionName: (name) =>
+        ['NZ', 'Z', 'NC', 'C', 'PO', 'PE', 'P', 'M'].includes(name) ? name : undefined,
+    });
+
+    expect(helpers.substituteOperand(immOperand('arg'))).toEqual(regOperand('B'));
+    expect(helpers.substituteOperand(memOperand('arg'))).toEqual({
+      kind: 'Mem',
+      span,
+      expr: { kind: 'EaName', span, name: 'B' },
+    });
+    expect(helpers.substituteImmWithOpLabels(immName('loop'), localLabelMap)).toEqual({
+      kind: 'ImmName',
+      span,
+      name: '__hidden_loop_0',
+    });
+    expect(helpers.substituteConditionWithOpLabels('cond', span, 'my_op')).toBe('NZ');
+    expect(diagnostics).toEqual([]);
+  });
+});


### PR DESCRIPTION
Issue: #510

First narrow #510 slice only.

This extracts the op-substitution / operand-rewrite helper cluster from src/lowering/emit.ts into src/lowering/opSubstitution.ts.

Moved in this slice:
- bindingAsImmExpr(...)
- substituteImm(...)
- substituteOperand(...)
- label-aware substitution helpers for imm/operand/condition

Not moved in this slice:
- the heavier op-expansion execution path
- lowerAsmRange(...) orchestration
- select/case execution logic

Verification:
- npm run typecheck
- npm test -- --run test/pr510_op_substitution_helpers.test.ts test/pr230_lowering_rst_call_boundary_matrix.test.ts test/pr468_typed_step_integration.test.ts test/smoke_language_tour_compile.test.ts