### PR TITLE
[v0.5] Enforce parser rejection of bare section data markers

### DIFF
--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -472,16 +472,16 @@ export function parseModuleFile(
       }
 
       if (rest.toLowerCase() === 'data') {
-        const parsedData = parseDataBlock(index, {
-          file,
-          lineCount,
+        diag(
           diagnostics,
           modulePath,
-          getRawLine,
-          stopOnEnd: true,
-        });
-        sectionItems.push(parsedData.node);
-        index = parsedData.nextIndex;
+          `Bare "data" marker lines are removed; declare symbols directly inside named data sections.`,
+          {
+            line: lineNo,
+            column: 1,
+          },
+        );
+        index++;
         continue;
       }
 

--- a/test/pr572_named_sections_parser.test.ts
+++ b/test/pr572_named_sections_parser.test.ts
@@ -9,12 +9,9 @@ describe('PR572 named section parser scaffolding', () => {
     const program = parseProgram(
       'pr572_named_sections.zax',
       [
-        'section code boot at $1000 size $40',
+        'section data assets at $1000 size $40',
         '  align $10',
-        '  export func main(): HL',
-        '    ret',
-        '  end',
-        '  data',
+        '  export const Version = 1',
         '    message: byte[3] = "abc"',
         'end',
       ].join('\n'),
@@ -25,8 +22,8 @@ describe('PR572 named section parser scaffolding', () => {
     const section = program.files[0]?.items[0];
     expect(section).toMatchObject({
       kind: 'NamedSection',
-      section: 'code',
-      name: 'boot',
+      section: 'data',
+      name: 'assets',
       anchor: {
         kind: 'SectionAnchor',
         at: { kind: 'ImmLiteral', value: 0x1000 },
@@ -39,11 +36,11 @@ describe('PR572 named section parser scaffolding', () => {
     expect(section.items).toHaveLength(3);
     expect(section.items[0]).toMatchObject({ kind: 'Align' });
     expect(section.items[1]).toMatchObject({
-      kind: 'FuncDecl',
-      name: 'main',
+      kind: 'ConstDecl',
+      name: 'Version',
       exported: true,
     });
-    expect(section.items[2]).toMatchObject({ kind: 'DataBlock' });
+    expect(section.items[2]).toMatchObject({ kind: 'DataDecl', name: 'message' });
   });
 
   it('keeps imports module-scoped and rejects legacy section directives', () => {

--- a/test/pr611_parser_data_marker_enforcement.test.ts
+++ b/test/pr611_parser_data_marker_enforcement.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { parseProgram } from '../src/frontend/parser.js';
+
+describe('PR611 parser data marker enforcement', () => {
+  it('rejects bare data marker lines inside named sections', () => {
+    const diagnostics: Diagnostic[] = [];
+    const program = parseProgram(
+      'pr611_section_data_marker.zax',
+      [
+        'section data vars',
+        '  data',
+        '  counter: byte',
+        'end',
+      ].join('\n'),
+      diagnostics,
+    );
+
+    const section = program.files[0]?.items[0];
+    expect(section).toMatchObject({ kind: 'NamedSection', section: 'data', name: 'vars' });
+    if (!section || section.kind !== 'NamedSection') {
+      throw new Error('expected named section');
+    }
+    expect(section.items).toHaveLength(1);
+    expect(section.items[0]).toMatchObject({ kind: 'DataDecl', name: 'counter' });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      line: 2,
+      column: 1,
+      message:
+        'Bare "data" marker lines are removed; declare symbols directly inside named data sections.',
+    });
+  });
+
+  it('keeps top-level legacy data blocks as hard errors', () => {
+    const diagnostics: Diagnostic[] = [];
+    parseProgram(
+      'pr611_top_level_data_block.zax',
+      ['data', '  msg: byte[] = "HELLO"', 'end'].join('\n'),
+      diagnostics,
+    );
+
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          line: 1,
+          column: 1,
+          message:
+            'Legacy top-level "data ... end" blocks are removed; use direct declarations inside named data sections.',
+        }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
Closes #611

## What changed
- Removed parser acceptance for bare `data` marker lines inside named sections.
- Added explicit parse error:
  - `Bare "data" marker lines are removed; declare symbols directly inside named data sections.`
- Updated named-section parser scaffolding test to use direct declarations inside named data sections.
- Added dedicated enforcement tests for:
  - bare marker rejection in named sections
  - top-level legacy `data ... end` block still rejected

## Validation run
- `npm run typecheck`
- `npm test -- --run test/pr611_parser_data_marker_enforcement.test.ts test/pr572_named_sections_parser.test.ts test/pr476_parse_data_helpers.test.ts test/pr576_unified_data_sections.test.ts`

## Follow-up required
This enforcement intentionally surfaces remaining section-internal `data` marker lines in existing fixtures/examples. Broad suites (for example language-tour smoke) fail until those files are migrated to direct declarations.
