### PR TITLE
Extract asm instruction lowering dispatcher

### DIFF
--- a/src/lowering/asmInstructionLowering.ts
+++ b/src/lowering/asmInstructionLowering.ts
@@ -1,0 +1,380 @@
+import type { Diagnostic } from '../diagnostics/types.js';
+import type { AsmInstructionNode, AsmOperandNode } from '../frontend/ast.js';
+
+type DiagAt = (diagnostics: Diagnostic[], span: AsmInstructionNode['span'], message: string) => void;
+
+type Context = {
+  diagnostics: Diagnostic[];
+  diagAt: DiagAt;
+  emitInstr: (head: string, operands: AsmOperandNode[], span: AsmInstructionNode['span']) => boolean;
+  emitRawCodeBytes: (bytes: Uint8Array, file: string, asmText: string) => void;
+  emitAbs16Fixup: (
+    opcode: number,
+    baseLower: string,
+    addend: number,
+    span: AsmInstructionNode['span'],
+    asmText?: string,
+  ) => void;
+  emitAbs16FixupPrefixed: (
+    prefix: number,
+    opcode2: number,
+    baseLower: string,
+    addend: number,
+    span: AsmInstructionNode['span'],
+    asmText?: string,
+  ) => void;
+  emitRel8Fixup: (
+    opcode: number,
+    baseLower: string,
+    addend: number,
+    span: AsmInstructionNode['span'],
+    mnemonic: string,
+    asmText?: string,
+  ) => void;
+  conditionOpcodeFromName: (nameRaw: string) => number | undefined;
+  conditionNameFromOpcode: (opcode: number) => string | undefined;
+  callConditionOpcodeFromName: (nameRaw: string) => number | undefined;
+  jrConditionOpcodeFromName: (nameRaw: string) => number | undefined;
+  conditionOpcode: (op: AsmOperandNode) => number | undefined;
+  symbolicTargetFromExpr: (
+    expr: Extract<AsmOperandNode, { kind: 'Imm' }>['expr'],
+  ) => { baseLower: string; addend: number } | undefined;
+  evalImmExpr: (expr: Extract<AsmOperandNode, { kind: 'Imm' }>['expr']) => number | undefined;
+  resolveScalarBinding: (name: string) => 'byte' | 'word' | 'addr' | undefined;
+  diagIfRetStackImbalanced: (span: AsmInstructionNode['span'], mnemonic?: string) => void;
+  diagIfCallStackUnverifiable: (options: {
+    span: AsmInstructionNode['span'];
+    mnemonic?: string;
+    contractKind?: 'callee' | 'typed-call';
+  }) => void;
+  warnIfRawCallTargetsTypedCallable: (
+    span: AsmInstructionNode['span'],
+    symbolicTarget: { baseLower: string; addend: number } | undefined,
+  ) => void;
+  lowerLdWithEa: (asmItem: AsmInstructionNode) => boolean;
+  emitVirtualReg16Transfer: (asmItem: AsmInstructionNode) => boolean;
+  emitSyntheticEpilogue: boolean;
+  epilogueLabel: string;
+  emitJumpTo: (label: string, span: AsmInstructionNode['span']) => void;
+  emitJumpCondTo: (opcode: number, label: string, span: AsmInstructionNode['span']) => void;
+  syncToFlow: () => void;
+  flow: { reachable: boolean };
+};
+
+export function createAsmInstructionLoweringHelpers(ctx: Context) {
+  const emitRel8FromOperand = (
+    asmItem: AsmInstructionNode,
+    operand: AsmOperandNode,
+    opcode: number,
+    mnemonic: string,
+  ): boolean => {
+    if (operand.kind !== 'Imm') {
+      if (mnemonic === 'djnz' || mnemonic.startsWith('jr')) {
+        ctx.diagAt(ctx.diagnostics, asmItem.span, `${mnemonic} expects disp8`);
+      } else {
+        ctx.diagAt(ctx.diagnostics, asmItem.span, `${mnemonic} expects an immediate target.`);
+      }
+      return false;
+    }
+    const symbolicTarget = ctx.symbolicTargetFromExpr(operand.expr);
+    if (symbolicTarget) {
+      ctx.emitRel8Fixup(opcode, symbolicTarget.baseLower, symbolicTarget.addend, asmItem.span, mnemonic);
+      return true;
+    }
+    const value = ctx.evalImmExpr(operand.expr);
+    if (value === undefined) {
+      ctx.diagAt(ctx.diagnostics, asmItem.span, `Failed to evaluate ${mnemonic} target.`);
+      return false;
+    }
+    if (value < -128 || value > 127) {
+      ctx.diagAt(
+        ctx.diagnostics,
+        asmItem.span,
+        `${mnemonic} relative branch displacement out of range (-128..127): ${value}.`,
+      );
+      return false;
+    }
+    ctx.emitRawCodeBytes(Uint8Array.of(opcode, value & 0xff), asmItem.span.file, `${mnemonic} ${value}`);
+    return true;
+  };
+
+  const lowerAsmInstructionDispatcher = (asmItem: AsmInstructionNode): void => {
+    const head = asmItem.head.toLowerCase();
+
+    if (head === 'jr') {
+      if (asmItem.operands.length === 1) {
+        if (asmItem.operands[0]!.kind === 'Mem') {
+          ctx.diagAt(ctx.diagnostics, asmItem.span, `jr does not support indirect targets; expects disp8`);
+          return;
+        }
+        const single = asmItem.operands[0]!;
+        const ccSingle =
+          single.kind === 'Imm' && single.expr.kind === 'ImmName'
+            ? single.expr.name
+            : single.kind === 'Reg'
+              ? single.name
+              : undefined;
+        if (ccSingle && ctx.jrConditionOpcodeFromName(ccSingle) !== undefined) {
+          ctx.diagAt(ctx.diagnostics, asmItem.span, `jr cc, disp expects two operands (cc, disp8)`);
+          return;
+        }
+        if (single.kind === 'Imm') {
+          const symbolicTarget = ctx.symbolicTargetFromExpr(single.expr);
+          if (symbolicTarget && ctx.jrConditionOpcodeFromName(symbolicTarget.baseLower) !== undefined) {
+            ctx.diagAt(ctx.diagnostics, asmItem.span, `jr cc, disp expects two operands (cc, disp8)`);
+            return;
+          }
+        }
+        if (single.kind === 'Reg') {
+          ctx.diagAt(ctx.diagnostics, asmItem.span, `jr does not support register targets; expects disp8`);
+          return;
+        }
+        if (!emitRel8FromOperand(asmItem, single, 0x18, 'jr')) return;
+        ctx.flow.reachable = false;
+        ctx.syncToFlow();
+        return;
+      }
+      if (asmItem.operands.length === 2) {
+        const ccOp = asmItem.operands[0]!;
+        const ccName =
+          ccOp.kind === 'Imm' && ccOp.expr.kind === 'ImmName'
+            ? ccOp.expr.name
+            : ccOp.kind === 'Reg'
+              ? ccOp.name
+              : undefined;
+        const opcode = ccName ? ctx.jrConditionOpcodeFromName(ccName) : undefined;
+        if (opcode === undefined) {
+          ctx.diagAt(ctx.diagnostics, asmItem.span, `jr cc expects valid condition code NZ/Z/NC/C`);
+          return;
+        }
+        const target = asmItem.operands[1]!;
+        if (target.kind === 'Mem') {
+          ctx.diagAt(ctx.diagnostics, asmItem.span, `jr cc, disp does not support indirect targets`);
+          return;
+        }
+        if (target.kind === 'Reg') {
+          ctx.diagAt(ctx.diagnostics, asmItem.span, `jr cc, disp does not support register targets; expects disp8`);
+          return;
+        }
+        if (target.kind !== 'Imm') {
+          ctx.diagAt(ctx.diagnostics, asmItem.span, `jr cc, disp expects disp8`);
+          return;
+        }
+        if (!emitRel8FromOperand(asmItem, target, opcode, `jr ${ccName!.toLowerCase()}`)) return;
+        ctx.syncToFlow();
+        return;
+      }
+    }
+
+    if (head === 'djnz') {
+      if (asmItem.operands.length !== 1) {
+        ctx.diagAt(ctx.diagnostics, asmItem.span, `djnz expects one operand (disp8)`);
+        return;
+      }
+      const target = asmItem.operands[0]!;
+      if (target.kind === 'Mem') {
+        ctx.diagAt(ctx.diagnostics, asmItem.span, `djnz does not support indirect targets; expects disp8`);
+        return;
+      }
+      if (target.kind === 'Reg') {
+        ctx.diagAt(ctx.diagnostics, asmItem.span, `djnz does not support register targets; expects disp8`);
+        return;
+      }
+      if (target.kind !== 'Imm') {
+        ctx.diagAt(ctx.diagnostics, asmItem.span, `djnz expects disp8`);
+        return;
+      }
+      if (!emitRel8FromOperand(asmItem, target, 0x10, 'djnz')) return;
+      ctx.syncToFlow();
+      return;
+    }
+
+    if (head === 'call') {
+      ctx.diagIfCallStackUnverifiable({ span: asmItem.span });
+    }
+    if (head === 'rst' && asmItem.operands.length === 1) {
+      ctx.diagIfCallStackUnverifiable({ span: asmItem.span, mnemonic: 'rst' });
+    }
+    if (head === 'ret') {
+      if (asmItem.operands.length === 0) {
+        ctx.diagIfRetStackImbalanced(asmItem.span);
+        if (ctx.emitSyntheticEpilogue) {
+          ctx.emitJumpTo(ctx.epilogueLabel, asmItem.span);
+        } else {
+          ctx.emitInstr('ret', [], asmItem.span);
+        }
+        ctx.flow.reachable = false;
+        ctx.syncToFlow();
+        return;
+      }
+      if (asmItem.operands.length === 1) {
+        const op = ctx.conditionOpcode(asmItem.operands[0]!);
+        if (op === undefined) {
+          ctx.diagAt(ctx.diagnostics, asmItem.span, `ret cc expects a valid condition code`);
+          return;
+        }
+        ctx.diagIfRetStackImbalanced(asmItem.span);
+        if (ctx.emitSyntheticEpilogue) {
+          ctx.emitJumpCondTo(op, ctx.epilogueLabel, asmItem.span);
+        } else {
+          ctx.emitInstr('ret', [asmItem.operands[0]!], asmItem.span);
+        }
+        ctx.syncToFlow();
+        return;
+      }
+    }
+
+    if ((head === 'retn' || head === 'reti') && asmItem.operands.length === 0) {
+      ctx.diagIfRetStackImbalanced(asmItem.span, head);
+      if (ctx.emitSyntheticEpilogue) {
+        ctx.diagAt(
+          ctx.diagnostics,
+          asmItem.span,
+          `${head} is not supported in functions that require cleanup; use ret/ret cc so cleanup epilogue can run.`,
+        );
+      }
+      ctx.emitInstr(head, [], asmItem.span);
+      ctx.flow.reachable = false;
+      ctx.syncToFlow();
+      return;
+    }
+
+    if (head === 'jp' && asmItem.operands.length === 1) {
+      const target = asmItem.operands[0]!;
+      if (target.kind === 'Imm') {
+        const symbolicTarget = ctx.symbolicTargetFromExpr(target.expr);
+        if (symbolicTarget && ctx.conditionOpcodeFromName(symbolicTarget.baseLower) !== undefined) {
+          ctx.diagAt(ctx.diagnostics, asmItem.span, `jp cc, nn expects two operands (cc, nn)`);
+          return;
+        }
+        if (symbolicTarget) {
+          ctx.emitAbs16Fixup(0xc3, symbolicTarget.baseLower, symbolicTarget.addend, asmItem.span);
+          ctx.flow.reachable = false;
+          ctx.syncToFlow();
+          return;
+        }
+      }
+    }
+
+    if (head === 'jp' && asmItem.operands.length === 2) {
+      const ccOp = asmItem.operands[0]!;
+      const ccName =
+        ccOp.kind === 'Imm' && ccOp.expr.kind === 'ImmName'
+          ? ccOp.expr.name
+          : ccOp.kind === 'Reg'
+            ? ccOp.name
+            : undefined;
+      const opcode = ccName ? ctx.conditionOpcodeFromName(ccName) : undefined;
+      const target = asmItem.operands[1]!;
+      if (opcode !== undefined && target.kind === 'Imm') {
+        const symbolicTarget = ctx.symbolicTargetFromExpr(target.expr);
+        if (symbolicTarget) {
+          ctx.emitAbs16Fixup(opcode, symbolicTarget.baseLower, symbolicTarget.addend, asmItem.span);
+          ctx.syncToFlow();
+          return;
+        }
+      }
+    }
+
+    if (head === 'call' && asmItem.operands.length === 1) {
+      const target = asmItem.operands[0]!;
+      if (target.kind === 'Imm') {
+        const symbolicTarget = ctx.symbolicTargetFromExpr(target.expr);
+        if (symbolicTarget && ctx.callConditionOpcodeFromName(symbolicTarget.baseLower) !== undefined) {
+          ctx.diagAt(ctx.diagnostics, asmItem.span, `call cc, nn expects two operands (cc, nn)`);
+          return;
+        }
+        if (symbolicTarget) {
+          ctx.warnIfRawCallTargetsTypedCallable(asmItem.span, symbolicTarget);
+          ctx.emitAbs16Fixup(0xcd, symbolicTarget.baseLower, symbolicTarget.addend, asmItem.span);
+          ctx.syncToFlow();
+          return;
+        }
+      }
+    }
+
+    if (head === 'call' && asmItem.operands.length === 2) {
+      const ccOp = asmItem.operands[0]!;
+      const ccName =
+        ccOp.kind === 'Imm' && ccOp.expr.kind === 'ImmName'
+          ? ccOp.expr.name
+          : ccOp.kind === 'Reg'
+            ? ccOp.name
+            : undefined;
+      const opcode = ccName ? ctx.callConditionOpcodeFromName(ccName) : undefined;
+      const target = asmItem.operands[1]!;
+      if (opcode !== undefined && target.kind === 'Imm') {
+        const symbolicTarget = ctx.symbolicTargetFromExpr(target.expr);
+        if (symbolicTarget) {
+          ctx.warnIfRawCallTargetsTypedCallable(asmItem.span, symbolicTarget);
+          ctx.emitAbs16Fixup(opcode, symbolicTarget.baseLower, symbolicTarget.addend, asmItem.span);
+          ctx.syncToFlow();
+          return;
+        }
+      }
+    }
+
+    if (head === 'ld' && asmItem.operands.length === 2) {
+      const dstOp = asmItem.operands[0]!;
+      const srcOp = asmItem.operands[1]!;
+      const dst = dstOp.kind === 'Reg' ? dstOp.name.toUpperCase() : undefined;
+      const opcode =
+        dst === 'BC'
+          ? 0x01
+          : dst === 'DE'
+            ? 0x11
+            : dst === 'HL'
+              ? 0x21
+              : dst === 'SP'
+                ? 0x31
+                : undefined;
+      if (
+        opcode !== undefined &&
+        srcOp.kind === 'Imm' &&
+        srcOp.expr.kind === 'ImmName' &&
+        !ctx.resolveScalarBinding(srcOp.expr.name)
+      ) {
+        const v = ctx.evalImmExpr(srcOp.expr);
+        if (v === undefined) {
+          ctx.emitAbs16Fixup(opcode, srcOp.expr.name.toLowerCase(), 0, asmItem.span);
+          ctx.syncToFlow();
+          return;
+        }
+      }
+      if (
+        (dst === 'IX' || dst === 'IY') &&
+        srcOp.kind === 'Imm' &&
+        srcOp.expr.kind === 'ImmName' &&
+        !ctx.resolveScalarBinding(srcOp.expr.name)
+      ) {
+        const v = ctx.evalImmExpr(srcOp.expr);
+        if (v === undefined) {
+          ctx.emitAbs16FixupPrefixed(dst === 'IX' ? 0xdd : 0xfd, 0x21, srcOp.expr.name.toLowerCase(), 0, asmItem.span);
+          ctx.syncToFlow();
+          return;
+        }
+      }
+    }
+
+    if (ctx.lowerLdWithEa(asmItem)) {
+      ctx.syncToFlow();
+      return;
+    }
+
+    if (ctx.emitVirtualReg16Transfer(asmItem)) {
+      ctx.syncToFlow();
+      return;
+    }
+
+    if (!ctx.emitInstr(asmItem.head, asmItem.operands, asmItem.span)) return;
+
+    if ((head === 'jp' || head === 'jr') && asmItem.operands.length === 1) {
+      ctx.flow.reachable = false;
+    } else if ((head === 'ret' || head === 'retn' || head === 'reti') && asmItem.operands.length === 0) {
+      ctx.flow.reachable = false;
+    }
+    ctx.syncToFlow();
+  };
+
+  return { lowerAsmInstructionDispatcher };
+}

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -94,6 +94,7 @@ import { createAsmBodyOrchestrationHelpers } from './asmBodyOrchestration.js';
 import { createOpMatchingHelpers } from './opMatching.js';
 import { createEmissionCoreHelpers } from './emissionCore.js';
 import { createValueMaterializationHelpers } from './valueMaterialization.js';
+import { createAsmInstructionLoweringHelpers } from './asmInstructionLowering.js';
 import { createFixupEmissionHelpers } from './fixupEmission.js';
 import {
   cloneEaExpr,
@@ -1632,6 +1633,101 @@ export function emitProgram(
           return false;
         };
 
+        const { lowerAsmInstructionDispatcher } = createAsmInstructionLoweringHelpers({
+          diagnostics,
+          diagAt,
+          emitInstr,
+          emitRawCodeBytes,
+          emitAbs16Fixup,
+          emitAbs16FixupPrefixed,
+          emitRel8Fixup,
+          conditionOpcodeFromName,
+          conditionNameFromOpcode,
+          callConditionOpcodeFromName,
+          jrConditionOpcodeFromName,
+          conditionOpcode,
+          symbolicTargetFromExpr,
+          evalImmExpr: (expr) => evalImmExpr(expr, env, diagnostics),
+          resolveScalarBinding,
+          diagIfRetStackImbalanced: (span, mnemonic) => {
+            if (emitSyntheticEpilogue) return;
+            if (spTrackingValid && spDeltaTracked !== 0) {
+              diagAt(
+                diagnostics,
+                span,
+                `${mnemonic ?? 'ret'} with non-zero tracked stack delta (${spDeltaTracked}); function stack is imbalanced.`,
+              );
+              return;
+            }
+            if (!spTrackingValid && spTrackingInvalidatedByMutation && hasStackSlots) {
+              diagAt(
+                diagnostics,
+                span,
+                `${mnemonic ?? 'ret'} reached after untracked SP mutation; cannot verify function stack balance.`,
+              );
+              return;
+            }
+            if (!spTrackingValid && hasStackSlots) {
+              diagAt(
+                diagnostics,
+                span,
+                `${mnemonic ?? 'ret'} reached with unknown stack depth; cannot verify function stack balance.`,
+              );
+            }
+          },
+          diagIfCallStackUnverifiable: (options) => {
+            const span = options.span;
+            const mnemonic = options.mnemonic ?? 'call';
+            const contractKind = options.contractKind ?? 'callee';
+            const contractNoun =
+              contractKind === 'typed-call' ? 'typed-call boundary contract' : 'callee stack contract';
+            if (hasStackSlots && spTrackingValid && spDeltaTracked > 0) {
+              diagAt(
+                diagnostics,
+                span,
+                `${mnemonic} reached with positive tracked stack delta (${spDeltaTracked}); cannot verify ${contractNoun}.`,
+              );
+              return;
+            }
+            if (hasStackSlots && !spTrackingValid && spTrackingInvalidatedByMutation) {
+              diagAt(
+                diagnostics,
+                span,
+                `${mnemonic} reached after untracked SP mutation; cannot verify ${contractNoun}.`,
+              );
+              return;
+            }
+            if (hasStackSlots && !spTrackingValid) {
+              diagAt(
+                diagnostics,
+                span,
+                `${mnemonic} reached with unknown stack depth; cannot verify ${contractNoun}.`,
+              );
+            }
+          },
+          warnIfRawCallTargetsTypedCallable: (span, symbolicTarget) => {
+            if (!rawTypedCallWarningsEnabled || !symbolicTarget || symbolicTarget.addend !== 0) return;
+            const callable = callables.get(symbolicTarget.baseLower);
+            if (!callable) return;
+            const typedName = callable.node.name;
+            diagAtWithSeverityAndId(
+              diagnostics,
+              span,
+              DiagnosticIds.RawCallTypedTargetWarning,
+              'warning',
+              `Raw call targets typed callable \"${typedName}\" and bypasses typed-call argument/preservation semantics; use typed call syntax unless raw ABI is intentional.`,
+            );
+          },
+          lowerLdWithEa,
+          emitVirtualReg16Transfer,
+          emitSyntheticEpilogue,
+          epilogueLabel,
+          emitJumpTo,
+          emitJumpCondTo,
+          syncToFlow,
+          flow,
+        });
+
         const emitAsmInstruction = (asmItem: AsmInstructionNode): void => {
           const prevTag = currentCodeSegmentTag;
           const diagnosticsStart = diagnostics.length;
@@ -2065,385 +2161,7 @@ export function emitProgram(
               return;
             }
 
-            const head = asmItem.head.toLowerCase();
-
-            const emitRel8FromOperand = (
-              operand: AsmOperandNode,
-              opcode: number,
-              mnemonic: string,
-            ): boolean => {
-              if (operand.kind !== 'Imm') {
-                if (mnemonic === 'djnz' || mnemonic.startsWith('jr')) {
-                  diagAt(diagnostics, asmItem.span, `${mnemonic} expects disp8`);
-                } else {
-                  diagAt(diagnostics, asmItem.span, `${mnemonic} expects an immediate target.`);
-                }
-                return false;
-              }
-              const symbolicTarget = symbolicTargetFromExpr(operand.expr);
-              if (symbolicTarget) {
-                emitRel8Fixup(
-                  opcode,
-                  symbolicTarget.baseLower,
-                  symbolicTarget.addend,
-                  asmItem.span,
-                  mnemonic,
-                );
-                return true;
-              }
-              const value = evalImmExpr(operand.expr, env, diagnostics);
-              if (value === undefined) {
-                diagAt(diagnostics, asmItem.span, `Failed to evaluate ${mnemonic} target.`);
-                return false;
-              }
-              if (value < -128 || value > 127) {
-                diagAt(
-                  diagnostics,
-                  asmItem.span,
-                  `${mnemonic} relative branch displacement out of range (-128..127): ${value}.`,
-                );
-                return false;
-              }
-              emitRawCodeBytes(
-                Uint8Array.of(opcode, value & 0xff),
-                asmItem.span.file,
-                `${mnemonic} ${value}`,
-              );
-              return true;
-            };
-            if (head === 'jr') {
-              if (asmItem.operands.length === 1) {
-                if (asmItem.operands[0]!.kind === 'Mem') {
-                  diagAt(
-                    diagnostics,
-                    asmItem.span,
-                    `jr does not support indirect targets; expects disp8`,
-                  );
-                  return;
-                }
-                const single = asmItem.operands[0]!;
-                const ccSingle =
-                  single.kind === 'Imm' && single.expr.kind === 'ImmName'
-                    ? single.expr.name
-                    : single.kind === 'Reg'
-                      ? single.name
-                      : undefined;
-                if (ccSingle && jrConditionOpcodeFromName(ccSingle) !== undefined) {
-                  diagAt(diagnostics, asmItem.span, `jr cc, disp expects two operands (cc, disp8)`);
-                  return;
-                }
-                if (single.kind === 'Imm') {
-                  const symbolicTarget = symbolicTargetFromExpr(single.expr);
-                  if (
-                    symbolicTarget &&
-                    jrConditionOpcodeFromName(symbolicTarget.baseLower) !== undefined
-                  ) {
-                    diagAt(
-                      diagnostics,
-                      asmItem.span,
-                      `jr cc, disp expects two operands (cc, disp8)`,
-                    );
-                    return;
-                  }
-                }
-                if (single.kind === 'Reg') {
-                  diagAt(
-                    diagnostics,
-                    asmItem.span,
-                    `jr does not support register targets; expects disp8`,
-                  );
-                  return;
-                }
-                if (!emitRel8FromOperand(asmItem.operands[0]!, 0x18, 'jr')) return;
-                flow.reachable = false;
-                syncToFlow();
-                return;
-              }
-              if (asmItem.operands.length === 2) {
-                const ccOp = asmItem.operands[0]!;
-                const ccName =
-                  ccOp.kind === 'Imm' && ccOp.expr.kind === 'ImmName'
-                    ? ccOp.expr.name
-                    : ccOp.kind === 'Reg'
-                      ? ccOp.name
-                      : undefined;
-                const opcode = ccName ? jrConditionOpcodeFromName(ccName) : undefined;
-                if (opcode === undefined) {
-                  diagAt(diagnostics, asmItem.span, `jr cc expects valid condition code NZ/Z/NC/C`);
-                  return;
-                }
-                const target = asmItem.operands[1]!;
-                if (target.kind === 'Mem') {
-                  diagAt(
-                    diagnostics,
-                    asmItem.span,
-                    `jr cc, disp does not support indirect targets`,
-                  );
-                  return;
-                }
-                if (target.kind === 'Reg') {
-                  diagAt(
-                    diagnostics,
-                    asmItem.span,
-                    `jr cc, disp does not support register targets; expects disp8`,
-                  );
-                  return;
-                }
-                if (target.kind !== 'Imm') {
-                  diagAt(diagnostics, asmItem.span, `jr cc, disp expects disp8`);
-                  return;
-                }
-                if (!emitRel8FromOperand(target, opcode, `jr ${ccName!.toLowerCase()}`)) return;
-                syncToFlow();
-                return;
-              }
-            }
-            if (head === 'djnz') {
-              if (asmItem.operands.length !== 1) {
-                diagAt(diagnostics, asmItem.span, `djnz expects one operand (disp8)`);
-                return;
-              }
-              const target = asmItem.operands[0]!;
-              if (target.kind === 'Mem') {
-                diagAt(
-                  diagnostics,
-                  asmItem.span,
-                  `djnz does not support indirect targets; expects disp8`,
-                );
-                return;
-              }
-              if (target.kind === 'Reg') {
-                diagAt(
-                  diagnostics,
-                  asmItem.span,
-                  `djnz does not support register targets; expects disp8`,
-                );
-                return;
-              }
-              if (target.kind !== 'Imm') {
-                diagAt(diagnostics, asmItem.span, `djnz expects disp8`);
-                return;
-              }
-              if (!emitRel8FromOperand(target, 0x10, 'djnz')) return;
-              syncToFlow();
-              return;
-            }
-            if (head === 'call') {
-              diagIfCallStackUnverifiable();
-            }
-            if (head === 'rst' && asmItem.operands.length === 1) {
-              diagIfCallStackUnverifiable({ mnemonic: 'rst' });
-            }
-            if (head === 'ret') {
-              if (asmItem.operands.length === 0) {
-                diagIfRetStackImbalanced();
-                if (emitSyntheticEpilogue) {
-                  emitJumpTo(epilogueLabel, asmItem.span);
-                } else {
-                  emitInstr('ret', [], asmItem.span);
-                }
-                flow.reachable = false;
-                syncToFlow();
-                return;
-              }
-              if (asmItem.operands.length === 1) {
-                const op = conditionOpcode(asmItem.operands[0]!);
-                if (op === undefined) {
-                  diagAt(diagnostics, asmItem.span, `ret cc expects a valid condition code`);
-                  return;
-                }
-                diagIfRetStackImbalanced();
-                if (emitSyntheticEpilogue) {
-                  emitJumpCondTo(op, epilogueLabel, asmItem.span);
-                } else {
-                  emitInstr('ret', [asmItem.operands[0]!], asmItem.span);
-                }
-                syncToFlow();
-                return;
-              }
-            }
-            if ((head === 'retn' || head === 'reti') && asmItem.operands.length === 0) {
-              diagIfRetStackImbalanced(head);
-              if (emitSyntheticEpilogue) {
-                diagAt(
-                  diagnostics,
-                  asmItem.span,
-                  `${head} is not supported in functions that require cleanup; use ret/ret cc so cleanup epilogue can run.`,
-                );
-              }
-              emitInstr(head, [], asmItem.span);
-              flow.reachable = false;
-              syncToFlow();
-              return;
-            }
-
-            if (head === 'jp' && asmItem.operands.length === 1) {
-              const target = asmItem.operands[0]!;
-              if (target.kind === 'Imm') {
-                const symbolicTarget = symbolicTargetFromExpr(target.expr);
-                if (
-                  symbolicTarget &&
-                  conditionOpcodeFromName(symbolicTarget.baseLower) !== undefined
-                ) {
-                  diagAt(diagnostics, asmItem.span, `jp cc, nn expects two operands (cc, nn)`);
-                  return;
-                }
-                if (symbolicTarget) {
-                  emitAbs16Fixup(
-                    0xc3,
-                    symbolicTarget.baseLower,
-                    symbolicTarget.addend,
-                    asmItem.span,
-                  );
-                  flow.reachable = false;
-                  syncToFlow();
-                  return;
-                }
-              }
-            }
-            if (head === 'jp' && asmItem.operands.length === 2) {
-              const ccOp = asmItem.operands[0]!;
-              const ccName =
-                ccOp.kind === 'Imm' && ccOp.expr.kind === 'ImmName'
-                  ? ccOp.expr.name
-                  : ccOp.kind === 'Reg'
-                    ? ccOp.name
-                    : undefined;
-              const opcode = ccName ? conditionOpcodeFromName(ccName) : undefined;
-              const target = asmItem.operands[1]!;
-              if (opcode !== undefined && target.kind === 'Imm') {
-                const symbolicTarget = symbolicTargetFromExpr(target.expr);
-                if (symbolicTarget) {
-                  emitAbs16Fixup(
-                    opcode,
-                    symbolicTarget.baseLower,
-                    symbolicTarget.addend,
-                    asmItem.span,
-                  );
-                  syncToFlow();
-                  return;
-                }
-              }
-            }
-            if (head === 'call' && asmItem.operands.length === 1) {
-              const target = asmItem.operands[0]!;
-              if (target.kind === 'Imm') {
-                const symbolicTarget = symbolicTargetFromExpr(target.expr);
-                if (
-                  symbolicTarget &&
-                  callConditionOpcodeFromName(symbolicTarget.baseLower) !== undefined
-                ) {
-                  diagAt(diagnostics, asmItem.span, `call cc, nn expects two operands (cc, nn)`);
-                  return;
-                }
-                if (symbolicTarget) {
-                  warnIfRawCallTargetsTypedCallable(symbolicTarget);
-                  emitAbs16Fixup(
-                    0xcd,
-                    symbolicTarget.baseLower,
-                    symbolicTarget.addend,
-                    asmItem.span,
-                  );
-                  syncToFlow();
-                  return;
-                }
-              }
-            }
-            if (head === 'call' && asmItem.operands.length === 2) {
-              const ccOp = asmItem.operands[0]!;
-              const ccName =
-                ccOp.kind === 'Imm' && ccOp.expr.kind === 'ImmName'
-                  ? ccOp.expr.name
-                  : ccOp.kind === 'Reg'
-                    ? ccOp.name
-                    : undefined;
-              const opcode = ccName ? callConditionOpcodeFromName(ccName) : undefined;
-              const target = asmItem.operands[1]!;
-              if (opcode !== undefined && target.kind === 'Imm') {
-                const symbolicTarget = symbolicTargetFromExpr(target.expr);
-                if (symbolicTarget) {
-                  warnIfRawCallTargetsTypedCallable(symbolicTarget);
-                  emitAbs16Fixup(
-                    opcode,
-                    symbolicTarget.baseLower,
-                    symbolicTarget.addend,
-                    asmItem.span,
-                  );
-                  syncToFlow();
-                  return;
-                }
-              }
-            }
-
-            if (head === 'ld' && asmItem.operands.length === 2) {
-              const dstOp = asmItem.operands[0]!;
-              const srcOp = asmItem.operands[1]!;
-              const dst = dstOp.kind === 'Reg' ? dstOp.name.toUpperCase() : undefined;
-              const opcode =
-                dst === 'BC'
-                  ? 0x01
-                  : dst === 'DE'
-                    ? 0x11
-                    : dst === 'HL'
-                      ? 0x21
-                      : dst === 'SP'
-                        ? 0x31
-                        : undefined;
-              if (
-                opcode !== undefined &&
-                srcOp.kind === 'Imm' &&
-                srcOp.expr.kind === 'ImmName' &&
-                !resolveScalarBinding(srcOp.expr.name)
-              ) {
-                const v = evalImmExpr(srcOp.expr, env, diagnostics);
-                if (v === undefined) {
-                  emitAbs16Fixup(opcode, srcOp.expr.name.toLowerCase(), 0, asmItem.span);
-                  syncToFlow();
-                  return;
-                }
-              }
-              if (
-                (dst === 'IX' || dst === 'IY') &&
-                srcOp.kind === 'Imm' &&
-                srcOp.expr.kind === 'ImmName' &&
-                !resolveScalarBinding(srcOp.expr.name)
-              ) {
-                const v = evalImmExpr(srcOp.expr, env, diagnostics);
-                if (v === undefined) {
-                  emitAbs16FixupPrefixed(
-                    dst === 'IX' ? 0xdd : 0xfd,
-                    0x21,
-                    srcOp.expr.name.toLowerCase(),
-                    0,
-                    asmItem.span,
-                  );
-                  syncToFlow();
-                  return;
-                }
-              }
-            }
-
-            if (lowerLdWithEa(asmItem)) {
-              syncToFlow();
-              return;
-            }
-
-            if (emitVirtualReg16Transfer(asmItem)) {
-              syncToFlow();
-              return;
-            }
-
-            if (!emitInstr(asmItem.head, asmItem.operands, asmItem.span)) return;
-
-            if ((head === 'jp' || head === 'jr') && asmItem.operands.length === 1) {
-              flow.reachable = false;
-            } else if (
-              (head === 'ret' || head === 'retn' || head === 'reti') &&
-              asmItem.operands.length === 0
-            ) {
-              flow.reachable = false;
-            }
-            syncToFlow();
+            lowerAsmInstructionDispatcher(asmItem);
           } finally {
             appendInvalidOpExpansionDiagnostic(asmItem, diagnosticsStart);
             currentCodeSegmentTag = prevTag;

--- a/test/pr532_asm_instruction_lowering_integration.test.ts
+++ b/test/pr532_asm_instruction_lowering_integration.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import { createAsmInstructionLoweringHelpers } from '../src/lowering/asmInstructionLowering.js';
+import type { AsmInstructionNode, AsmOperandNode, SourceSpan } from '../src/frontend/ast.js';
+
+const span: SourceSpan = {
+  file: 'fixture.zax',
+  start: { line: 1, column: 1, offset: 0 },
+  end: { line: 1, column: 1, offset: 0 },
+};
+
+describe('PR532 asm instruction lowering integration', () => {
+  it('dispatches representative instruction paths through the extracted helper', () => {
+    const events: string[] = [];
+    const flow = { reachable: true };
+    const helper = createAsmInstructionLoweringHelpers({
+      diagnostics: [],
+      diagAt: (_diagnostics, _span, message) => {
+        events.push(`diag:${message}`);
+      },
+      emitInstr: (head, operands) => {
+        events.push(`instr:${head}:${operands.length}`);
+        return true;
+      },
+      emitRawCodeBytes: (_bytes, _file, asmText) => {
+        events.push(`raw:${asmText}`);
+      },
+      emitAbs16Fixup: (opcode, baseLower, addend) => {
+        events.push(`abs:${opcode.toString(16)}:${baseLower}:${addend}`);
+      },
+      emitAbs16FixupPrefixed: (prefix, opcode2, baseLower, addend) => {
+        events.push(`abs2:${prefix.toString(16)}:${opcode2.toString(16)}:${baseLower}:${addend}`);
+      },
+      emitRel8Fixup: (opcode, baseLower, addend, _span, mnemonic) => {
+        events.push(`rel:${opcode.toString(16)}:${baseLower}:${addend}:${mnemonic}`);
+      },
+      conditionOpcodeFromName: (name) => (name.toUpperCase() === 'NZ' ? 0xc2 : undefined),
+      conditionNameFromOpcode: (opcode) => (opcode === 0xc2 ? 'NZ' : undefined),
+      callConditionOpcodeFromName: (name) => (name.toUpperCase() === 'NZ' ? 0xc4 : undefined),
+      jrConditionOpcodeFromName: (name) => (name.toUpperCase() === 'NZ' ? 0x20 : undefined),
+      conditionOpcode: (op) =>
+        op.kind === 'Reg' && op.name.toUpperCase() === 'NZ'
+          ? 0xc2
+          : op.kind === 'Imm' && op.expr.kind === 'ImmName' && op.expr.name.toUpperCase() === 'NZ'
+            ? 0xc2
+            : undefined,
+      symbolicTargetFromExpr: (expr) => {
+        if (expr.kind === 'ImmName') return { baseLower: expr.name.toLowerCase(), addend: 0 };
+        return undefined;
+      },
+      evalImmExpr: (expr) => (expr.kind === 'ImmLiteral' ? expr.value : undefined),
+      resolveScalarBinding: () => undefined,
+      diagIfRetStackImbalanced: () => {},
+      diagIfCallStackUnverifiable: () => {},
+      warnIfRawCallTargetsTypedCallable: (_span, target) => {
+        if (target) events.push(`warn:${target.baseLower}`);
+      },
+      lowerLdWithEa: () => false,
+      emitVirtualReg16Transfer: () => false,
+      emitSyntheticEpilogue: true,
+      epilogueLabel: '__zax_epilogue_0',
+      emitJumpTo: (label) => {
+        events.push(`jmp:${label}`);
+      },
+      emitJumpCondTo: (opcode, label) => {
+        events.push(`jmpcc:${opcode.toString(16)}:${label}`);
+      },
+      syncToFlow: () => {
+        events.push(`sync:${flow.reachable ? 'reach' : 'dead'}`);
+      },
+      flow,
+    });
+
+    const jrItem: AsmInstructionNode = {
+      kind: 'AsmInstruction',
+      span,
+      head: 'jr',
+      operands: [{ kind: 'Imm', span, expr: { kind: 'ImmName', span, name: 'Loop' } }],
+    };
+    const retItem: AsmInstructionNode = {
+      kind: 'AsmInstruction',
+      span,
+      head: 'ret',
+      operands: [{ kind: 'Reg', span, name: 'nz' }],
+    };
+    const ldItem: AsmInstructionNode = {
+      kind: 'AsmInstruction',
+      span,
+      head: 'ld',
+      operands: [
+        { kind: 'Reg', span, name: 'HL' },
+        { kind: 'Imm', span, expr: { kind: 'ImmName', span, name: 'Target' } },
+      ] satisfies AsmOperandNode[],
+    };
+
+    helper.lowerAsmInstructionDispatcher(jrItem);
+    flow.reachable = true;
+    helper.lowerAsmInstructionDispatcher(retItem);
+    helper.lowerAsmInstructionDispatcher(ldItem);
+
+    expect(events).toContain('rel:18:loop:0:jr');
+    expect(events).toContain('jmpcc:c2:__zax_epilogue_0');
+    expect(events).toContain('abs:21:target:0');
+  });
+});


### PR DESCRIPTION
Summary:\n- extract the asm instruction lowering dispatcher from src/lowering/emit.ts\n- keep higher-level declaration and function orchestration in emit.ts\n- add focused integration coverage for representative instruction dispatch behavior\n\nVerification:\n- npm run typecheck\n- npm test -- --run test/pr532_asm_instruction_lowering_integration.test.ts test/pr531_value_materialization_helpers.test.ts test/pr530_asm_utils_helpers.test.ts test/pr529_fixup_emission_helpers.test.ts test/pr528_emission_core_helpers.test.ts test/pr468_typed_step_integration.test.ts test/smoke_language_tour_compile.test.ts