### PR TITLE
Polish lowering naming and comments

### DIFF
--- a/src/lowering/functionLowering.ts
+++ b/src/lowering/functionLowering.ts
@@ -32,6 +32,9 @@ import {
 } from './functionBodySetup.js';
 import { createFunctionCallLoweringHelpers } from './functionCallLowering.js';
 
+// This module owns the per-function lowering coordinator. It assembles the
+// function-local helpers, state, and diagnostics around the extracted
+// body-setup and call-lowering submodules.
 type ResolvedArrayType = { element: TypeExprNode; length?: number };
 export type FunctionLoweringContext = {
   item: FuncDeclNode;
@@ -268,7 +271,7 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
   const localBytes = localSlotCount * 2;
   const frameSize = localBytes + preserveBytes;
   const argc = item.params.length;
-  const hasStackSlots = frameSize > 0 || argc > 0 || preserveBytes > 0;
+  const hasStackSlots = frameSize > 0 || argc > 0;
   for (let paramIndex = 0; paramIndex < argc; paramIndex++) {
     const p = item.params[paramIndex]!;
     const base = 4 + 2 * paramIndex;
@@ -359,7 +362,8 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
       }
       const narrowed = init.scalarKind === 'byte' ? initValue! & 0xff : initValue! & 0xffff;
       if (hlPreserved) {
-        // Swap pattern: save incoming HL, load initializer, swap to stack, restore HL.
+        // Preserve caller-visible HL by swapping the initialized local word with
+        // the saved HL already at the top of the stack.
         emitInstr('push', [{ kind: 'Reg', span: init.span, name: 'HL' }], init.span);
         if (!loadImm16ToHL(narrowed, init.span)) continue;
         emitInstr(

--- a/src/lowering/ldLowering.ts
+++ b/src/lowering/ldLowering.ts
@@ -6,6 +6,9 @@ import type { CompileEnv } from '../semantics/env.js';
 import type { EaResolution } from './eaResolution.js';
 import type { ScalarKind } from './typeResolution.js';
 
+// ld lowering keeps the special-case routing for native Z80 encodings in one
+// place, then falls back to the extracted addressing helpers for complex EA
+// cases.
 type LdLoweringContext = {
   LOAD_RP_FVAR: (rp: 'HL' | 'DE' | 'BC', ixDisp: number) => StepPipeline;
   LOAD_RP_GLOB: (rp: 'HL' | 'DE' | 'BC', baseLower: string) => StepPipeline;

--- a/src/lowering/programLowering.ts
+++ b/src/lowering/programLowering.ts
@@ -34,6 +34,8 @@ import type {
 } from './loweringTypes.js';
 import type { AggregateType, ScalarKind } from './typeResolution.js';
 
+// Program lowering owns module-wide declaration traversal and the final
+// emission/fixup passes after all symbols and section bases are known.
 type Context = Omit<FunctionLoweringContext, 'item'> & {
   program: ProgramNode;
   includeDirs: string[];


### PR DESCRIPTION
Closes #567\n\n- clarifies remaining lowering naming hazards\n- adds targeted comments for non-obvious lowering patterns\n- simplifies hasStackSlots without behavior change