### PR TITLE
Extract shared lowering types

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -78,6 +78,7 @@ import type { CompileEnv } from '../semantics/env.js';
 import { evalImmExpr } from '../semantics/env.js';
 import { sizeOfTypeExpr } from '../semantics/layout.js';
 import { encodeInstruction } from '../z80/encode.js';
+import type { Callable, PendingSymbol, SectionKind, SourceSegmentTag } from './loweringTypes.js';
 import type { OpStackPolicyMode } from '../pipeline.js';
 import { loadBinInput, loadHexInput } from './inputAssets.js';
 import { createEaResolutionHelpers, type EaResolution } from './eaResolution.js';
@@ -156,23 +157,10 @@ export function emitProgram(
     defaultCodeBase?: number;
   },
 ): { map: EmittedByteMap; symbols: SymbolEntry[] } {
-  type SectionKind = 'code' | 'data' | 'var';
-  type PendingSymbol = {
-    kind: 'label' | 'data' | 'var';
-    name: string;
-    section: SectionKind;
-    offset: number;
-    file?: string;
-    line?: number;
-    scope?: 'global' | 'local';
-    size?: number;
-  };
-
   const bytes = new Map<number, number>();
   const codeBytes = new Map<number, number>();
   const dataBytes = new Map<number, number>();
   const hexBytes = new Map<number, number>();
-  type SourceSegmentTag = Omit<EmittedSourceSegment, 'start' | 'end'>;
   const codeSourceSegments: EmittedSourceSegment[] = [];
   const codeAsmTrace: EmittedAsmTraceEntry[] = [];
   let currentCodeSegmentTag: SourceSegmentTag | undefined;
@@ -197,9 +185,6 @@ export function emitProgram(
     line: number;
   }[] = [];
 
-  type Callable =
-    | { kind: 'func'; node: FuncDeclNode }
-    | { kind: 'extern'; node: ExternFuncNode; targetLower: string };
   const callables = new Map<string, Callable>();
   const opsByName = new Map<string, OpDeclNode[]>();
   type OpStackSummary =

--- a/src/lowering/functionBodySetup.ts
+++ b/src/lowering/functionBodySetup.ts
@@ -7,9 +7,7 @@ import type {
   ImmExprNode,
   SourceSpan,
 } from '../frontend/ast.js';
-import type { EmittedSourceSegment } from '../formats/types.js';
-
-type SourceSegmentTag = Omit<EmittedSourceSegment, 'start' | 'end'>;
+import type { SourceSegmentTag } from './loweringTypes.js';
 
 export type FlowState = {
   reachable: boolean;

--- a/src/lowering/functionCallLowering.ts
+++ b/src/lowering/functionCallLowering.ts
@@ -11,19 +11,15 @@ import type {
   SourceSpan,
   TypeExprNode,
 } from '../frontend/ast.js';
-import type { EmittedSourceSegment } from '../formats/types.js';
 import type { CompileEnv } from '../semantics/env.js';
 import type { StepPipeline } from '../addressing/steps.js';
 import type { OpStackPolicyMode } from '../pipeline.js';
+import type { Callable, SourceSegmentTag } from './loweringTypes.js';
 import type { ScalarKind } from './typeResolution.js';
 import type { FlowState, OpExpansionFrame } from './functionBodySetup.js';
 import { createAsmRangeLoweringHelpers } from './asmRangeLowering.js';
 import { createOpExpansionOrchestrationHelpers } from './opExpansionOrchestration.js';
 
-type SourceSegmentTag = Omit<EmittedSourceSegment, 'start' | 'end'>;
-type Callable =
-  | { kind: 'func'; node: { name: string; params: ParamNode[] } }
-  | { kind: 'extern'; node: { name: string; params: ParamNode[] }; targetLower: string };
 type ResolvedArrayType = { element: TypeExprNode; length?: number };
 type OpStackSummary =
   | { kind: 'known'; delta: number; hasUntrackedSpMutation: boolean }

--- a/src/lowering/functionLowering.ts
+++ b/src/lowering/functionLowering.ts
@@ -14,9 +14,13 @@ import type {
   SourceSpan,
   TypeExprNode,
 } from '../frontend/ast.js';
-import type { EmittedSourceSegment } from '../formats/types.js';
 import type { CompileEnv } from '../semantics/env.js';
 import type { OpStackPolicyMode } from '../pipeline.js';
+import type {
+  Callable,
+  PendingSymbol,
+  SourceSegmentTag,
+} from './loweringTypes.js';
 import type { ScalarKind } from './typeResolution.js';
 import { createAsmInstructionLoweringHelpers } from './asmInstructionLowering.js';
 import { createAsmBodyOrchestrationHelpers } from './asmBodyOrchestration.js';
@@ -27,22 +31,7 @@ import {
 } from './functionBodySetup.js';
 import { createFunctionCallLoweringHelpers } from './functionCallLowering.js';
 
-type PendingSymbol = {
-  kind: 'label' | 'data' | 'var';
-  name: string;
-  section: 'code' | 'data' | 'var';
-  offset: number;
-  file?: string;
-  line?: number;
-  scope?: 'global' | 'local';
-  size?: number;
-};
-
-type SourceSegmentTag = Omit<EmittedSourceSegment, 'start' | 'end'>;
 type ResolvedArrayType = { element: TypeExprNode; length?: number };
-type Callable =
-  | { kind: 'func'; node: FuncDeclNode }
-  | { kind: 'extern'; node: { name: string; params: ParamNode[] }; targetLower: string };
 type OpStackSummary =
   | { kind: 'known'; delta: number; hasUntrackedSpMutation: boolean }
   | { kind: 'complex' };

--- a/src/lowering/loweringTypes.ts
+++ b/src/lowering/loweringTypes.ts
@@ -1,0 +1,24 @@
+import type {
+  ExternFuncNode,
+  FuncDeclNode,
+} from '../frontend/ast.js';
+import type { EmittedSourceSegment } from '../formats/types.js';
+
+export type SectionKind = 'code' | 'data' | 'var';
+
+export type PendingSymbol = {
+  kind: 'label' | 'data' | 'var';
+  name: string;
+  section: SectionKind;
+  offset: number;
+  file?: string;
+  line?: number;
+  scope?: 'global' | 'local';
+  size?: number;
+};
+
+export type SourceSegmentTag = Omit<EmittedSourceSegment, 'start' | 'end'>;
+
+export type Callable =
+  | { kind: 'func'; node: FuncDeclNode }
+  | { kind: 'extern'; node: ExternFuncNode; targetLower: string };

--- a/src/lowering/programLowering.ts
+++ b/src/lowering/programLowering.ts
@@ -6,7 +6,6 @@ import type {
   EnumDeclNode,
   EaExprNode,
   ExternDeclNode,
-  ExternFuncNode,
   FuncDeclNode,
   HexDeclNode,
   ImmExprNode,
@@ -28,24 +27,12 @@ import type {
 } from '../formats/types.js';
 import type { CompileEnv } from '../semantics/env.js';
 import type { FunctionLoweringContext } from './functionLowering.js';
+import type {
+  Callable,
+  PendingSymbol,
+  SectionKind,
+} from './loweringTypes.js';
 import type { AggregateType, ScalarKind } from './typeResolution.js';
-
-type PendingSymbol = {
-  kind: 'label' | 'data' | 'var';
-  name: string;
-  section: 'code' | 'data' | 'var';
-  offset: number;
-  file?: string;
-  line?: number;
-  scope?: 'global' | 'local';
-  size?: number;
-};
-
-type SectionKind = 'code' | 'data' | 'var';
-
-type Callable =
-  | { kind: 'func'; node: FuncDeclNode }
-  | { kind: 'extern'; node: ExternFuncNode; targetLower: string };
 
 type Context = Omit<FunctionLoweringContext, 'item'> & {
   program: ProgramNode;


### PR DESCRIPTION
Closes #553

## What changed
- extract shared lowering-only types into loweringTypes.ts
- remove duplicate PendingSymbol, SectionKind, Callable, and SourceSegmentTag definitions
- keep the change strictly type-only

## Verification
- npm run typecheck
- npm test -- --run test/pr543_function_lowering_integration.test.ts test/pr544_program_lowering_integration.test.ts test/pr532_asm_instruction_lowering_integration.test.ts test/pr511_asm_body_orchestration_helpers.test.ts test/smoke_language_tour_compile.test.ts
