### PR TITLE
Extract asm utility helpers

### DIFF
--- a/src/lowering/asmUtils.ts
+++ b/src/lowering/asmUtils.ts
@@ -1,0 +1,101 @@
+import type { AsmOperandNode, EaExprNode, ImmExprNode, OffsetofPathNode } from '../frontend/ast.js';
+
+type Context = {
+  isEnumName: (name: string) => boolean;
+};
+
+function cloneOffsetofPath(path: OffsetofPathNode): OffsetofPathNode {
+  return {
+    ...path,
+    steps: path.steps.map((step) =>
+      step.kind === 'OffsetofIndex' ? { ...step, expr: cloneImmExpr(step.expr) } : { ...step },
+    ),
+  };
+}
+
+export function cloneImmExpr(expr: ImmExprNode): ImmExprNode {
+  if (expr.kind === 'ImmLiteral') return { ...expr };
+  if (expr.kind === 'ImmName') return { ...expr };
+  if (expr.kind === 'ImmSizeof') return { ...expr };
+  if (expr.kind === 'ImmOffsetof') return { ...expr, path: cloneOffsetofPath(expr.path) };
+  if (expr.kind === 'ImmUnary') return { ...expr, expr: cloneImmExpr(expr.expr) };
+  return { ...expr, left: cloneImmExpr(expr.left), right: cloneImmExpr(expr.right) };
+}
+
+export function cloneEaExpr(ea: EaExprNode): EaExprNode {
+  switch (ea.kind) {
+    case 'EaName':
+      return { ...ea };
+    case 'EaField':
+      return { ...ea, base: cloneEaExpr(ea.base) };
+    case 'EaIndex':
+      return {
+        ...ea,
+        base: cloneEaExpr(ea.base),
+        index:
+          ea.index.kind === 'IndexEa'
+            ? { ...ea.index, expr: cloneEaExpr(ea.index.expr) }
+            : ea.index.kind === 'IndexImm'
+              ? { ...ea.index, value: cloneImmExpr(ea.index.value) }
+              : ea.index.kind === 'IndexMemIxIy' && ea.index.disp
+                ? { ...ea.index, disp: cloneImmExpr(ea.index.disp) }
+                : { ...ea.index },
+      };
+    case 'EaAdd':
+    case 'EaSub':
+      return { ...ea, base: cloneEaExpr(ea.base), offset: cloneImmExpr(ea.offset) };
+  }
+}
+
+export function cloneOperand(op: AsmOperandNode): AsmOperandNode {
+  switch (op.kind) {
+    case 'Reg':
+    case 'PortC':
+      return { ...op };
+    case 'Imm':
+    case 'PortImm8':
+      return { ...op, expr: cloneImmExpr(op.expr) } as AsmOperandNode;
+    case 'Ea':
+    case 'Mem':
+      return { ...op, expr: cloneEaExpr(op.expr) } as AsmOperandNode;
+  }
+}
+
+export function flattenEaDottedName(ea: EaExprNode): string | undefined {
+  if (ea.kind === 'EaName') return ea.name;
+  if (ea.kind === 'EaField') {
+    const base = flattenEaDottedName(ea.base);
+    return base ? `${base}.${ea.field}` : undefined;
+  }
+  return undefined;
+}
+
+export function createAsmUtilityHelpers(ctx: Context) {
+  const enumImmExprFromOperand = (op: AsmOperandNode): ImmExprNode | undefined => {
+    if (op.kind === 'Imm') return op.expr;
+    if (op.kind !== 'Ea') return undefined;
+    const name = flattenEaDottedName(op.expr);
+    if (!name || !ctx.isEnumName(name)) return undefined;
+    return { kind: 'ImmName', span: op.span, name };
+  };
+
+  const normalizeFixedToken = (op: AsmOperandNode): string | undefined => {
+    switch (op.kind) {
+      case 'Reg':
+        return op.name.toUpperCase();
+      case 'Imm':
+        if (op.expr.kind === 'ImmName') return op.expr.name.toUpperCase();
+        return undefined;
+      case 'Ea': {
+        const enumExpr = enumImmExprFromOperand(op);
+        return enumExpr?.kind === 'ImmName' ? enumExpr.name.toUpperCase() : undefined;
+      }
+      default:
+        return undefined;
+    }
+  };
+
+  return {
+    normalizeFixedToken,
+  };
+}

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -95,6 +95,13 @@ import { createOpMatchingHelpers } from './opMatching.js';
 import { createEmissionCoreHelpers } from './emissionCore.js';
 import { createFixupEmissionHelpers } from './fixupEmission.js';
 import {
+  cloneEaExpr,
+  cloneImmExpr,
+  cloneOperand,
+  createAsmUtilityHelpers,
+  flattenEaDottedName,
+} from './asmUtils.js';
+import {
   alignTo,
   computeWrittenRange,
   rebaseAsmTrace,
@@ -515,38 +522,9 @@ export function emitProgram(
     emitAbs16FixupEd,
   }));
 
-  const flattenEaDottedName = (ea: EaExprNode): string | undefined => {
-    if (ea.kind === 'EaName') return ea.name;
-    if (ea.kind === 'EaField') {
-      const base = flattenEaDottedName(ea.base);
-      return base ? `${base}.${ea.field}` : undefined;
-    }
-    return undefined;
-  };
-
-  const enumImmExprFromOperand = (op: AsmOperandNode): ImmExprNode | undefined => {
-    if (op.kind === 'Imm') return op.expr;
-    if (op.kind !== 'Ea') return undefined;
-    const name = flattenEaDottedName(op.expr);
-    if (!name || !env.enums.has(name)) return undefined;
-    return { kind: 'ImmName', span: op.span, name };
-  };
-
-  const normalizeFixedToken = (op: AsmOperandNode): string | undefined => {
-    switch (op.kind) {
-      case 'Reg':
-        return op.name.toUpperCase();
-      case 'Imm':
-        if (op.expr.kind === 'ImmName') return op.expr.name.toUpperCase();
-        return undefined;
-      case 'Ea': {
-        const enumExpr = enumImmExprFromOperand(op);
-        return enumExpr?.kind === 'ImmName' ? enumExpr.name.toUpperCase() : undefined;
-      }
-      default:
-        return undefined;
-    }
-  };
+  const { normalizeFixedToken } = createAsmUtilityHelpers({
+    isEnumName: (name) => env.enums.has(name),
+  });
 
   const evalImmNoDiag = (expr: ImmExprNode): number | undefined => {
     const scratch: Diagnostic[] = [];
@@ -582,61 +560,6 @@ export function emitProgram(
     evalImmNoDiag,
     inferMemWidth,
   });
-
-  const cloneImmExpr = (expr: ImmExprNode): ImmExprNode => {
-    const cloneOffsetofPath = (path: any): any => ({
-      ...path,
-      steps: path.steps.map((step: any) =>
-        step.kind === 'OffsetofIndex' ? { ...step, expr: cloneImmExpr(step.expr) } : { ...step },
-      ),
-    });
-    if (expr.kind === 'ImmLiteral') return { ...expr };
-    if (expr.kind === 'ImmName') return { ...expr };
-    if (expr.kind === 'ImmSizeof') return { ...expr };
-    if (expr.kind === 'ImmOffsetof')
-      return { ...expr, path: cloneOffsetofPath(expr.path) as typeof expr.path };
-    if (expr.kind === 'ImmUnary') return { ...expr, expr: cloneImmExpr(expr.expr) };
-    return { ...expr, left: cloneImmExpr(expr.left), right: cloneImmExpr(expr.right) };
-  };
-
-  const cloneEaExpr = (ea: EaExprNode): EaExprNode => {
-    switch (ea.kind) {
-      case 'EaName':
-        return { ...ea };
-      case 'EaField':
-        return { ...ea, base: cloneEaExpr(ea.base) };
-      case 'EaIndex':
-        return {
-          ...ea,
-          base: cloneEaExpr(ea.base),
-          index:
-            ea.index.kind === 'IndexEa'
-              ? { ...ea.index, expr: cloneEaExpr(ea.index.expr) }
-              : ea.index.kind === 'IndexImm'
-                ? { ...ea.index, value: cloneImmExpr(ea.index.value) }
-                : ea.index.kind === 'IndexMemIxIy' && ea.index.disp
-                  ? { ...ea.index, disp: cloneImmExpr(ea.index.disp) }
-                  : { ...ea.index },
-        };
-      case 'EaAdd':
-      case 'EaSub':
-        return { ...ea, base: cloneEaExpr(ea.base), offset: cloneImmExpr(ea.offset) };
-    }
-  };
-
-  const cloneOperand = (op: AsmOperandNode): AsmOperandNode => {
-    switch (op.kind) {
-      case 'Reg':
-      case 'PortC':
-        return { ...op };
-      case 'Imm':
-      case 'PortImm8':
-        return { ...op, expr: cloneImmExpr(op.expr) } as AsmOperandNode;
-      case 'Ea':
-      case 'Mem':
-        return { ...op, expr: cloneEaExpr(op.expr) } as AsmOperandNode;
-    }
-  };
 
   const {
     resolveAggregateType,

--- a/test/pr530_asm_utils_helpers.test.ts
+++ b/test/pr530_asm_utils_helpers.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  cloneEaExpr,
+  cloneImmExpr,
+  cloneOperand,
+  createAsmUtilityHelpers,
+  flattenEaDottedName,
+} from '../src/lowering/asmUtils.js';
+import type { AsmOperandNode, EaExprNode, ImmExprNode, SourceSpan } from '../src/frontend/ast.js';
+
+const span: SourceSpan = {
+  file: 'fixture.zax',
+  start: { line: 1, column: 1, offset: 0 },
+  end: { line: 1, column: 1, offset: 0 },
+};
+
+describe('PR530 asm utility helpers', () => {
+  it('clones immediate, ea, and operand nodes deeply', () => {
+    const imm: ImmExprNode = {
+      kind: 'ImmBinary',
+      span,
+      op: '+',
+      left: { kind: 'ImmName', span, name: 'lhs' },
+      right: { kind: 'ImmLiteral', span, value: 4 },
+    };
+    const ea: EaExprNode = {
+      kind: 'EaAdd',
+      span,
+      base: {
+        kind: 'EaIndex',
+        span,
+        base: { kind: 'EaField', span, base: { kind: 'EaName', span, name: 'obj' }, field: 'arr' },
+        index: { kind: 'IndexImm', span, value: imm },
+      },
+      offset: { kind: 'ImmLiteral', span, value: 2 },
+    };
+    const operand: AsmOperandNode = { kind: 'Mem', span, expr: ea };
+
+    const clonedImm = cloneImmExpr(imm);
+    const clonedEa = cloneEaExpr(ea);
+    const clonedOperand = cloneOperand(operand);
+
+    expect(clonedImm).toEqual(imm);
+    expect(clonedImm).not.toBe(imm);
+    expect(clonedEa).toEqual(ea);
+    expect(clonedEa).not.toBe(ea);
+    expect(clonedOperand).toEqual(operand);
+    expect(clonedOperand).not.toBe(operand);
+    expect((clonedOperand as Extract<AsmOperandNode, { kind: 'Mem' }>).expr).not.toBe(ea);
+  });
+
+  it('keeps asm utility token normalization stable', () => {
+    const { normalizeFixedToken } = createAsmUtilityHelpers({
+      isEnumName: (name) => name === 'Mode.Fast',
+    });
+
+    expect(
+      flattenEaDottedName({
+        kind: 'EaField',
+        span,
+        base: { kind: 'EaName', span, name: 'Mode' },
+        field: 'Fast',
+      }),
+    ).toBe('Mode.Fast');
+
+    expect(normalizeFixedToken({ kind: 'Reg', span, name: 'ixh' })).toBe('IXH');
+    expect(
+      normalizeFixedToken({
+        kind: 'Imm',
+        span,
+        expr: { kind: 'ImmName', span, name: 'nz' },
+      }),
+    ).toBe('NZ');
+    expect(
+      normalizeFixedToken({
+        kind: 'Ea',
+        span,
+        expr: {
+          kind: 'EaField',
+          span,
+          base: { kind: 'EaName', span, name: 'Mode' },
+          field: 'Fast',
+        },
+      }),
+    ).toBe('MODE.FAST');
+  });
+});


### PR DESCRIPTION
Summary:\n- extract operand clone and asm utility helpers from src/lowering/emit.ts\n- keep the execution/lowering orchestration in emit.ts while reducing its helper load\n- add focused helper coverage for clone behavior and token normalization\n\nVerification:\n- npm run typecheck\n- npm test -- --run test/pr530_asm_utils_helpers.test.ts test/pr529_fixup_emission_helpers.test.ts test/pr528_emission_core_helpers.test.ts test/pr510_op_substitution_helpers.test.ts test/pr468_typed_step_integration.test.ts test/smoke_language_tour_compile.test.ts