### PR TITLE
docs: add source overview, quality report, and refactor plan

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,9 @@ This directory is intentionally constrained. Every file below has a unique purpo
 - `codegen-corpus-workflow.md` — supported workflow and ownership rules for the curated codegen corpus.
 - `virtual-reg16-transfer-patterns.md` — supported `rp -> rp` virtual transfer patterns for the current low-level convenience slice.
 - `github-backlog-workflow.md` — GitHub issue/label/milestone workflow used as the project backlog system.
+- `source-overview.md` — description of the current source tree: modules, pipeline, subsystems, state lifetimes.
+- `quality-report.md` — code quality analysis: specific issues rated by severity, with locations and fix directions.
+- `refactor-plan.md` — phased improvement plan: ordered phases, per-ticket descriptions, success criteria.
 
 ## Content Ownership
 

--- a/docs/quality-report.md
+++ b/docs/quality-report.md
@@ -1,0 +1,360 @@
+# ZAX Code Quality Report
+
+Status: non-normative. Developer-facing analysis of current code quality, produced as input for
+the refactor planning track. Issues are rated by severity: **Critical** (correctness risk or
+major maintainability block), **High** (significant maintainability/readability harm),
+**Medium** (moderate friction), **Low** (polish).
+
+Last updated to reflect the state after the v0.4 decomposition sequence culminating in
+`emit.ts` reaching **956 lines** (hard cap: 1 000; preferred cap: 750). Twelve extraction
+PRs have landed in total. The original god-file blocker is resolved.
+
+---
+
+## Executive Summary
+
+The v0.4 structural target has been met. `emit.ts` is now 956 lines — a reduction of
+approximately 3 200 lines from the pre-v0.4 starting point. All emission concerns now live
+in named, individually readable modules. The `loweringDiagnostics.ts` extraction resolved the
+`diagAt` shadow collision. The `functionCallLowering.ts` extraction resolved the duplicate
+diagnostic closure problem.
+
+The remaining open issues fall into three categories:
+
+1. **Type safety**: `ldLowering.ts` still uses `ctx: any` (QR-2), and
+   `functionBodySetup.ts` still uses `any`-equivalent conditional types (QR-18). These are
+   the highest-priority remaining items.
+
+2. **Internal cleanup**: `summarizeOpStackEffect` is still a 90-line inline closure in
+   `emit.ts` (QR-8). `applySpTracking` and `emitInstr` are also inline. The `PendingSymbol`
+   type is duplicated across three files (QR-19). `warnAt` still uses the wrong diagnostic ID
+   (QR-16).
+
+3. **Documentation and polish**: naming hazards (QR-5, QR-6), undocumented patterns
+   (QR-7, QR-9, QR-10, QR-11, QR-12), and structural cleanups (QR-13, QR-14, QR-15).
+
+---
+
+## Issue 1 — ~~Critical~~ **RESOLVED**: `emit.ts` is now 956 lines
+
+**Location**: `src/lowering/emit.ts` (956 lines)
+
+The 1 000-line hard cap has been met. The full decomposition sequence extracted the
+following concerns from `emit.ts`:
+
+| Extracted to | What moved out | PR |
+|---|---|---|
+| `emissionCore.ts` | `emitCodeBytes`, `emitRawCodeBytes`, `emitStepPipeline` | #528 |
+| `fixupEmission.ts` | `emitAbs16Fixup`, fixup helpers, condition opcode maps | #529 |
+| `asmUtils.ts` | AST clone helpers, `flattenEaDottedName`, `normalizeFixedToken` | #530 |
+| `valueMaterialization.ts` | `pushEaAddress`, `pushMemValue`, runtime linear analysis | #531 |
+| `asmInstructionLowering.ts` | `lowerAsmInstructionDispatcher` (ret/call/jp/jr/djnz) | #532 |
+| `functionBodySetup.ts` | Flow state, labels, `joinFlows`, select helpers | #546 |
+| `opMatching.ts` | Op overload matching, specificity, diagnostic formatting | #538 |
+| `asmBodyOrchestration.ts` | `lowerAndFinalizeFunctionBody`, fallthrough checks | — |
+| `loweringDiagnostics.ts` | `diag`, `diagAt`, `diagAtWithId`, `diagAtWithSeverityAndId`, `warnAt` | #547 |
+| `functionLowering.ts` | FuncDecl frame setup, prologue, epilogue, `FunctionLoweringContext` | #547 |
+| `functionCallLowering.ts` | Typed-call argument dispatch (byte/word/ea/mem variants) | #547 |
+| `programLowering.ts` | Pre-scan pass, program item dispatch, DataBlock/VarBlock handling | #548 |
+
+**What remains in `emit.ts`** (956 lines):
+
+- Import block and `emitProgram` function signature (~150 lines)
+- Module-level state declarations (bytes maps, fixup queues, callables, section counters)
+- `summarizeOpStackEffect` inline closure (lines ~225–314, ~90 lines) — see QR-8
+- `applySpTracking` inline closure (lines ~367–412, ~46 lines)
+- `emitInstr` inline closure (lines ~414–426, ~13 lines)
+- All helper module wiring (`createXxxHelpers` calls) (~280 lines)
+- `programLoweringContext` assembly object (~130 lines)
+- `preScanProgramDeclarations`, `lowerProgramDeclarations`, `finalizeProgramEmission` calls
+- Module-alias resolution post-pass
+
+These are all reasonable orchestration-layer concerns. The file is now well within the cap.
+
+---
+
+## Issue 2 — Critical: `ldLowering.ts` uses `ctx: any`
+
+**Location**: `src/lowering/ldLowering.ts`, line 4
+
+```typescript
+export function createLdLoweringHelpers(ctx: any) {
+  const { emitInstr, resolveEa, buildEaBytePipeline, ... } = ctx;
+```
+
+`ctx: any` completely disables TypeScript type checking for the entire LD lowering module —
+the most complex lowering code in the compiler. The destructuring unpacks approximately 50
+named dependencies with no type verification. The call site in `emit.ts` (line 693) passes
+`evalImmExpr: (expr: any) => ...`, confirming the any leaks outward too.
+
+**Impact**: Type errors in LD lowering are invisible to `tsc`. Regressions will only surface
+at runtime.
+
+**Fix direction**: Define `type LdLoweringContext = { ... }` at the top of `ldLowering.ts`.
+Audit every property used by the destructuring. Change `ctx: any` to `ctx: LdLoweringContext`.
+
+---
+
+## Issue 3 — ~~High~~ **RESOLVED**: `diagAt` shadow collision in `emit.ts`
+
+**Location**: `src/lowering/loweringDiagnostics.ts` (resolved by #547)
+
+The five file-scope diagnostic helpers have been extracted to `loweringDiagnostics.ts` as
+named exports. `emit.ts` now imports them. The file-scope vs closure-scope shadow ambiguity is
+gone. The only remaining sub-issue is that `warnAt` still uses `DiagnosticIds.EmitError` for
+warnings — see QR-16.
+
+---
+
+## Issue 4 — High: Function-lifetime and program-lifetime state in the same scope
+
+**Location**: `src/lowering/emit.ts` / `src/lowering/functionLowering.ts`
+
+**Partially resolved** by #547. `FunctionLoweringContext` is now an exported interface in
+`functionLowering.ts` and function-lifetime state is managed inside `lowerFunctionDecl`. The
+`trackedSpRef` proxy object (a getter/setter bridge for the three SP tracking scalars, now at
+`programLoweringContext.trackedSpRef` in `emit.ts`) still exists, but it is now confined to
+the wiring section only — it is no longer interleaved with unrelated program-lifetime state.
+
+**Remaining concern**: `stackSlotOffsets`, `stackSlotTypes`, and `localAliasTargets` are still
+declared as `let`/`const` closures in `emitProgram` and passed by reference into
+`programLoweringContext` (lines 851–853). They are reset inside `lowerFunctionDecl`, but there
+is no structural guarantee. Full resolution requires making these allocations happen inside
+`lowerFunctionDecl`.
+
+**Fix direction**: Move the remaining function-lifetime state declarations into
+`functionLowering.ts`. Eliminate the `trackedSpRef` proxy by making `FlowState` the
+authoritative source.
+
+---
+
+## Issue 5 — High: `resolveScalarTypeForLd` and `resolveScalarTypeForEa` undocumented
+
+**Location**: `src/lowering/typeResolution.ts`
+
+Two functions with nearly identical names differ critically: `resolveScalarTypeForLd` returns
+a scalar kind for `rawAddressSymbols` (variables whose stored value is wanted), while
+`resolveScalarTypeForEa` does not. Neither has a doc comment.
+
+**Fix direction**: Add JSDoc to each function explaining the `rawAddressSymbols` distinction
+and when each is appropriate.
+
+---
+
+## Issue 6 — High: `resolvedScalarKind` and `resolveScalarKind` naming hazard
+
+**Location**: `src/lowering/ldLowering.ts`
+
+`resolvedScalarKind(resolution: EaResolution | undefined)` and
+`resolveScalarKind(typeExpr: TypeExprNode)` differ only by the past-tense `-d`. Easy to confuse.
+
+**Fix direction**: Rename `resolvedScalarKind` → `scalarKindOfResolution`.
+
+---
+
+## Issue 7 — High: Raw opcode bytes in `ldLowering.ts` lack mnemonic comments
+
+**Location**: `src/lowering/ldLowering.ts`, multiple `emitRawCodeBytes(Uint8Array.of(...))` calls
+
+The IX byte-lane shuttle and other encoding sites emit raw byte sequences without inline
+comments explaining the Z80 mnemonic.
+
+**Fix direction**: Add a comment with the canonical mnemonic at every `emitRawCodeBytes` call.
+Where practical, route through `encodeInstruction` instead of raw bytes.
+
+---
+
+## Issue 8 — High: `summarizeOpStackEffect` still inline in `emit.ts`
+
+**Location**: `src/lowering/emit.ts`, lines ~225–314 (~90 lines)
+
+`summarizeOpStackEffect` is a 90-line closure that analyses an op body to compute its net
+stack push/pop delta. It captures `opsByName` (immutable after pre-scan) and
+`opStackSummaryCache` from the outer scope. Despite having no dependency on mutable
+program-lifetime or function-lifetime state, it was not extracted during the decomposition
+sequence because `opsByName` is not yet part of an injectable context.
+
+**Impact**: Cannot be independently unit-tested. The only remaining large cohesive logic
+block still inline in `emitProgram`.
+
+**Fix direction**: Extract to `src/lowering/opStackAnalysis.ts` with
+`type OpStackAnalysisContext = { opsByName: Map<string, OpDeclNode[]> }`. Add unit tests.
+
+---
+
+## Issue 9 — Medium: HL-preserve swap pattern undocumented
+
+**Location**: `src/lowering/functionLowering.ts` (previously `emit.ts`)
+
+The local initializer loop uses a non-obvious HL-preserve swap pattern. No reference comment
+points to `docs/return-register-policy.md §4.2` at the implementation site.
+
+**Fix direction**: Add comment: `// HL-preserve swap pattern: return-register-policy.md §4.2`
+
+---
+
+## Issue 10 — Medium: `ptr` alias handled independently in layout and typeResolution
+
+**Location**: `src/semantics/layout.ts`, `src/lowering/typeResolution.ts`
+
+The `ptr` type alias for `addr` is normalised in `typeResolution.ts` but handled
+independently in `layout.ts` with no cross-reference comment.
+
+**Fix direction**: Add a comment at each `ptr` handling site explaining the alias.
+
+---
+
+## Issue 11 — Medium: `coerceValueOperand` is an anonymous closure with no explanation
+
+**Location**: `src/lowering/ldLowering.ts`
+
+`coerceValueOperand` and its helper `isRegisterToken` (a 17-element duplicate token list)
+have no documentation. The spec rule they implement is not referenced.
+
+**Fix direction**: Add JSDoc. Extract `isRegisterToken` as a named helper and deduplicate
+against `reg8`.
+
+---
+
+## Issue 12 — Medium: No section comment on the fixup-resolution second pass
+
+**Location**: `src/lowering/programLowering.ts` (was `emit.ts`)
+
+The ABS16/REL8 fixup resolution loop (now in `finalizeProgramEmission` in `programLowering.ts`)
+begins without a header comment explaining its purpose as a second pass.
+
+**Fix direction**: Add a comment before the resolution loop:
+```
+// Second pass: resolve forward-reference fixups and finalise section base addresses.
+```
+
+---
+
+## Issue 13 — Medium: `hasStackSlots` condition is redundant
+
+**Location**: `src/lowering/functionLowering.ts` (was `emit.ts`)
+
+```typescript
+const hasStackSlots = frameSize > 0 || argc > 0 || preserveBytes > 0;
+```
+`frameSize` already includes `preserveBytes`, so `preserveBytes > 0` is checked twice.
+
+**Fix direction**: Rename to `needsFrame` and simplify to
+`localSlotCount > 0 || argc > 0 || preserveSet.length > 0`.
+
+---
+
+## Issue 14 — Medium: Line-by-line parser is fragile for future extension
+
+**Location**: `src/frontend/parser.ts` and related files
+
+Manual string tokenization with no canonical token boundary makes future grammar additions
+brittle.
+
+**Fix direction**: Introduce `src/frontend/tokenizer.ts` and migrate `parseImm.ts` and
+`parseOperands.ts` to use it.
+
+---
+
+## Issue 15 — Low: No file-level documentation on any source file
+
+All `src/**/*.ts` files lack a module-level doc comment.
+
+**Fix direction**: Add one-paragraph module comments. Priority: `emit.ts`, `ldLowering.ts`,
+`valueMaterialization.ts`, `functionLowering.ts`, `programLowering.ts`.
+
+---
+
+## Issue 16 — Low: `warnAt` uses `EmitError` diagnostic ID
+
+**Location**: `src/lowering/loweringDiagnostics.ts`, line 55
+
+```typescript
+export function warnAt(...): void {
+  diagnostics.push({ id: DiagnosticIds.EmitError, severity: 'warning', ... });
+}
+```
+
+`warnAt` still emits `ZAX300` (the error ID) for a warning-severity diagnostic.
+
+**Fix direction**: Add `DiagnosticIds.EmitWarning = 'ZAX301'` to `diagnostics/types.ts`.
+Change `warnAt` to use it. Update relevant tests.
+
+---
+
+## Issue 17 — ~~High~~ **RESOLVED**: Duplicate diagnostic closures in `emitAsmInstruction`
+
+Resolved by extracting typed call dispatch into `functionCallLowering.ts` (#547). The
+duplicate `diagIfRetStackImbalanced` / `diagIfCallStackUnverifiable` closures no longer exist.
+
+---
+
+## Issue 18 — High: `functionBodySetup.ts` uses `any`-equivalent types in its Context
+
+**Location**: `src/lowering/functionBodySetup.ts`, lines 59–66
+
+```typescript
+pushEaAddress: (ea: AsmOperandNode extends never ? never : any, span: SourceSpan) => boolean;
+evalImmExpr: (expr: any) => number | undefined;
+env: unknown;
+```
+
+`AsmOperandNode extends never ? never : any` evaluates to `any` — a linting-bypass technique.
+The correct types are `EaExprNode` (for `pushEaAddress`/`pushMemValue`), `ImmExprNode` (for
+`evalImmExpr`), and `CompileEnv` (for `env`).
+
+**Fix direction**: Import `EaExprNode`, `ImmExprNode` from `../frontend/ast.js` and
+`CompileEnv` from `../semantics/env.js`. Replace all `any`-equivalent entries.
+
+---
+
+## Issue 19 — Medium: `PendingSymbol` type duplicated across three files
+
+**Location**: `src/lowering/emit.ts` (line 160), `src/lowering/functionLowering.ts` (line 30),
+`src/lowering/programLowering.ts` (line 33)
+
+```typescript
+type PendingSymbol = {
+  kind: 'label' | 'data' | 'var';
+  name: string;
+  section: 'code' | 'data' | 'var';
+  offset: number;
+  file?: string;
+  line?: number;
+  scope?: 'global' | 'local';
+  size?: number;
+};
+```
+
+This type is copy-pasted in three places. Similarly, `Callable`, `SourceSegmentTag`, and
+`SectionKind` are locally redefined in multiple files. If the shape changes, all three copies
+must be updated simultaneously.
+
+**Fix direction**: Create `src/lowering/loweringTypes.ts` and export `PendingSymbol`,
+`SectionKind`, and `SourceSegmentTag` from there. Import in all three files.
+
+---
+
+## Summary Table
+
+| ID | Severity | Status | Title |
+|---|---|---|---|
+| QR-1 | Critical | ✅ Resolved | `emit.ts` now 956 lines (under hard cap) |
+| QR-2 | Critical | Open | `ldLowering.ts` uses `ctx: any` |
+| QR-3 | High | ✅ Resolved | `diagAt` shadow resolved by `loweringDiagnostics.ts` |
+| QR-4 | High | Partially resolved | Function/program state partially separated |
+| QR-5 | High | Open | `resolveScalarTypeForLd` vs `resolveScalarTypeForEa` undocumented |
+| QR-6 | High | Open | `resolvedScalarKind` / `resolveScalarKind` naming hazard |
+| QR-7 | High | Open | Raw opcode bytes lack mnemonic comments |
+| QR-8 | High | Open | `summarizeOpStackEffect` still inline in `emit.ts` |
+| QR-9 | Medium | Open | HL-preserve swap undocumented (now in `functionLowering.ts`) |
+| QR-10 | Medium | Open | `ptr` alias not cross-referenced |
+| QR-11 | Medium | Open | `coerceValueOperand` undocumented / `isRegisterToken` duplicated |
+| QR-12 | Medium | Open | No section comment on fixup-resolution second pass |
+| QR-13 | Medium | Open | `hasStackSlots` condition is redundant (now in `functionLowering.ts`) |
+| QR-14 | Medium | Open | Line-by-line parser fragile for future extension |
+| QR-15 | Low | Open | No file-level documentation |
+| QR-16 | Low | Open | `warnAt` uses `EmitError` ID for warnings |
+| QR-17 | High | ✅ Resolved | Duplicate diagnostic closures eliminated |
+| QR-18 | High | Open | `functionBodySetup.ts` `any`-equivalent types in Context |
+| QR-19 | Medium | Open | `PendingSymbol` / `SectionKind` / `Callable` duplicated across 3 files |

--- a/docs/refactor-plan.md
+++ b/docs/refactor-plan.md
@@ -1,0 +1,301 @@
+# ZAX Refactor Plan
+
+Status: non-normative planning document. Describes an ordered sequence of improvements to
+take the codebase from its current state to a rigorous, well-maintained implementation
+of the ZAX v0.2 specification. Each phase is scoped to be independently mergeable.
+
+Source: `docs/quality-report.md` (issues QR-1 to QR-19).
+
+Last updated to reflect the v0.4 hard-cap milestone: `emit.ts` is now **956 lines**.
+
+---
+
+## Guiding Principles
+
+1. **Test first, then refactor.** Each extraction must leave all existing tests passing.
+2. **Type everything.** No `ctx: any`. Every helper module context must have an explicit type.
+3. **Document spec references.** Where code implements a spec rule, cite the section.
+4. **Keep PRs small.** Each task below should be one atomic PR.
+5. **No regressions.** The test suite is the acceptance criterion.
+
+---
+
+## Hard Acceptance Criteria (v0.4)
+
+- `src/lowering/emit.ts` must be under **1 000 lines**. ✅ **MET — 956 lines.**
+- Preferred end state: under **750 lines**. Still open (956 > 750).
+- Every helper module context interface must have **no `any`** (including `any`-equivalent
+  conditional types). Still open (QR-2, QR-18).
+
+---
+
+## Completed Work
+
+All items that have landed and are no longer the active blocker.
+
+| PR | Extracted to | What was moved |
+|---|---|---|
+| Earlier | `asmRangeLowering.ts` | if/while/loop/select structured control flow |
+| Earlier | `opExpansionOrchestration.ts` | op expansion dispatch and stack-effect policy |
+| Earlier | `opExpansionExecution.ts` | op body expansion execution |
+| Earlier | `opSubstitution.ts` | op body token substitution and operand rewriting |
+| Earlier | `eaResolution.ts` | EA name resolution helpers |
+| Earlier | `eaMaterialization.ts` | EA address materialization to HL register |
+| Earlier | `addressingPipelines.ts` | step pipeline builders (EA/load/store templates) |
+| Earlier | `runtimeAtomBudget.ts` | runtime atom budget enforcement |
+| Earlier | `runtimeImmediates.ts` | runtime immediate helpers |
+| Earlier | `scalarWordAccessors.ts` | scalar word accessor helpers |
+| Earlier | `typeResolution.ts` | type expression resolution helpers |
+| #528 | `emissionCore.ts` | `emitCodeBytes`, `emitRawCodeBytes`, `emitStepPipeline` |
+| #529 | `fixupEmission.ts` | fixup emission, condition opcode maps, `symbolicTargetFromExpr` |
+| #530 | `asmUtils.ts` | AST clone helpers, `flattenEaDottedName`, `normalizeFixedToken` |
+| #531 | `valueMaterialization.ts` | `pushEaAddress`, `pushMemValue`, runtime linear analysis |
+| #532 | `asmInstructionLowering.ts` | `lowerAsmInstructionDispatcher` (ret/call/jp/jr/djnz) |
+| #546 | `functionBodySetup.ts` | flow state, labels, `joinFlows`, select helpers |
+| #538 | `opMatching.ts` | op matcher, overload resolution, `formatOpSignature` |
+| — | `asmBodyOrchestration.ts` | `lowerAndFinalizeFunctionBody`, fallthrough checks |
+| #547 | `loweringDiagnostics.ts` | `diag`, `diagAt`, `diagAtWithId`, `warnAt` (QR-3 ✅) |
+| #547 | `functionLowering.ts` | FuncDecl frame setup, prologue, epilogue, `FunctionLoweringContext` |
+| #547 | `functionCallLowering.ts` | typed-call argument dispatch (QR-17 ✅) |
+| #548 | `programLowering.ts` | pre-scan pass, DataBlock/VarBlock, `finalizeProgramEmission` |
+
+---
+
+## Phase 0: Foundations (No behavioral change)
+
+### P0-1: Fix `warnAt` diagnostic ID (QR-16) ✗ Open
+
+**Files**: `src/diagnostics/types.ts`, `src/lowering/loweringDiagnostics.ts`
+
+Add `DiagnosticIds.EmitWarning = 'ZAX301'`. Change `warnAt` to use it.
+Update any test asserting `ZAX300` for a warning to expect `ZAX301`.
+
+Acceptance: All tests pass. No `warnAt` call emits `ZAX300`.
+
+---
+
+### P0-2: Add file-level documentation to all source files (QR-15) ✗ Open
+
+**Files**: All `src/**/*.ts`
+
+Add a `/** ... */` block comment at the top of each file. Priority: `emit.ts`,
+`ldLowering.ts`, `valueMaterialization.ts`, `functionLowering.ts`, `programLowering.ts`.
+
+---
+
+### P0-3: Document `ptr` alias (QR-10) ✗ Open
+
+Add cross-reference comments at each `ptr`-handling site in `layout.ts` and
+`typeResolution.ts`.
+
+---
+
+### P0-4: Add spec reference to HL-preserve swap (QR-9) ✗ Open
+
+**Location**: `src/lowering/functionLowering.ts`, local initializer loop.
+
+Add comment: `// HL-preserve swap pattern: return-register-policy.md §4.2`
+
+---
+
+### P0-5: Simplify `hasStackSlots` → `needsFrame` (QR-13) ✗ Open
+
+**Location**: `src/lowering/functionLowering.ts`
+
+Replace the redundant condition and rename `hasStackSlots` → `needsFrame`.
+
+---
+
+### P0-6: Add fixup-resolution section comment (QR-12) ✗ Open
+
+**Location**: `src/lowering/programLowering.ts`, `finalizeProgramEmission`
+
+Add header comment before the ABS16/REL8 resolution loop.
+
+---
+
+## Phase 1: Type Safety
+
+### P1-1: Define `LdLoweringContext` and type `createLdLoweringHelpers` (QR-2) ✗ Open
+
+**File**: `src/lowering/ldLowering.ts`
+
+Audit all ~50 destructured properties. Define `type LdLoweringContext`. Change `ctx: any`.
+Fix any `tsc` errors that surface (including the `evalImmExpr: (expr: any) =>` at the
+call site in `emit.ts`, line 693).
+
+Acceptance: `tsc --noEmit` clean. All tests pass.
+
+---
+
+### P1-2: Fix `any`-equivalent types in `functionBodySetup.ts` (QR-18) ✗ Open
+
+**File**: `src/lowering/functionBodySetup.ts`, lines 59–66
+
+Replace the `AsmOperandNode extends never ? never : any` trick with proper imports:
+- `pushEaAddress` / `pushMemValue` → `ea: EaExprNode`
+- `evalImmExpr` → `expr: ImmExprNode`
+- `env: unknown` → `env: CompileEnv`
+
+Acceptance: `tsc --noEmit` clean. No behavioral change.
+
+---
+
+### P1-3: Rename `resolvedScalarKind` → `scalarKindOfResolution` (QR-6) ✗ Open
+
+**Files**: `src/lowering/ldLowering.ts`, call sites
+
+Update all call sites.
+
+---
+
+### P1-4: Document `resolveScalarTypeForLd` vs `resolveScalarTypeForEa` (QR-5) ✗ Open
+
+**File**: `src/lowering/typeResolution.ts`
+
+Add JSDoc explaining the `rawAddressSymbols` distinction.
+
+---
+
+## Phase 2: Shared Type Definitions
+
+### P2-1: Extract `PendingSymbol`, `SectionKind`, `Callable` to `loweringTypes.ts` (QR-19) ✗ Open
+
+**New file**: `src/lowering/loweringTypes.ts`
+
+The following types are currently copy-pasted across `emit.ts`, `functionLowering.ts`, and
+`programLowering.ts`:
+- `PendingSymbol`
+- `SectionKind` (`'code' | 'data' | 'var'`)
+- `SourceSegmentTag` (local alias of `Omit<EmittedSourceSegment, 'start' | 'end'>`)
+- `Callable` union
+
+Export them from `loweringTypes.ts`. Import in all three files.
+
+Acceptance: No behavioral change. `tsc --noEmit` clean. No duplicate type definitions.
+
+---
+
+### P2-2: Extract `summarizeOpStackEffect` to `opStackAnalysis.ts` (QR-8) ✗ Open
+
+**New file**: `src/lowering/opStackAnalysis.ts`
+
+Extract the `summarizeOpStackEffect` closure (lines ~225–314 of `emit.ts`) and its
+memoisation cache. This function only depends on `opsByName` (immutable after pre-scan) and
+a cache map — it has no dependency on mutable state.
+
+Define `type OpStackAnalysisContext = { opsByName: Map<string, OpDeclNode[]> }`. Pass
+`opsByName` in through the context. Move the cache into the factory closure.
+
+Add unit tests: single push/pop, nested push+pop, conditional, empty body, recursion guard.
+
+Acceptance: All tests pass. New unit tests cover the extracted function.
+
+---
+
+## Phase 3: Code Documentation and Cleanup
+
+### P3-1: Document and clean up `coerceValueOperand` (QR-11) ✗ Open
+
+After Phase 1 types `ldLowering.ts`:
+
+1. Extract `coerceValueOperand` as a named function with JSDoc citing the spec rule.
+2. Extract and deduplicate `isRegisterToken` against `reg8`.
+
+---
+
+### P3-2: Audit and comment raw opcode bytes (QR-7) ✗ Open
+
+**File**: `src/lowering/ldLowering.ts`
+
+For every `emitRawCodeBytes(Uint8Array.of(...))` call:
+1. Add an inline comment with the Z80 mnemonic.
+2. Where practical, route through `encodeInstruction`.
+3. Document the IX byte-lane shuttle pattern with a reference to `addressing-model.md §2`.
+
+---
+
+## Phase 4: Function State Encapsulation (QR-4)
+
+After Phases 1–3:
+
+Move the remaining function-lifetime state declarations (`stackSlotOffsets`, `stackSlotTypes`,
+`localAliasTargets`) from `emit.ts` closures into `functionLowering.ts`. Eliminate the
+`trackedSpRef` proxy by making `FlowState` (from `functionBodySetup.ts`) the single
+authoritative source of SP tracking state.
+
+Acceptance: All tests pass. No behavioral change. No proxy getter/setter in the wiring section.
+
+---
+
+## Phase 5: Parser Robustness (QR-14)
+
+Long-term. Only after Phases 0–4 stabilise the lowering.
+
+### P5-1: Introduce a `Tokenizer` helper
+
+Add `src/frontend/tokenizer.ts`. Migrate `parseImm.ts` and `parseOperands.ts`.
+
+### P5-2: Register canonicalization in the tokenizer
+
+Move register name normalisation into a single lookup table in the tokenizer.
+
+---
+
+## Ticket Backlog
+
+| Ticket | Phase | QR | Severity | Status | Description |
+|---|---|---|---|---|---|
+| T-001 | P0-1 | QR-16 | Low | Open | Add `ZAX301` warning ID; fix `warnAt` |
+| T-002 | P0-2 | QR-15 | Low | Open | Add file-level documentation to all src files |
+| T-003 | P0-3 | QR-10 | Low | Open | Document `ptr` alias in layout and typeResolution |
+| T-004 | P0-4 | QR-9 | Low | Open | Add spec reference comment to HL-swap pattern |
+| T-005 | P0-5 | QR-13 | Med | Open | Simplify `hasStackSlots` → `needsFrame` |
+| T-006 | P0-6 | QR-12 | Low | Open | Add fixup-resolution section comment |
+| T-007 | P1-1 | QR-2 | Crit | Open | Define `LdLoweringContext`; type `createLdLoweringHelpers` |
+| T-008 | P1-2 | QR-18 | High | Open | Fix `any`-equivalent types in `functionBodySetup.ts` Context |
+| T-009 | P1-3 | QR-6 | High | Open | Rename `resolvedScalarKind` → `scalarKindOfResolution` |
+| T-010 | P1-4 | QR-5 | High | Open | Document `resolveScalarTypeForLd` vs `resolveScalarTypeForEa` |
+| T-011 | P2-1 | QR-19 | Med | Open | Extract shared types to `loweringTypes.ts` |
+| T-012 | P2-2 | QR-8 | High | Open | Extract `summarizeOpStackEffect` to `opStackAnalysis.ts` |
+| T-013 | P3-1 | QR-11 | Med | Open | Extract/document `coerceValueOperand`; deduplicate `isRegisterToken` |
+| T-014 | P3-2 | QR-7 | High | Open | Audit and comment all raw opcode bytes in `ldLowering.ts` |
+| T-015 | P4 | QR-4 | High | Open | Eliminate `trackedSpRef` proxy; encapsulate function-lifetime state |
+| T-016 | P5-1 | QR-14 | Med | Open | Add `Tokenizer` helper; migrate `parseImm` and `parseOperands` |
+| T-017 | P5-2 | QR-14 | Med | Open | Move register canonicalization into tokenizer |
+
+**Closed tickets** (completed during v0.4 structural decomposition):
+
+| Ticket | QR | Description |
+|---|---|---|
+| ~~T-012~~ (old) | QR-3 | `diagAt` shadow resolved → `loweringDiagnostics.ts` ✅ |
+| ~~T-013~~ (old) | QR-17 | Duplicate diagnostics resolved → `functionCallLowering.ts` ✅ |
+| ~~T-011~~ (old) | QR-1 | Frame generation extracted → `functionLowering.ts` ✅ |
+| ~~T-014~~ (old) | QR-1 | DataBlock/VarBlock extracted → `programLowering.ts` ✅ |
+
+---
+
+## Non-Goals
+
+- Changing the ZAX language specification or adding new language features
+- Changing the encoding of any Z80 instruction
+- Modifying the frame model or preservation matrix
+- Changing test fixture expected outputs (unless a bug is discovered)
+- Refactoring format writers (`formats/*.ts`) — already well-factored
+- Refactoring `compile.ts` or `pipeline.ts` — already clean
+
+---
+
+## Success Criteria
+
+At the end of this track, the codebase should satisfy:
+
+1. ✅ `emit.ts` is under 1 000 lines (met: 956).
+2. `emit.ts` is under 750 lines (still open: 956 > 750; achievable with P2-2 + P4).
+3. Every helper module has a fully typed context interface with no `any` (QR-2, QR-18 open).
+4. No type is copy-pasted across more than one module (QR-19 open).
+5. Every emitted raw opcode byte has a mnemonic comment (QR-7 open).
+6. Every implementation of a spec rule has an inline comment citing the section (QR-9, QR-11).
+7. Program-lifetime and function-lifetime state are structurally separated (QR-4 partially met).
+8. All existing tests continue to pass.
+9. New unit tests cover all extracted helpers.

--- a/docs/source-overview.md
+++ b/docs/source-overview.md
@@ -1,0 +1,437 @@
+# ZAX Source Code Overview
+
+Status: non-normative developer reference. Describes the current (v0.2) source structure for
+developers working on the codebase.
+
+---
+
+## 1. What ZAX Is
+
+ZAX is a structured assembler for Z80-family targets. It compiles `.zax` source files directly
+to binary output (`.bin`, Intel HEX `.hex`, D8 debug map `.d8dbg.json`, listing `.lst`, and ASM
+trace `.asm`). There is no external linker. The compiler is a single-pass whole-program tool
+written in TypeScript and runs on Node.js ≥ 20.
+
+The compiler accepts one entry file plus transitive imports, resolves them into a single program
+in topological order, runs a sequential pipeline (parse → semantics → lowering), and writes
+in-memory artifacts through injected format writers.
+
+---
+
+## 2. Repository Layout
+
+```
+src/
+  cli.ts                  CLI entry point (argument parsing, file I/O, format wiring)
+  compile.ts              Top-level compile orchestrator (import resolution + pipeline)
+  pipeline.ts             Type contracts only: CompilerOptions, CompileResult, PipelineDeps
+
+  addressing/
+    steps.ts              Step-pipeline primitives (EA builders, load/store templates)
+
+  diagnostics/
+    types.ts              Diagnostic type + stable ID registry (ZAX000–ZAX501)
+
+  formats/
+    types.ts              Output artifact and format-writer contracts
+    index.ts              Format writer factory
+    writeAsm.ts           ASM trace writer (.asm)
+    writeBin.ts           Binary writer (.bin)
+    writeD8m.ts           D8 debug map writer (.d8dbg.json)
+    writeHex.ts           Intel HEX writer (.hex)
+    writeListing.ts       Listing writer (.lst)
+    range.ts              Byte-range utilities
+
+  frontend/
+    ast.ts                Pure AST type definitions (no parsing logic)
+    source.ts             SourceFile: line-start index for span construction
+    parser.ts             Top-level dispatch: iterates lines, dispatches to sub-parsers
+    parseModuleCommon.ts  Shared parse helpers: keyword prefix matching, error messages
+    parseAsmStatements.ts ASM block body parser (instruction + control nodes)
+    parseData.ts          Data block parser
+    parseEnum.ts          Enum declaration parser
+    parseExtern.ts        Extern function binding parser (single extern func line)
+    parseExternBlock.ts   Extern block parser (extern…end)
+    parseFunc.ts          Function declaration parser (header + locals + asm body)
+    parseGlobals.ts       Module-scope var/globals block parser
+    parseImm.ts           Immediate expression parser (literals, names, sizeof, binary)
+    parseOp.ts            Op declaration parser (header + asm body)
+    parseOperands.ts      Operand parser (Reg, Imm, Ea, Mem, PortC, PortImm8)
+    parseParams.ts        Parameter list parser (typed params and op matcher params)
+    parseTopLevelSimple.ts Simple single-line parsers: import, const, section, align, bin, hex
+    parseTypes.ts         Type and union declaration parsers (multi-line blocks)
+
+  lint/
+    case_style.ts         Case-style lint pass (optional; warns on mixed reg/keyword casing)
+
+  lowering/
+    emit.ts               Program emission orchestrator (956 lines — hard cap met ✅)
+    ldLowering.ts         LD instruction lowering helpers (~800 lines; ctx: any — see QR-2)
+    programLowering.ts    Program item dispatch: pre-scan, DataBlock/VarBlock, finalization
+    functionLowering.ts   FuncDecl coordinator: frame setup, prologue, epilogue, body
+    functionCallLowering.ts  Typed-call argument dispatch (byte/word/ea/mem variants)
+    loweringDiagnostics.ts  Shared diagnostic helpers: diag, diagAt, warnAt, etc.
+    eaResolution.ts       EA address resolution: name → {abs, stack} + addend
+    eaMaterialization.ts  EA address materialization to HL register
+    addressingPipelines.ts Build byte/word step pipelines from EA expressions
+    typeResolution.ts     Scalar kind and aggregate type resolution from TypeExprNode
+    asmRangeLowering.ts   Structured control flow lowering (if/while/repeat/select)
+    asmBodyOrchestration.ts  lowerAndFinalizeFunctionBody: fallthrough/balance checks
+    asmInstructionLowering.ts lowerAsmInstructionDispatcher: ret/call/jp/jr/djnz dispatch
+    functionBodySetup.ts  Flow state, labels, joinFlows, select helpers, sourceTagForSpan
+    valueMaterialization.ts  pushEaAddress, pushMemValue, runtime linear expression analysis
+    opMatching.ts         Op overload matching, specificity, diagnostic formatting
+    opExpansionOrchestration.ts  Op expansion: arity/overload check, stack-policy enforcement
+    opExpansionExecution.ts     Op expansion: substitution + re-lowering
+    opSubstitution.ts     Op parameter substitution (replace matcher params with args)
+    emissionCore.ts       Core byte emission: emitCodeBytes, emitRawCodeBytes, emitStepPipeline
+    fixupEmission.ts      Fixup emission: ABS16, REL8, condition opcode maps, symbolicTarget
+    asmUtils.ts           ASM clone utilities (cloneImmExpr, cloneEaExpr), flattenEaDottedName
+    runtimeAtomBudget.ts  Runtime-atom budget enforcement for indexed EA
+    runtimeImmediates.ts  Runtime immediate helpers (loadImm16ToHL/DE, negateHL)
+    scalarWordAccessors.ts Scalar word load/store helpers
+    sectionLayout.ts      Section layout: alignTo, writeSection, computeWrittenRange
+    traceFormat.ts        Trace/ASM output formatting helpers
+    inputAssets.ts        BIN/HEX file ingestion
+
+  semantics/
+    env.ts                Build CompileEnv: resolve consts, enums, type declarations
+    layout.ts             Type size (sizeof) and field offset (offsetof) computation
+
+  z80/
+    encode.ts             Main Z80 instruction encoder dispatch
+    encodeAlu.ts          ALU instruction encoding (add, sub, adc, sbc, and, or, xor, cp)
+    encodeBitOps.ts       Bit operation encoding (bit, set, res, rl, rr, rlc, rrc, sla, sra, srl)
+    encodeControl.ts      Control flow encoding (jp, jr, call, ret, djnz)
+    encodeCoreOps.ts      Core operations encoding (push, pop, inc, dec, ex, exx, nop, halt)
+    encodeIo.ts           I/O instruction encoding (in, out)
+    encodeLd.ts           LD instruction direct encoding (handled before EA lowering)
+```
+
+---
+
+## 3. Compilation Pipeline
+
+```
+CLI / test harness
+  │
+  ▼
+compile(entryFile, options, deps)           [compile.ts]
+  │
+  ├─ loadProgram()
+  │    ├─ readFile + parseModuleFile()      [frontend/parser.ts]
+  │    ├─ resolve imports (BFS + topo sort)
+  │    └─ cycle detection, ID collision check
+  │
+  ├─ lintCaseStyle()                        [lint/case_style.ts]
+  │
+  ├─ buildEnv()                             [semantics/env.ts]
+  │    ├─ collect types, unions
+  │    ├─ collect func/extern names (for collision)
+  │    ├─ resolve enum members (qualified names)
+  │    └─ evaluate const expressions
+  │
+  ├─ emitProgram()                          [lowering/emit.ts]
+  │    ├─ first pass: collect callables, ops, section directives
+  │    │    extern declarations, bin/hex ingestion
+  │    ├─ second pass: emit each module item
+  │    │    ├─ FuncDecl → frame setup + ASM body
+  │    │    ├─ DataBlock → data section bytes
+  │    │    ├─ VarBlock → var section bytes (zero-initialized)
+  │    │    ├─ SectionDirective → update section counter
+  │    │    └─ AlignDirective → pad section
+  │    └─ fixup resolution (ABS16, REL8, extern patches)
+  │
+  └─ format writers                         [formats/*.ts]
+       ├─ writeBin → .bin
+       ├─ writeHex → .hex
+       ├─ writeD8m → .d8dbg.json
+       ├─ writeListing → .lst
+       └─ writeAsm → .asm
+```
+
+---
+
+## 4. Key Subsystems
+
+### 4.1 AST
+
+`frontend/ast.ts` defines pure TypeScript interfaces for all AST nodes. There is **no code** in
+this file — only types. The key node families are:
+
+- **Module structure**: `ProgramNode → ModuleFileNode → ModuleItemNode[]`
+- **Declarations**: `FuncDeclNode`, `OpDeclNode`, `ExternDeclNode`, `DataBlockNode`,
+  `VarBlockNode`, `EnumDeclNode`, `ConstDeclNode`, `TypeDeclNode`, `UnionDeclNode`
+- **ASM body**: `AsmBlockNode → AsmItemNode[]` where items are
+  `AsmInstructionNode | AsmControlNode | AsmLabelNode`
+- **Expressions**: `ImmExprNode` (compile-time), `EaExprNode` (effective address), `TypeExprNode`
+- **Operands**: `AsmOperandNode` variants: `Reg | Imm | Ea | Mem | PortC | PortImm8`
+- **Op matchers**: `OpMatcherNode` variants for overload dispatch
+
+`AsmInstructionNode` stores the mnemonic in canonical lower-case (`head`) and operands as
+`AsmOperandNode[]`. All register names in `Reg` nodes are canonical upper-case.
+
+### 4.2 Frontend Parser
+
+The parser is line-oriented and recursive-but-manual (not a grammar-driven parser). It:
+
+1. Splits source text into lines using pre-computed `lineStarts` (from `source.ts`).
+2. Strips semicolon comments from each line.
+3. Tries each keyword prefix in order (a cascade of `consumeTopKeyword` / `consumeKeywordPrefix`
+   calls) to dispatch to the appropriate sub-parser.
+4. Multi-line constructs (func, op, type, union, extern, var, data blocks) advance the line
+   counter `i` through the block body looking for terminating keywords.
+5. Each sub-parser returns `{ node, nextIndex }` so the top-level loop can skip the consumed
+   lines.
+
+Error handling is best-effort: malformed lines emit a diagnostic and parsing continues at the
+next line where possible.
+
+**Characteristic weakness**: Operand parsing (`parseOperands.ts`) and ASM statement parsing
+(`parseAsmStatements.ts`) use manual string tokenization. The boundary between a ZAX identifier
+and a Z80 register/mnemonic token is resolved by priority matching (registers checked first,
+then ZAX bindings), mirroring the spec but implemented ad hoc.
+
+### 4.3 Semantics
+
+`semantics/env.ts` builds the `CompileEnv` in one pass over the program:
+- Registers all type/union declarations (name → node map)
+- Registers func/extern names (for duplicate detection only — not used in lowering)
+- Assigns sequential ordinal values to enum members (`EnumName.MemberName → index`)
+- Evaluates `const` expressions using `evalImmExpr`
+
+`semantics/layout.ts` implements:
+- `sizeOfTypeExpr` — returns the power-of-2 padded storage size
+- `storageInfoForTypeExpr` — returns `{ preRoundSize, storageSize }` pair
+- `offsetOfPathInTypeExpr` — resolves `offsetof(T, a.b[2])` paths to byte offsets
+
+Type resolution is recursive with cycle detection via `visiting` sets.
+
+### 4.4 Lowering: The Frame Model
+
+Every `func` declaration with parameters, locals, or preserved registers gets an
+IX-anchored stack frame:
+
+```asm
+; prologue
+push ix
+ld ix, 0
+add ix, sp         ; IX = frame pointer
+
+; local initializers (for each local with initializer, in declaration order):
+;   if HL is preserved (not in return set):
+push hl            ; save incoming HL
+ld hl, <init>
+ex (sp), hl        ; init on stack, incoming HL restored
+;   if HL is volatile (in return set):
+ld hl, <init>
+push hl            ; init on stack
+
+; preserved registers (per preservation matrix):
+push AF / BC / DE / HL (as applicable)
+
+; === user ASM body ===
+
+; epilogue (at __zax_epilogue_N label):
+pop HL / DE / BC / AF (reverse order)
+ld sp, ix
+pop ix
+ret
+```
+
+The preservation matrix is: `Preserve = {AF, BC, DE, HL} \ ReturnSet`. IX is always preserved
+via the frame mechanism. All `ret` / `ret cc` within the body are rewritten to `jp` / `jp cc
+__zax_epilogue_N` when any cleanup is needed.
+
+Stack slot layout (relative to IX):
+- Locals: `IX-2`, `IX-4`, `IX-6`, … (in declaration order; all word-sized slots)
+- Parameters: `IX+4`, `IX+6`, `IX+8`, … (first param at IX+4; two words above return address)
+
+### 4.5 Lowering: EA Resolution
+
+Effective-address expressions (`EaExprNode`) are resolved to one of:
+
+```typescript
+type EaResolution =
+  | { kind: 'abs'; baseLower: string; addend: number; typeExpr?: TypeExprNode }
+  | { kind: 'stack'; ixDisp: number; typeExpr?: TypeExprNode };
+```
+
+`'abs'` means a module-scope global symbol (emitted as a fixup). `'stack'` means an IX-relative
+displacement. The `typeExpr` carries the declared type for scalar-kind and width checks.
+
+Field access (`.field`) and constant index (`[n]`) are folded into the addend/ixDisp at
+resolution time. Runtime-indexed access (reg8/reg16 index) falls back to address materialization
+into HL.
+
+### 4.6 Lowering: LD Instruction
+
+`ldLowering.ts` handles the core complexity of the `ld` instruction, which must cover:
+
+- `ld r8, (ea)` — load byte from EA into reg8
+- `ld r16, (ea)` — load word from EA into reg16 pair
+- `ld (ea), r8` — store reg8 to byte EA
+- `ld (ea), r16` — store reg16 to word EA
+- `ld (ea), (ea)` — memory-to-memory copy (byte or word)
+- `ld (ea), imm` — store immediate to EA
+
+Each case tries multiple paths in priority order:
+1. Direct IX+d form (for stack slots within ±128 byte range)
+2. Step-pipeline template (for EAs that can be resolved to a step sequence)
+3. Absolute fixup (for global symbols with zero addend)
+4. EA address materialization to HL as fallback
+
+The H/L register special case: `LD H,(IX+d)` and `LD L,(IX+d)` are illegal on Z80. The code
+uses a DE shuttle (`ex de,hl` / `ld d/e,(ix+d)` / `ex de,hl`) for these cases.
+
+### 4.7 Lowering: Step Pipelines
+
+`addressing/steps.ts` defines a step-pipeline abstraction. A `StepPipeline` is an ordered list
+of `AddressingStep` values. Steps are combined by templates (e.g., `TEMPLATE_L_ABC`,
+`TEMPLATE_LW_HL`) and then executed by `emitStepPipeline` in `emissionCore.ts`.
+
+Steps encode operations like:
+- `LOAD_BASE_GLOB` / `LOAD_BASE_FVAR` — load base address into DE
+- `LOAD_RP_EA` / `LOAD_RP_GLOB` / `LOAD_RP_FVAR` — load register pair from EA
+- `STORE_RP_EA` / `STORE_RP_GLOB` / `STORE_RP_FVAR` — store register pair to EA
+- `CALC_EA` / `CALC_EA_2` — compute effective address (HL = HL + DE)
+- `TEMPLATE_L_ABC` / `TEMPLATE_L_HL` / `TEMPLATE_L_DE` — load byte via EA builder
+- `TEMPLATE_LW_HL` / `TEMPLATE_LW_DE` / etc. — load word via EA builder
+
+Steps are executed by `emitStepPipeline` in `emissionCore.ts`. This abstraction insulates
+the lowering code from the register-allocation details of the addressing model
+(DE = base, HL = index/EA).
+
+### 4.8 Lowering: Structured Control Flow
+
+`asmRangeLowering.ts` handles `if/else/end`, `while/end`, `repeat/until`, and
+`select/case/selectelse/end`. It:
+
+1. Scans forward from a control keyword to its matching terminator using a `stopKinds` set.
+2. Generates hidden labels (`__zax_if_else_N`, `__zax_if_end_N`, etc.).
+3. Emits conditional jumps to the hidden labels.
+4. Tracks flow reachability and SP delta state through branches.
+
+The SP tracking is conservative: if two branches diverge in SP state, the joined state is
+marked invalid.
+
+### 4.9 Lowering: Op Expansion
+
+Op expansion (`opExpansionOrchestration.ts`, `opExpansionExecution.ts`, `opSubstitution.ts`)
+handles inline macro-instruction expansion:
+
+1. An ASM instruction whose `head` matches a declared `op` name triggers op dispatch.
+2. Arity is checked first; then each overload is pattern-matched via `opMatching.ts`.
+3. The best-matching (most specific) overload is selected.
+4. The op body is recursively lowered with parameter substitution applied.
+5. Cycle detection prevents infinite recursion.
+
+### 4.10 Z80 Encoder
+
+`z80/encode.ts` dispatches to encoder subfamilies by mnemonic. The encoder handles only
+**concrete** instructions (no EA lowering — that happens upstream in lowering). It returns
+a `Uint8Array` of bytes or `undefined` on error.
+
+Encoding is table-driven for register codes (e.g., `reg8Code` maps `A/B/C/D/E/H/L` to
+opcode bits) and conditional codes (`conditionOpcode` maps `NZ/Z/NC/C/PO/PE/P/M` to bits).
+
+---
+
+## 5. Helper Module Injection Pattern
+
+After the refactor splitting `emit.ts`, the lowering helpers use a dependency-injection pattern.
+Each helper module exports a `createXxxHelpers(ctx)` factory that takes a context object and
+returns a set of closures. The closures close over the context properties they need.
+
+**Typed context** (correct pattern):
+```typescript
+// eaResolution.ts
+type EaResolutionContext = { env, diagnostics, diagAt, stackSlotOffsets, ... };
+export function createEaResolutionHelpers(ctx: EaResolutionContext) { ... }
+```
+
+**Untyped context** (problem area):
+```typescript
+// ldLowering.ts
+export function createLdLoweringHelpers(ctx: any) {
+  const { emitInstr, resolveEa, buildEaBytePipeline, ... } = ctx;
+  ...
+}
+```
+
+As of the current codebase:
+- `ldLowering.ts` still uses `ctx: any` (QR-2) — the only untyped module.
+- `functionBodySetup.ts` uses `AsmOperandNode extends never ? never : any` as a
+  linting-bypass technique for `pushEaAddress`, `pushMemValue`, and `evalImmExpr` (QR-18).
+  The correct types are `EaExprNode`, `ImmExprNode`, and `CompileEnv`.
+- All other extracted helper modules have properly typed context interfaces.
+
+These two typing gaps are the primary remaining items in the v0.4 type-safety track.
+
+---
+
+## 6. State Lifetime in emitProgram
+
+`emitProgram` maintains state at two lifetimes:
+
+**Program lifetime** (allocated once, lives for entire compilation):
+- `bytes`, `codeBytes`, `dataBytes`, `hexBytes` — section byte maps
+- `codeSourceSegments`, `codeAsmTrace` — source mapping / trace data
+- `symbols`, `pending`, `taken` — symbol table
+- `fixups`, `rel8Fixups`, `deferredExterns` — forward-reference fixup queues
+- `callables`, `opsByName` — callable and op registries
+- `storageTypes`, `moduleAliasTargets`, `rawAddressSymbols` — module-scope type/alias state
+- `generatedLabelCounter` — global hidden label counter (must not reset between functions)
+- `opStackSummaryCache` — memoized op stack-effect analysis
+
+**Function lifetime** (reset at the start of each `FuncDecl`):
+- `stackSlotOffsets`, `stackSlotTypes` — local/param IX-displacement maps
+- `localAliasTargets` — function-local alias bindings
+- `spDeltaTracked`, `spTrackingValid`, `spTrackingInvalidatedByMutation` — SP tracking state
+
+Function-lifetime state is now managed inside `lowerFunctionDecl` in `functionLowering.ts`
+(PR #547). The `FunctionLoweringContext` interface is an exported type that documents
+which state is function-scoped. The `trackedSpRef` proxy (getter/setter bridge for the three
+SP tracking scalars) still exists in the `programLoweringContext` wiring in `emit.ts`, but
+it is now confined to the wiring section only.
+
+**Remaining risk (QR-4)**: `stackSlotOffsets`, `stackSlotTypes`, and `localAliasTargets`
+are still declared as closures in `emitProgram` and passed by reference to both modules.
+Full resolution (Phase 4) requires moving these allocations into `lowerFunctionDecl` and
+eliminating the `trackedSpRef` proxy.
+
+---
+
+## 7. Diagnostic Architecture
+
+All diagnostics use a shared `Diagnostic` interface with a stable `id` (e.g., `ZAX300`).
+The IDs are defined as constants in `diagnostics/types.ts`. There are roughly 20 named IDs
+plus the catch-all `ZAX000` (Unknown).
+
+Within `emit.ts`, there are five diagnostic helper functions at file scope:
+- `diag(diagnostics, file, message)` — generic file-level error
+- `diagAt(diagnostics, span, message)` — span-precise error
+- `diagAtWithId(diagnostics, span, id, message)` — span-precise with specific ID
+- `diagAtWithSeverityAndId(diagnostics, span, id, severity, message)` — flexible
+- `warnAt(diagnostics, span, message)` — warning
+
+Inside the `emitProgram` function body, there are closure-bound curried versions of some of
+these (particularly `diagAt`, which is passed into helper modules) that shadow the file-scope
+names within the closure scope.
+
+---
+
+## 8. Testing Infrastructure
+
+Tests are in `test/` and run with Vitest. There are ~200 test files. Key categories:
+
+- **Parser tests** (`pr4xx_parse_*`): unit tests for specific parser helpers
+- **Encoder tests** (`pr4xx_encode_*`): unit tests for Z80 encoding functions
+- **Lowering tests** (`pr*_lowering_*`): integration tests for specific lowering cases
+- **Corpus tests** (`pr303_*`, `pr312_*`): codegen corpus (expected `.asm` trace output)
+- **CLI tests** (`cli_*`): end-to-end tests via the CLI entry point
+- **Smoke tests** (`smoke_*`, `examples_compile.test.ts`): compile example `.zax` files
+
+The corpus tests use a snapshot-comparison approach: the `.asm` trace is compared against
+a stored expected file. Regeneration scripts exist (`regen:codegen-corpus`,
+`regen:language-tour`).


### PR DESCRIPTION
## Summary

- Adds \`docs/source-overview.md\` — full description of the current source tree, compilation pipeline, all 28 lowering modules, subsystem deep-dives (frame model, EA resolution, LD lowering, step pipelines, structured control flow, op expansion, Z80 encoder), helper injection pattern, and state lifetime analysis.
- Adds \`docs/quality-report.md\` — 19 rated code quality issues (QR-1 to QR-19) with file locations, code excerpts, impact, and fix directions. Reflects the post-v0.4 decomposition state: \`emit.ts\` at 956 lines (hard cap met ✅), QR-1/3/17 resolved, QR-2/18 (typing) and QR-4/8/19 (structural) still open.
- Adds \`docs/refactor-plan.md\` — phased improvement plan (P0–P5) with 17 active tickets, a completed-work table tracking all 12 extraction PRs, updated success criteria, and explicit non-goals.
- Updates \`docs/README.md\` with entries for the three new files.

## Test plan

- [ ] Review \`source-overview.md\` for accuracy against the current \`src/lowering/\` module set
- [ ] Review \`quality-report.md\` issue list — verify locations and severities are reasonable
- [ ] Review \`refactor-plan.md\` ticket list and completed-work table
- [ ] Confirm no source code was changed (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)