### PR TITLE
Add unified data declarations in data sections

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -5,7 +5,7 @@ import type { Diagnostic } from './diagnostics/types.js';
 import { DiagnosticIds } from './diagnostics/types.js';
 import type { CompileFn, CompilerOptions, CompileResult, PipelineDeps } from './pipeline.js';
 
-import type { ModuleItemNode, ProgramNode } from './frontend/ast.js';
+import type { ModuleItemNode, ProgramNode, SectionItemNode } from './frontend/ast.js';
 import type { ImportNode, ModuleFileNode } from './frontend/ast.js';
 import { parseModuleFile } from './frontend/parser.js';
 import { lintCaseStyle } from './lint/case_style.js';
@@ -43,7 +43,7 @@ function normalizePath(p: string): string {
 }
 
 function hasMainFunction(program: ProgramNode): boolean {
-  const hasMainInItems = (items: ModuleItemNode[]): boolean => {
+  const hasMainInItems = (items: Array<ModuleItemNode | SectionItemNode>): boolean => {
     for (const item of items) {
       if (item.kind === 'FuncDecl' && item.name.toLowerCase() === 'main') return true;
       if (item.kind === 'NamedSection' && item.section === 'code' && hasMainInItems(item.items)) return true;

--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -79,6 +79,7 @@ export type ModuleItemNode =
 export type SectionItemNode =
   | ConstDeclNode
   | EnumDeclNode
+  | DataDeclNode
   | DataBlockNode
   | VarBlockNode
   | FuncDeclNode
@@ -233,6 +234,7 @@ export interface DataDeclNode extends BaseNode {
  * Data initializer expression.
  */
 export type DataInitializerNode =
+  | { kind: 'InitZero'; span: SourceSpan }
   | { kind: 'InitArray'; span: SourceSpan; elements: ImmExprNode[] }
   | { kind: 'InitString'; span: SourceSpan; value: string }
   | { kind: 'InitRecordNamed'; span: SourceSpan; fields: DataRecordFieldInitNode[] };

--- a/src/frontend/parseData.ts
+++ b/src/frontend/parseData.ts
@@ -106,6 +106,174 @@ type ParsedDataBlock = {
   nextIndex: number;
 };
 
+type ParseDataDeclOptions = {
+  allowOmittedInitializer: boolean;
+  allowInferredArrayLength: boolean;
+  modulePath: string;
+  diagnostics: Diagnostic[];
+  lineNo: number;
+  text: string;
+  span: ReturnType<typeof span>;
+  seenNames?: Set<string>;
+};
+
+export function parseDataDeclLine(opts: ParseDataDeclOptions): DataDeclNode | undefined {
+  const {
+    allowOmittedInitializer,
+    allowInferredArrayLength,
+    modulePath,
+    diagnostics,
+    lineNo,
+    text,
+    span: lineSpan,
+    seenNames,
+  } = opts;
+
+  const withInit = /^([^:]+)\s*:\s*([^=]+?)\s*=\s*(.+)$/.exec(text);
+  const withoutInit = allowOmittedInitializer ? /^([^:]+)\s*:\s*(.+)$/.exec(text) : undefined;
+  const match = withInit ?? withoutInit;
+  if (!match) {
+    diagInvalidBlockLine(
+      diagnostics,
+      modulePath,
+      'data declaration',
+      text,
+      allowOmittedInitializer ? '<name>: <type> [= <initializer>]' : '<name>: <type> = <initializer>',
+      lineNo,
+    );
+    return undefined;
+  }
+
+  const name = match[1]!.trim();
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    diag(
+      diagnostics,
+      modulePath,
+      `Invalid data declaration name ${formatIdentifierToken(name)}: expected <identifier>.`,
+      { line: lineNo, column: 1 },
+    );
+    return undefined;
+  }
+  if (TOP_LEVEL_KEYWORDS.has(name.toLowerCase())) {
+    diag(
+      diagnostics,
+      modulePath,
+      `Invalid data declaration name "${name}": collides with a top-level keyword.`,
+      { line: lineNo, column: 1 },
+    );
+    return undefined;
+  }
+  const nameLower = name.toLowerCase();
+  if (seenNames?.has(nameLower)) {
+    diag(diagnostics, modulePath, `Duplicate data declaration name "${name}".`, {
+      line: lineNo,
+      column: 1,
+    });
+    return undefined;
+  }
+
+  const typeText = (withInit ? withInit[2] : withoutInit?.[2])!.trim();
+  const initText = withInit?.[3]?.trim();
+  const typeExpr = parseTypeExprFromText(typeText, lineSpan, {
+    allowInferredArrayLength,
+  });
+
+  if (!typeExpr) {
+    diagInvalidBlockLine(
+      diagnostics,
+      modulePath,
+      'data declaration',
+      text,
+      allowOmittedInitializer ? '<name>: <type> [= <initializer>]' : '<name>: <type> = <initializer>',
+      lineNo,
+    );
+    return undefined;
+  }
+
+  let initializer: DataDeclNode['initializer'] | undefined;
+  if (!initText) {
+    initializer = { kind: 'InitZero', span: lineSpan };
+  } else if (initText.startsWith('"') && initText.endsWith('"') && initText.length >= 2) {
+    initializer = { kind: 'InitString', span: lineSpan, value: initText.slice(1, -1) };
+  } else if (initText.startsWith('{') && initText.endsWith('}')) {
+    const inner = initText.slice(1, -1).trim();
+    const parts = inner.length === 0 ? [] : splitTopLevelComma(inner).map((p) => p.trim());
+    const namedFields: DataRecordFieldInitNode[] = [];
+    const positionalElements: ImmExprNode[] = [];
+    let sawNamed = false;
+    let sawPositional = false;
+    let parseFailed = false;
+
+    for (const part of parts) {
+      if (part.length === 0) {
+        parseFailed = true;
+        break;
+      }
+      const namedMatch = /^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+)$/.exec(part);
+      if (namedMatch) {
+        sawNamed = true;
+        const value = parseImmExprFromText(modulePath, namedMatch[2]!.trim(), lineSpan, diagnostics);
+        if (!value) {
+          parseFailed = true;
+          continue;
+        }
+        namedFields.push({
+          kind: 'DataRecordFieldInit',
+          span: lineSpan,
+          name: namedMatch[1]!,
+          value,
+        });
+        continue;
+      }
+      sawPositional = true;
+      const e = parseImmExprFromText(modulePath, part, lineSpan, diagnostics);
+      if (!e) {
+        parseFailed = true;
+        continue;
+      }
+      positionalElements.push(e);
+    }
+
+    if (sawNamed && sawPositional) {
+      diag(
+        diagnostics,
+        modulePath,
+        `Mixed positional and named aggregate initializer entries are not allowed for "${name}".`,
+        { line: lineNo, column: 1 },
+      );
+      parseFailed = true;
+    }
+
+    if (!parseFailed) {
+      initializer = sawNamed
+        ? { kind: 'InitRecordNamed', span: lineSpan, fields: namedFields }
+        : { kind: 'InitArray', span: lineSpan, elements: positionalElements };
+    }
+  } else if (initText.startsWith('[') && initText.endsWith(']')) {
+    const inner = initText.slice(1, -1).trim();
+    const parts = inner.length === 0 ? [] : splitTopLevelComma(inner).map((p) => p.trim());
+    const elements: ImmExprNode[] = [];
+    for (const part of parts) {
+      const e = parseImmExprFromText(modulePath, part, lineSpan, diagnostics);
+      if (e) elements.push(e);
+    }
+    initializer = { kind: 'InitArray', span: lineSpan, elements };
+  } else {
+    const e = parseImmExprFromText(modulePath, initText, lineSpan, diagnostics);
+    if (e) initializer = { kind: 'InitArray', span: lineSpan, elements: [e] };
+  }
+
+  if (!initializer) return undefined;
+  seenNames?.add(nameLower);
+  return {
+    kind: 'DataDecl',
+    span: lineSpan,
+    name,
+    typeExpr,
+    initializer,
+  };
+}
+
 export function parseDataBlock(startIndex: number, ctx: ParseDataContext): ParsedDataBlock {
   const { file, lineCount, diagnostics, modulePath, getRawLine, stopOnEnd = false } = ctx;
   const blockStart = getRawLine(startIndex).startOffset;
@@ -148,160 +316,18 @@ export function parseDataBlock(startIndex: number, ctx: ParseDataContext): Parse
       break;
     }
 
-    const m = /^([^:]+)\s*:\s*([^=]+?)\s*=\s*(.+)$/.exec(t);
-    if (!m) {
-      diagInvalidBlockLine(
-        diagnostics,
-        modulePath,
-        'data declaration',
-        t,
-        '<name>: <type> = <initializer>',
-        index + 1,
-      );
-      index++;
-      continue;
-    }
-
-    const name = m[1]!.trim();
-    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
-      diag(
-        diagnostics,
-        modulePath,
-        `Invalid data declaration name ${formatIdentifierToken(name)}: expected <identifier>.`,
-        { line: index + 1, column: 1 },
-      );
-      index++;
-      continue;
-    }
-    if (TOP_LEVEL_KEYWORDS.has(name.toLowerCase())) {
-      diag(
-        diagnostics,
-        modulePath,
-        `Invalid data declaration name "${name}": collides with a top-level keyword.`,
-        { line: index + 1, column: 1 },
-      );
-      index++;
-      continue;
-    }
-    const nameLower = name.toLowerCase();
-    if (declNamesLower.has(nameLower)) {
-      diag(diagnostics, modulePath, `Duplicate data declaration name "${name}".`, {
-        line: index + 1,
-        column: 1,
-      });
-      index++;
-      continue;
-    }
-    declNamesLower.add(nameLower);
-    const typeText = m[2]!.trim();
-    const initText = m[3]!.trim();
-
     const lineSpan = span(file, so, eo);
-    const typeExpr = parseTypeExprFromText(typeText, lineSpan, {
+    const decl = parseDataDeclLine({
+      allowOmittedInitializer: false,
       allowInferredArrayLength: true,
-    });
-
-    if (!typeExpr) {
-      diagInvalidBlockLine(
-        diagnostics,
-        modulePath,
-        'data declaration',
-        t,
-        '<name>: <type> = <initializer>',
-        index + 1,
-      );
-      index++;
-      continue;
-    }
-
-    let initializer: DataDeclNode['initializer'] | undefined;
-    if (initText.startsWith('"') && initText.endsWith('"') && initText.length >= 2) {
-      initializer = { kind: 'InitString', span: lineSpan, value: initText.slice(1, -1) };
-    } else if (initText.startsWith('{') && initText.endsWith('}')) {
-      const inner = initText.slice(1, -1).trim();
-      const parts = inner.length === 0 ? [] : splitTopLevelComma(inner).map((p) => p.trim());
-      const namedFields: DataRecordFieldInitNode[] = [];
-      const positionalElements: ImmExprNode[] = [];
-      let sawNamed = false;
-      let sawPositional = false;
-      let parseFailed = false;
-
-      for (const part of parts) {
-        if (part.length === 0) {
-          parseFailed = true;
-          break;
-        }
-        const namedMatch = /^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+)$/.exec(part);
-        if (namedMatch) {
-          sawNamed = true;
-          const value = parseImmExprFromText(
-            modulePath,
-            namedMatch[2]!.trim(),
-            lineSpan,
-            diagnostics,
-          );
-          if (!value) {
-            parseFailed = true;
-            continue;
-          }
-          namedFields.push({
-            kind: 'DataRecordFieldInit',
-            span: lineSpan,
-            name: namedMatch[1]!,
-            value,
-          });
-          continue;
-        }
-        sawPositional = true;
-        const e = parseImmExprFromText(modulePath, part, lineSpan, diagnostics);
-        if (!e) {
-          parseFailed = true;
-          continue;
-        }
-        positionalElements.push(e);
-      }
-
-      if (sawNamed && sawPositional) {
-        diag(
-          diagnostics,
-          modulePath,
-          `Mixed positional and named aggregate initializer entries are not allowed for "${name}".`,
-          { line: index + 1, column: 1 },
-        );
-        parseFailed = true;
-      }
-
-      if (!parseFailed) {
-        initializer = sawNamed
-          ? { kind: 'InitRecordNamed', span: lineSpan, fields: namedFields }
-          : { kind: 'InitArray', span: lineSpan, elements: positionalElements };
-      }
-    } else if (initText.startsWith('[') && initText.endsWith(']')) {
-      const inner = initText.slice(1, -1).trim();
-      const parts = inner.length === 0 ? [] : splitTopLevelComma(inner).map((p) => p.trim());
-      const elements: ImmExprNode[] = [];
-      for (const part of parts) {
-        const e = parseImmExprFromText(modulePath, part, lineSpan, diagnostics);
-        if (e) elements.push(e);
-      }
-      initializer = { kind: 'InitArray', span: lineSpan, elements };
-    } else {
-      const e = parseImmExprFromText(modulePath, initText, lineSpan, diagnostics);
-      if (e) initializer = { kind: 'InitArray', span: lineSpan, elements: [e] };
-    }
-
-    if (!initializer) {
-      index++;
-      continue;
-    }
-
-    decls.push({
-      kind: 'DataDecl',
+      modulePath,
+      diagnostics,
+      lineNo: index + 1,
+      text: t,
       span: lineSpan,
-      name,
-      typeExpr,
-      initializer,
+      seenNames: declNamesLower,
     });
+    if (decl) decls.push(decl);
     index++;
   }
 

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -37,7 +37,7 @@ import {
   parseImportDecl,
   parseSectionDirectiveDecl,
 } from './parseTopLevelSimple.js';
-import { parseDataBlock } from './parseData.js';
+import { parseDataBlock, parseDataDeclLine } from './parseData.js';
 import { canonicalModuleId } from '../moduleIdentity.js';
 
 const RESERVED_TOP_LEVEL_KEYWORDS = new Set([
@@ -176,13 +176,14 @@ export function parseModuleFile(
     return { section, name, ...(anchor ? { anchor } : {}) };
   }
 
-  function parseSectionItems(startIndex: number): {
+  function parseSectionItems(startIndex: number, sectionKind: 'code' | 'data'): {
     items: SectionItemNode[];
     nextIndex: number;
     closed: boolean;
   } {
     const sectionItems: SectionItemNode[] = [];
     let index = startIndex;
+    const directDeclNamesLower = new Set<string>();
 
     while (index < lineCount) {
       const { raw, startOffset, endOffset } = getRawLine(index);
@@ -495,6 +496,36 @@ export function parseModuleFile(
         continue;
       }
 
+      if (/^[A-Za-z_][A-Za-z0-9_]*\s*:/.test(rest)) {
+        const sectionDataDecl = parseDataDeclLine({
+          allowOmittedInitializer: true,
+          allowInferredArrayLength: false,
+          modulePath,
+          diagnostics,
+          lineNo,
+          text: rest,
+          span: sectionSpan,
+          seenNames: directDeclNamesLower,
+        });
+        if (sectionDataDecl) {
+          if (sectionKind !== 'data') {
+            diag(
+              diagnostics,
+              modulePath,
+              `Data declarations are only permitted inside data sections.`,
+              {
+                line: lineNo,
+                column: 1,
+              },
+            );
+          } else {
+            sectionItems.push(sectionDataDecl);
+          }
+          index++;
+          continue;
+        }
+      }
+
       const asmTail = consumeKeywordPrefix(text, 'asm');
       const asmAfterExportTail = hasExportPrefix ? consumeKeywordPrefix(rest, 'asm') : undefined;
       if (asmTail !== undefined || asmAfterExportTail !== undefined) {
@@ -799,7 +830,7 @@ export function parseModuleFile(
           i++;
           continue;
         }
-        const parsedSection = parseSectionItems(i + 1);
+        const parsedSection = parseSectionItems(i + 1, header.section);
         const sectionEndIndex = Math.max(parsedSection.nextIndex - 1, i);
         const sectionEnd = getRawLine(sectionEndIndex);
         const sectionNode: NamedSectionNode = {

--- a/src/lowering/programLowering.ts
+++ b/src/lowering/programLowering.ts
@@ -3,6 +3,7 @@ import type {
   BinDeclNode,
   ConstDeclNode,
   DataBlockNode,
+  DataDeclNode,
   EnumDeclNode,
   EaExprNode,
   ExternDeclNode,
@@ -560,6 +561,14 @@ export function lowerProgramDeclarations(ctx: Context): void {
     }
 
     if (item.kind === 'DataBlock') {
+      if (namedSection && namedSection.node.section !== 'data') {
+        ctx.diag(
+          ctx.diagnostics,
+          item.span.file,
+          `Data declarations are not allowed inside code section "${namedSection.node.name}".`,
+        );
+        return;
+      }
       if (namedSection) {
         lowerDataBlock(ctx, item as DataBlockNode, {
           section: namedSection.node.section,
@@ -570,6 +579,33 @@ export function lowerProgramDeclarations(ctx: Context): void {
       } else {
         lowerDataBlock(ctx, item as DataBlockNode);
       }
+      return;
+    }
+
+    if (item.kind === 'DataDecl') {
+      if (!namedSection || namedSection.node.section !== 'data') {
+        const sectionName = namedSection?.node.name ?? 'module scope';
+        ctx.diag(
+          ctx.diagnostics,
+          item.span.file,
+          `Data declarations are only allowed inside data sections${namedSection ? ` like "${sectionName}"` : ''}.`,
+        );
+        return;
+      }
+      lowerDataBlock(
+        ctx,
+        {
+          kind: 'DataBlock',
+          span: item.span,
+          decls: [item as DataDeclNode],
+        },
+        {
+          section: namedSection.node.section,
+          bytes: namedSection.sink.bytes,
+          offsetRef: sinkOffsetRef(namedSection.sink),
+          pending: namedSection.sink.pendingSymbols,
+        },
+      );
       return;
     }
 
@@ -644,6 +680,12 @@ function lowerDataBlock(
 
     const recordType = ctx.resolveAggregateType(type);
     if (recordType?.kind === 'record') {
+      if (init.kind === 'InitZero') {
+        const storageBytes = ctx.sizeOfTypeExpr(type, ctx.env, ctx.diagnostics);
+        if (storageBytes === undefined) continue;
+        for (let pad = 0; pad < storageBytes; pad++) emitByte(0);
+        continue;
+      }
       if (init.kind === 'InitString') {
         ctx.diag(ctx.diagnostics, decl.span.file, `Record initializer for "${decl.name}" must use aggregate form.`);
         continue;
@@ -722,6 +764,13 @@ function lowerDataBlock(
 
     if (init.kind === 'InitRecordNamed') {
       ctx.diag(ctx.diagnostics, decl.span.file, `Named-field aggregate initializer requires a record type for "${decl.name}".`);
+      continue;
+    }
+
+    if (init.kind === 'InitZero') {
+      const storageBytes = ctx.sizeOfTypeExpr(type, ctx.env, ctx.diagnostics);
+      if (storageBytes === undefined) continue;
+      for (let pad = 0; pad < storageBytes; pad++) emitByte(0);
       continue;
     }
 

--- a/test/fixtures/pr576_named_data_decls.zax
+++ b/test/fixtures/pr576_named_data_decls.zax
@@ -1,0 +1,5 @@
+section data vars at $4000 size $10
+  counter: byte
+  message: byte[3] = "abc"
+  flag: word = 1
+end

--- a/test/pr576_unified_data_sections.test.ts
+++ b/test/pr576_unified_data_sections.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { parseProgram } from '../src/frontend/parser.js';
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { D8mArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR576 unified data declarations inside data sections', () => {
+  it('parses direct declarations in data sections and rejects them in code sections', () => {
+    const diagnostics: Diagnostic[] = [];
+    const program = parseProgram(
+      'pr576_sections.zax',
+      [
+        'section data vars',
+        '  count: byte',
+        'end',
+        'section code boot',
+        '  temp: byte',
+        'end',
+      ].join('\n'),
+      diagnostics,
+    );
+
+    const dataSection = program.files[0]?.items[0];
+    expect(dataSection).toMatchObject({
+      kind: 'NamedSection',
+      section: 'data',
+    });
+    if (!dataSection || dataSection.kind !== 'NamedSection') {
+      throw new Error('expected data section');
+    }
+    expect(dataSection.items[0]).toMatchObject({
+      kind: 'DataDecl',
+      name: 'count',
+      initializer: { kind: 'InitZero' },
+    });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      message: 'Data declarations are only permitted inside data sections.',
+      line: 5,
+      column: 1,
+    });
+  });
+
+  it('lowers direct data declarations in named data sections', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr576_named_data_decls.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+
+    const d8m = res.artifacts.find((a): a is D8mArtifact => a.kind === 'd8m');
+    expect(d8m).toBeDefined();
+    const symbols = d8m!.json.symbols as Array<{ name: string; address: number }>;
+    expect(symbols.find((s) => s.name === 'counter')?.address).toBe(0x4000);
+    expect(symbols.find((s) => s.name === 'message')?.address).toBe(0x4001);
+    expect(symbols.find((s) => s.name === 'flag')?.address).toBe(0x4005);
+  });
+});


### PR DESCRIPTION
## Summary\n- add direct data declaration syntax inside named data sections\n- support omitted initializers as zero-initialized storage\n- reject data declarations and legacy data blocks in code sections while keeping legacy top-level forms intact\n\n## Verification\n- npm run typecheck\n- npm test -- --run test/pr576_unified_data_sections.test.ts test/pr572_named_sections_parser.test.ts test/pr585_named_section_layout_integration.test.ts test/smoke_language_tour_compile.test.ts