### PR TITLE
Remove legacy section and storage syntax

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,7 +26,6 @@ type CliOptions = {
   opStackPolicy: OpStackPolicyMode;
   typePaddingWarnings: boolean;
   rawTypedCallWarnings: boolean;
-  emitLegacyWarnings: boolean;
   includeDirs: string[];
 };
 
@@ -46,7 +45,6 @@ function usage(): string {
     '      --op-stack-policy <m> Op stack-policy mode: off|warn|error',
     '      --type-padding-warn Emit warnings for power-of-2 type storage padding',
     '      --raw-typed-call-warn Emit warnings for raw call to typed callable targets',
-    '      --legacy-syntax-warn Emit warnings for accepted legacy syntax scheduled for migration',
     '  -I, --include <dir>   Add import search path (repeatable)',
     '  -V, --version         Print version',
     '  -h, --help            Show help',
@@ -74,7 +72,6 @@ function parseArgs(argv: string[]): CliOptions | CliExit {
   let opStackPolicy: OpStackPolicyMode = 'off';
   let typePaddingWarnings = false;
   let rawTypedCallWarnings = false;
-  let emitLegacyWarnings = false;
   const includeDirs: string[] = [];
   let entryFile: string | undefined;
 
@@ -169,10 +166,6 @@ function parseArgs(argv: string[]): CliOptions | CliExit {
       rawTypedCallWarnings = true;
       continue;
     }
-    if (a === '--legacy-syntax-warn') {
-      emitLegacyWarnings = true;
-      continue;
-    }
     if (a === '-I' || a === '--include' || a.startsWith('--include=')) {
       if (a.startsWith('--include=')) {
         const v = a.slice('--include='.length);
@@ -225,7 +218,6 @@ function parseArgs(argv: string[]): CliOptions | CliExit {
     opStackPolicy,
     typePaddingWarnings,
     rawTypedCallWarnings,
-    emitLegacyWarnings,
     includeDirs,
   };
 }
@@ -342,7 +334,6 @@ export async function runCli(argv: string[]): Promise<number> {
         opStackPolicy: parsed.opStackPolicy,
         typePaddingWarnings: parsed.typePaddingWarnings,
         rawTypedCallWarnings: parsed.rawTypedCallWarnings,
-        emitLegacyWarnings: parsed.emitLegacyWarnings,
         includeDirs: parsed.includeDirs,
         requireMain: true,
         defaultCodeBase: 0x0100,

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -96,7 +96,7 @@ type LoadedProgram = {
 async function loadProgram(
   entryFile: string,
   diagnostics: Diagnostic[],
-  options: Pick<CompilerOptions, 'includeDirs' | 'emitLegacyWarnings'>,
+  options: Pick<CompilerOptions, 'includeDirs'>,
 ): Promise<LoadedProgram | undefined> {
   const entryPath = normalizePath(entryFile);
   const modules = new Map<string, ModuleFileNode>();
@@ -129,11 +129,7 @@ async function loadProgram(
 
     let moduleFile: ModuleFileNode;
     try {
-      moduleFile = parseModuleFile(p, sourceText, diagnostics, {
-        ...(options.emitLegacyWarnings !== undefined
-          ? { emitLegacyWarnings: options.emitLegacyWarnings }
-          : {}),
-      });
+      moduleFile = parseModuleFile(p, sourceText, diagnostics);
     } catch (err) {
       diagnostics.push({
         id: DiagnosticIds.InternalParseError,

--- a/src/diagnostics/types.ts
+++ b/src/diagnostics/types.ts
@@ -45,9 +45,6 @@ export const DiagnosticIds = {
   /** Generic parse error (syntax / unsupported in current PR subset). */
   ParseError: 'ZAX100',
 
-  /** Legacy syntax is accepted but scheduled for migration/removal. */
-  LegacySyntaxWarning: 'ZAX101',
-
   /** Generic instruction encoding error (unsupported mnemonic/operands, out-of-range imm, etc.). */
   EncodeError: 'ZAX200',
 

--- a/src/frontend/parseData.ts
+++ b/src/frontend/parseData.ts
@@ -27,21 +27,6 @@ function diag(
   });
 }
 
-function warnLegacy(
-  diagnostics: Diagnostic[],
-  file: string,
-  message: string,
-  where?: { line: number; column: number },
-): void {
-  diagnostics.push({
-    id: DiagnosticIds.LegacySyntaxWarning,
-    severity: 'warning',
-    message,
-    file,
-    ...(where ? { line: where.line, column: where.column } : {}),
-  });
-}
-
 function stripComment(line: string): string {
   const semi = line.indexOf(';');
   return semi >= 0 ? line.slice(0, semi) : line;
@@ -113,7 +98,6 @@ type ParseDataContext = {
   diagnostics: Diagnostic[];
   modulePath: string;
   getRawLine: (lineIndex: number) => RawLine;
-  emitLegacyWarnings?: boolean;
   stopOnEnd?: boolean;
 };
 
@@ -292,11 +276,11 @@ export function parseDataDeclLine(opts: ParseDataDeclOptions): DataDeclNode | un
 
 export function parseDataBlock(startIndex: number, ctx: ParseDataContext): ParsedDataBlock {
   const { file, lineCount, diagnostics, modulePath, getRawLine, stopOnEnd = false } = ctx;
-  if (!stopOnEnd && ctx.emitLegacyWarnings) {
-    warnLegacy(
+  if (!stopOnEnd) {
+    diag(
       diagnostics,
       modulePath,
-      'Legacy "data ... end" blocks are deprecated; prefer direct declarations inside named data sections.',
+      'Legacy top-level "data ... end" blocks are removed; use direct declarations inside named data sections.',
       { line: startIndex + 1, column: 1 },
     );
   }

--- a/src/frontend/parseGlobals.ts
+++ b/src/frontend/parseGlobals.ts
@@ -26,21 +26,6 @@ function diag(
   });
 }
 
-function warnLegacy(
-  diagnostics: Diagnostic[],
-  file: string,
-  message: string,
-  where?: { line: number; column: number },
-): void {
-  diagnostics.push({
-    id: DiagnosticIds.LegacySyntaxWarning,
-    severity: 'warning',
-    message,
-    file,
-    ...(where ? { line: where.line, column: where.column } : {}),
-  });
-}
-
 function stripComment(line: string): string {
   const semi = line.indexOf(';');
   return semi >= 0 ? line.slice(0, semi) : line;
@@ -58,7 +43,6 @@ type ParseGlobalsContext = {
   diagnostics: Diagnostic[];
   modulePath: string;
   getRawLine: (lineIndex: number) => RawLine;
-  emitLegacyWarnings?: boolean;
   isReservedTopLevelName: (name: string) => boolean;
 };
 
@@ -75,15 +59,15 @@ export function parseGlobalsBlock(
 ): ParsedGlobalsBlock {
   const { file, lineCount, diagnostics, modulePath, getRawLine, isReservedTopLevelName } = ctx;
   if (storageHeader === 'var') {
-    diag(diagnostics, modulePath, `Top-level "var" block has been renamed to "globals".`, {
+    diag(diagnostics, modulePath, `Legacy "var ... end" storage blocks are removed; use direct declarations inside named data sections.`, {
       line: lineNo,
       column: 1,
     });
-  } else if (ctx.emitLegacyWarnings) {
-    warnLegacy(
+  } else {
+    diag(
       diagnostics,
       modulePath,
-      'Legacy "globals ... end" storage blocks are deprecated; prefer direct declarations inside named data sections.',
+      'Legacy "globals ... end" storage blocks are removed; use direct declarations inside named data sections.',
       { line: lineNo, column: 1 },
     );
   }

--- a/src/frontend/parseTopLevelSimple.ts
+++ b/src/frontend/parseTopLevelSimple.ts
@@ -27,28 +27,12 @@ function diag(
   });
 }
 
-function warnLegacy(
-  diagnostics: Diagnostic[],
-  file: string,
-  message: string,
-  where?: { line: number; column: number },
-): void {
-  diagnostics.push({
-    id: DiagnosticIds.LegacySyntaxWarning,
-    severity: 'warning',
-    message,
-    file,
-    ...(where ? { line: where.line, column: where.column } : {}),
-  });
-}
-
 type SimpleTopLevelContext = {
   diagnostics: Diagnostic[];
   modulePath: string;
   lineNo: number;
   text: string;
   span: SourceSpan;
-  emitLegacyWarnings?: boolean;
   isReservedTopLevelName: (name: string) => boolean;
 };
 
@@ -107,23 +91,13 @@ export function parseSectionDirectiveDecl(
 
   const section = m[1]! as SectionDirectiveNode['section'];
   const atText = m[2]?.trim();
-  const at = atText ? parseImmExprFromText(modulePath, atText, span, diagnostics) : undefined;
-
-  if (ctx.emitLegacyWarnings) {
-    warnLegacy(
-      diagnostics,
-      modulePath,
-      `Legacy active-counter section directive "section ${section}${atText ? ' at ...' : ''}" is deprecated; use named sections instead.`,
-      { line: lineNo, column: 1 },
-    );
-  }
-
-  return {
-    kind: 'Section',
-    span,
-    section,
-    ...(at ? { at } : {}),
-  };
+  diag(
+    diagnostics,
+    modulePath,
+    `Legacy active-counter section directive "section ${section}${atText ? ' at ...' : ''}" is removed; use a named section like "section ${section === 'var' ? 'data' : section} <name>${atText ? ' at ...' : ''}" instead.`,
+    { line: lineNo, column: 1 },
+  );
+  return undefined;
 }
 
 export function parseAlignDirectiveDecl(

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -26,6 +26,7 @@ import { parseTopLevelExternDecl } from './parseExternBlock.js';
 import { parseEnumDecl } from './parseEnum.js';
 import { parseTopLevelFuncDecl } from './parseFunc.js';
 import { parseGlobalsBlock } from './parseGlobals.js';
+import { parseImmExprFromText } from './parseImm.js';
 import { parseTopLevelOpDecl } from './parseOp.js';
 import { parseOpParamsFromText, parseParamsFromText } from './parseParams.js';
 import { parseTypeDecl, parseUnionDecl } from './parseTypes.js';
@@ -93,7 +94,6 @@ export function parseModuleFile(
   modulePath: string,
   sourceText: string,
   diagnostics: Diagnostic[],
-  options: { emitLegacyWarnings?: boolean } = {},
 ): ModuleFileNode {
   const file = makeSourceFile(modulePath, sourceText);
   const lineCount = file.lineStarts.length;
@@ -108,7 +108,6 @@ export function parseModuleFile(
   }
 
   const items: ModuleItemNode[] = [];
-  const emitLegacyWarnings = options.emitLegacyWarnings ?? false;
 
   function parseNamedSectionHeader(
     sectionText: string,
@@ -138,19 +137,7 @@ export function parseModuleFile(
     const rangeExprText = m[5]?.trim();
     let anchor: SectionAnchorNode | undefined;
     if (atText) {
-      const at = parseSectionDirectiveDecl(
-        `section ${section} at ${atText}`,
-        `${section} at ${atText}`,
-        {
-          diagnostics,
-          modulePath,
-          lineNo,
-          text: originalText,
-          span: sectionSpan,
-          emitLegacyWarnings: false,
-          isReservedTopLevelName,
-        },
-      )?.at;
+      const at = parseImmExprFromText(modulePath, atText, sectionSpan, diagnostics);
       if (!at) return undefined;
       anchor = {
         kind: 'SectionAnchor',
@@ -167,7 +154,6 @@ export function parseModuleFile(
             lineNo,
             text: originalText,
             span: sectionSpan,
-            emitLegacyWarnings: false,
             isReservedTopLevelName,
           },
         )?.value;
@@ -319,10 +305,8 @@ export function parseModuleFile(
           diagnostics,
           modulePath,
           getRawLine,
-          emitLegacyWarnings,
           isReservedTopLevelName,
         });
-        sectionItems.push(parsedGlobals.varBlock);
         index = parsedGlobals.nextIndex;
         continue;
       }
@@ -494,7 +478,6 @@ export function parseModuleFile(
           diagnostics,
           modulePath,
           getRawLine,
-          emitLegacyWarnings,
           stopOnEnd: true,
         });
         sectionItems.push(parsedData.node);
@@ -723,10 +706,8 @@ export function parseModuleFile(
         diagnostics,
         modulePath,
         getRawLine,
-        emitLegacyWarnings,
         isReservedTopLevelName,
       });
-      items.push(parsedGlobals.varBlock);
       i = parsedGlobals.nextIndex;
       continue;
     }
@@ -867,7 +848,6 @@ export function parseModuleFile(
         lineNo,
         text,
         span: dirSpan,
-        emitLegacyWarnings,
         isReservedTopLevelName,
       });
       if (!sectionNode) {
@@ -964,9 +944,7 @@ export function parseModuleFile(
         diagnostics,
         modulePath,
         getRawLine,
-        emitLegacyWarnings,
       });
-      items.push(parsedData.node);
       i = parsedData.nextIndex;
       continue;
     }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -39,8 +39,6 @@ export interface CompilerOptions {
   typePaddingWarnings?: boolean;
   /** Emit warnings when raw `call` targets a typed callable symbol. */
   rawTypedCallWarnings?: boolean;
-  /** Emit parser warnings for accepted legacy syntax that is now deprecated. */
-  emitLegacyWarnings?: boolean;
   /** Require a callable `main` entry symbol for runnable builds. */
   requireMain?: boolean;
   /** Default code section base address when no `section code at` is provided. */

--- a/test/pr578_legacy_syntax_warnings.test.ts
+++ b/test/pr578_legacy_syntax_warnings.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Diagnostic } from '../src/diagnostics/types.js';
-import { DiagnosticIds } from '../src/diagnostics/types.js';
 import { parseModuleFile } from '../src/frontend/parser.js';
 
-describe('PR578 legacy syntax warnings', () => {
-  it('warns for legacy globals/data blocks and active-counter section directives', () => {
+describe('PR578 legacy syntax removal', () => {
+  it('rejects legacy globals/data blocks and active-counter section directives', () => {
     const file = 'legacy.zax';
     const source = [
       'section code at $1000',
@@ -19,11 +18,25 @@ describe('PR578 legacy syntax warnings', () => {
     ].join('\n');
 
     const diagnostics: Diagnostic[] = [];
-    parseModuleFile(file, source, diagnostics, { emitLegacyWarnings: true });
+    parseModuleFile(file, source, diagnostics);
 
-    const warnings = diagnostics.filter((d) => d.id === DiagnosticIds.LegacySyntaxWarning);
-    expect(warnings).toHaveLength(3);
-    expect(warnings.map((d) => d.line)).toEqual([1, 2, 5]);
-    expect(warnings.every((d) => d.severity === 'warning')).toBe(true);
+    const messagesByLine = diagnostics.map((d) => ({ line: d.line, message: d.message }));
+    expect(messagesByLine).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          line: 1,
+          message: expect.stringContaining('Legacy active-counter section directive'),
+        }),
+        expect.objectContaining({
+          line: 2,
+          message: expect.stringContaining('Legacy "globals ... end"'),
+        }),
+        expect.objectContaining({
+          line: 5,
+          message: expect.stringContaining('Legacy top-level "data ... end"'),
+        }),
+      ]),
+    );
+    expect(diagnostics.every((d) => d.severity === 'error')).toBe(true);
   });
 });

--- a/test/pr578_legacy_warning_cli.test.ts
+++ b/test/pr578_legacy_warning_cli.test.ts
@@ -6,8 +6,8 @@ import { describe, expect, it } from 'vitest';
 
 import { ensureCliBuilt, runCli } from './helpers/cli.js';
 
-describe('PR578 legacy warning CLI enablement', () => {
-  it('emits legacy syntax warnings only when the CLI flag is enabled', async () => {
+describe('PR578 legacy warning CLI removal', () => {
+  it('rejects the removed legacy warning flag', async () => {
     await ensureCliBuilt();
     const work = await mkdtemp(join(tmpdir(), 'zax-cli-legacy-warn-'));
     const entry = join(work, 'legacy.zax');
@@ -17,13 +17,8 @@ describe('PR578 legacy warning CLI enablement', () => {
       'utf8',
     );
 
-    const quiet = await runCli([entry], work);
-    expect(quiet.code).toBe(0);
-    expect(quiet.stderr).not.toContain('[ZAX101]');
-
     const warned = await runCli(['--legacy-syntax-warn', entry], work);
-    expect(warned.code).toBe(0);
-    expect(warned.stderr).toContain('[ZAX101]');
-    expect(warned.stderr).toContain('Legacy "globals ... end" storage blocks are deprecated');
+    expect(warned.code).not.toBe(0);
+    expect(warned.stderr).toContain('Unknown option "--legacy-syntax-warn"');
   }, 15000);
 });


### PR DESCRIPTION
## Scope\n- remove legacy parser acceptance for active-counter section directives\n- remove legacy globals/data block acceptance\n- remove legacy warning infrastructure and CLI flag\n- convert PR578 tests to hard-error coverage\n\n## Note\nThis intentionally makes the tree red against existing legacy fixtures/examples. That migration is the next planned work in #603 and #604.