### PR TITLE
Extract asm body orchestration helper

### DIFF
--- a/src/lowering/asmBodyOrchestration.ts
+++ b/src/lowering/asmBodyOrchestration.ts
@@ -1,0 +1,81 @@
+import type { AsmItemNode, SourceSpan } from '../frontend/ast.js';
+
+type FlowState = {
+  reachable: boolean;
+  spDelta: number;
+  spValid: boolean;
+  spInvalidDueToMutation: boolean;
+};
+
+type Context = {
+  asmItems: readonly AsmItemNode[];
+  itemName: string;
+  itemSpan: SourceSpan;
+  emitSyntheticEpilogue: boolean;
+  hasStackSlots: boolean;
+  lowerAsmRange: (asmItems: readonly AsmItemNode[], startIndex: number, stopKinds: Set<string>) => number;
+  syncToFlow: () => void;
+  getFlow: () => FlowState;
+  setFlow: (state: FlowState) => void;
+  diagAt: (span: SourceSpan, message: string) => void;
+  emitImplicitRet: () => void;
+  emitSyntheticEpilogueBody: () => void;
+  traceFunctionEnd: () => void;
+};
+
+export function createAsmBodyOrchestrationHelpers(ctx: Context) {
+  const lowerAndFinalizeFunctionBody = (): void => {
+    const consumed = ctx.lowerAsmRange(ctx.asmItems, 0, new Set());
+    if (consumed < ctx.asmItems.length) {
+      ctx.diagAt(ctx.asmItems[consumed]!.span, 'Internal control-flow lowering error.');
+    }
+
+    ctx.syncToFlow();
+
+    if (ctx.emitSyntheticEpilogue) {
+      ctx.setFlow({
+        ...ctx.getFlow(),
+        spDelta: 0,
+        spValid: true,
+        spInvalidDueToMutation: false,
+      });
+    }
+
+    const flow = ctx.getFlow();
+    if (flow.reachable && flow.spValid && flow.spDelta !== 0) {
+      ctx.diagAt(
+        ctx.itemSpan,
+        `Function "${ctx.itemName}" has non-zero stack delta at fallthrough (${flow.spDelta}).`,
+      );
+    } else if (flow.reachable && !flow.spValid && flow.spInvalidDueToMutation && ctx.hasStackSlots) {
+      ctx.diagAt(
+        ctx.itemSpan,
+        `Function "${ctx.itemName}" has untracked SP mutation at fallthrough; cannot verify stack balance.`,
+      );
+    } else if (flow.reachable && !flow.spValid && ctx.hasStackSlots) {
+      ctx.diagAt(
+        ctx.itemSpan,
+        `Function "${ctx.itemName}" has unknown stack depth at fallthrough; cannot verify stack balance.`,
+      );
+    }
+
+    if (!ctx.emitSyntheticEpilogue && flow.reachable) {
+      ctx.emitImplicitRet();
+      ctx.setFlow({
+        ...ctx.getFlow(),
+        reachable: false,
+      });
+      ctx.syncToFlow();
+    }
+
+    if (ctx.emitSyntheticEpilogue) {
+      ctx.emitSyntheticEpilogueBody();
+    }
+
+    ctx.traceFunctionEnd();
+  };
+
+  return {
+    lowerAndFinalizeFunctionBody,
+  };
+}

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -92,6 +92,7 @@ import { createScalarWordAccessorHelpers } from './scalarWordAccessors.js';
 import { createLdLoweringHelpers } from './ldLowering.js';
 import { createOpExpansionOrchestrationHelpers } from './opExpansionOrchestration.js';
 import { createAsmRangeLoweringHelpers } from './asmRangeLowering.js';
+import { createAsmBodyOrchestrationHelpers } from './asmBodyOrchestration.js';
 import {
   alignTo,
   computeWrittenRange,
@@ -3988,89 +3989,59 @@ export function emitProgram(
           emitInstr,
         });
 
-        const consumed = lowerAsmRange(item.asm.items, 0, new Set());
-        if (consumed < item.asm.items.length) {
-          diagAt(
-            diagnostics,
-            item.asm.items[consumed]!.span,
-            `Internal control-flow lowering error.`,
-          );
-        }
-        syncToFlow();
-        // For framed functions with a synthetic epilogue, we reset the tracked delta here because
-        // the epilogue unconditionally restores SP/IX. This avoids false imbalance reports from
-        // conservative tracking inside the body.
-        if (emitSyntheticEpilogue) {
-          flow.spDelta = 0;
-          flow.spValid = true;
-          flow.spInvalidDueToMutation = false;
-        }
-        if (flow.reachable && flow.spValid && flow.spDelta !== 0) {
-          diagAt(
-            diagnostics,
-            item.span,
-            `Function "${item.name}" has non-zero stack delta at fallthrough (${flow.spDelta}).`,
-          );
-        } else if (
-          flow.reachable &&
-          !flow.spValid &&
-          flow.spInvalidDueToMutation &&
-          hasStackSlots
-        ) {
-          diagAt(
-            diagnostics,
-            item.span,
-            `Function "${item.name}" has untracked SP mutation at fallthrough; cannot verify stack balance.`,
-          );
-        } else if (flow.reachable && !flow.spValid && hasStackSlots) {
-          diagAt(
-            diagnostics,
-            item.span,
-            `Function "${item.name}" has unknown stack depth at fallthrough; cannot verify stack balance.`,
-          );
-        }
-        if (!emitSyntheticEpilogue && flow.reachable) {
-          withCodeSourceTag(sourceTagForSpan(item.span), () => {
-            emitInstr('ret', [], item.span);
-          });
-          flow.reachable = false;
-          syncToFlow();
-        }
-
-        if (emitSyntheticEpilogue) {
-          withCodeSourceTag(sourceTagForSpan(item.span), () => {
-            // When control can fall through to the end of the function body, route it through the
-            // synthetic epilogue. If flow is unreachable here (e.g. a terminal `ret`), avoid emitting
-            // a dead jump before the epilogue label. If flow is reachable, fall through directly.
-            pending.push({
-              kind: 'label',
-              name: epilogueLabel,
-              section: 'code',
-              offset: codeOffset,
-              file: item.span.file,
-              line: item.span.start.line,
-              scope: 'local',
+        const { lowerAndFinalizeFunctionBody } = createAsmBodyOrchestrationHelpers({
+          asmItems: item.asm.items,
+          itemName: item.name,
+          itemSpan: item.span,
+          emitSyntheticEpilogue,
+          hasStackSlots,
+          lowerAsmRange,
+          syncToFlow,
+          getFlow: () => flow,
+          setFlow: (state) => {
+            flow = state;
+          },
+          diagAt: (span, message) => diagAt(diagnostics, span, message),
+          emitImplicitRet: () => {
+            withCodeSourceTag(sourceTagForSpan(item.span), () => {
+              emitInstr('ret', [], item.span);
             });
-            traceLabel(codeOffset, epilogueLabel);
-            const popOrder = preserveSet.slice().reverse();
-            for (const reg of popOrder) {
-              emitInstr('pop', [{ kind: 'Reg', span: item.span, name: reg }], item.span);
-            }
-            if (hasStackSlots) {
-              emitInstr(
-                'ld',
-                [
-                  { kind: 'Reg', span: item.span, name: 'SP' },
-                  { kind: 'Reg', span: item.span, name: 'IX' },
-                ],
-                item.span,
-              );
-              emitInstr('pop', [{ kind: 'Reg', span: item.span, name: 'IX' }], item.span);
-            }
-            emitInstr('ret', [], item.span);
-          });
-        }
-        traceComment(codeOffset, `func ${item.name} end`);
+          },
+          emitSyntheticEpilogueBody: () => {
+            withCodeSourceTag(sourceTagForSpan(item.span), () => {
+              pending.push({
+                kind: 'label',
+                name: epilogueLabel,
+                section: 'code',
+                offset: codeOffset,
+                file: item.span.file,
+                line: item.span.start.line,
+                scope: 'local',
+              });
+              traceLabel(codeOffset, epilogueLabel);
+              const popOrder = preserveSet.slice().reverse();
+              for (const reg of popOrder) {
+                emitInstr('pop', [{ kind: 'Reg', span: item.span, name: reg }], item.span);
+              }
+              if (hasStackSlots) {
+                emitInstr(
+                  'ld',
+                  [
+                    { kind: 'Reg', span: item.span, name: 'SP' },
+                    { kind: 'Reg', span: item.span, name: 'IX' },
+                  ],
+                  item.span,
+                );
+                emitInstr('pop', [{ kind: 'Reg', span: item.span, name: 'IX' }], item.span);
+              }
+              emitInstr('ret', [], item.span);
+            });
+          },
+          traceFunctionEnd: () => {
+            traceComment(codeOffset, `func ${item.name} end`);
+          },
+        });
+        lowerAndFinalizeFunctionBody();
         continue;
       }
 

--- a/test/pr511_asm_body_orchestration_helpers.test.ts
+++ b/test/pr511_asm_body_orchestration_helpers.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AsmItemNode, SourceSpan } from '../src/frontend/ast.js';
+import { createAsmBodyOrchestrationHelpers } from '../src/lowering/asmBodyOrchestration.js';
+
+const span: SourceSpan = {
+  file: 'test.zax',
+  start: { offset: 0, line: 1, column: 1 },
+  end: { offset: 0, line: 1, column: 1 },
+};
+
+describe('#511 asm body orchestration helpers', () => {
+  it('keeps non-epilogue fallthrough routing stable', () => {
+    let flow = {
+      reachable: true,
+      spDelta: 0,
+      spValid: true,
+      spInvalidDueToMutation: false,
+    };
+    let implicitRetCount = 0;
+    let syntheticCount = 0;
+    let traceCount = 0;
+    const diagnostics: string[] = [];
+
+    const { lowerAndFinalizeFunctionBody } = createAsmBodyOrchestrationHelpers({
+      asmItems: [] as AsmItemNode[],
+      itemName: 'main',
+      itemSpan: span,
+      emitSyntheticEpilogue: false,
+      hasStackSlots: false,
+      lowerAsmRange: () => 0,
+      syncToFlow: () => {},
+      getFlow: () => flow,
+      setFlow: (state) => {
+        flow = state;
+      },
+      diagAt: (_span, message) => {
+        diagnostics.push(message);
+      },
+      emitImplicitRet: () => {
+        implicitRetCount++;
+      },
+      emitSyntheticEpilogueBody: () => {
+        syntheticCount++;
+      },
+      traceFunctionEnd: () => {
+        traceCount++;
+      },
+    });
+
+    lowerAndFinalizeFunctionBody();
+
+    expect(diagnostics).toEqual([]);
+    expect(implicitRetCount).toBe(1);
+    expect(syntheticCount).toBe(0);
+    expect(traceCount).toBe(1);
+    expect(flow.reachable).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary\n- extract the remaining function-body orchestration after lowerAsmRange into a dedicated helper\n- keep emit as the outer coordinator while delegating fallthrough diagnostics, implicit ret, and synthetic epilogue handoff\n- add focused helper coverage for the new orchestration boundary\n\n## Verification\n- npm run typecheck\n- npm test -- --run test/pr511_asm_body_orchestration_helpers.test.ts test/pr511_asm_range_lowering_integration.test.ts test/pr510_op_expansion_orchestration_helpers.test.ts test/pr509_lower_ld_integration.test.ts test/pr468_typed_step_integration.test.ts test/smoke_language_tour_compile.test.ts\n