### PR TITLE
Extract op stack analysis helpers

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -79,6 +79,7 @@ import { evalImmExpr } from '../semantics/env.js';
 import { sizeOfTypeExpr } from '../semantics/layout.js';
 import { encodeInstruction } from '../z80/encode.js';
 import type { Callable, PendingSymbol, SectionKind, SourceSegmentTag } from './loweringTypes.js';
+import { createOpStackAnalysisHelpers } from './opStackAnalysis.js';
 import type { OpStackPolicyMode } from '../pipeline.js';
 import { loadBinInput, loadHexInput } from './inputAssets.js';
 import { createEaResolutionHelpers, type EaResolution } from './eaResolution.js';
@@ -187,10 +188,6 @@ export function emitProgram(
 
   const callables = new Map<string, Callable>();
   const opsByName = new Map<string, OpDeclNode[]>();
-  type OpStackSummary =
-    | { kind: 'known'; delta: number; hasUntrackedSpMutation: boolean }
-    | { kind: 'complex' };
-  const opStackSummaryCache = new Map<OpDeclNode, OpStackSummary>();
   const opStackPolicyMode = options?.opStackPolicy ?? 'off';
   const rawTypedCallWarningsEnabled = options?.rawTypedCallWarnings === true;
   const declaredOpNames = new Set<string>();
@@ -207,96 +204,7 @@ export function emitProgram(
     ['L', 5],
     ['A', 7],
   ]);
-  const opStackSummaryKey = (decl: OpDeclNode): string =>
-    `${decl.name.toLowerCase()}@${decl.span.file}:${decl.span.start.line}`;
-  const summarizeOpStackEffect = (
-    decl: OpDeclNode,
-    visiting: Set<string> = new Set(),
-  ): OpStackSummary => {
-    const cached = opStackSummaryCache.get(decl);
-    if (cached) return cached;
-    const key = opStackSummaryKey(decl);
-    if (visiting.has(key)) return { kind: 'complex' };
-    visiting.add(key);
-    let delta = 0;
-    let hasUntrackedSpMutation = false;
-    let complex = false;
-    for (const item of decl.body.items) {
-      if (item.kind === 'AsmLabel') continue;
-      if (item.kind !== 'AsmInstruction') {
-        complex = true;
-        break;
-      }
-      const head = item.head.toLowerCase();
-      const operands = item.operands;
-      if (head === 'push' && operands.length === 1) {
-        delta -= 2;
-        continue;
-      }
-      if (head === 'pop' && operands.length === 1) {
-        delta += 2;
-        continue;
-      }
-      if (
-        head === 'inc' &&
-        operands.length === 1 &&
-        operands[0]?.kind === 'Reg' &&
-        operands[0].name.toUpperCase() === 'SP'
-      ) {
-        delta += 1;
-        continue;
-      }
-      if (
-        head === 'dec' &&
-        operands.length === 1 &&
-        operands[0]?.kind === 'Reg' &&
-        operands[0].name.toUpperCase() === 'SP'
-      ) {
-        delta -= 1;
-        continue;
-      }
-      if (
-        head === 'ld' &&
-        operands.length === 2 &&
-        operands[0]?.kind === 'Reg' &&
-        operands[0].name.toUpperCase() === 'SP'
-      ) {
-        hasUntrackedSpMutation = true;
-        continue;
-      }
-      if (
-        head === 'ret' ||
-        head === 'retn' ||
-        head === 'reti' ||
-        head === 'jp' ||
-        head === 'jr' ||
-        head === 'djnz'
-      ) {
-        complex = true;
-        break;
-      }
-      const nestedCandidates = opsByName.get(head);
-      if (nestedCandidates && nestedCandidates.length > 0) {
-        if (nestedCandidates.length !== 1) {
-          complex = true;
-          break;
-        }
-        const nested = summarizeOpStackEffect(nestedCandidates[0]!, visiting);
-        if (nested.kind !== 'known') {
-          complex = true;
-          break;
-        }
-        delta += nested.delta;
-        hasUntrackedSpMutation = hasUntrackedSpMutation || nested.hasUntrackedSpMutation;
-      }
-    }
-    visiting.delete(key);
-    const out: OpStackSummary = complex
-      ? { kind: 'complex' }
-      : { kind: 'known', delta, hasUntrackedSpMutation };
-    opStackSummaryCache.set(decl, out);
-    return out;
-  };
+  const { summarizeOpStackEffect } = createOpStackAnalysisHelpers({ opsByName });
 
   const storageTypes = new Map<string, TypeExprNode>();
   const moduleAliasTargets = new Map<string, EaExprNode>();

--- a/src/lowering/functionCallLowering.ts
+++ b/src/lowering/functionCallLowering.ts
@@ -15,16 +15,13 @@ import type { CompileEnv } from '../semantics/env.js';
 import type { StepPipeline } from '../addressing/steps.js';
 import type { OpStackPolicyMode } from '../pipeline.js';
 import type { Callable, SourceSegmentTag } from './loweringTypes.js';
+import type { OpStackSummary } from './opStackAnalysis.js';
 import type { ScalarKind } from './typeResolution.js';
 import type { FlowState, OpExpansionFrame } from './functionBodySetup.js';
 import { createAsmRangeLoweringHelpers } from './asmRangeLowering.js';
 import { createOpExpansionOrchestrationHelpers } from './opExpansionOrchestration.js';
 
 type ResolvedArrayType = { element: TypeExprNode; length?: number };
-type OpStackSummary =
-  | { kind: 'known'; delta: number; hasUntrackedSpMutation: boolean }
-  | { kind: 'complex' };
-
 type Context = {
   diagnostics: Diagnostic[];
   asmItemSpanSourceTag: (span: SourceSpan) => SourceSegmentTag;

--- a/src/lowering/functionLowering.ts
+++ b/src/lowering/functionLowering.ts
@@ -21,6 +21,7 @@ import type {
   PendingSymbol,
   SourceSegmentTag,
 } from './loweringTypes.js';
+import type { OpStackSummary } from './opStackAnalysis.js';
 import type { ScalarKind } from './typeResolution.js';
 import { createAsmInstructionLoweringHelpers } from './asmInstructionLowering.js';
 import { createAsmBodyOrchestrationHelpers } from './asmBodyOrchestration.js';
@@ -32,10 +33,6 @@ import {
 import { createFunctionCallLoweringHelpers } from './functionCallLowering.js';
 
 type ResolvedArrayType = { element: TypeExprNode; length?: number };
-type OpStackSummary =
-  | { kind: 'known'; delta: number; hasUntrackedSpMutation: boolean }
-  | { kind: 'complex' };
-
 export type FunctionLoweringContext = {
   item: FuncDeclNode;
   diagnostics: Diagnostic[];

--- a/src/lowering/opExpansionOrchestration.ts
+++ b/src/lowering/opExpansionOrchestration.ts
@@ -10,6 +10,7 @@ import type {
   SourceSpan,
 } from '../frontend/ast.js';
 import type { CompileEnv } from '../semantics/env.js';
+import type { OpStackSummary } from './opStackAnalysis.js';
 import { createOpExpansionExecutionHelpers } from './opExpansionExecution.js';
 import { createOpSubstitutionHelpers } from './opSubstitution.js';
 
@@ -19,10 +20,6 @@ type OpExpansionStackEntry = {
   declSpan: SourceSpan;
   callSiteSpan: SourceSpan;
 };
-
-type OpStackSummary =
-  | { kind: 'known'; delta: number; hasUntrackedSpMutation: boolean }
-  | { kind: 'complex' };
 
 type CloneHelper<T> = (value: T) => T;
 

--- a/src/lowering/opStackAnalysis.ts
+++ b/src/lowering/opStackAnalysis.ts
@@ -1,0 +1,109 @@
+import type { OpDeclNode } from '../frontend/ast.js';
+
+export type OpStackSummary =
+  | { kind: 'known'; delta: number; hasUntrackedSpMutation: boolean }
+  | { kind: 'complex' };
+
+type Context = {
+  opsByName: Map<string, OpDeclNode[]>;
+};
+
+export function createOpStackAnalysisHelpers({ opsByName }: Context) {
+  const opStackSummaryCache = new Map<OpDeclNode, OpStackSummary>();
+
+  const opStackSummaryKey = (decl: OpDeclNode): string =>
+    `${decl.name.toLowerCase()}@${decl.span.file}:${decl.span.start.line}`;
+
+  const summarizeOpStackEffect = (
+    decl: OpDeclNode,
+    visiting: Set<string> = new Set(),
+  ): OpStackSummary => {
+    const cached = opStackSummaryCache.get(decl);
+    if (cached) return cached;
+    const key = opStackSummaryKey(decl);
+    if (visiting.has(key)) return { kind: 'complex' };
+    visiting.add(key);
+    let delta = 0;
+    let hasUntrackedSpMutation = false;
+    let complex = false;
+    for (const item of decl.body.items) {
+      if (item.kind === 'AsmLabel') continue;
+      if (item.kind !== 'AsmInstruction') {
+        complex = true;
+        break;
+      }
+      const head = item.head.toLowerCase();
+      const operands = item.operands;
+      if (head === 'push' && operands.length === 1) {
+        delta -= 2;
+        continue;
+      }
+      if (head === 'pop' && operands.length === 1) {
+        delta += 2;
+        continue;
+      }
+      if (
+        head === 'inc' &&
+        operands.length === 1 &&
+        operands[0]?.kind === 'Reg' &&
+        operands[0].name.toUpperCase() === 'SP'
+      ) {
+        delta += 1;
+        continue;
+      }
+      if (
+        head === 'dec' &&
+        operands.length === 1 &&
+        operands[0]?.kind === 'Reg' &&
+        operands[0].name.toUpperCase() === 'SP'
+      ) {
+        delta -= 1;
+        continue;
+      }
+      if (
+        head === 'ld' &&
+        operands.length === 2 &&
+        operands[0]?.kind === 'Reg' &&
+        operands[0].name.toUpperCase() === 'SP'
+      ) {
+        hasUntrackedSpMutation = true;
+        continue;
+      }
+      if (
+        head === 'ret' ||
+        head === 'retn' ||
+        head === 'reti' ||
+        head === 'jp' ||
+        head === 'jr' ||
+        head === 'djnz'
+      ) {
+        complex = true;
+        break;
+      }
+      const nestedCandidates = opsByName.get(head);
+      if (nestedCandidates && nestedCandidates.length > 0) {
+        if (nestedCandidates.length !== 1) {
+          complex = true;
+          break;
+        }
+        const nested = summarizeOpStackEffect(nestedCandidates[0]!, visiting);
+        if (nested.kind !== 'known') {
+          complex = true;
+          break;
+        }
+        delta += nested.delta;
+        hasUntrackedSpMutation = hasUntrackedSpMutation || nested.hasUntrackedSpMutation;
+      }
+    }
+    visiting.delete(key);
+    const out: OpStackSummary = complex
+      ? { kind: 'complex' }
+      : { kind: 'known', delta, hasUntrackedSpMutation };
+    opStackSummaryCache.set(decl, out);
+    return out;
+  };
+
+  return {
+    summarizeOpStackEffect,
+  };
+}

--- a/test/pr554_op_stack_analysis_helpers.test.ts
+++ b/test/pr554_op_stack_analysis_helpers.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { createOpStackAnalysisHelpers } from '../src/lowering/opStackAnalysis.js';
+import type { OpDeclNode } from '../src/frontend/ast.js';
+
+const span = {
+  file: 'test.zax',
+  start: { line: 1, column: 1, offset: 0 },
+  end: { line: 1, column: 1, offset: 0 },
+};
+
+const opDecl = (name: string, items: OpDeclNode['body']['items']): OpDeclNode =>
+  ({
+    kind: 'OpDecl',
+    span,
+    name,
+    params: [],
+    body: { kind: 'AsmBlock', span, items },
+  }) as unknown as OpDeclNode;
+
+describe('PR554: extracted op stack analysis helpers', () => {
+  it('summarizes simple stack deltas and SP mutation', () => {
+    const leaf = opDecl('leaf', [
+      {
+        kind: 'AsmInstruction',
+        span,
+        head: 'push',
+        operands: [{ kind: 'Reg', span, name: 'HL' }],
+      },
+      {
+        kind: 'AsmInstruction',
+        span,
+        head: 'ld',
+        operands: [
+          { kind: 'Reg', span, name: 'SP' },
+          { kind: 'Reg', span, name: 'HL' },
+        ],
+      },
+      {
+        kind: 'AsmInstruction',
+        span,
+        head: 'pop',
+        operands: [{ kind: 'Reg', span, name: 'HL' }],
+      },
+    ]);
+
+    const { summarizeOpStackEffect } = createOpStackAnalysisHelpers({
+      opsByName: new Map([['leaf', [leaf]]]),
+    });
+
+    expect(summarizeOpStackEffect(leaf)).toEqual({
+      kind: 'known',
+      delta: 0,
+      hasUntrackedSpMutation: true,
+    });
+  });
+
+  it('marks recursive op cycles as complex', () => {
+    const recur = opDecl('recur', [
+      {
+        kind: 'AsmInstruction',
+        span,
+        head: 'recur',
+        operands: [],
+      },
+    ]);
+
+    const { summarizeOpStackEffect } = createOpStackAnalysisHelpers({
+      opsByName: new Map([['recur', [recur]]]),
+    });
+
+    expect(summarizeOpStackEffect(recur)).toEqual({ kind: 'complex' });
+  });
+});


### PR DESCRIPTION
Closes #554

## What changed
- extract summarizeOpStackEffect into opStackAnalysis.ts
- centralize the shared OpStackSummary type there
- keep the change semantics-preserving and focused on stack analysis only

## Verification
- npm run typecheck
- npm test -- --run test/pr554_op_stack_analysis_helpers.test.ts test/pr543_function_lowering_integration.test.ts test/pr544_program_lowering_integration.test.ts test/pr532_asm_instruction_lowering_integration.test.ts test/pr511_asm_body_orchestration_helpers.test.ts test/smoke_language_tour_compile.test.ts
