### PR TITLE
Extract asm range lowering helper

### DIFF
--- a/src/lowering/asmRangeLowering.ts
+++ b/src/lowering/asmRangeLowering.ts
@@ -1,0 +1,396 @@
+import type { AsmInstructionNode, AsmItemNode, AsmOperandNode, ImmExprNode, SourceSpan } from '../frontend/ast.js';
+
+type FlowState = {
+  reachable: boolean;
+  spDelta: number;
+  spValid: boolean;
+  spInvalidDueToMutation: boolean;
+};
+
+type Context<TCodeSegmentTag> = {
+  sourceTagForSpan: (span: SourceSpan) => TCodeSegmentTag;
+  getCurrentCodeSegmentTag: () => TCodeSegmentTag | undefined;
+  setCurrentCodeSegmentTag: (tag: TCodeSegmentTag | undefined) => void;
+  defineCodeLabel: (name: string, span: SourceSpan, scope: 'global' | 'local') => void;
+  emitAsmInstruction: (item: AsmInstructionNode) => void;
+  flowRef: { readonly current: FlowState };
+  syncFromFlow: () => void;
+  snapshotFlow: () => FlowState;
+  restoreFlow: (state: FlowState) => void;
+  newHiddenLabel: (prefix: string) => string;
+  emitJumpIfFalse: (cc: string, label: string, span: SourceSpan) => boolean;
+  emitJumpTo: (label: string, span: SourceSpan) => void;
+  diagAt: (span: SourceSpan, message: string) => void;
+  warnAt: (span: SourceSpan, message: string) => void;
+  joinFlows: (left: FlowState, right: FlowState, span: SourceSpan, contextName: string) => FlowState;
+  hasStackSlots: boolean;
+  reg8: Set<string>;
+  evalImmExpr: (expr: ImmExprNode) => number | undefined;
+  loadSelectorIntoHL: (selector: AsmOperandNode, span: SourceSpan) => boolean;
+  emitRawCodeBytes: (bytes: Uint8Array, file: string, trace: string) => void;
+  emitSelectCompareReg8ToImm8: (value: number, missLabel: string, span: SourceSpan) => void;
+  emitSelectCompareToImm16: (value: number, missLabel: string, span: SourceSpan) => void;
+  emitInstr: (name: string, operands: AsmOperandNode[], span: SourceSpan) => boolean;
+};
+
+export function createAsmRangeLoweringHelpers<TCodeSegmentTag>(ctx: Context<TCodeSegmentTag>) {
+  const lowerAsmRange = (
+    asmItems: readonly AsmItemNode[],
+    startIndex: number,
+    stopKinds: Set<string>,
+  ): number => {
+    let i = startIndex;
+    while (i < asmItems.length) {
+      const it = asmItems[i]!;
+      if (stopKinds.has(it.kind)) return i;
+      const prevTag = ctx.getCurrentCodeSegmentTag();
+      ctx.setCurrentCodeSegmentTag(ctx.sourceTagForSpan(it.span));
+      try {
+        if (it.kind === 'AsmLabel') {
+          ctx.defineCodeLabel(it.name, it.span, 'global');
+          if (!ctx.flowRef.current.reachable) {
+            ctx.flowRef.current.reachable = true;
+            ctx.flowRef.current.spValid = false;
+            ctx.flowRef.current.spDelta = 0;
+            ctx.flowRef.current.spInvalidDueToMutation = false;
+            ctx.syncFromFlow();
+          }
+          i++;
+          continue;
+        }
+        if (it.kind === 'AsmInstruction') {
+          ctx.emitAsmInstruction(it);
+          i++;
+          continue;
+        }
+        if (it.kind === 'If') {
+          const entry = ctx.snapshotFlow();
+          const elseLabel = ctx.newHiddenLabel('__zax_if_else');
+          const endLabel = ctx.newHiddenLabel('__zax_if_end');
+          ctx.emitJumpIfFalse(it.cc, elseLabel, it.span);
+
+          let j = lowerAsmRange(asmItems, i + 1, new Set(['Else', 'End']));
+          const thenExit = ctx.snapshotFlow();
+          if (j >= asmItems.length) {
+            ctx.diagAt(it.span, 'if without matching end.');
+            return asmItems.length;
+          }
+          const term = asmItems[j]!;
+          if (term.kind === 'Else') {
+            if (thenExit.reachable) ctx.emitJumpTo(endLabel, term.span);
+            ctx.defineCodeLabel(elseLabel, term.span, 'local');
+            ctx.restoreFlow(entry);
+            j = lowerAsmRange(asmItems, j + 1, new Set(['End']));
+            const elseExit = ctx.snapshotFlow();
+            if (j >= asmItems.length || asmItems[j]!.kind !== 'End') {
+              ctx.diagAt(it.span, 'if/else without matching end.');
+              return asmItems.length;
+            }
+            ctx.defineCodeLabel(endLabel, asmItems[j]!.span, 'local');
+            ctx.restoreFlow(ctx.joinFlows(thenExit, elseExit, asmItems[j]!.span, 'if/else'));
+            i = j + 1;
+            continue;
+          }
+          if (term.kind !== 'End') {
+            ctx.diagAt(it.span, 'if without matching end.');
+            return asmItems.length;
+          }
+          ctx.defineCodeLabel(elseLabel, term.span, 'local');
+          ctx.restoreFlow(ctx.joinFlows(thenExit, entry, term.span, 'if'));
+          i = j + 1;
+          continue;
+        }
+        if (it.kind === 'While') {
+          const entry = ctx.snapshotFlow();
+          const condLabel = ctx.newHiddenLabel('__zax_while_cond');
+          const endLabel = ctx.newHiddenLabel('__zax_while_end');
+          let backEdgeUnknown = false;
+          let backEdgeMutation = false;
+          ctx.defineCodeLabel(condLabel, it.span, 'local');
+          ctx.emitJumpIfFalse(it.cc, endLabel, it.span);
+
+          const j = lowerAsmRange(asmItems, i + 1, new Set(['End']));
+          const bodyExit = ctx.snapshotFlow();
+          if (j >= asmItems.length || asmItems[j]!.kind !== 'End') {
+            ctx.diagAt(it.span, 'while without matching end.');
+            return asmItems.length;
+          }
+          if (
+            bodyExit.reachable &&
+            bodyExit.spValid &&
+            entry.spValid &&
+            bodyExit.spDelta !== entry.spDelta
+          ) {
+            backEdgeUnknown = true;
+            ctx.diagAt(
+              asmItems[j]!.span,
+              `Stack depth mismatch at while back-edge (${bodyExit.spDelta} vs ${entry.spDelta}).`,
+            );
+          } else if (
+            bodyExit.reachable &&
+            (!bodyExit.spValid || !entry.spValid) &&
+            (bodyExit.spInvalidDueToMutation || entry.spInvalidDueToMutation)
+          ) {
+            backEdgeUnknown = true;
+            backEdgeMutation = true;
+            ctx.diagAt(
+              asmItems[j]!.span,
+              'Cannot verify stack depth at while back-edge due to untracked SP mutation.',
+            );
+          } else if (
+            bodyExit.reachable &&
+            (!bodyExit.spValid || !entry.spValid) &&
+            ctx.hasStackSlots
+          ) {
+            backEdgeUnknown = true;
+            ctx.diagAt(asmItems[j]!.span, 'Cannot verify stack depth at while back-edge due to unknown stack state.');
+          }
+          if (bodyExit.reachable) ctx.emitJumpTo(condLabel, asmItems[j]!.span);
+          ctx.defineCodeLabel(endLabel, asmItems[j]!.span, 'local');
+          if (backEdgeUnknown) {
+            ctx.restoreFlow({
+              reachable: entry.reachable,
+              spDelta: 0,
+              spValid: false,
+              spInvalidDueToMutation: backEdgeMutation,
+            });
+          } else {
+            ctx.restoreFlow(entry);
+          }
+          i = j + 1;
+          continue;
+        }
+        if (it.kind === 'Repeat') {
+          const entry = ctx.snapshotFlow();
+          const loopLabel = ctx.newHiddenLabel('__zax_repeat_body');
+          let backEdgeUnknown = false;
+          let backEdgeMutation = false;
+          ctx.defineCodeLabel(loopLabel, it.span, 'local');
+          const j = lowerAsmRange(asmItems, i + 1, new Set(['Until']));
+          if (j >= asmItems.length || asmItems[j]!.kind !== 'Until') {
+            ctx.diagAt(it.span, 'repeat without matching until.');
+            return asmItems.length;
+          }
+          const untilNode = asmItems[j]!;
+          const bodyExit = ctx.snapshotFlow();
+          const ok = ctx.emitJumpIfFalse(untilNode.cc, loopLabel, untilNode.span);
+          if (!ok) return asmItems.length;
+          if (
+            bodyExit.reachable &&
+            bodyExit.spValid &&
+            entry.spValid &&
+            bodyExit.spDelta !== entry.spDelta
+          ) {
+            backEdgeUnknown = true;
+            ctx.diagAt(
+              untilNode.span,
+              `Stack depth mismatch at repeat/until (${bodyExit.spDelta} vs ${entry.spDelta}).`,
+            );
+          } else if (
+            bodyExit.reachable &&
+            (!bodyExit.spValid || !entry.spValid) &&
+            (bodyExit.spInvalidDueToMutation || entry.spInvalidDueToMutation)
+          ) {
+            backEdgeUnknown = true;
+            backEdgeMutation = true;
+            ctx.diagAt(
+              untilNode.span,
+              'Cannot verify stack depth at repeat/until due to untracked SP mutation.',
+            );
+          } else if (
+            bodyExit.reachable &&
+            (!bodyExit.spValid || !entry.spValid) &&
+            ctx.hasStackSlots
+          ) {
+            backEdgeUnknown = true;
+            ctx.diagAt(untilNode.span, 'Cannot verify stack depth at repeat/until due to unknown stack state.');
+          }
+          if (backEdgeUnknown) {
+            ctx.restoreFlow({
+              reachable: bodyExit.reachable,
+              spDelta: 0,
+              spValid: false,
+              spInvalidDueToMutation: backEdgeMutation,
+            });
+          }
+          i = j + 1;
+          continue;
+        }
+        if (it.kind === 'Select') {
+          const entry = ctx.snapshotFlow();
+          const dispatchLabel = ctx.newHiddenLabel('__zax_select_dispatch');
+          const endLabel = ctx.newHiddenLabel('__zax_select_end');
+          const selectorIsReg8 =
+            it.selector.kind === 'Reg' && ctx.reg8.has(it.selector.name.toUpperCase());
+          const caseValues = new Set<number>();
+          const caseArms: { value: number; bodyLabel: string; span: SourceSpan }[] = [];
+          let elseLabel: string | undefined;
+          let sawArm = false;
+          const armExits: FlowState[] = [];
+
+          ctx.emitJumpTo(dispatchLabel, it.span);
+          let j = i + 1;
+
+          const closeArm = (span: SourceSpan) => {
+            armExits.push(ctx.snapshotFlow());
+            if (ctx.flowRef.current.reachable) ctx.emitJumpTo(endLabel, span);
+          };
+
+          while (j < asmItems.length) {
+            const armItem = asmItems[j]!;
+            if (armItem.kind === 'Case') {
+              const bodyLabel = ctx.newHiddenLabel('__zax_case');
+              ctx.defineCodeLabel(bodyLabel, armItem.span, 'local');
+              let k = j;
+              while (k < asmItems.length) {
+                const caseItem = asmItems[k]!;
+                if (caseItem.kind !== 'Case') break;
+                const v = ctx.evalImmExpr(caseItem.value);
+                if (v === undefined) {
+                  ctx.diagAt(caseItem.span, 'Failed to evaluate case value.');
+                } else {
+                  const key = v & 0xffff;
+                  const canMatchSelector = !selectorIsReg8 || key <= 0xff;
+                  if (selectorIsReg8 && key > 0xff) {
+                    ctx.warnAt(caseItem.span, `Case value ${key} can never match reg8 selector.`);
+                  }
+                  if (caseValues.has(key)) {
+                    ctx.diagAt(caseItem.span, `Duplicate case value ${key}.`);
+                  } else {
+                    caseValues.add(key);
+                    if (canMatchSelector) caseArms.push({ value: key, bodyLabel, span: caseItem.span });
+                  }
+                }
+                k++;
+              }
+              ctx.restoreFlow(entry);
+              sawArm = true;
+              j = lowerAsmRange(asmItems, k, new Set(['Case', 'SelectElse', 'End']));
+              closeArm(asmItems[Math.min(j, asmItems.length - 1)]!.span);
+              continue;
+            }
+            if (armItem.kind === 'SelectElse') {
+              if (elseLabel) {
+                ctx.diagAt(armItem.span, 'Duplicate else in select.');
+              }
+              elseLabel = ctx.newHiddenLabel('__zax_select_else');
+              ctx.defineCodeLabel(elseLabel, armItem.span, 'local');
+              ctx.restoreFlow(entry);
+              sawArm = true;
+              j = lowerAsmRange(asmItems, j + 1, new Set(['End']));
+              closeArm(asmItems[Math.min(j, asmItems.length - 1)]!.span);
+              continue;
+            }
+            if (armItem.kind === 'End') break;
+            ctx.diagAt(armItem.span, 'Expected case/else/end inside select.');
+            j++;
+          }
+
+          if (j >= asmItems.length || asmItems[j]!.kind !== 'End') {
+            ctx.diagAt(it.span, 'select without matching end.');
+            return asmItems.length;
+          }
+          if (!sawArm) {
+            ctx.diagAt(it.span, 'select must contain at least one case or else arm.');
+          }
+
+          ctx.defineCodeLabel(dispatchLabel, asmItems[j]!.span, 'local');
+          let selectorConst: number | undefined;
+          if (it.selector.kind === 'Imm') {
+            const v = ctx.evalImmExpr(it.selector.expr);
+            if (v !== undefined) selectorConst = v & 0xffff;
+          }
+          if (selectorConst !== undefined) {
+            const matched = caseArms.find((arm) => arm.value === selectorConst);
+            ctx.emitJumpTo(matched?.bodyLabel ?? elseLabel ?? endLabel, asmItems[j]!.span);
+          } else if (caseArms.length === 0) {
+            ctx.emitJumpTo(elseLabel ?? endLabel, asmItems[j]!.span);
+          } else {
+            if (!ctx.emitInstr('push', [{ kind: 'Reg', span: it.span, name: 'HL' }], it.span)) {
+              return asmItems.length;
+            }
+            if (!ctx.loadSelectorIntoHL(it.selector, it.span)) {
+              return asmItems.length;
+            }
+            if (selectorIsReg8) {
+              ctx.emitRawCodeBytes(Uint8Array.of(0x7d), it.span.file, 'ld a, l');
+            }
+            for (const arm of caseArms) {
+              const miss = ctx.newHiddenLabel('__zax_select_next');
+              if (selectorIsReg8) {
+                ctx.emitSelectCompareReg8ToImm8(arm.value, miss, arm.span);
+              } else {
+                ctx.emitSelectCompareToImm16(arm.value, miss, arm.span);
+              }
+              ctx.emitInstr('pop', [{ kind: 'Reg', span: arm.span, name: 'HL' }], arm.span);
+              ctx.emitJumpTo(arm.bodyLabel, arm.span);
+              ctx.defineCodeLabel(miss, arm.span, 'local');
+            }
+            ctx.emitInstr('pop', [{ kind: 'Reg', span: asmItems[j]!.span, name: 'HL' }], asmItems[j]!.span);
+            ctx.emitJumpTo(elseLabel ?? endLabel, asmItems[j]!.span);
+          }
+
+          ctx.defineCodeLabel(endLabel, asmItems[j]!.span, 'local');
+          const joinInputs = [...armExits];
+          if (!elseLabel) joinInputs.push(entry);
+          const reachable = joinInputs.filter((f) => f.reachable);
+          if (reachable.length === 0) {
+            ctx.restoreFlow({
+              reachable: false,
+              spDelta: 0,
+              spValid: true,
+              spInvalidDueToMutation: false,
+            });
+          } else {
+            const base = reachable[0]!;
+            const allValid = reachable.every((f) => f.spValid);
+            let hasMismatch = false;
+            if (allValid) {
+              const mismatchFlow = reachable.find((f) => f.spDelta !== base.spDelta);
+              if (mismatchFlow) {
+                hasMismatch = true;
+                ctx.diagAt(
+                  asmItems[j]!.span,
+                  `Stack depth mismatch at select join (${base.spDelta} vs ${mismatchFlow.spDelta}).`,
+                );
+              }
+            } else if (reachable.some((f) => f.spInvalidDueToMutation)) {
+              ctx.diagAt(
+                asmItems[j]!.span,
+                'Cannot verify stack depth at select join due to untracked SP mutation.',
+              );
+            } else if (ctx.hasStackSlots) {
+              ctx.diagAt(asmItems[j]!.span, 'Cannot verify stack depth at select join due to unknown stack state.');
+            }
+            ctx.restoreFlow({
+              reachable: true,
+              spDelta: base.spDelta,
+              spValid: allValid && !hasMismatch,
+              spInvalidDueToMutation: reachable.some((f) => f.spInvalidDueToMutation),
+            });
+          }
+          i = j + 1;
+          continue;
+        }
+        if (
+          it.kind === 'Else' ||
+          it.kind === 'End' ||
+          it.kind === 'Until' ||
+          it.kind === 'Case' ||
+          it.kind === 'SelectElse'
+        ) {
+          ctx.diagAt(it.span, `Unexpected "${it.kind.toLowerCase()}" in asm block.`);
+          i++;
+          continue;
+        }
+      } finally {
+        ctx.setCurrentCodeSegmentTag(prevTag);
+      }
+    }
+    return i;
+  };
+
+  return {
+    lowerAsmRange,
+  };
+}

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -91,6 +91,7 @@ import { createRuntimeAtomBudgetHelpers } from './runtimeAtomBudget.js';
 import { createScalarWordAccessorHelpers } from './scalarWordAccessors.js';
 import { createLdLoweringHelpers } from './ldLowering.js';
 import { createOpExpansionOrchestrationHelpers } from './opExpansionOrchestration.js';
+import { createAsmRangeLoweringHelpers } from './asmRangeLowering.js';
 import {
   alignTo,
   computeWrittenRange,
@@ -2830,6 +2831,11 @@ export function emitProgram(
           spValid: true,
           spInvalidDueToMutation: false,
         };
+        const flowRef: { readonly current: FlowState } = {
+          get current() {
+            return flow;
+          },
+        };
         type OpExpansionFrame = {
           key: string;
           name: string;
@@ -3954,393 +3960,33 @@ export function emitProgram(
           }
         };
 
-        const lowerAsmRange = (
-          asmItems: readonly AsmItemNode[],
-          startIndex: number,
-          stopKinds: Set<string>,
-        ): number => {
-          let i = startIndex;
-          while (i < asmItems.length) {
-            const it = asmItems[i]!;
-            if (stopKinds.has(it.kind)) return i;
-            const prevTag = currentCodeSegmentTag;
-            currentCodeSegmentTag = sourceTagForSpan(it.span);
-            try {
-              if (it.kind === 'AsmLabel') {
-                defineCodeLabel(it.name, it.span, 'global');
-                if (!flow.reachable) {
-                  flow.reachable = true;
-                  flow.spValid = false;
-                  flow.spDelta = 0;
-                  flow.spInvalidDueToMutation = false;
-                  syncFromFlow();
-                }
-                i++;
-                continue;
-              }
-              if (it.kind === 'AsmInstruction') {
-                emitAsmInstruction(it);
-                i++;
-                continue;
-              }
-              if (it.kind === 'If') {
-                const entry = snapshotFlow();
-                const elseLabel = newHiddenLabel('__zax_if_else');
-                const endLabel = newHiddenLabel('__zax_if_end');
-                emitJumpIfFalse(it.cc, elseLabel, it.span);
-
-                let j = lowerAsmRange(asmItems, i + 1, new Set(['Else', 'End']));
-                const thenExit = snapshotFlow();
-                if (j >= asmItems.length) {
-                  diagAt(diagnostics, it.span, `if without matching end.`);
-                  return asmItems.length;
-                }
-                const term = asmItems[j]!;
-                if (term.kind === 'Else') {
-                  if (thenExit.reachable) emitJumpTo(endLabel, term.span);
-                  defineCodeLabel(elseLabel, term.span, 'local');
-                  restoreFlow(entry);
-                  j = lowerAsmRange(asmItems, j + 1, new Set(['End']));
-                  const elseExit = snapshotFlow();
-                  if (j >= asmItems.length || asmItems[j]!.kind !== 'End') {
-                    diagAt(diagnostics, it.span, `if/else without matching end.`);
-                    return asmItems.length;
-                  }
-                  defineCodeLabel(endLabel, asmItems[j]!.span, 'local');
-                  restoreFlow(joinFlows(thenExit, elseExit, asmItems[j]!.span, 'if/else'));
-                  i = j + 1;
-                  continue;
-                }
-                if (term.kind !== 'End') {
-                  diagAt(diagnostics, it.span, `if without matching end.`);
-                  return asmItems.length;
-                }
-                defineCodeLabel(elseLabel, term.span, 'local');
-                restoreFlow(joinFlows(thenExit, entry, term.span, 'if'));
-                i = j + 1;
-                continue;
-              }
-              if (it.kind === 'While') {
-                const entry = snapshotFlow();
-                const condLabel = newHiddenLabel('__zax_while_cond');
-                const endLabel = newHiddenLabel('__zax_while_end');
-                let backEdgeUnknown = false;
-                let backEdgeMutation = false;
-                defineCodeLabel(condLabel, it.span, 'local');
-                emitJumpIfFalse(it.cc, endLabel, it.span);
-
-                const j = lowerAsmRange(asmItems, i + 1, new Set(['End']));
-                const bodyExit = snapshotFlow();
-                if (j >= asmItems.length || asmItems[j]!.kind !== 'End') {
-                  diagAt(diagnostics, it.span, `while without matching end.`);
-                  return asmItems.length;
-                }
-                if (
-                  bodyExit.reachable &&
-                  bodyExit.spValid &&
-                  entry.spValid &&
-                  bodyExit.spDelta !== entry.spDelta
-                ) {
-                  backEdgeUnknown = true;
-                  diagAt(
-                    diagnostics,
-                    asmItems[j]!.span,
-                    `Stack depth mismatch at while back-edge (${bodyExit.spDelta} vs ${entry.spDelta}).`,
-                  );
-                } else if (
-                  bodyExit.reachable &&
-                  (!bodyExit.spValid || !entry.spValid) &&
-                  (bodyExit.spInvalidDueToMutation || entry.spInvalidDueToMutation)
-                ) {
-                  backEdgeUnknown = true;
-                  backEdgeMutation = true;
-                  diagAt(
-                    diagnostics,
-                    asmItems[j]!.span,
-                    `Cannot verify stack depth at while back-edge due to untracked SP mutation.`,
-                  );
-                } else if (
-                  bodyExit.reachable &&
-                  (!bodyExit.spValid || !entry.spValid) &&
-                  hasStackSlots
-                ) {
-                  backEdgeUnknown = true;
-                  diagAt(
-                    diagnostics,
-                    asmItems[j]!.span,
-                    `Cannot verify stack depth at while back-edge due to unknown stack state.`,
-                  );
-                }
-                if (bodyExit.reachable) emitJumpTo(condLabel, asmItems[j]!.span);
-                defineCodeLabel(endLabel, asmItems[j]!.span, 'local');
-                if (backEdgeUnknown) {
-                  restoreFlow({
-                    reachable: entry.reachable,
-                    spDelta: 0,
-                    spValid: false,
-                    spInvalidDueToMutation: backEdgeMutation,
-                  });
-                } else {
-                  restoreFlow(entry);
-                }
-                i = j + 1;
-                continue;
-              }
-              if (it.kind === 'Repeat') {
-                const entry = snapshotFlow();
-                const loopLabel = newHiddenLabel('__zax_repeat_body');
-                let backEdgeUnknown = false;
-                let backEdgeMutation = false;
-                defineCodeLabel(loopLabel, it.span, 'local');
-                const j = lowerAsmRange(asmItems, i + 1, new Set(['Until']));
-                if (j >= asmItems.length || asmItems[j]!.kind !== 'Until') {
-                  diagAt(diagnostics, it.span, `repeat without matching until.`);
-                  return asmItems.length;
-                }
-                const untilNode = asmItems[j]!;
-                const bodyExit = snapshotFlow();
-                const ok = emitJumpIfFalse(untilNode.cc, loopLabel, untilNode.span);
-                if (!ok) return asmItems.length;
-                if (
-                  bodyExit.reachable &&
-                  bodyExit.spValid &&
-                  entry.spValid &&
-                  bodyExit.spDelta !== entry.spDelta
-                ) {
-                  backEdgeUnknown = true;
-                  diagAt(
-                    diagnostics,
-                    untilNode.span,
-                    `Stack depth mismatch at repeat/until (${bodyExit.spDelta} vs ${entry.spDelta}).`,
-                  );
-                } else if (
-                  bodyExit.reachable &&
-                  (!bodyExit.spValid || !entry.spValid) &&
-                  (bodyExit.spInvalidDueToMutation || entry.spInvalidDueToMutation)
-                ) {
-                  backEdgeUnknown = true;
-                  backEdgeMutation = true;
-                  diagAt(
-                    diagnostics,
-                    untilNode.span,
-                    `Cannot verify stack depth at repeat/until due to untracked SP mutation.`,
-                  );
-                } else if (
-                  bodyExit.reachable &&
-                  (!bodyExit.spValid || !entry.spValid) &&
-                  hasStackSlots
-                ) {
-                  backEdgeUnknown = true;
-                  diagAt(
-                    diagnostics,
-                    untilNode.span,
-                    `Cannot verify stack depth at repeat/until due to unknown stack state.`,
-                  );
-                }
-                if (backEdgeUnknown) {
-                  restoreFlow({
-                    reachable: bodyExit.reachable,
-                    spDelta: 0,
-                    spValid: false,
-                    spInvalidDueToMutation: backEdgeMutation,
-                  });
-                }
-                i = j + 1;
-                continue;
-              }
-              if (it.kind === 'Select') {
-                const entry = snapshotFlow();
-                const dispatchLabel = newHiddenLabel('__zax_select_dispatch');
-                const endLabel = newHiddenLabel('__zax_select_end');
-                const selectorIsReg8 =
-                  it.selector.kind === 'Reg' && reg8.has(it.selector.name.toUpperCase());
-                const caseValues = new Set<number>();
-                const caseArms: { value: number; bodyLabel: string; span: SourceSpan }[] = [];
-                let elseLabel: string | undefined;
-                let sawArm = false;
-                const armExits: FlowState[] = [];
-
-                emitJumpTo(dispatchLabel, it.span);
-                let j = i + 1;
-
-                const closeArm = (span: SourceSpan) => {
-                  armExits.push(snapshotFlow());
-                  if (flow.reachable) emitJumpTo(endLabel, span);
-                };
-
-                while (j < asmItems.length) {
-                  const armItem = asmItems[j]!;
-                  if (armItem.kind === 'Case') {
-                    const bodyLabel = newHiddenLabel('__zax_case');
-                    defineCodeLabel(bodyLabel, armItem.span, 'local');
-                    let k = j;
-                    while (k < asmItems.length) {
-                      const caseItem = asmItems[k]!;
-                      if (caseItem.kind !== 'Case') break;
-                      const v = evalImmExpr(caseItem.value, env, diagnostics);
-                      if (v === undefined) {
-                        diagAt(diagnostics, caseItem.span, `Failed to evaluate case value.`);
-                      } else {
-                        const key = v & 0xffff;
-                        const canMatchSelector = !selectorIsReg8 || key <= 0xff;
-                        if (selectorIsReg8 && key > 0xff) {
-                          warnAt(
-                            diagnostics,
-                            caseItem.span,
-                            `Case value ${key} can never match reg8 selector.`,
-                          );
-                        }
-                        if (caseValues.has(key)) {
-                          diagAt(diagnostics, caseItem.span, `Duplicate case value ${key}.`);
-                        } else {
-                          caseValues.add(key);
-                          if (canMatchSelector) {
-                            caseArms.push({ value: key, bodyLabel, span: caseItem.span });
-                          }
-                        }
-                      }
-                      k++;
-                    }
-                    restoreFlow(entry);
-                    sawArm = true;
-                    j = lowerAsmRange(asmItems, k, new Set(['Case', 'SelectElse', 'End']));
-                    closeArm(asmItems[Math.min(j, asmItems.length - 1)]!.span);
-                    continue;
-                  }
-                  if (armItem.kind === 'SelectElse') {
-                    if (elseLabel) {
-                      diagAt(diagnostics, armItem.span, `Duplicate else in select.`);
-                    }
-                    elseLabel = newHiddenLabel('__zax_select_else');
-                    defineCodeLabel(elseLabel, armItem.span, 'local');
-                    restoreFlow(entry);
-                    sawArm = true;
-                    j = lowerAsmRange(asmItems, j + 1, new Set(['End']));
-                    closeArm(asmItems[Math.min(j, asmItems.length - 1)]!.span);
-                    continue;
-                  }
-                  if (armItem.kind === 'End') break;
-                  diagAt(diagnostics, armItem.span, `Expected case/else/end inside select.`);
-                  j++;
-                }
-
-                if (j >= asmItems.length || asmItems[j]!.kind !== 'End') {
-                  diagAt(diagnostics, it.span, `select without matching end.`);
-                  return asmItems.length;
-                }
-                if (!sawArm) {
-                  diagAt(
-                    diagnostics,
-                    it.span,
-                    `select must contain at least one case or else arm.`,
-                  );
-                }
-
-                defineCodeLabel(dispatchLabel, asmItems[j]!.span, 'local');
-                let selectorConst: number | undefined;
-                if (it.selector.kind === 'Imm') {
-                  const v = evalImmExpr(it.selector.expr, env, diagnostics);
-                  if (v !== undefined) selectorConst = v & 0xffff;
-                }
-                if (selectorConst !== undefined) {
-                  const matched = caseArms.find((arm) => arm.value === selectorConst);
-                  emitJumpTo(matched?.bodyLabel ?? elseLabel ?? endLabel, asmItems[j]!.span);
-                } else if (caseArms.length === 0) {
-                  emitJumpTo(elseLabel ?? endLabel, asmItems[j]!.span);
-                } else {
-                  if (!emitInstr('push', [{ kind: 'Reg', span: it.span, name: 'HL' }], it.span)) {
-                    return asmItems.length;
-                  }
-                  if (!loadSelectorIntoHL(it.selector, it.span)) {
-                    return asmItems.length;
-                  }
-                  if (selectorIsReg8) {
-                    emitRawCodeBytes(Uint8Array.of(0x7d), it.span.file, 'ld a, l');
-                  }
-                  for (const arm of caseArms) {
-                    const miss = newHiddenLabel('__zax_select_next');
-                    if (selectorIsReg8) {
-                      emitSelectCompareReg8ToImm8(arm.value, miss, arm.span);
-                    } else {
-                      emitSelectCompareToImm16(arm.value, miss, arm.span);
-                    }
-                    emitInstr('pop', [{ kind: 'Reg', span: arm.span, name: 'HL' }], arm.span);
-                    emitJumpTo(arm.bodyLabel, arm.span);
-                    defineCodeLabel(miss, arm.span, 'local');
-                  }
-                  emitInstr(
-                    'pop',
-                    [{ kind: 'Reg', span: asmItems[j]!.span, name: 'HL' }],
-                    asmItems[j]!.span,
-                  );
-                  emitJumpTo(elseLabel ?? endLabel, asmItems[j]!.span);
-                }
-
-                defineCodeLabel(endLabel, asmItems[j]!.span, 'local');
-                const joinInputs = [...armExits];
-                if (!elseLabel) joinInputs.push(entry);
-                const reachable = joinInputs.filter((f) => f.reachable);
-                if (reachable.length === 0) {
-                  restoreFlow({
-                    reachable: false,
-                    spDelta: 0,
-                    spValid: true,
-                    spInvalidDueToMutation: false,
-                  });
-                } else {
-                  const base = reachable[0]!;
-                  const allValid = reachable.every((f) => f.spValid);
-                  let hasMismatch = false;
-                  if (allValid) {
-                    const mismatchFlow = reachable.find((f) => f.spDelta !== base.spDelta);
-                    if (mismatchFlow) {
-                      hasMismatch = true;
-                      diagAt(
-                        diagnostics,
-                        asmItems[j]!.span,
-                        `Stack depth mismatch at select join (${base.spDelta} vs ${mismatchFlow.spDelta}).`,
-                      );
-                    }
-                  } else if (reachable.some((f) => f.spInvalidDueToMutation)) {
-                    diagAt(
-                      diagnostics,
-                      asmItems[j]!.span,
-                      `Cannot verify stack depth at select join due to untracked SP mutation.`,
-                    );
-                  } else if (hasStackSlots) {
-                    diagAt(
-                      diagnostics,
-                      asmItems[j]!.span,
-                      `Cannot verify stack depth at select join due to unknown stack state.`,
-                    );
-                  }
-                  restoreFlow({
-                    reachable: true,
-                    spDelta: base.spDelta,
-                    spValid: allValid && !hasMismatch,
-                    spInvalidDueToMutation: reachable.some((f) => f.spInvalidDueToMutation),
-                  });
-                }
-                i = j + 1;
-                continue;
-              }
-              if (
-                it.kind === 'Else' ||
-                it.kind === 'End' ||
-                it.kind === 'Until' ||
-                it.kind === 'Case' ||
-                it.kind === 'SelectElse'
-              ) {
-                diagAt(diagnostics, it.span, `Unexpected "${it.kind.toLowerCase()}" in asm block.`);
-                i++;
-                continue;
-              }
-            } finally {
-              currentCodeSegmentTag = prevTag;
-            }
-          }
-          return i;
-        };
+        const { lowerAsmRange } = createAsmRangeLoweringHelpers({
+          sourceTagForSpan,
+          getCurrentCodeSegmentTag: () => currentCodeSegmentTag,
+          setCurrentCodeSegmentTag: (tag) => {
+            currentCodeSegmentTag = tag;
+          },
+          defineCodeLabel,
+          emitAsmInstruction,
+          flowRef,
+          syncFromFlow,
+          snapshotFlow,
+          restoreFlow,
+          newHiddenLabel,
+          emitJumpIfFalse,
+          emitJumpTo,
+          diagAt: (span, message) => diagAt(diagnostics, span, message),
+          warnAt: (span, message) => warnAt(diagnostics, span, message),
+          joinFlows,
+          hasStackSlots,
+          reg8,
+          evalImmExpr: (expr) => evalImmExpr(expr, env, diagnostics),
+          loadSelectorIntoHL,
+          emitRawCodeBytes,
+          emitSelectCompareReg8ToImm8,
+          emitSelectCompareToImm16,
+          emitInstr,
+        });
 
         const consumed = lowerAsmRange(item.asm.items, 0, new Set());
         if (consumed < item.asm.items.length) {

--- a/test/pr511_asm_range_lowering_integration.test.ts
+++ b/test/pr511_asm_range_lowering_integration.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('#511 asm range lowering integration', () => {
+  it('keeps structured if/else lowering stable through the extracted asm-range helper', async () => {
+    const res = await compile(
+      join(__dirname, 'fixtures', 'pr15_if_else.zax'),
+      {},
+      { formats: defaultFormatWriters },
+    );
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    const bytes = Array.from(bin!.bytes);
+    expect(bytes.slice(0, 3)).toEqual([0xdd, 0xe5, 0xdd]);
+    expect(bytes).toContain(0xca);
+    expect(bytes).toContain(0xc3);
+    expect(bytes.at(-1)).toBe(0xc9);
+  });
+
+  it('keeps structured select lowering stable through the extracted asm-range helper', async () => {
+    const res = await compile(
+      join(__dirname, 'fixtures', 'pr15_select_cases.zax'),
+      {},
+      { formats: defaultFormatWriters },
+    );
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    const bytes = Array.from(bin!.bytes);
+    expect(bytes.slice(0, 3)).toEqual([0xdd, 0xe5, 0xdd]);
+    expect(bytes).toContain(0xc3);
+    expect(bytes).toContain(0xfe);
+    expect(bytes.at(-1)).toBe(0xc9);
+  });
+});


### PR DESCRIPTION
## Summary\n- extract lowerAsmRange from emit into a dedicated asm-range lowering helper\n- keep top-level emitter orchestration in emit while delegating the recursive structured-control lowering\n- add focused integration coverage for the extracted asm-range boundary\n\n## Verification\n- npm run typecheck\n- npm test -- --run test/pr511_asm_range_lowering_integration.test.ts test/pr510_op_expansion_orchestration_helpers.test.ts test/pr509_lower_ld_integration.test.ts test/pr468_typed_step_integration.test.ts test/smoke_language_tour_compile.test.ts\n