### PR TITLE
Resolve named section symbols and fixups

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -108,7 +108,11 @@ import {
   createNamedSectionContributionSinks,
   type NamedSectionContributionSink,
 } from './sectionContributions.js';
-import { placeNonBankedSectionContributions } from './sectionPlacement.js';
+import {
+  collectPlacedNamedSectionSymbols,
+  placeNonBankedSectionContributions,
+  resolvePlacedNamedSectionFixups,
+} from './sectionPlacement.js';
 import {
   finalizeProgramEmission,
   lowerProgramDeclarations,
@@ -799,20 +803,13 @@ export function emitProgram(
   preScanProgramDeclarations(programLoweringContext);
   lowerProgramDeclarations(programLoweringContext);
 
-  const hasNamedSectionOutput = (sink: NamedSectionContributionSink): boolean =>
-    sink.offset > 0 ||
-    sink.bytes.size > 0 ||
-    sink.pendingSymbols.length > 0 ||
-    sink.fixups.length > 0 ||
-    sink.rel8Fixups.length > 0 ||
-    sink.sourceSegments.length > 0 ||
-    sink.asmTrace.length > 0;
-
   const { placedContributions } = placeNonBankedSectionContributions(namedSectionSinks, {
     diagnostics,
     env,
     evalImmExpr,
   });
+  const placedSymbols = collectPlacedNamedSectionSymbols(placedContributions, diagnostics);
+  symbols.push(...placedSymbols);
 
   const placedSourceSegments: EmittedSourceSegment[] = [];
   const placedAsmTrace: EmittedAsmTraceEntry[] = [];
@@ -842,13 +839,6 @@ export function emitProgram(
       placedSourceSegments.push(...rebaseCodeSourceSegments(placed.baseAddress, sink.sourceSegments));
       placedAsmTrace.push(...rebaseAsmTrace(placed.baseAddress, sink.asmTrace));
     }
-    if (!hasNamedSectionOutput(sink)) continue;
-    if (sink.pendingSymbols.length === 0 && sink.fixups.length === 0 && sink.rel8Fixups.length === 0) continue;
-    diagAt(
-      diagnostics,
-      sink.contribution.node.span,
-      `Named section symbol and fixup resolution is not implemented yet for section "${sink.anchor.key.section} ${sink.anchor.key.name}".`,
-    );
   }
 
   const { writtenRange, sourceSegments, asmTrace } = finalizeProgramEmission({
@@ -882,6 +872,8 @@ export function emitProgram(
       ? { defaultCodeBase: options.defaultCodeBase }
       : {}),
   });
+
+  resolvePlacedNamedSectionFixups(placedContributions, diagnostics, bytes, symbols);
 
   const mergedSourceSegments = [...placedSourceSegments, ...sourceSegments].sort((a, b) =>
     a.start === b.start ? a.end - b.end : a.start - b.start,

--- a/src/lowering/sectionPlacement.ts
+++ b/src/lowering/sectionPlacement.ts
@@ -1,5 +1,6 @@
 import type { Diagnostic } from '../diagnostics/types.js';
 import { DiagnosticIds } from '../diagnostics/types.js';
+import type { SymbolEntry } from '../formats/types.js';
 import type { CompileEnv } from '../semantics/env.js';
 import type { ImmExprNode } from '../frontend/ast.js';
 import type { NamedSectionContributionSink } from './sectionContributions.js';
@@ -246,4 +247,116 @@ export function placeNonBankedSectionContributions(
   }
 
   return { placedRegions, placedContributions };
+}
+
+export function collectPlacedNamedSectionSymbols(
+  placedContributions: PlacedNamedSectionContribution[],
+  diagnostics: Diagnostic[],
+): SymbolEntry[] {
+  const symbols: SymbolEntry[] = [];
+
+  for (const placed of placedContributions) {
+    for (const pending of placed.sink.pendingSymbols) {
+      const address = placed.baseAddress + pending.offset;
+      if (address < 0 || address > 0xffff) {
+        const where = startOf(placed.sink);
+        diagAt(
+          diagnostics,
+          where.file,
+          where.line,
+          where.column,
+          `Named section symbol "${pending.name}" resolves out of range in section "${formatKey(placed.sink)}".`,
+        );
+        continue;
+      }
+      symbols.push({
+        kind: pending.kind,
+        name: pending.name,
+        address,
+        ...(pending.file !== undefined ? { file: pending.file } : {}),
+        ...(pending.line !== undefined ? { line: pending.line } : {}),
+        ...(pending.scope !== undefined ? { scope: pending.scope } : {}),
+        ...(pending.size !== undefined ? { size: pending.size } : {}),
+      });
+    }
+  }
+
+  return symbols;
+}
+
+export function resolvePlacedNamedSectionFixups(
+  placedContributions: PlacedNamedSectionContribution[],
+  diagnostics: Diagnostic[],
+  bytes: Map<number, number>,
+  symbols: SymbolEntry[],
+): void {
+  const addrByNameLower = new Map<string, number>();
+  for (const sym of symbols) {
+    if (sym.kind === 'constant' || sym.address === undefined) continue;
+    addrByNameLower.set(sym.name.toLowerCase(), sym.address);
+  }
+
+  for (const placed of placedContributions) {
+    const sink = placed.sink;
+
+    for (const fx of sink.fixups) {
+      const base = addrByNameLower.get(fx.baseLower);
+      const addr = base === undefined ? undefined : base + fx.addend;
+      if (addr === undefined) {
+        const where = startOf(sink);
+        diagAt(
+          diagnostics,
+          where.file,
+          where.line,
+          where.column,
+          `Unresolved symbol "${fx.baseLower}" in named-section 16-bit fixup.`,
+        );
+        continue;
+      }
+      if (addr < 0 || addr > 0xffff) {
+        const where = startOf(sink);
+        diagAt(
+          diagnostics,
+          where.file,
+          where.line,
+          where.column,
+          `Named-section 16-bit fixup address out of range for "${fx.baseLower}" with addend ${fx.addend}: ${addr}.`,
+        );
+        continue;
+      }
+      const patch = placed.baseAddress + fx.offset;
+      bytes.set(patch, addr & 0xff);
+      bytes.set(patch + 1, (addr >> 8) & 0xff);
+    }
+
+    for (const fx of sink.rel8Fixups) {
+      const base = addrByNameLower.get(fx.baseLower);
+      const target = base === undefined ? undefined : base + fx.addend;
+      if (target === undefined) {
+        const where = startOf(sink);
+        diagAt(
+          diagnostics,
+          where.file,
+          where.line,
+          where.column,
+          `Unresolved symbol "${fx.baseLower}" in named-section rel8 ${fx.mnemonic} fixup.`,
+        );
+        continue;
+      }
+      const origin = placed.baseAddress + fx.origin;
+      const disp = target - origin;
+      if (disp < -128 || disp > 127) {
+        const where = startOf(sink);
+        diagAt(
+          diagnostics,
+          where.file,
+          where.line,
+          where.column,
+          `Named-section ${fx.mnemonic} target out of range for rel8 branch (${disp}, expected -128..127).`,
+        );
+        continue;
+      }
+      bytes.set(placed.baseAddress + fx.offset, disp & 0xff);
+    }
+  }
 }

--- a/test/fixtures/pr584_named_section_fixups.zax
+++ b/test/fixtures/pr584_named_section_fixups.zax
@@ -1,0 +1,15 @@
+func main(): AF, BC, DE, HL
+  call boot_main
+  ret
+end
+
+section code boot at $1000
+  func helper(): AF, BC, DE, HL
+    ret
+  end
+
+  func boot_main(): AF, BC, DE, HL
+    call helper
+    ret
+  end
+end

--- a/test/pr582_named_section_routing_integration.test.ts
+++ b/test/pr582_named_section_routing_integration.test.ts
@@ -35,10 +35,6 @@ describe('PR582 named section routing integration', () => {
         severity: 'error',
         message: 'Unsupported instruction: nonsense',
       }),
-      expect.objectContaining({
-        severity: 'error',
-        message: 'Named section symbol and fixup resolution is not implemented yet for section "code boot".',
-      }),
     ]);
     expect(map.bytes.size).toBeGreaterThan(0);
   });

--- a/test/pr582_named_section_semantics_integration.test.ts
+++ b/test/pr582_named_section_semantics_integration.test.ts
@@ -12,18 +12,12 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR582 named section semantics integration', () => {
-  it('treats main inside a named code section as satisfying requireMain before placement runs', async () => {
+  it('accepts main inside a named code section when requireMain is enabled', async () => {
     const entry = join(__dirname, 'fixtures', 'pr582_main_in_named_section.zax');
     const res = await compile(entry, { requireMain: true }, { formats: defaultFormatWriters });
 
-    expect(res.diagnostics).toEqual([
-      expect.objectContaining({
-        severity: 'error',
-        message: 'Named section symbol and fixup resolution is not implemented yet for section "code boot".',
-      }),
-    ]);
-    expect(res.diagnostics.some((d) => d.message.includes('Program must define a callable "main"'))).toBe(false);
-    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics).toEqual([]);
+    expect(res.artifacts.length).toBeGreaterThan(0);
   });
 
   it('does not treat main inside a named data section as satisfying requireMain', async () => {

--- a/test/pr583_section_placement_helpers.test.ts
+++ b/test/pr583_section_placement_helpers.test.ts
@@ -87,7 +87,7 @@ describe('PR583 section placement helpers', () => {
     ]);
   });
 
-  it('still finalizes legacy output when named sections have unresolved symbols', () => {
+  it('still finalizes legacy output when named sections are present', () => {
     const diagnostics: Diagnostic[] = [];
     const program = parseProgram(
       'pr583_mixed_sections.zax',
@@ -112,12 +112,7 @@ describe('PR583 section placement helpers', () => {
 
     const { map } = emitProgram(program, env, diagnostics, { namedSectionKeys: sectionKeys });
 
-    expect(diagnostics).toContainEqual(
-      expect.objectContaining({
-        severity: 'error',
-        message: 'Named section symbol and fixup resolution is not implemented yet for section "code boot".',
-      }),
-    );
+    expect(diagnostics).toEqual([]);
     expect(map.bytes.get(0)).toBe(0xc9);
     expect(map.bytes.get(0x1000)).toBe(0xc9);
   });

--- a/test/pr584_named_section_fixups_integration.test.ts
+++ b/test/pr584_named_section_fixups_integration.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { BinArtifact } from '../src/formats/types.js';
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR584 named section fixups integration', () => {
+  it('resolves symbols and fixups against placed named-section ranges', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr584_named_section_fixups.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics).toEqual([]);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    expect(bin?.bytes.slice(0, 4)).toEqual(Uint8Array.from([0xcd, 0x01, 0x10, 0xc9]));
+    expect(bin?.bytes.slice(0x1000, 0x1005)).toEqual(Uint8Array.from([0xc9, 0xcd, 0x00, 0x10, 0xc9]));
+  });
+});


### PR DESCRIPTION
## Summary\n- resolve named-section pending symbols against placed contribution ranges\n- resolve named-section absolute and rel8 fixups after legacy finalization\n- remove the temporary unresolved named-section symbol/fixup blocker\n\n## Verification\n- npm run typecheck\n- npm test -- --run test/pr584_named_section_fixups_integration.test.ts test/pr583_section_placement_helpers.test.ts test/pr582_program_prescan_named_section_rules.test.ts test/pr582_section_contribution_sinks.test.ts test/pr582_named_section_routing_integration.test.ts test/pr582_named_section_semantics_integration.test.ts test/pr573_section_key_collection.test.ts test/pr572_named_sections_parser.test.ts test/smoke_language_tour_compile.test.ts