### PR TITLE
docs: prioritize remaining emit split

### DIFF
--- a/docs/v04-planning-track.md
+++ b/docs/v04-planning-track.md
@@ -41,28 +41,28 @@ shape and the existing implementation is better understood.
 
 ## 3. Active workstreams
 
-### Track A. Codebase audit and understanding
+### Track A. Remaining emitter decomposition
 
-The first job is to understand what the compiler is actually doing now:
+The original audit and broad refactor pass have been completed, but one major
+structural failure remains:
 
-- identify stale lowering paths
-- identify duplicated logic
-- identify paths that no longer match the current spec
-- identify areas where behavior is poorly explained by the current structure
+- `src/lowering/emit.ts` is still above the hard cap
+- it remains the only unacceptable source-file-size violation in `src/`
+- v0.4 is not complete until it is reduced below 1000 lines
 
-This is especially important in:
+The current active work is therefore a strict decomposition sequence for the
+remaining `emit.ts` clusters:
 
-- `src/lowering/emit.ts`
-- encoding / parsing boundaries where old and new behavior may overlap
-
-Primary issue:
-
-- `#465` — audit current lowering behavior in `src/lowering/emit.ts`
+- `#528`
+- `#529`
+- `#530`
+- `#531`
+- `#532`
+- `#533`
 
 ### Track B. Refactoring and modularization
 
-Once the current behavior is understood, refactor for structure without changing
-intended semantics:
+The guiding rule for the active refactor sequence is still the same:
 
 - break oversized files into clearer modules
 - isolate reusable lowering helpers
@@ -70,26 +70,23 @@ intended semantics:
 - keep behavior-preserving refactors separate from functional changes wherever
   possible
 
-Primary issue:
+Current hard acceptance criteria:
 
-- `#466` — refactor the lowering emitter into smaller modules without semantic drift
+- `src/lowering/emit.ts` must end below 1000 lines
+- preferred end state is below 750 lines
+- no newly extracted file may exceed 1000 lines
 
 ### Track C. Documentation consolidation
 
-The current docs set has accumulated over time. v0.4 should reduce sprawl:
+The first consolidation pass is complete. The remaining rule is simple:
 
-- merge overlapping guidance into fewer, clearer docs
-- keep one authoritative place per topic
-- remove or archive stale supporting notes when their content is absorbed
-- keep normative vs non-normative boundaries explicit
-
-Primary issue:
-
-- `#467` — consolidate documentation and reduce overlapping support docs
+- keep the docs set small
+- delete stale planning/support notes rather than preserving them
+- keep one active planning layer for the current release line
 
 ### Track D. Coverage and regression hardening
 
-v0.4 should increase confidence in the current compiler before new feature work:
+Coverage work remains active, but it is not the current blocker:
 
 - identify low-coverage areas
 - add focused regression tests around poorly covered lowering paths

--- a/docs/v04-priority-queue.md
+++ b/docs/v04-priority-queue.md
@@ -4,67 +4,115 @@ This is the active short-form developer queue for the v0.4 era.
 
 v0.4 is focused on code quality and maintainability only.
 
+Current hard blocker:
+
+- `src/lowering/emit.ts` is still over the hard cap at 4170 lines.
+- v0.4 is not complete until `emit.ts` is under 1000 lines.
+- Preferred end state is under 750 lines.
+
 ## Active order
 
-### 1. Codebase audit of current compiler behavior
+### 1. Extract emission core and step-pipeline helpers
 
 Issue:
 
-- `#465`
+- `#528`
 
-Why first:
+Why first now:
 
-- the current implementation needs to be understood before it is restructured
-- stale, duplicated, or obsolete paths need to be identified before refactors
-- this is the foundation for all later v0.4 cleanup
+- this is the first remaining large cohesive cluster in `src/lowering/emit.ts`
+- it pulls out the byte emission, trace, SP-tracking, and typed step emission path
+- it should materially reduce the current hard-cap breach
 
 Priority focus:
 
 - `src/lowering/emit.ts`
-- places where spec evolution may have left old behavior behind
+- `emitInstr(...)`
+- `emitStepPipeline(...)`
 
-### 2. Refactoring and modularization of high-risk areas
+### 2. Extract fixup emission and condition helpers
 
 Issue:
 
-- `#466`
+- `#529`
 
 Why second:
 
-- once current behavior is mapped, large files can be broken down safely
-- refactoring should follow understanding, not precede it
-- the main target is better structure without semantic drift
+- the fixup and branch-helper cluster is still tightly packed in `emit.ts`
+- it is a clear next slice after the emission core cluster
+- it further reduces emitter-local encoding utility noise
 
-### 3. Documentation consolidation
+### 3. Extract operand clone and asm utility helpers
 
 Issue:
 
-- `#467`
+- `#530`
 
 Why third:
 
-- the docs should reflect the cleaned-up implementation structure
-- overlapping docs should be merged or clarified while the code is being
-  understood and reorganized
+- `emit.ts` still contains a broad AST/operand utility cluster
+- those helpers are reusable and should not stay buried in the emitter
+- this slice reduces local utility sprawl before deeper lowering extraction
 
-### 4. Coverage gap audit and targeted test expansion
+### 4. Extract value push and memory materialization helpers
+
+Issue:
+
+- `#531`
+
+Why fourth:
+
+- this is the next heavy lowering helper cluster still trapped in `emit.ts`
+- it moves the value/materialization path out before the large dispatcher move
+- it prepares the emitter for the later final orchestration split
+
+### 5. Extract asm instruction lowering dispatcher
+
+Issue:
+
+- `#532`
+
+Why fifth:
+
+- a major remaining body in `emit.ts` is the asm instruction lowering dispatcher
+- this is a substantial reduction step and should happen only after the helper
+  clusters above are already out
+
+### 6. Extract the remaining declaration/function lowering orchestration
+
+Issue:
+
+- `#533`
+
+Why sixth:
+
+- this is the final structural reduction pass for `emit.ts`
+- the goal is to make `emit.ts` the outer coordinator only
+- this slice must leave `emit.ts` under the 1000-line hard cap
+
+### 7. Coverage hardening after the emitter is under the cap
 
 Issue:
 
 - `#468`
 
-Why fourth:
+Why after the split:
 
-- test gaps should be closed around the areas identified during the audit
-- stronger regression coverage makes deeper cleanup safer
+- the structural refactor is still the blocker
+- targeted tests remain important, but they are not the current size-policy
+  failure
+- once `emit.ts` is below the cap, remaining weak spots can be hardened
 
-### 5. Reassess future syntax work only after the code-quality pass
+## Completed enabling work
 
-Why last:
+These v0.4 items are no longer the active blocker:
 
-- syntax changes are intentionally deferred until the compiler internals are in
-  better shape
-- this is a reassessment gate, not active feature work yet
+- `#465` — audit completed
+- `#466` — umbrella refactor track completed by its child slices
+- `#467` — docs consolidation completed
+- `#472` through `#477` — prior structural slices completed
+- `#504` through `#511` — earlier emitter decomposition slices completed or in
+  progress where already landed
 
 ## Activation rule
 
@@ -76,3 +124,5 @@ Why last:
 
 - v0.3 is treated as complete.
 - v0.4 starts as a code-quality cycle, not a feature-expansion cycle.
+- The active v0.4 blocker is structural: `src/lowering/emit.ts` must be
+  reduced below the hard cap before v0.4 can be considered complete.


### PR DESCRIPTION
Closes #534

- make the remaining `emit.ts` hard-cap breach the explicit v0.4 blocker
- reorder the active queue around `#528` through `#533`
- move earlier v0.4 audit/refactor/docs items into completed enabling work