### PR TITLE
Add lowering warning diagnostic id

### DIFF
--- a/src/diagnostics/types.ts
+++ b/src/diagnostics/types.ts
@@ -50,6 +50,8 @@ export const DiagnosticIds = {
 
   /** Generic emission/lowering error (layout/packing/symbol collisions, etc.). */
   EmitError: 'ZAX300',
+  /** Generic emission/lowering warning. */
+  EmitWarning: 'ZAX301',
 
   /** Op invocation arity mismatch against available overload set. */
   OpArityMismatch: 'ZAX310',

--- a/src/lowering/loweringDiagnostics.ts
+++ b/src/lowering/loweringDiagnostics.ts
@@ -52,7 +52,7 @@ export function diagAtWithSeverityAndId(
 
 export function warnAt(diagnostics: Diagnostic[], span: SourceSpan, message: string): void {
   diagnostics.push({
-    id: DiagnosticIds.EmitError,
+    id: DiagnosticIds.EmitWarning,
     severity: 'warning',
     message,
     file: span.file,

--- a/test/pr552_lowering_warning_id.test.ts
+++ b/test/pr552_lowering_warning_id.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { DiagnosticIds } from '../src/diagnostics/types.js';
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { warnAt } from '../src/lowering/loweringDiagnostics.js';
+
+describe('PR552 lowering warning diagnostic id', () => {
+  it('uses EmitWarning for generic lowering warnings', () => {
+    const diagnostics: Diagnostic[] = [];
+
+    warnAt(
+      diagnostics,
+      {
+        file: 'test.zax',
+        start: { offset: 0, line: 3, column: 5 },
+        end: { offset: 1, line: 3, column: 6 },
+      },
+      'warning text',
+    );
+
+    expect(diagnostics).toEqual([
+      {
+        id: DiagnosticIds.EmitWarning,
+        severity: 'warning',
+        message: 'warning text',
+        file: 'test.zax',
+        line: 3,
+        column: 5,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
This fixes the lowering warning path to use a dedicated diagnostic ID instead of EmitError.\n\nVerification:\n- npm run typecheck\n- npm test -- --run test/pr552_lowering_warning_id.test.ts test/pr511_asm_body_orchestration_helpers.test.ts test/pr468_typed_step_integration.test.ts test/smoke_language_tour_compile.test.ts