### PR TITLE
Extract emission core helpers

### DIFF
--- a/src/lowering/emissionCore.ts
+++ b/src/lowering/emissionCore.ts
@@ -1,0 +1,226 @@
+import type { AsmOperandNode, ImmExprNode, SourceSpan } from '../frontend/ast.js';
+import { renderStepInstr, type StepInstr, type StepPipeline } from '../addressing/steps.js';
+
+type Context = {
+  getCodeOffset: () => number;
+  setCodeOffset: (value: number) => void;
+  setCodeByte: (offset: number, value: number) => void;
+  recordCodeSourceRange: (start: number, end: number) => void;
+  traceInstruction: (start: number, bytes: Uint8Array, traceText: string) => void;
+  emitInstr: (head: string, operands: AsmOperandNode[], span: SourceSpan) => boolean;
+  loadImm16ToDE: (value: number, span: SourceSpan) => boolean;
+  loadImm16ToHL: (value: number, span: SourceSpan) => boolean;
+  emitAbs16Fixup: (
+    opcode: number,
+    baseLower: string,
+    addend: number,
+    span: SourceSpan,
+    asmText?: string,
+  ) => void;
+  emitAbs16FixupEd: (
+    opcode2: number,
+    baseLower: string,
+    addend: number,
+    span: SourceSpan,
+    asmText?: string,
+  ) => void;
+};
+
+export function createEmissionCoreHelpers(ctx: Context) {
+  const emitCodeBytes = (bs: Uint8Array, _file: string): number => {
+    const start = ctx.getCodeOffset();
+    let codeOffset = start;
+    for (const b of bs) {
+      ctx.setCodeByte(codeOffset, b);
+      codeOffset++;
+    }
+    ctx.setCodeOffset(codeOffset);
+    ctx.recordCodeSourceRange(start, codeOffset);
+    return start;
+  };
+
+  const emitRawCodeBytes = (bs: Uint8Array, _file: string, traceText: string): void => {
+    const start = emitCodeBytes(bs, _file);
+    ctx.traceInstruction(start, bs, traceText);
+  };
+
+  const emitStepPipeline = (pipe: StepPipeline, span: SourceSpan): boolean => {
+    const rpByte = (rp: string, which: 'lo' | 'hi'): string | undefined => {
+      const up = rp.toUpperCase();
+      if (up === 'HL') return which === 'lo' ? 'L' : 'H';
+      if (up === 'DE') return which === 'lo' ? 'E' : 'D';
+      if (up === 'BC') return which === 'lo' ? 'C' : 'B';
+      return undefined;
+    };
+
+    const mkReg = (name: string): AsmOperandNode => ({ kind: 'Reg', span, name });
+    const mkStepReg = (name: string): AsmOperandNode => mkReg(name.toUpperCase());
+    const mkMemHl = (): AsmOperandNode => ({
+      kind: 'Mem',
+      span,
+      expr: { kind: 'EaName', span, name: 'HL' },
+    });
+    const mkMemIxDisp = (disp: number): AsmOperandNode => {
+      if (disp === 0) {
+        return { kind: 'Mem', span, expr: { kind: 'EaName', span, name: 'IX' } };
+      }
+      const offsetImm: ImmExprNode = {
+        kind: 'ImmLiteral',
+        span,
+        value: Math.abs(disp),
+      };
+      return {
+        kind: 'Mem',
+        span,
+        expr:
+          disp >= 0
+            ? { kind: 'EaAdd', span, base: { kind: 'EaName', span, name: 'IX' }, offset: offsetImm }
+            : {
+                kind: 'EaSub',
+                span,
+                base: { kind: 'EaName', span, name: 'IX' },
+                offset: offsetImm,
+              },
+      };
+    };
+
+    const emitStepInstr = (step: StepInstr): boolean => {
+      switch (step.kind) {
+        case 'push':
+          return ctx.emitInstr('push', [mkReg(step.reg)], span);
+        case 'pop':
+          return ctx.emitInstr('pop', [mkReg(step.reg)], span);
+        case 'exDeHl':
+          return ctx.emitInstr('ex', [mkReg('DE'), mkReg('HL')], span);
+        case 'exSpHl':
+          return ctx.emitInstr(
+            'ex',
+            [{ kind: 'Mem', span, expr: { kind: 'EaName', span, name: 'SP' } }, mkReg('HL')],
+            span,
+          );
+        case 'addHlDe':
+          return ctx.emitInstr('add', [mkReg('HL'), mkReg('DE')], span);
+        case 'addHlHl':
+          return ctx.emitInstr('add', [mkReg('HL'), mkReg('HL')], span);
+        case 'incHl':
+          return ctx.emitInstr('inc', [mkReg('HL')], span);
+        case 'ldHZero':
+          return ctx.emitInstr(
+            'ld',
+            [mkReg('H'), { kind: 'Imm', span, expr: { kind: 'ImmLiteral', span, value: 0 } }],
+            span,
+          );
+        case 'ldRegReg':
+          return ctx.emitInstr('ld', [mkStepReg(step.dst), mkStepReg(step.src)], span);
+        case 'ldRegMemHl':
+          return ctx.emitInstr('ld', [mkStepReg(step.reg), mkMemHl()], span);
+        case 'ldMemHlReg':
+          return ctx.emitInstr('ld', [mkMemHl(), mkStepReg(step.reg)], span);
+        case 'ldRegIxDisp':
+          return ctx.emitInstr('ld', [mkStepReg(step.reg), mkMemIxDisp(step.disp)], span);
+        case 'ldIxDispReg':
+          return ctx.emitInstr('ld', [mkMemIxDisp(step.disp), mkStepReg(step.reg)], span);
+        case 'ldRpByteFromIx': {
+          const regName = rpByte(step.rp, step.part);
+          if (!regName) return false;
+          return ctx.emitInstr('ld', [mkReg(regName), mkMemIxDisp(step.disp)], span);
+        }
+        case 'ldIxDispFromRpByte': {
+          const regName = rpByte(step.rp, step.part);
+          if (!regName) return false;
+          return ctx.emitInstr('ld', [mkMemIxDisp(step.disp), mkReg(regName)], span);
+        }
+        case 'ldRpImm':
+          return step.rp === 'DE'
+            ? ctx.loadImm16ToDE(step.value, span)
+            : ctx.loadImm16ToHL(step.value, span);
+        case 'ldRpGlob':
+          ctx.emitAbs16Fixup(
+            step.rp === 'DE' ? 0x11 : 0x21,
+            step.glob.toLowerCase(),
+            0,
+            span,
+            renderStepInstr(step),
+          );
+          return true;
+        case 'ldHlPtrGlob':
+          ctx.emitAbs16Fixup(0x2a, step.glob.toLowerCase(), 0, span, renderStepInstr(step));
+          return true;
+        case 'ldRpPtrGlob':
+          ctx.emitAbs16FixupEd(
+            step.rp === 'BC' ? 0x4b : 0x5b,
+            step.glob.toLowerCase(),
+            0,
+            span,
+            renderStepInstr(step),
+          );
+          return true;
+        case 'ldPtrGlobRp':
+          if (step.rp === 'HL') {
+            ctx.emitAbs16Fixup(0x22, step.glob.toLowerCase(), 0, span, renderStepInstr(step));
+          } else {
+            ctx.emitAbs16FixupEd(
+              step.rp === 'BC' ? 0x43 : 0x53,
+              step.glob.toLowerCase(),
+              0,
+              span,
+              renderStepInstr(step),
+            );
+          }
+          return true;
+        case 'ldHlRp':
+          if (step.rp === 'HL') return true;
+          if (step.rp === 'DE') {
+            return (
+              ctx.emitInstr('ld', [mkReg('H'), mkReg('D')], span) &&
+              ctx.emitInstr('ld', [mkReg('L'), mkReg('E')], span)
+            );
+          }
+          return (
+            ctx.emitInstr('ld', [mkReg('H'), mkReg('B')], span) &&
+            ctx.emitInstr('ld', [mkReg('L'), mkReg('C')], span)
+          );
+        case 'ldRegGlob':
+          return ctx.emitInstr(
+            'ld',
+            [
+              mkStepReg(step.reg),
+              { kind: 'Mem', span, expr: { kind: 'EaName', span, name: step.glob } },
+            ],
+            span,
+          );
+        case 'ldGlobReg':
+          return ctx.emitInstr(
+            'ld',
+            [
+              { kind: 'Mem', span, expr: { kind: 'EaName', span, name: step.glob } },
+              mkStepReg(step.reg),
+            ],
+            span,
+          );
+        case 'ldRpByteFromReg': {
+          const regName = rpByte(step.rp, step.part);
+          if (!regName) return false;
+          return ctx.emitInstr('ld', [mkReg(regName), mkStepReg(step.reg)], span);
+        }
+        case 'ldRegFromRpByte': {
+          const src = rpByte(step.rp, step.part);
+          if (!src) return false;
+          return ctx.emitInstr('ld', [mkStepReg(step.reg), mkReg(src)], span);
+        }
+      }
+      return false;
+    };
+
+    for (const step of pipe) {
+      if (!emitStepInstr(step)) return false;
+    }
+    return true;
+  };
+
+  return {
+    emitCodeBytes,
+    emitRawCodeBytes,
+    emitStepPipeline,
+  };
+}

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -40,8 +40,6 @@ import {
   TEMPLATE_SW_HL,
   TEMPLATE_S_ANY,
   TEMPLATE_S_HL,
-  renderStepInstr,
-  type StepInstr,
   type StepPipeline,
 } from '../addressing/steps.js';
 import type { Diagnostic, DiagnosticId } from '../diagnostics/types.js';
@@ -94,6 +92,7 @@ import { createOpExpansionOrchestrationHelpers } from './opExpansionOrchestratio
 import { createAsmRangeLoweringHelpers } from './asmRangeLowering.js';
 import { createAsmBodyOrchestrationHelpers } from './asmBodyOrchestration.js';
 import { createOpMatchingHelpers } from './opMatching.js';
+import { createEmissionCoreHelpers } from './emissionCore.js';
 import {
   alignTo,
   computeWrittenRange,
@@ -396,20 +395,9 @@ export function emitProgram(
     codeAsmTrace.push({ kind: 'comment', offset, text });
   };
 
-  const emitCodeBytes = (bs: Uint8Array, file: string) => {
-    const start = codeOffset;
-    for (const b of bs) {
-      codeBytes.set(codeOffset, b);
-      codeOffset++;
-    }
-    recordCodeSourceRange(start, codeOffset);
-  };
-
-  const emitRawCodeBytes = (bs: Uint8Array, file: string, traceText: string): void => {
-    const start = codeOffset;
-    emitCodeBytes(bs, file);
-    traceInstruction(start, bs, traceText);
-  };
+  let emitCodeBytes: (bs: Uint8Array, file: string) => void;
+  let emitRawCodeBytes: (bs: Uint8Array, file: string, traceText: string) => void;
+  let emitStepPipeline: (pipe: StepPipeline, span: SourceSpan) => boolean;
 
   const applySpTracking = (headRaw: string, operands: AsmOperandNode[]) => {
     const head = headRaw.toLowerCase();
@@ -477,179 +465,6 @@ export function emitProgram(
       emitInstr,
     });
 
-  const emitStepPipeline = (pipe: StepPipeline, span: SourceSpan): boolean => {
-    const rpByte = (rp: string, which: 'lo' | 'hi'): string | undefined => {
-      const up = rp.toUpperCase();
-      if (up === 'HL') return which === 'lo' ? 'L' : 'H';
-      if (up === 'DE') return which === 'lo' ? 'E' : 'D';
-      if (up === 'BC') return which === 'lo' ? 'C' : 'B';
-      return undefined;
-    };
-
-    const mkReg = (name: string): AsmOperandNode => ({ kind: 'Reg', span, name });
-    const mkStepReg = (name: string): AsmOperandNode => mkReg(name.toUpperCase());
-    const mkMemHl = (): AsmOperandNode => ({
-      kind: 'Mem',
-      span,
-      expr: { kind: 'EaName', span, name: 'HL' },
-    });
-    const mkMemIxDisp = (disp: number): AsmOperandNode => {
-      if (disp === 0) {
-        return { kind: 'Mem', span, expr: { kind: 'EaName', span, name: 'IX' } };
-      }
-      const offsetImm: ImmExprNode = {
-        kind: 'ImmLiteral',
-        span,
-        value: Math.abs(disp),
-      };
-      return {
-        kind: 'Mem',
-        span,
-        expr:
-          disp >= 0
-            ? { kind: 'EaAdd', span, base: { kind: 'EaName', span, name: 'IX' }, offset: offsetImm }
-            : {
-                kind: 'EaSub',
-                span,
-                base: { kind: 'EaName', span, name: 'IX' },
-                offset: offsetImm,
-              },
-      };
-    };
-
-    const emitStepInstr = (step: StepInstr): boolean => {
-      switch (step.kind) {
-        case 'push':
-          return emitInstr('push', [mkReg(step.reg)], span);
-        case 'pop':
-          return emitInstr('pop', [mkReg(step.reg)], span);
-        case 'exDeHl':
-          return emitInstr('ex', [mkReg('DE'), mkReg('HL')], span);
-        case 'exSpHl':
-          return emitInstr(
-            'ex',
-            [{ kind: 'Mem', span, expr: { kind: 'EaName', span, name: 'SP' } }, mkReg('HL')],
-            span,
-          );
-        case 'addHlDe':
-          return emitInstr('add', [mkReg('HL'), mkReg('DE')], span);
-        case 'addHlHl':
-          return emitInstr('add', [mkReg('HL'), mkReg('HL')], span);
-        case 'incHl':
-          return emitInstr('inc', [mkReg('HL')], span);
-        case 'ldHZero':
-          return emitInstr(
-            'ld',
-            [mkReg('H'), { kind: 'Imm', span, expr: { kind: 'ImmLiteral', span, value: 0 } }],
-            span,
-          );
-        case 'ldRegReg':
-          return emitInstr('ld', [mkStepReg(step.dst), mkStepReg(step.src)], span);
-        case 'ldRegMemHl':
-          return emitInstr('ld', [mkStepReg(step.reg), mkMemHl()], span);
-        case 'ldMemHlReg':
-          return emitInstr('ld', [mkMemHl(), mkStepReg(step.reg)], span);
-        case 'ldRegIxDisp':
-          return emitInstr('ld', [mkStepReg(step.reg), mkMemIxDisp(step.disp)], span);
-        case 'ldIxDispReg':
-          return emitInstr('ld', [mkMemIxDisp(step.disp), mkStepReg(step.reg)], span);
-        case 'ldRpByteFromIx': {
-          const regName = rpByte(step.rp, step.part);
-          if (!regName) return false;
-          return emitInstr('ld', [mkReg(regName), mkMemIxDisp(step.disp)], span);
-        }
-        case 'ldIxDispFromRpByte': {
-          const regName = rpByte(step.rp, step.part);
-          if (!regName) return false;
-          return emitInstr('ld', [mkMemIxDisp(step.disp), mkReg(regName)], span);
-        }
-        case 'ldRpImm':
-          return step.rp === 'DE'
-            ? loadImm16ToDE(step.value, span)
-            : loadImm16ToHL(step.value, span);
-        case 'ldRpGlob':
-          emitAbs16Fixup(
-            step.rp === 'DE' ? 0x11 : 0x21,
-            step.glob.toLowerCase(),
-            0,
-            span,
-            renderStepInstr(step),
-          );
-          return true;
-        case 'ldHlPtrGlob':
-          emitAbs16Fixup(0x2a, step.glob.toLowerCase(), 0, span, renderStepInstr(step));
-          return true;
-        case 'ldRpPtrGlob':
-          emitAbs16FixupEd(
-            step.rp === 'BC' ? 0x4b : 0x5b,
-            step.glob.toLowerCase(),
-            0,
-            span,
-            renderStepInstr(step),
-          );
-          return true;
-        case 'ldPtrGlobRp':
-          if (step.rp === 'HL') {
-            emitAbs16Fixup(0x22, step.glob.toLowerCase(), 0, span, renderStepInstr(step));
-          } else {
-            emitAbs16FixupEd(
-              step.rp === 'BC' ? 0x43 : 0x53,
-              step.glob.toLowerCase(),
-              0,
-              span,
-              renderStepInstr(step),
-            );
-          }
-          return true;
-        case 'ldHlRp':
-          if (step.rp === 'HL') return true;
-          if (step.rp === 'DE') {
-            return (
-              emitInstr('ld', [mkReg('H'), mkReg('D')], span) &&
-              emitInstr('ld', [mkReg('L'), mkReg('E')], span)
-            );
-          }
-          return (
-            emitInstr('ld', [mkReg('H'), mkReg('B')], span) &&
-            emitInstr('ld', [mkReg('L'), mkReg('C')], span)
-          );
-        case 'ldRegGlob':
-          return emitInstr(
-            'ld',
-            [
-              mkStepReg(step.reg),
-              { kind: 'Mem', span, expr: { kind: 'EaName', span, name: step.glob } },
-            ],
-            span,
-          );
-        case 'ldGlobReg':
-          return emitInstr(
-            'ld',
-            [
-              { kind: 'Mem', span, expr: { kind: 'EaName', span, name: step.glob } },
-              mkStepReg(step.reg),
-            ],
-            span,
-          );
-        case 'ldRpByteFromReg': {
-          const regName = rpByte(step.rp, step.part);
-          if (!regName) return false;
-          return emitInstr('ld', [mkReg(regName), mkStepReg(step.reg)], span);
-        }
-        case 'ldRegFromRpByte': {
-          const src = rpByte(step.rp, step.part);
-          if (!src) return false;
-          return emitInstr('ld', [mkStepReg(step.reg), mkReg(src)], span);
-        }
-      }
-    };
-
-    for (const step of pipe) {
-      if (!emitStepInstr(step)) return false;
-    }
-    return true;
-  };
-
   const emitAbs16Fixup = (
     opcode: number,
     baseLower: string,
@@ -690,6 +505,27 @@ export function emitProgram(
       asmText ?? formatAbs16FixupEdAsm(opcode2, baseLower, addend),
     );
   };
+
+  ({
+    emitCodeBytes,
+    emitRawCodeBytes,
+    emitStepPipeline,
+  } = createEmissionCoreHelpers({
+    getCodeOffset: () => codeOffset,
+    setCodeOffset: (value) => {
+      codeOffset = value;
+    },
+    setCodeByte: (offset, value) => {
+      codeBytes.set(offset, value);
+    },
+    recordCodeSourceRange,
+    traceInstruction,
+    emitInstr: (head, operands, span) => emitInstr(head, operands, span),
+    loadImm16ToDE: (value, span) => loadImm16ToDE(value, span),
+    loadImm16ToHL: (value, span) => loadImm16ToHL(value, span),
+    emitAbs16Fixup,
+    emitAbs16FixupEd,
+  }));
 
   const emitAbs16FixupPrefixed = (
     prefix: number,

--- a/test/pr528_emission_core_helpers.test.ts
+++ b/test/pr528_emission_core_helpers.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AsmOperandNode, SourceSpan } from '../src/frontend/ast.js';
+import { createEmissionCoreHelpers } from '../src/lowering/emissionCore.js';
+import type { StepPipeline } from '../src/addressing/steps.js';
+
+const span: SourceSpan = {
+  file: 'test.zax',
+  start: { offset: 0, line: 1, column: 1 },
+  end: { offset: 0, line: 1, column: 1 },
+};
+
+describe('#528 emission core helpers', () => {
+  it('keeps raw byte emission and step-pipeline execution stable', () => {
+    let codeOffset = 0;
+    const bytes = new Map<number, number>();
+    const ranges: Array<[number, number]> = [];
+    const traces: Array<{ start: number; bytes: number[]; text: string }> = [];
+    const emittedInstrs: Array<{ head: string; operands: AsmOperandNode[] }> = [];
+    const fixups: string[] = [];
+
+    const { emitRawCodeBytes, emitStepPipeline } = createEmissionCoreHelpers({
+      getCodeOffset: () => codeOffset,
+      setCodeOffset: (value) => {
+        codeOffset = value;
+      },
+      setCodeByte: (offset, value) => {
+        bytes.set(offset, value);
+      },
+      recordCodeSourceRange: (start, end) => {
+        ranges.push([start, end]);
+      },
+      traceInstruction: (start, bs, traceText) => {
+        traces.push({ start, bytes: Array.from(bs), text: traceText });
+      },
+      emitInstr: (head, operands) => {
+        emittedInstrs.push({ head, operands });
+        return true;
+      },
+      loadImm16ToDE: () => {
+        emittedInstrs.push({ head: 'ldImm16ToDE', operands: [] });
+        return true;
+      },
+      loadImm16ToHL: () => {
+        emittedInstrs.push({ head: 'ldImm16ToHL', operands: [] });
+        return true;
+      },
+      emitAbs16Fixup: (_opcode, _baseLower, _addend, _span, asmText) => {
+        fixups.push(asmText ?? '');
+      },
+      emitAbs16FixupEd: (_opcode2, _baseLower, _addend, _span, asmText) => {
+        fixups.push(asmText ?? '');
+      },
+    });
+
+    emitRawCodeBytes(Uint8Array.of(0x3e, 0x12), span.file, 'ld a, $12');
+    const pipe: StepPipeline = [
+      { kind: 'push', reg: 'HL' },
+      { kind: 'ldRpGlob', rp: 'HL', glob: 'glob_w' },
+      { kind: 'ldRegReg', dst: 'A', src: 'B' },
+    ];
+    expect(emitStepPipeline(pipe, span)).toBe(true);
+
+    expect(codeOffset).toBe(2);
+    expect(Array.from(bytes.entries())).toEqual([
+      [0, 0x3e],
+      [1, 0x12],
+    ]);
+    expect(ranges).toEqual([[0, 2]]);
+    expect(traces).toEqual([{ start: 0, bytes: [0x3e, 0x12], text: 'ld a, $12' }]);
+    expect(emittedInstrs.map((entry) => entry.head)).toEqual(['push', 'ld']);
+    expect(fixups).toEqual(['ld hl, glob_w']);
+  });
+});


### PR DESCRIPTION
## Summary\n- extract the generic emission core and typed step-pipeline helper from emit\n- keep fixup helpers in emit and pass them into the extracted module as callbacks\n- add focused helper coverage for raw byte emission and step-pipeline execution\n\n## Verification\n- npm run typecheck\n- npm test -- --run test/pr528_emission_core_helpers.test.ts test/pr407_step_matrix.test.ts test/pr468_typed_step_integration.test.ts test/pr511_asm_body_orchestration_helpers.test.ts test/smoke_language_tour_compile.test.ts\n