### PR TITLE
Extract fixup emission helpers

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -93,6 +93,7 @@ import { createAsmRangeLoweringHelpers } from './asmRangeLowering.js';
 import { createAsmBodyOrchestrationHelpers } from './asmBodyOrchestration.js';
 import { createOpMatchingHelpers } from './opMatching.js';
 import { createEmissionCoreHelpers } from './emissionCore.js';
+import { createFixupEmissionHelpers } from './fixupEmission.js';
 import {
   alignTo,
   computeWrittenRange,
@@ -101,9 +102,6 @@ import {
   writeSection,
 } from './sectionLayout.js';
 import {
-  formatAbs16FixupAsm,
-  formatAbs16FixupEdAsm,
-  formatAbs16FixupPrefixedAsm,
   formatAsmInstrForTrace,
   formatIxDisp,
   toHexByte,
@@ -465,46 +463,36 @@ export function emitProgram(
       emitInstr,
     });
 
-  const emitAbs16Fixup = (
-    opcode: number,
-    baseLower: string,
-    addend: number,
-    span: SourceSpan,
-    asmText?: string,
-  ): void => {
-    const start = codeOffset;
-    codeBytes.set(codeOffset++, opcode);
-    codeBytes.set(codeOffset++, 0x00);
-    codeBytes.set(codeOffset++, 0x00);
-    recordCodeSourceRange(start, codeOffset);
-    fixups.push({ offset: start + 1, baseLower, addend, file: span.file });
-    traceInstruction(
-      start,
-      Uint8Array.of(opcode, 0x00, 0x00),
-      asmText ?? formatAbs16FixupAsm(opcode, baseLower, addend),
-    );
-  };
-
-  const emitAbs16FixupEd = (
-    opcode2: number,
-    baseLower: string,
-    addend: number,
-    span: SourceSpan,
-    asmText?: string,
-  ): void => {
-    const start = codeOffset;
-    codeBytes.set(codeOffset++, 0xed);
-    codeBytes.set(codeOffset++, opcode2);
-    codeBytes.set(codeOffset++, 0x00);
-    codeBytes.set(codeOffset++, 0x00);
-    recordCodeSourceRange(start, codeOffset);
-    fixups.push({ offset: start + 2, baseLower, addend, file: span.file });
-    traceInstruction(
-      start,
-      Uint8Array.of(0xed, opcode2, 0x00, 0x00),
-      asmText ?? formatAbs16FixupEdAsm(opcode2, baseLower, addend),
-    );
-  };
+  const {
+    callConditionOpcodeFromName,
+    conditionNameFromOpcode,
+    conditionOpcode,
+    conditionOpcodeFromName,
+    emitAbs16Fixup,
+    emitAbs16FixupEd,
+    emitAbs16FixupPrefixed,
+    emitRel8Fixup,
+    inverseConditionName,
+    jrConditionOpcodeFromName,
+    symbolicTargetFromExpr,
+  } = createFixupEmissionHelpers({
+    getCodeOffset: () => codeOffset,
+    setCodeOffset: (value) => {
+      codeOffset = value;
+    },
+    setCodeByte: (offset, value) => {
+      codeBytes.set(offset, value);
+    },
+    recordCodeSourceRange,
+    pushFixup: (fixup) => {
+      fixups.push(fixup);
+    },
+    pushRel8Fixup: (fixup) => {
+      rel8Fixups.push(fixup);
+    },
+    traceInstruction,
+    evalImmExpr: (expr) => evalImmExpr(expr, env, diagnostics),
+  });
 
   ({
     emitCodeBytes,
@@ -526,194 +514,6 @@ export function emitProgram(
     emitAbs16Fixup,
     emitAbs16FixupEd,
   }));
-
-  const emitAbs16FixupPrefixed = (
-    prefix: number,
-    opcode2: number,
-    baseLower: string,
-    addend: number,
-    span: SourceSpan,
-    asmText?: string,
-  ): void => {
-    const start = codeOffset;
-    codeBytes.set(codeOffset++, prefix);
-    codeBytes.set(codeOffset++, opcode2);
-    codeBytes.set(codeOffset++, 0x00);
-    codeBytes.set(codeOffset++, 0x00);
-    recordCodeSourceRange(start, codeOffset);
-    fixups.push({ offset: start + 2, baseLower, addend, file: span.file });
-    traceInstruction(
-      start,
-      Uint8Array.of(prefix, opcode2, 0x00, 0x00),
-      asmText ?? formatAbs16FixupPrefixedAsm(prefix, opcode2, baseLower, addend),
-    );
-  };
-
-  const emitRel8Fixup = (
-    opcode: number,
-    baseLower: string,
-    addend: number,
-    span: SourceSpan,
-    mnemonic: string,
-    asmText?: string,
-  ): void => {
-    const start = codeOffset;
-    codeBytes.set(codeOffset++, opcode);
-    codeBytes.set(codeOffset++, 0x00);
-    recordCodeSourceRange(start, codeOffset);
-    rel8Fixups.push({
-      offset: start + 1,
-      origin: start + 2,
-      baseLower,
-      addend,
-      file: span.file,
-      mnemonic,
-    });
-    traceInstruction(start, Uint8Array.of(opcode, 0x00), asmText ?? `${mnemonic} ${baseLower}`);
-  };
-
-  const conditionOpcodeFromName = (nameRaw: string): number | undefined => {
-    const asName = nameRaw.toUpperCase();
-    switch (asName) {
-      case 'NZ':
-        return 0xc2;
-      case 'Z':
-        return 0xca;
-      case 'NC':
-        return 0xd2;
-      case 'C':
-        return 0xda;
-      case 'PO':
-        return 0xe2;
-      case 'PE':
-        return 0xea;
-      case 'P':
-        return 0xf2;
-      case 'M':
-        return 0xfa;
-      default:
-        return undefined;
-    }
-  };
-  const conditionNameFromOpcode = (opcode: number): string | undefined => {
-    switch (opcode) {
-      case 0xc2:
-        return 'NZ';
-      case 0xca:
-        return 'Z';
-      case 0xd2:
-        return 'NC';
-      case 0xda:
-        return 'C';
-      case 0xe2:
-        return 'PO';
-      case 0xea:
-        return 'PE';
-      case 0xf2:
-        return 'P';
-      case 0xfa:
-        return 'M';
-      default:
-        return undefined;
-    }
-  };
-  const callConditionOpcodeFromName = (nameRaw: string): number | undefined => {
-    switch (nameRaw.toUpperCase()) {
-      case 'NZ':
-        return 0xc4;
-      case 'Z':
-        return 0xcc;
-      case 'NC':
-        return 0xd4;
-      case 'C':
-        return 0xdc;
-      case 'PO':
-        return 0xe4;
-      case 'PE':
-        return 0xec;
-      case 'P':
-        return 0xf4;
-      case 'M':
-        return 0xfc;
-      default:
-        return undefined;
-    }
-  };
-
-  const symbolicTargetFromExpr = (
-    expr: ImmExprNode,
-  ): { baseLower: string; addend: number } | undefined => {
-    if (expr.kind === 'ImmName') return { baseLower: expr.name.toLowerCase(), addend: 0 };
-
-    if (expr.kind !== 'ImmBinary') return undefined;
-    if (expr.op !== '+' && expr.op !== '-') return undefined;
-
-    const leftName = expr.left.kind === 'ImmName' ? expr.left.name.toLowerCase() : undefined;
-    const rightName = expr.right.kind === 'ImmName' ? expr.right.name.toLowerCase() : undefined;
-
-    if (leftName) {
-      const right = evalImmExpr(expr.right, env, diagnostics);
-      if (right === undefined) return undefined;
-      const addend = expr.op === '+' ? right : -right;
-      return { baseLower: leftName, addend };
-    }
-
-    if (expr.op === '+' && rightName) {
-      const left = evalImmExpr(expr.left, env, diagnostics);
-      if (left === undefined) return undefined;
-      return { baseLower: rightName, addend: left };
-    }
-
-    return undefined;
-  };
-  const jrConditionOpcodeFromName = (nameRaw: string): number | undefined => {
-    switch (nameRaw.toUpperCase()) {
-      case 'NZ':
-        return 0x20;
-      case 'Z':
-        return 0x28;
-      case 'NC':
-        return 0x30;
-      case 'C':
-        return 0x38;
-      default:
-        return undefined;
-    }
-  };
-
-  const conditionOpcode = (op: AsmOperandNode): number | undefined => {
-    const asName =
-      op.kind === 'Imm' && op.expr.kind === 'ImmName'
-        ? op.expr.name
-        : op.kind === 'Reg'
-          ? op.name
-          : undefined;
-    return asName ? conditionOpcodeFromName(asName) : undefined;
-  };
-
-  const inverseConditionName = (nameRaw: string): string | undefined => {
-    const name = nameRaw.toUpperCase();
-    switch (name) {
-      case 'NZ':
-        return 'Z';
-      case 'Z':
-        return 'NZ';
-      case 'NC':
-        return 'C';
-      case 'C':
-        return 'NC';
-      case 'PO':
-        return 'PE';
-      case 'PE':
-        return 'PO';
-      case 'P':
-        return 'M';
-      case 'M':
-        return 'P';
-      default:
-        return undefined;
-    }
-  };
 
   const flattenEaDottedName = (ea: EaExprNode): string | undefined => {
     if (ea.kind === 'EaName') return ea.name;

--- a/src/lowering/fixupEmission.ts
+++ b/src/lowering/fixupEmission.ts
@@ -1,0 +1,288 @@
+import type { Diagnostic } from '../diagnostics/types.js';
+import type { AsmOperandNode, ImmExprNode, SourceSpan } from '../frontend/ast.js';
+import {
+  formatAbs16FixupAsm,
+  formatAbs16FixupEdAsm,
+  formatAbs16FixupPrefixedAsm,
+} from './traceFormat.js';
+
+type FixupRecord = {
+  offset: number;
+  baseLower: string;
+  addend: number;
+  file: string;
+};
+
+type Rel8FixupRecord = {
+  offset: number;
+  origin: number;
+  baseLower: string;
+  addend: number;
+  file: string;
+  mnemonic: string;
+};
+
+type EvalImmExpr = (expr: ImmExprNode) => number | undefined;
+
+type TraceInstruction = (start: number, bytes: Uint8Array, asmText: string) => void;
+
+type Context = {
+  getCodeOffset: () => number;
+  setCodeOffset: (value: number) => void;
+  setCodeByte: (offset: number, value: number) => void;
+  recordCodeSourceRange: (start: number, end: number) => void;
+  pushFixup: (fixup: FixupRecord) => void;
+  pushRel8Fixup: (fixup: Rel8FixupRecord) => void;
+  traceInstruction: TraceInstruction;
+  evalImmExpr: EvalImmExpr;
+};
+
+export function createFixupEmissionHelpers(ctx: Context) {
+  const emitAbs16Fixup = (
+    opcode: number,
+    baseLower: string,
+    addend: number,
+    span: SourceSpan,
+    asmText?: string,
+  ): void => {
+    const start = ctx.getCodeOffset();
+    ctx.setCodeByte(start, opcode);
+    ctx.setCodeByte(start + 1, 0x00);
+    ctx.setCodeByte(start + 2, 0x00);
+    ctx.setCodeOffset(start + 3);
+    ctx.recordCodeSourceRange(start, start + 3);
+    ctx.pushFixup({ offset: start + 1, baseLower, addend, file: span.file });
+    ctx.traceInstruction(
+      start,
+      Uint8Array.of(opcode, 0x00, 0x00),
+      asmText ?? formatAbs16FixupAsm(opcode, baseLower, addend),
+    );
+  };
+
+  const emitAbs16FixupEd = (
+    opcode2: number,
+    baseLower: string,
+    addend: number,
+    span: SourceSpan,
+    asmText?: string,
+  ): void => {
+    const start = ctx.getCodeOffset();
+    ctx.setCodeByte(start, 0xed);
+    ctx.setCodeByte(start + 1, opcode2);
+    ctx.setCodeByte(start + 2, 0x00);
+    ctx.setCodeByte(start + 3, 0x00);
+    ctx.setCodeOffset(start + 4);
+    ctx.recordCodeSourceRange(start, start + 4);
+    ctx.pushFixup({ offset: start + 2, baseLower, addend, file: span.file });
+    ctx.traceInstruction(
+      start,
+      Uint8Array.of(0xed, opcode2, 0x00, 0x00),
+      asmText ?? formatAbs16FixupEdAsm(opcode2, baseLower, addend),
+    );
+  };
+
+  const emitAbs16FixupPrefixed = (
+    prefix: number,
+    opcode2: number,
+    baseLower: string,
+    addend: number,
+    span: SourceSpan,
+    asmText?: string,
+  ): void => {
+    const start = ctx.getCodeOffset();
+    ctx.setCodeByte(start, prefix);
+    ctx.setCodeByte(start + 1, opcode2);
+    ctx.setCodeByte(start + 2, 0x00);
+    ctx.setCodeByte(start + 3, 0x00);
+    ctx.setCodeOffset(start + 4);
+    ctx.recordCodeSourceRange(start, start + 4);
+    ctx.pushFixup({ offset: start + 2, baseLower, addend, file: span.file });
+    ctx.traceInstruction(
+      start,
+      Uint8Array.of(prefix, opcode2, 0x00, 0x00),
+      asmText ?? formatAbs16FixupPrefixedAsm(prefix, opcode2, baseLower, addend),
+    );
+  };
+
+  const emitRel8Fixup = (
+    opcode: number,
+    baseLower: string,
+    addend: number,
+    span: SourceSpan,
+    mnemonic: string,
+    asmText?: string,
+  ): void => {
+    const start = ctx.getCodeOffset();
+    ctx.setCodeByte(start, opcode);
+    ctx.setCodeByte(start + 1, 0x00);
+    ctx.setCodeOffset(start + 2);
+    ctx.recordCodeSourceRange(start, start + 2);
+    ctx.pushRel8Fixup({
+      offset: start + 1,
+      origin: start + 2,
+      baseLower,
+      addend,
+      file: span.file,
+      mnemonic,
+    });
+    ctx.traceInstruction(start, Uint8Array.of(opcode, 0x00), asmText ?? `${mnemonic} ${baseLower}`);
+  };
+
+  const conditionOpcodeFromName = (nameRaw: string): number | undefined => {
+    const asName = nameRaw.toUpperCase();
+    switch (asName) {
+      case 'NZ':
+        return 0xc2;
+      case 'Z':
+        return 0xca;
+      case 'NC':
+        return 0xd2;
+      case 'C':
+        return 0xda;
+      case 'PO':
+        return 0xe2;
+      case 'PE':
+        return 0xea;
+      case 'P':
+        return 0xf2;
+      case 'M':
+        return 0xfa;
+      default:
+        return undefined;
+    }
+  };
+
+  const conditionNameFromOpcode = (opcode: number): string | undefined => {
+    switch (opcode) {
+      case 0xc2:
+        return 'NZ';
+      case 0xca:
+        return 'Z';
+      case 0xd2:
+        return 'NC';
+      case 0xda:
+        return 'C';
+      case 0xe2:
+        return 'PO';
+      case 0xea:
+        return 'PE';
+      case 0xf2:
+        return 'P';
+      case 0xfa:
+        return 'M';
+      default:
+        return undefined;
+    }
+  };
+
+  const callConditionOpcodeFromName = (nameRaw: string): number | undefined => {
+    switch (nameRaw.toUpperCase()) {
+      case 'NZ':
+        return 0xc4;
+      case 'Z':
+        return 0xcc;
+      case 'NC':
+        return 0xd4;
+      case 'C':
+        return 0xdc;
+      case 'PO':
+        return 0xe4;
+      case 'PE':
+        return 0xec;
+      case 'P':
+        return 0xf4;
+      case 'M':
+        return 0xfc;
+      default:
+        return undefined;
+    }
+  };
+
+  const symbolicTargetFromExpr = (
+    expr: ImmExprNode,
+  ): { baseLower: string; addend: number } | undefined => {
+    if (expr.kind === 'ImmName') return { baseLower: expr.name.toLowerCase(), addend: 0 };
+    if (expr.kind !== 'ImmBinary') return undefined;
+    if (expr.op !== '+' && expr.op !== '-') return undefined;
+
+    const leftName = expr.left.kind === 'ImmName' ? expr.left.name.toLowerCase() : undefined;
+    const rightName = expr.right.kind === 'ImmName' ? expr.right.name.toLowerCase() : undefined;
+
+    if (leftName) {
+      const right = ctx.evalImmExpr(expr.right);
+      if (right === undefined) return undefined;
+      return { baseLower: leftName, addend: expr.op === '+' ? right : -right };
+    }
+
+    if (expr.op === '+' && rightName) {
+      const left = ctx.evalImmExpr(expr.left);
+      if (left === undefined) return undefined;
+      return { baseLower: rightName, addend: left };
+    }
+
+    return undefined;
+  };
+
+  const jrConditionOpcodeFromName = (nameRaw: string): number | undefined => {
+    switch (nameRaw.toUpperCase()) {
+      case 'NZ':
+        return 0x20;
+      case 'Z':
+        return 0x28;
+      case 'NC':
+        return 0x30;
+      case 'C':
+        return 0x38;
+      default:
+        return undefined;
+    }
+  };
+
+  const conditionOpcode = (op: AsmOperandNode): number | undefined => {
+    const asName =
+      op.kind === 'Imm' && op.expr.kind === 'ImmName'
+        ? op.expr.name
+        : op.kind === 'Reg'
+          ? op.name
+          : undefined;
+    return asName ? conditionOpcodeFromName(asName) : undefined;
+  };
+
+  const inverseConditionName = (nameRaw: string): string | undefined => {
+    const name = nameRaw.toUpperCase();
+    switch (name) {
+      case 'NZ':
+        return 'Z';
+      case 'Z':
+        return 'NZ';
+      case 'NC':
+        return 'C';
+      case 'C':
+        return 'NC';
+      case 'PO':
+        return 'PE';
+      case 'PE':
+        return 'PO';
+      case 'P':
+        return 'M';
+      case 'M':
+        return 'P';
+      default:
+        return undefined;
+    }
+  };
+
+  return {
+    callConditionOpcodeFromName,
+    conditionNameFromOpcode,
+    conditionOpcode,
+    conditionOpcodeFromName,
+    emitAbs16Fixup,
+    emitAbs16FixupEd,
+    emitAbs16FixupPrefixed,
+    emitRel8Fixup,
+    inverseConditionName,
+    jrConditionOpcodeFromName,
+    symbolicTargetFromExpr,
+  };
+}

--- a/test/pr529_fixup_emission_helpers.test.ts
+++ b/test/pr529_fixup_emission_helpers.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+
+import { createFixupEmissionHelpers } from '../src/lowering/fixupEmission.js';
+
+describe('PR529 fixup emission helpers', () => {
+  it('emits abs16 and rel8 fixups with the current trace shape', () => {
+    let codeOffset = 0;
+    const bytes = new Map<number, number>();
+    const fixups: Array<{ offset: number; baseLower: string; addend: number; file: string }> = [];
+    const rel8Fixups: Array<{
+      offset: number;
+      origin: number;
+      baseLower: string;
+      addend: number;
+      file: string;
+      mnemonic: string;
+    }> = [];
+    const traces: Array<{ start: number; bytes: number[]; asmText: string }> = [];
+    const ranges: Array<[number, number]> = [];
+
+    const helpers = createFixupEmissionHelpers({
+      getCodeOffset: () => codeOffset,
+      setCodeOffset: (value) => {
+        codeOffset = value;
+      },
+      setCodeByte: (offset, value) => {
+        bytes.set(offset, value);
+      },
+      recordCodeSourceRange: (start, end) => {
+        ranges.push([start, end]);
+      },
+      pushFixup: (fixup) => {
+        fixups.push(fixup);
+      },
+      pushRel8Fixup: (fixup) => {
+        rel8Fixups.push(fixup);
+      },
+      traceInstruction: (start, emitted, asmText) => {
+        traces.push({ start, bytes: [...emitted], asmText });
+      },
+      evalImmExpr: (expr) => {
+        if (expr.kind === 'ImmLiteral') return expr.value;
+        return undefined;
+      },
+    });
+
+    const span = {
+      file: 'fixture.zax',
+      start: { line: 1, column: 1, offset: 0 },
+      end: { line: 1, column: 1, offset: 0 },
+    };
+
+    helpers.emitAbs16Fixup(0x21, 'glob_w', 2, span);
+    helpers.emitRel8Fixup(0x18, 'loop', -1, span, 'jr');
+
+    expect(codeOffset).toBe(5);
+    expect([...bytes.entries()]).toEqual([
+      [0, 0x21],
+      [1, 0x00],
+      [2, 0x00],
+      [3, 0x18],
+      [4, 0x00],
+    ]);
+    expect(fixups).toEqual([{ offset: 1, baseLower: 'glob_w', addend: 2, file: 'fixture.zax' }]);
+    expect(rel8Fixups).toEqual([
+      {
+        offset: 4,
+        origin: 5,
+        baseLower: 'loop',
+        addend: -1,
+        file: 'fixture.zax',
+        mnemonic: 'jr',
+      },
+    ]);
+    expect(ranges).toEqual([
+      [0, 3],
+      [3, 5],
+    ]);
+    expect(traces).toEqual([
+      { start: 0, bytes: [0x21, 0x00, 0x00], asmText: 'ld HL, glob_w + 2' },
+      { start: 3, bytes: [0x18, 0x00], asmText: 'jr loop' },
+    ]);
+  });
+
+  it('keeps condition helpers and symbolic targets stable', () => {
+    const helpers = createFixupEmissionHelpers({
+      getCodeOffset: () => 0,
+      setCodeOffset: () => {},
+      setCodeByte: () => {},
+      recordCodeSourceRange: () => {},
+      pushFixup: () => {},
+      pushRel8Fixup: () => {},
+      traceInstruction: () => {},
+      evalImmExpr: (expr) => (expr.kind === 'ImmLiteral' ? expr.value : undefined),
+    });
+
+    expect(helpers.conditionOpcodeFromName('nz')).toBe(0xc2);
+    expect(helpers.conditionNameFromOpcode(0xfa)).toBe('M');
+    expect(helpers.callConditionOpcodeFromName('c')).toBe(0xdc);
+    expect(helpers.jrConditionOpcodeFromName('z')).toBe(0x28);
+    expect(helpers.inverseConditionName('po')).toBe('PE');
+    expect(
+      helpers.conditionOpcode({
+        kind: 'Reg',
+        span: {
+          file: 'fixture.zax',
+          start: { line: 1, column: 1, offset: 0 },
+          end: { line: 1, column: 1, offset: 0 },
+        },
+        name: 'nz',
+      }),
+    ).toBe(0xc2);
+    expect(
+      helpers.symbolicTargetFromExpr({
+        kind: 'ImmBinary',
+        span: {
+          file: 'fixture.zax',
+          start: { line: 1, column: 1, offset: 0 },
+          end: { line: 1, column: 1, offset: 0 },
+        },
+        op: '+',
+        left: {
+          kind: 'ImmName',
+          span: {
+            file: 'fixture.zax',
+            start: { line: 1, column: 1, offset: 0 },
+            end: { line: 1, column: 1, offset: 0 },
+          },
+          name: 'target',
+        },
+        right: {
+          kind: 'ImmLiteral',
+          span: {
+            file: 'fixture.zax',
+            start: { line: 1, column: 1, offset: 0 },
+            end: { line: 1, column: 1, offset: 0 },
+          },
+          value: 4,
+        },
+      }),
+    ).toEqual({ baseLower: 'target', addend: 4 });
+  });
+});


### PR DESCRIPTION
Summary:\n- extract the fixup emission and condition helper cluster from src/lowering/emit.ts\n- add focused helper coverage for fixup emission, condition mapping, and symbolic target folding\n- keep the #528 emission core boundary intact while reducing emit.ts\n\nVerification:\n- npm run typecheck\n- npm test -- --run test/pr529_fixup_emission_helpers.test.ts test/pr528_emission_core_helpers.test.ts test/pr468_typed_step_integration.test.ts test/pr511_asm_body_orchestration_helpers.test.ts test/smoke_language_tour_compile.test.ts