### PR TITLE
Emit startup init runtime handoff

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -10,6 +10,7 @@ import type { ImportNode, ModuleFileNode } from './frontend/ast.js';
 import { parseModuleFile } from './frontend/parser.js';
 import { lintCaseStyle } from './lint/case_style.js';
 import { emitProgram } from './lowering/emit.js';
+import { STARTUP_ENTRY_LABEL } from './lowering/startupInit.js';
 import type { Artifact } from './formats/types.js';
 import { collectNonBankedSectionKeys } from './sectionKeys.js';
 import { canonicalModuleId } from './moduleIdentity.js';
@@ -378,9 +379,13 @@ export const compile: CompileFn = async (
     artifacts.push(deps.formats.writeHex(map, symbols));
   }
   if (emit.emitD8m) {
-    const mainEntry = symbols.find((s) => s.kind === 'label' && s.name.toLowerCase() === 'main') as
-      | { kind: 'label'; name: string; address: number }
-      | undefined;
+    const mainEntry =
+      (symbols.find((s) => s.kind === 'label' && s.name.toLowerCase() === STARTUP_ENTRY_LABEL) as
+        | { kind: 'label'; name: string; address: number }
+        | undefined) ??
+      (symbols.find((s) => s.kind === 'label' && s.name.toLowerCase() === 'main') as
+        | { kind: 'label'; name: string; address: number }
+        | undefined);
     artifacts.push(
       deps.formats.writeD8m(map, symbols, {
         rootDir: dirname(entryPath),

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -114,7 +114,12 @@ import {
   placeNonBankedSectionContributions,
   resolvePlacedNamedSectionFixups,
 } from './sectionPlacement.js';
-import { appendStartupInitRegion, buildStartupInitRegion } from './startupInit.js';
+import {
+  appendStartupInitRegion,
+  buildStartupInitRegion,
+  buildStartupInitRoutine,
+  STARTUP_ENTRY_LABEL,
+} from './startupInit.js';
 import {
   finalizeProgramEmission,
   lowerProgramDeclarations,
@@ -945,11 +950,42 @@ export function emitProgram(
   );
 
   const startupInitRegion = buildStartupInitRegion(placedContributions);
-  appendStartupInitRegion(bytes, diagnostics, primaryFile, startupInitRegion);
-  const finalWrittenRange =
-    startupInitRegion.encoded.length > 0
-      ? { start: writtenRange.start, end: writtenRange.end + startupInitRegion.encoded.length }
-      : writtenRange;
+  let finalWrittenRange = writtenRange;
+  if (startupInitRegion.encoded.length > 0) {
+    const mainEntry = symbols.find(
+      (symbol): symbol is SymbolEntry & { kind: 'label' } =>
+        symbol.kind === 'label' && symbol.name.toLowerCase() === 'main',
+    );
+    if (!mainEntry) {
+      const highest = [...bytes.keys()].reduce((max, value) => (value > max ? value : max), -1);
+      appendStartupInitRegion(bytes, diagnostics, primaryFile, startupInitRegion);
+      finalWrittenRange = { start: writtenRange.start, end: highest + startupInitRegion.encoded.length };
+    } else {
+      const highest = [...bytes.keys()].reduce((max, value) => (value > max ? value : max), -1);
+      const startupAddress = highest + 1;
+      const startupTemplate = buildStartupInitRoutine(0, startupInitRegion, 0);
+      const initRegionAddress = startupAddress + startupTemplate.length;
+      const startupBytes = buildStartupInitRoutine(initRegionAddress, startupInitRegion, mainEntry.address);
+      const startupEnd = startupAddress + startupBytes.length - 1;
+      const startupRegionEnd = startupEnd + startupInitRegion.encoded.length;
+      if (startupRegionEnd > 0xffff) {
+        diag(diagnostics, primaryFile, 'Compiler-owned startup routine exceeds 16-bit address space.');
+      } else {
+        for (let i = 0; i < startupBytes.length; i++) {
+          bytes.set(startupAddress + i, startupBytes[i]!);
+        }
+        appendStartupInitRegion(bytes, diagnostics, primaryFile, startupInitRegion);
+        symbols.push({
+          kind: 'label',
+          name: STARTUP_ENTRY_LABEL,
+          address: startupAddress,
+          file: primaryFile,
+          scope: 'global',
+        });
+        finalWrittenRange = { start: writtenRange.start, end: startupRegionEnd };
+      }
+    }
+  }
 
   return {
     map: {

--- a/src/lowering/startupInit.ts
+++ b/src/lowering/startupInit.ts
@@ -25,6 +25,8 @@ export type StartupInitRegion = {
   encoded: number[];
 };
 
+export const STARTUP_ENTRY_LABEL = '__zax_startup';
+
 function encodeWord(value: number): [number, number] {
   return [value & 0xff, (value >> 8) & 0xff];
 }
@@ -113,4 +115,91 @@ export function appendStartupInitRegion(
   for (let i = 0; i < region.encoded.length; i++) {
     bytes.set(start + i, region.encoded[i]!);
   }
+}
+
+export function buildStartupInitRoutine(
+  initRegionAddress: number,
+  region: StartupInitRegion,
+  mainAddress: number,
+): number[] {
+  const bytes: number[] = [];
+  const labels = new Map<string, number>();
+  const relPatches: Array<{ index: number; origin: number; label: string }> = [];
+  const blobBase = initRegionAddress + (region.encoded.length - region.blob.length);
+
+  const emit = (...values: number[]) => {
+    bytes.push(...values.map((value) => value & 0xff));
+  };
+  const mark = (label: string) => {
+    labels.set(label, bytes.length);
+  };
+  const emitWord = (value: number) => {
+    emit(value & 0xff, (value >> 8) & 0xff);
+  };
+  const emitLdHlImm = (value: number) => {
+    emit(0x21);
+    emitWord(value);
+  };
+  const emitJr = (opcode: number, label: string) => {
+    emit(opcode, 0x00);
+    relPatches.push({ index: bytes.length - 1, origin: bytes.length, label });
+  };
+
+  emitLdHlImm(initRegionAddress);
+  emit(0x4e, 0x23, 0x46, 0x23); // ld c,(hl) / inc hl / ld b,(hl) / inc hl
+
+  mark('copy_count_test');
+  emit(0x78, 0xb1); // ld a,b / or c
+  emitJr(0x28, 'load_zero_count');
+
+  emit(0xc5); // push bc
+  emit(0x5e, 0x23, 0x56, 0x23); // ld e,(hl) / inc hl / ld d,(hl) / inc hl
+  emit(0x4e, 0x23, 0x46, 0x23); // ld c,(hl) / inc hl / ld b,(hl) / inc hl
+  emit(0xe5); // push hl
+  emitLdHlImm(blobBase);
+  emit(0x09, 0xe3); // add hl,bc / ex (sp),hl
+  emit(0x4e, 0x23, 0x46, 0x23); // ld c,(hl) / inc hl / ld b,(hl) / inc hl
+  emit(0xe3); // ex (sp),hl
+  emit(0xed, 0xb0); // ldir
+  emit(0xe1, 0xc1, 0x0b); // pop hl / pop bc / dec bc
+  emitJr(0x18, 'copy_count_test');
+
+  mark('load_zero_count');
+  emit(0x4e, 0x23, 0x46, 0x23); // ld c,(hl) / inc hl / ld b,(hl) / inc hl
+
+  mark('zero_count_test');
+  emit(0x78, 0xb1); // ld a,b / or c
+  emitJr(0x28, 'jump_main');
+
+  emit(0xc5); // push bc
+  emit(0x5e, 0x23, 0x56, 0x23); // ld e,(hl) / inc hl / ld d,(hl) / inc hl
+  emit(0x4e, 0x23, 0x46, 0x23); // ld c,(hl) / inc hl / ld b,(hl) / inc hl
+
+  mark('zero_bytes_test');
+  emit(0x78, 0xb1); // ld a,b / or c
+  emitJr(0x28, 'zero_done');
+  emit(0xaf, 0x12, 0x13, 0x0b); // xor a / ld (de),a / inc de / dec bc
+  emitJr(0x18, 'zero_bytes_test');
+
+  mark('zero_done');
+  emit(0xc1, 0x0b); // pop bc / dec bc
+  emitJr(0x18, 'zero_count_test');
+
+  mark('jump_main');
+  emit(0xc3);
+  emitWord(mainAddress);
+
+  for (const patch of relPatches) {
+    const target = labels.get(patch.label);
+    if (target === undefined) {
+      throw new Error(`Unknown startup routine label "${patch.label}".`);
+    }
+    const displacement = target - patch.origin;
+    if (displacement < -128 || displacement > 127) {
+      throw new Error(`Startup routine jump out of range for "${patch.label}".`);
+    }
+    bytes[patch.index] = displacement & 0xff;
+  }
+
+  return bytes;
 }

--- a/test/fixtures/pr577_startup_init_main.zax
+++ b/test/fixtures/pr577_startup_init_main.zax
@@ -1,0 +1,11 @@
+section data vars at $4000 size $10
+  counter: byte
+  message: byte[3] = "abc"
+  flag: word = 1
+end
+
+section code boot at $4010 size $40
+  func main()
+    ret
+  end
+end

--- a/test/pr577_startup_init_region.test.ts
+++ b/test/pr577_startup_init_region.test.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { buildStartupInitRegion } from '../src/lowering/startupInit.js';
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
-import type { BinArtifact } from '../src/formats/types.js';
+import type { BinArtifact, D8mArtifact } from '../src/formats/types.js';
 import type { PlacedNamedSectionContribution } from '../src/lowering/sectionPlacement.js';
 import type { NamedSectionContributionSink } from '../src/lowering/sectionContributions.js';
 
@@ -93,22 +93,31 @@ describe('PR577 startup init region', () => {
   });
 
   it('emits a compiler-owned init region for named data sections', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr576_named_data_decls.zax');
+    const entry = join(__dirname, 'fixtures', 'pr577_startup_init_main.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
 
     const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    const d8m = res.artifacts.find((a): a is D8mArtifact => a.kind === 'd8m');
     expect(bin).toBeDefined();
+    expect(d8m).toBeDefined();
     const bytes = Array.from(bin!.bytes);
     expect(bytes.slice(0, 7)).toEqual([0x00, 0x61, 0x62, 0x63, 0x00, 0x01, 0x00]);
-    expect(bytes.slice(7)).toEqual([
+
+    const generator = d8m!.json.generator as { entrySymbol?: string; entryAddress?: number };
+    expect(generator.entrySymbol).toBe('__zax_startup');
+    expect(generator.entryAddress).toBeGreaterThan(0x4010);
+    const entryOffset = (generator.entryAddress ?? 0) - 0x4000;
+    expect(bytes[entryOffset]).toBe(0x21);
+
+    expect(bytes.slice(-28)).toEqual([
       0x02, 0x00,
       0x01, 0x40, 0x00, 0x00, 0x03, 0x00,
       0x05, 0x40, 0x03, 0x00, 0x02, 0x00,
       0x02, 0x00,
       0x00, 0x40, 0x01, 0x00,
       0x04, 0x40, 0x01, 0x00,
-      0x61, 0x62, 0x63, 0x01, 0x00,
+      0x61, 0x62, 0x63, 0x01,
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- emit a compiler-owned startup routine when startup init actions exist and a callable main is present
- fall back to appending only the init region when no main is present, so library-style modules still compile
- add integration coverage for startup entry handoff and region placement

## Verification
- npm run typecheck
- npm test -- --run test/pr577_startup_init_region.test.ts test/pr576_unified_data_sections.test.ts test/pr585_named_section_layout_integration.test.ts test/smoke_language_tour_compile.test.ts
- npm test -- --run test/pr583_section_placement_helpers.test.ts test/pr577_startup_init_region.test.ts test/pr576_unified_data_sections.test.ts test/pr585_named_section_layout_integration.test.ts test/smoke_language_tour_compile.test.ts