### PR TITLE
Extract op expansion execution helpers

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -91,6 +91,7 @@ import { createRuntimeAtomBudgetHelpers } from './runtimeAtomBudget.js';
 import { createScalarWordAccessorHelpers } from './scalarWordAccessors.js';
 import { createLdLoweringHelpers } from './ldLowering.js';
 import { createOpSubstitutionHelpers } from './opSubstitution.js';
+import { createOpExpansionExecutionHelpers } from './opExpansionExecution.js';
 import {
   alignTo,
   computeWrittenRange,
@@ -3676,71 +3677,18 @@ export function emitProgram(
                 callSiteSpan: asmItem.span,
               });
               try {
-                const localLabelMap = new Map<string, string>();
-                for (const bodyItem of opDecl.body.items) {
-                  if (bodyItem.kind !== 'AsmLabel') continue;
-                  const key = bodyItem.name.toLowerCase();
-                  if (!localLabelMap.has(key)) {
-                    localLabelMap.set(
-                      key,
-                      newHiddenLabel(`__zax_op_${opDecl.name.toLowerCase()}_lbl`),
-                    );
-                  }
-                }
-
-                const expandedItems: AsmItemNode[] = opDecl.body.items.map((bodyItem) => {
-                  if (bodyItem.kind === 'AsmInstruction') {
-                    return {
-                      kind: 'AsmInstruction',
-                      span: bodyItem.span,
-                      head: bodyItem.head,
-                      operands: bodyItem.operands.map((o) =>
-                        substituteOperandWithOpLabels(o, localLabelMap),
-                      ),
-                    };
-                  }
-                  if (bodyItem.kind === 'AsmLabel') {
-                    return {
-                      kind: 'AsmLabel',
-                      span: bodyItem.span,
-                      name: localLabelMap.get(bodyItem.name.toLowerCase()) ?? bodyItem.name,
-                    };
-                  }
-                  if (bodyItem.kind === 'Select') {
-                    return {
-                      kind: 'Select',
-                      span: bodyItem.span,
-                      selector: substituteOperandWithOpLabels(bodyItem.selector, localLabelMap),
-                    };
-                  }
-                  if (bodyItem.kind === 'Case') {
-                    return {
-                      kind: 'Case',
-                      span: bodyItem.span,
-                      value: substituteImmWithOpLabels(bodyItem.value, localLabelMap),
-                    };
-                  }
-                  if (
-                    bodyItem.kind === 'If' ||
-                    bodyItem.kind === 'While' ||
-                    bodyItem.kind === 'Until'
-                  ) {
-                    return {
-                      ...bodyItem,
-                      cc: substituteConditionWithOpLabels(bodyItem.cc, bodyItem.span, opDecl.name),
-                    };
-                  }
-                  return { ...bodyItem };
+                const { expandAndLowerOpBody } = createOpExpansionExecutionHelpers({
+                  diagnostics,
+                  diagAt,
+                  newHiddenLabel,
+                  lowerAsmRange,
                 });
-
-                const consumed = lowerAsmRange(expandedItems, 0, new Set());
-                if (consumed < expandedItems.length) {
-                  diagAt(
-                    diagnostics,
-                    expandedItems[consumed]!.span,
-                    `Internal control-flow lowering error.`,
-                  );
-                }
+                expandAndLowerOpBody({
+                  opDecl,
+                  substituteOperandWithOpLabels,
+                  substituteImmWithOpLabels,
+                  substituteConditionWithOpLabels,
+                });
               } finally {
                 opExpansionStack.pop();
               }

--- a/src/lowering/opExpansionExecution.ts
+++ b/src/lowering/opExpansionExecution.ts
@@ -1,0 +1,98 @@
+import type {
+  AsmItemNode,
+  AsmInstructionNode,
+  OpDeclNode,
+} from '../frontend/ast.js';
+import type { Diagnostic } from '../diagnostics/types.js';
+
+type OpExpansionExecutionContext = {
+  diagnostics: Diagnostic[];
+  diagAt: (diagnostics: Diagnostic[], span: AsmInstructionNode['span'], message: string) => void;
+  newHiddenLabel: (prefix: string) => string;
+  lowerAsmRange: (items: AsmItemNode[], startIndex: number, stopKinds: Set<AsmItemNode['kind']>) => number;
+};
+
+type ExpandAndLowerArgs = {
+  opDecl: OpDeclNode;
+  substituteOperandWithOpLabels: (
+    operand: AsmInstructionNode['operands'][number],
+    localLabelMap: Map<string, string>,
+  ) => AsmInstructionNode['operands'][number];
+  substituteImmWithOpLabels: (
+    expr: Extract<Extract<AsmItemNode, { kind: 'Case' }>['value'], object>,
+    localLabelMap: Map<string, string>,
+  ) => Extract<Extract<AsmItemNode, { kind: 'Case' }>['value'], object>;
+  substituteConditionWithOpLabels: (condition: string, span: AsmInstructionNode['span'], opName: string) => string;
+};
+
+export function createOpExpansionExecutionHelpers(ctx: OpExpansionExecutionContext) {
+  const expandAndLowerOpBody = ({
+    opDecl,
+    substituteOperandWithOpLabels,
+    substituteImmWithOpLabels,
+    substituteConditionWithOpLabels,
+  }: ExpandAndLowerArgs): void => {
+    const localLabelMap = new Map<string, string>();
+    for (const bodyItem of opDecl.body.items) {
+      if (bodyItem.kind !== 'AsmLabel') continue;
+      const key = bodyItem.name.toLowerCase();
+      if (!localLabelMap.has(key)) {
+        localLabelMap.set(key, ctx.newHiddenLabel(`__zax_op_${opDecl.name.toLowerCase()}_lbl`));
+      }
+    }
+
+    const expandedItems: AsmItemNode[] = opDecl.body.items.map((bodyItem) => {
+      if (bodyItem.kind === 'AsmInstruction') {
+        return {
+          kind: 'AsmInstruction',
+          span: bodyItem.span,
+          head: bodyItem.head,
+          operands: bodyItem.operands.map((operand) =>
+            substituteOperandWithOpLabels(operand, localLabelMap),
+          ),
+        };
+      }
+      if (bodyItem.kind === 'AsmLabel') {
+        return {
+          kind: 'AsmLabel',
+          span: bodyItem.span,
+          name: localLabelMap.get(bodyItem.name.toLowerCase()) ?? bodyItem.name,
+        };
+      }
+      if (bodyItem.kind === 'Select') {
+        return {
+          kind: 'Select',
+          span: bodyItem.span,
+          selector: substituteOperandWithOpLabels(bodyItem.selector, localLabelMap),
+        };
+      }
+      if (bodyItem.kind === 'Case') {
+        return {
+          kind: 'Case',
+          span: bodyItem.span,
+          value: substituteImmWithOpLabels(bodyItem.value, localLabelMap),
+        };
+      }
+      if (bodyItem.kind === 'If' || bodyItem.kind === 'While' || bodyItem.kind === 'Until') {
+        return {
+          ...bodyItem,
+          cc: substituteConditionWithOpLabels(bodyItem.cc, bodyItem.span, opDecl.name),
+        };
+      }
+      return { ...bodyItem };
+    });
+
+    const consumed = ctx.lowerAsmRange(expandedItems, 0, new Set());
+    if (consumed < expandedItems.length) {
+      ctx.diagAt(
+        ctx.diagnostics,
+        expandedItems[consumed]!.span,
+        'Internal control-flow lowering error.',
+      );
+    }
+  };
+
+  return {
+    expandAndLowerOpBody,
+  };
+}

--- a/test/pr510_op_expansion_execution_helpers.test.ts
+++ b/test/pr510_op_expansion_execution_helpers.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import { DiagnosticIds, type Diagnostic } from '../src/diagnostics/types.js';
+import type { AsmItemNode, OpDeclNode, SourceSpan } from '../src/frontend/ast.js';
+import { createOpExpansionExecutionHelpers } from '../src/lowering/opExpansionExecution.js';
+
+const span: SourceSpan = {
+  file: 'test.zax',
+  start: { offset: 0, line: 1, column: 1 },
+  end: { offset: 0, line: 1, column: 1 },
+};
+
+describe('#510 op expansion execution helpers', () => {
+  it('keeps label mapping and lowering handoff stable', () => {
+    const diagnostics: Diagnostic[] = [];
+    let hiddenCounter = 0;
+    let loweredItems: AsmItemNode[] = [];
+
+    const opDecl: OpDeclNode = {
+      kind: 'OpDecl',
+      span,
+      name: 'my_op',
+      params: [],
+      stackPolicy: 'default',
+      body: {
+        kind: 'AsmBlock',
+        span,
+        items: [
+          { kind: 'AsmLabel', span, name: 'loop' },
+          {
+            kind: 'AsmInstruction',
+            span,
+            head: 'jp',
+            operands: [{ kind: 'Imm', span, expr: { kind: 'ImmName', span, name: 'loop' } }],
+          },
+          { kind: 'Case', span, value: { kind: 'ImmName', span, name: 'loop' } },
+          { kind: 'If', span, cc: 'cond' },
+        ],
+      },
+    } as unknown as OpDeclNode;
+
+    const helpers = createOpExpansionExecutionHelpers({
+      diagnostics,
+      diagAt: (list, sourceSpan, message) => {
+        list.push({
+          id: DiagnosticIds.EmitError,
+          severity: 'error',
+          file: sourceSpan.file,
+          message,
+        });
+      },
+      newHiddenLabel: (prefix) => `${prefix}_${hiddenCounter++}`,
+      lowerAsmRange: (items) => {
+        loweredItems = items;
+        return items.length;
+      },
+    });
+
+    helpers.expandAndLowerOpBody({
+      opDecl,
+      substituteOperandWithOpLabels: (operand, localLabelMap) =>
+        operand.kind === 'Imm' && operand.expr.kind === 'ImmName'
+          ? {
+              ...operand,
+              expr: {
+                ...operand.expr,
+                name: localLabelMap.get(operand.expr.name.toLowerCase()) ?? operand.expr.name,
+              },
+            }
+          : operand,
+      substituteImmWithOpLabels: (expr, localLabelMap) =>
+        expr.kind === 'ImmName'
+          ? { ...expr, name: localLabelMap.get(expr.name.toLowerCase()) ?? expr.name }
+          : expr,
+      substituteConditionWithOpLabels: (condition) => (condition === 'cond' ? 'NZ' : condition),
+    });
+
+    expect(diagnostics).toEqual([]);
+    expect(loweredItems).toHaveLength(4);
+    expect(loweredItems[0]).toMatchObject({ kind: 'AsmLabel', name: '__zax_op_my_op_lbl_0' });
+    expect(loweredItems[1]).toMatchObject({
+      kind: 'AsmInstruction',
+      operands: [{ kind: 'Imm', expr: { kind: 'ImmName', name: '__zax_op_my_op_lbl_0' } }],
+    });
+    expect(loweredItems[2]).toMatchObject({
+      kind: 'Case',
+      value: { kind: 'ImmName', name: '__zax_op_my_op_lbl_0' },
+    });
+    expect(loweredItems[3]).toMatchObject({ kind: 'If', cc: 'NZ' });
+  });
+});


### PR DESCRIPTION
Issue: #510

Second narrow #510 slice only.

This extracts the op-expansion execution helper cluster from src/lowering/emit.ts into src/lowering/opExpansionExecution.ts.

Moved in this slice:
- local label map construction for expanded ops
- expanded item rewriting handoff
- lowerAsmRange(...) invocation for expanded op bodies
- internal consumed-count diagnostic for expanded bodies

Not moved in this slice:
- overload selection
- cycle detection
- select/case orchestration outside the op-expansion body path
- lowerAsmRange(...) itself

Verification:
- npm run typecheck
- npm test -- --run test/pr510_op_expansion_execution_helpers.test.ts test/pr510_op_substitution_helpers.test.ts test/pr230_lowering_rst_call_boundary_matrix.test.ts test/pr468_typed_step_integration.test.ts test/smoke_language_tour_compile.test.ts