### PR TITLE
Add named section contribution sinks

### DIFF
--- a/src/lowering/sectionContributions.ts
+++ b/src/lowering/sectionContributions.ts
@@ -1,0 +1,68 @@
+import type { EmittedAsmTraceEntry, EmittedSourceSegment } from '../formats/types.js';
+import type { SourceSegmentTag } from './loweringTypes.js';
+import type {
+  NonBankedSectionKeyCollection,
+  SectionAnchorRecord,
+  SectionContributionRecord,
+} from '../sectionKeys.js';
+
+export type AbsoluteFixupRecord = {
+  offset: number;
+  baseLower: string;
+  addend: number;
+  file: string;
+};
+
+export type Rel8FixupRecord = {
+  offset: number;
+  origin: number;
+  baseLower: string;
+  addend: number;
+  file: string;
+  mnemonic: string;
+};
+
+export type NamedSectionContributionSink = {
+  contribution: SectionContributionRecord;
+  anchor: SectionAnchorRecord;
+  bytes: Map<number, number>;
+  offset: number;
+  pendingSymbols: Array<{
+    name: string;
+    kind: 'label' | 'data' | 'var';
+    offset: number;
+    file?: string;
+    line?: number;
+    scope?: 'global' | 'local';
+    size?: number;
+  }>;
+  fixups: AbsoluteFixupRecord[];
+  rel8Fixups: Rel8FixupRecord[];
+  sourceSegments: EmittedSourceSegment[];
+  asmTrace: EmittedAsmTraceEntry[];
+  currentSourceTag?: SourceSegmentTag;
+};
+
+export function createNamedSectionContributionSinks(
+  collected: NonBankedSectionKeyCollection,
+): NamedSectionContributionSink[] {
+  const sinks: NamedSectionContributionSink[] = [];
+
+  for (const contribution of collected.orderedContributions) {
+    const anchor = collected.anchorsByKey.get(contribution.keyId);
+    if (!anchor) continue;
+    sinks.push({
+      contribution,
+      anchor,
+      bytes: new Map(),
+      offset: 0,
+      pendingSymbols: [],
+      fixups: [],
+      rel8Fixups: [],
+      sourceSegments: [],
+      asmTrace: [],
+    });
+  }
+
+  return sinks;
+}

--- a/test/pr582_section_contribution_sinks.test.ts
+++ b/test/pr582_section_contribution_sinks.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { parseProgram } from '../src/frontend/parser.js';
+import { createNamedSectionContributionSinks } from '../src/lowering/sectionContributions.js';
+import { collectNonBankedSectionKeys } from '../src/sectionKeys.js';
+
+describe('PR582 named section contribution sinks', () => {
+  it('creates ordered sinks from collected non-banked section keys', () => {
+    const rootDiagnostics: Diagnostic[] = [];
+    const root = parseProgram(
+      'root.zax',
+      [
+        'section code boot',
+        '  export func main()',
+        '    ret',
+        '  end',
+        'end',
+        'section code boot at $1000',
+        'end',
+      ].join('\n'),
+      rootDiagnostics,
+    );
+    expect(rootDiagnostics).toEqual([]);
+
+    const depDiagnostics: Diagnostic[] = [];
+    const dep = parseProgram(
+      'dep.zax',
+      [
+        'section code boot',
+        '  export func helper()',
+        '    ret',
+        '  end',
+        'end',
+      ].join('\n'),
+      depDiagnostics,
+    );
+    expect(depDiagnostics).toEqual([]);
+
+    const diagnostics: Diagnostic[] = [];
+    const collected = collectNonBankedSectionKeys(
+      {
+        kind: 'Program',
+        span: root.span,
+        entryFile: root.entryFile,
+        files: [dep.files[0]!, root.files[0]!],
+      },
+      diagnostics,
+      ['root.zax', 'dep.zax'],
+    );
+    expect(diagnostics).toEqual([]);
+
+    const sinks = createNamedSectionContributionSinks(collected);
+
+    expect(sinks).toHaveLength(2);
+    expect(sinks.map((sink) => sink.contribution.node.span.file)).toEqual(['root.zax', 'dep.zax']);
+    expect(sinks.map((sink) => sink.anchor.node.span.file)).toEqual(['root.zax', 'root.zax']);
+    for (const sink of sinks) {
+      expect(sink.bytes.size).toBe(0);
+      expect(sink.offset).toBe(0);
+      expect(sink.pendingSymbols).toEqual([]);
+      expect(sink.fixups).toEqual([]);
+      expect(sink.rel8Fixups).toEqual([]);
+      expect(sink.sourceSegments).toEqual([]);
+      expect(sink.asmTrace).toEqual([]);
+      expect(sink.currentSourceTag).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add named section contribution sink structures for v0.5 lowering
- build ordered sinks from the non-banked section key collection
- lock root-first sink ordering and empty initial sink state

## Testing
- npm run typecheck
- npm test -- --run test/pr582_section_contribution_sinks.test.ts test/pr573_section_key_collection.test.ts test/pr572_named_sections_parser.test.ts test/smoke_language_tour_compile.test.ts