### PR TITLE
Collect non-banked section keys

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -89,6 +89,7 @@ function isIgnorableImportProbeError(err: unknown): boolean {
 type LoadedProgram = {
   program: ProgramNode;
   sourceTexts: Map<string, string>;
+  moduleTraversal: string[];
 };
 
 async function loadProgram(
@@ -269,9 +270,22 @@ async function loadProgram(
   const entryModule = modules.get(entryPath);
   if (!entryModule) return undefined;
 
+  const traversalVisited = new Set<string>();
+  const moduleTraversal: string[] = [];
+  const walkTraversal = (modulePath: string) => {
+    if (traversalVisited.has(modulePath)) return;
+    traversalVisited.add(modulePath);
+    moduleTraversal.push(modulePath);
+    for (const dep of (edges.get(modulePath) ?? new Map()).keys()) {
+      walkTraversal(dep);
+    }
+  };
+  walkTraversal(entryPath);
+
   return {
     program: { kind: 'Program', span: entryModule.span, entryFile: entryPath, files: moduleFiles },
     sourceTexts,
+    moduleTraversal,
   };
 }
 
@@ -292,13 +306,13 @@ export const compile: CompileFn = async (
   const diagnostics: Diagnostic[] = [];
   const loaded = await loadProgram(entryPath, diagnostics, options);
   if (!loaded) return { diagnostics, artifacts: [] };
-  const { program, sourceTexts } = loaded;
+  const { program, sourceTexts, moduleTraversal } = loaded;
 
   if (hasErrors(diagnostics)) {
     return { diagnostics, artifacts: [] };
   }
 
-  collectNonBankedSectionKeys(program, diagnostics);
+  collectNonBankedSectionKeys(program, diagnostics, moduleTraversal);
   if (hasErrors(diagnostics)) {
     return { diagnostics, artifacts: [] };
   }

--- a/src/sectionKeys.ts
+++ b/src/sectionKeys.ts
@@ -68,13 +68,32 @@ function startOf(node: NamedSectionNode): { file: string; line: number; column: 
 export function collectNonBankedSectionKeys(
   program: ProgramNode,
   diagnostics: Diagnostic[],
+  moduleTraversal?: readonly string[],
 ): NonBankedSectionKeyCollection {
   const orderedContributions: SectionContributionRecord[] = [];
   const orderedAnchors: SectionAnchorRecord[] = [];
   const contributionsByKey = new Map<string, SectionContributionRecord[]>();
   const anchorsByKey = new Map<string, SectionAnchorRecord>();
 
-  for (const [moduleIndex, moduleFile] of program.files.entries()) {
+  const traversalIndexByFile = new Map<string, number>();
+  if (moduleTraversal) {
+    for (const [index, file] of moduleTraversal.entries()) {
+      traversalIndexByFile.set(file, index);
+    }
+  }
+
+  const orderedModules = [...program.files]
+    .map((moduleFile, moduleIndex) => ({
+      moduleFile,
+      moduleIndex,
+      traversalIndex: traversalIndexByFile.get(moduleFile.span.file) ?? Number.MAX_SAFE_INTEGER,
+    }))
+    .sort((a, b) => {
+      if (a.traversalIndex !== b.traversalIndex) return a.traversalIndex - b.traversalIndex;
+      return a.moduleIndex - b.moduleIndex;
+    });
+
+  for (const { moduleFile, moduleIndex } of orderedModules) {
     for (const [itemIndex, item] of moduleFile.items.entries()) {
       if (item.kind !== 'NamedSection') continue;
       const node = item;

--- a/test/pr573_section_key_collection.test.ts
+++ b/test/pr573_section_key_collection.test.ts
@@ -33,21 +33,22 @@ describe('PR573 non-banked section key collection', () => {
         kind: 'Program',
         span: root.span,
         entryFile: root.entryFile,
-        files: [root.files[0]!, dep.files[0]!],
+        files: [dep.files[0]!, root.files[0]!],
       },
       diagnostics,
+      ['root.zax', 'dep.zax'],
     );
 
     expect(
       collected.orderedContributions.map((entry) => [
         entry.key.section,
         entry.key.name,
-        entry.moduleIndex,
-        entry.itemIndex,
+        entry.node.span.file,
+        entry.order,
       ]),
     ).toEqual([
-      ['code', 'shared', 0, 0],
-      ['code', 'shared', 1, 0],
+      ['code', 'shared', 'root.zax', 0],
+      ['code', 'shared', 'dep.zax', 1],
     ]);
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]).toMatchObject({


### PR DESCRIPTION
## Summary
- collect non-banked section contributions and anchors by section key
- emit duplicate-anchor, missing-anchor, and empty-anchor diagnostics
- wire collection into compile after program loading

## Testing
- npm run typecheck
- npm test -- --run test/pr573_section_key_collection.test.ts test/pr572_named_sections_parser.test.ts test/pr476_parse_top_level_simple_helpers.test.ts test/smoke_language_tour_compile.test.ts