### PR TITLE
Add opt-in legacy syntax warnings

### DIFF
--- a/src/diagnostics/types.ts
+++ b/src/diagnostics/types.ts
@@ -45,6 +45,9 @@ export const DiagnosticIds = {
   /** Generic parse error (syntax / unsupported in current PR subset). */
   ParseError: 'ZAX100',
 
+  /** Legacy syntax is accepted but scheduled for migration/removal. */
+  LegacySyntaxWarning: 'ZAX101',
+
   /** Generic instruction encoding error (unsupported mnemonic/operands, out-of-range imm, etc.). */
   EncodeError: 'ZAX200',
 

--- a/src/frontend/parseData.ts
+++ b/src/frontend/parseData.ts
@@ -27,6 +27,21 @@ function diag(
   });
 }
 
+function warnLegacy(
+  diagnostics: Diagnostic[],
+  file: string,
+  message: string,
+  where?: { line: number; column: number },
+): void {
+  diagnostics.push({
+    id: DiagnosticIds.LegacySyntaxWarning,
+    severity: 'warning',
+    message,
+    file,
+    ...(where ? { line: where.line, column: where.column } : {}),
+  });
+}
+
 function stripComment(line: string): string {
   const semi = line.indexOf(';');
   return semi >= 0 ? line.slice(0, semi) : line;
@@ -98,6 +113,7 @@ type ParseDataContext = {
   diagnostics: Diagnostic[];
   modulePath: string;
   getRawLine: (lineIndex: number) => RawLine;
+  emitLegacyWarnings?: boolean;
   stopOnEnd?: boolean;
 };
 
@@ -276,6 +292,14 @@ export function parseDataDeclLine(opts: ParseDataDeclOptions): DataDeclNode | un
 
 export function parseDataBlock(startIndex: number, ctx: ParseDataContext): ParsedDataBlock {
   const { file, lineCount, diagnostics, modulePath, getRawLine, stopOnEnd = false } = ctx;
+  if (!stopOnEnd && ctx.emitLegacyWarnings) {
+    warnLegacy(
+      diagnostics,
+      modulePath,
+      'Legacy "data ... end" blocks are deprecated; prefer direct declarations inside named data sections.',
+      { line: startIndex + 1, column: 1 },
+    );
+  }
   const blockStart = getRawLine(startIndex).startOffset;
   let index = startIndex + 1;
   const decls: DataDeclNode[] = [];

--- a/src/frontend/parseGlobals.ts
+++ b/src/frontend/parseGlobals.ts
@@ -26,6 +26,21 @@ function diag(
   });
 }
 
+function warnLegacy(
+  diagnostics: Diagnostic[],
+  file: string,
+  message: string,
+  where?: { line: number; column: number },
+): void {
+  diagnostics.push({
+    id: DiagnosticIds.LegacySyntaxWarning,
+    severity: 'warning',
+    message,
+    file,
+    ...(where ? { line: where.line, column: where.column } : {}),
+  });
+}
+
 function stripComment(line: string): string {
   const semi = line.indexOf(';');
   return semi >= 0 ? line.slice(0, semi) : line;
@@ -43,6 +58,7 @@ type ParseGlobalsContext = {
   diagnostics: Diagnostic[];
   modulePath: string;
   getRawLine: (lineIndex: number) => RawLine;
+  emitLegacyWarnings?: boolean;
   isReservedTopLevelName: (name: string) => boolean;
 };
 
@@ -63,6 +79,13 @@ export function parseGlobalsBlock(
       line: lineNo,
       column: 1,
     });
+  } else if (ctx.emitLegacyWarnings) {
+    warnLegacy(
+      diagnostics,
+      modulePath,
+      'Legacy "globals ... end" storage blocks are deprecated; prefer direct declarations inside named data sections.',
+      { line: lineNo, column: 1 },
+    );
   }
 
   const blockDeclKind = 'globals declaration';

--- a/src/frontend/parseTopLevelSimple.ts
+++ b/src/frontend/parseTopLevelSimple.ts
@@ -27,12 +27,28 @@ function diag(
   });
 }
 
+function warnLegacy(
+  diagnostics: Diagnostic[],
+  file: string,
+  message: string,
+  where?: { line: number; column: number },
+): void {
+  diagnostics.push({
+    id: DiagnosticIds.LegacySyntaxWarning,
+    severity: 'warning',
+    message,
+    file,
+    ...(where ? { line: where.line, column: where.column } : {}),
+  });
+}
+
 type SimpleTopLevelContext = {
   diagnostics: Diagnostic[];
   modulePath: string;
   lineNo: number;
   text: string;
   span: SourceSpan;
+  emitLegacyWarnings?: boolean;
   isReservedTopLevelName: (name: string) => boolean;
 };
 
@@ -92,6 +108,15 @@ export function parseSectionDirectiveDecl(
   const section = m[1]! as SectionDirectiveNode['section'];
   const atText = m[2]?.trim();
   const at = atText ? parseImmExprFromText(modulePath, atText, span, diagnostics) : undefined;
+
+  if (ctx.emitLegacyWarnings) {
+    warnLegacy(
+      diagnostics,
+      modulePath,
+      `Legacy active-counter section directive "section ${section}${atText ? ' at ...' : ''}" is deprecated; use named sections instead.`,
+      { line: lineNo, column: 1 },
+    );
+  }
 
   return {
     kind: 'Section',

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -93,6 +93,7 @@ export function parseModuleFile(
   modulePath: string,
   sourceText: string,
   diagnostics: Diagnostic[],
+  options: { emitLegacyWarnings?: boolean } = {},
 ): ModuleFileNode {
   const file = makeSourceFile(modulePath, sourceText);
   const lineCount = file.lineStarts.length;
@@ -107,6 +108,7 @@ export function parseModuleFile(
   }
 
   const items: ModuleItemNode[] = [];
+  const emitLegacyWarnings = options.emitLegacyWarnings ?? false;
 
   function parseNamedSectionHeader(
     sectionText: string,
@@ -145,6 +147,7 @@ export function parseModuleFile(
           lineNo,
           text: originalText,
           span: sectionSpan,
+          emitLegacyWarnings: false,
           isReservedTopLevelName,
         },
       )?.at;
@@ -164,6 +167,7 @@ export function parseModuleFile(
             lineNo,
             text: originalText,
             span: sectionSpan,
+            emitLegacyWarnings: false,
             isReservedTopLevelName,
           },
         )?.value;
@@ -315,6 +319,7 @@ export function parseModuleFile(
           diagnostics,
           modulePath,
           getRawLine,
+          emitLegacyWarnings,
           isReservedTopLevelName,
         });
         sectionItems.push(parsedGlobals.varBlock);
@@ -489,6 +494,7 @@ export function parseModuleFile(
           diagnostics,
           modulePath,
           getRawLine,
+          emitLegacyWarnings,
           stopOnEnd: true,
         });
         sectionItems.push(parsedData.node);
@@ -717,6 +723,7 @@ export function parseModuleFile(
         diagnostics,
         modulePath,
         getRawLine,
+        emitLegacyWarnings,
         isReservedTopLevelName,
       });
       items.push(parsedGlobals.varBlock);
@@ -860,6 +867,7 @@ export function parseModuleFile(
         lineNo,
         text,
         span: dirSpan,
+        emitLegacyWarnings,
         isReservedTopLevelName,
       });
       if (!sectionNode) {
@@ -956,6 +964,7 @@ export function parseModuleFile(
         diagnostics,
         modulePath,
         getRawLine,
+        emitLegacyWarnings,
       });
       items.push(parsedData.node);
       i = parsedData.nextIndex;

--- a/test/pr578_legacy_syntax_warnings.test.ts
+++ b/test/pr578_legacy_syntax_warnings.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { DiagnosticIds } from '../src/diagnostics/types.js';
+import { parseModuleFile } from '../src/frontend/parser.js';
+
+describe('PR578 legacy syntax warnings', () => {
+  it('warns for legacy globals/data blocks and active-counter section directives', () => {
+    const file = 'legacy.zax';
+    const source = [
+      'section code at $1000',
+      'globals',
+      '  count: byte',
+      'end',
+      'data',
+      '  msg: byte[2] = "hi"',
+      'end',
+      '',
+    ].join('\n');
+
+    const diagnostics: Diagnostic[] = [];
+    parseModuleFile(file, source, diagnostics, { emitLegacyWarnings: true });
+
+    const warnings = diagnostics.filter((d) => d.id === DiagnosticIds.LegacySyntaxWarning);
+    expect(warnings).toHaveLength(3);
+    expect(warnings.map((d) => d.line)).toEqual([1, 2, 5]);
+    expect(warnings.every((d) => d.severity === 'warning')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add an opt-in parser warning path for legacy globals/data blocks and active-counter section directives
- keep default compiler behavior unchanged so existing compile paths stay clean until migration warnings are explicitly enabled
- add focused coverage for the legacy warning surface

## Verification
- npm run typecheck
- npm test -- --run test/pr578_legacy_syntax_warnings.test.ts test/pr576_unified_data_sections.test.ts test/pr572_named_sections_parser.test.ts test/smoke_language_tour_compile.test.ts