### PR TITLE
Migrate examples to direct section data declarations

### DIFF
--- a/examples/codegen-corpus/30_scalar_byte_glob.zax
+++ b/examples/codegen-corpus/30_scalar_byte_glob.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_b: byte = $AA
 end
 

--- a/examples/codegen-corpus/31_scalar_byte_frame.zax
+++ b/examples/codegen-corpus/31_scalar_byte_frame.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     dummy: byte = 0
 end
 

--- a/examples/codegen-corpus/32_scalar_word_glob.zax
+++ b/examples/codegen-corpus/32_scalar_word_glob.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_w: word = $BEEF
 end
 

--- a/examples/codegen-corpus/33_scalar_word_frame.zax
+++ b/examples/codegen-corpus/33_scalar_word_frame.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     dummy: word = 0
 end
 

--- a/examples/codegen-corpus/advanced_typed_calls.zax
+++ b/examples/codegen-corpus/advanced_typed_calls.zax
@@ -1,5 +1,4 @@
 section data vars at $1000
-  data
     idx: byte = 0
     arr: byte[16] = {}
     out: word = 0

--- a/examples/codegen-corpus/intermediate_indexing.zax
+++ b/examples/codegen-corpus/intermediate_indexing.zax
@@ -1,5 +1,4 @@
 section data vars at $1000
-  data
     idx: byte = 0
     idxw: word = 0
     arr: byte[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }

--- a/examples/codegen-corpus/invalid_runtime_atom_budget.zax
+++ b/examples/codegen-corpus/invalid_runtime_atom_budget.zax
@@ -1,5 +1,4 @@
 section data vars at $1000
-  data
     i: byte = 0
     j: byte = 0
     arr: byte[16] = {}

--- a/examples/codegen-corpus/pr259_op_ea_dotted_field.zax
+++ b/examples/codegen-corpus/pr259_op_ea_dotted_field.zax
@@ -4,7 +4,6 @@ type Pair
 end
 
 section data vars at $1000
-  data
   p: Pair = { lo: 0, hi: 0 }
 end
 

--- a/examples/codegen-corpus/pr272_runtime_affine_valid.zax
+++ b/examples/codegen-corpus/pr272_runtime_affine_valid.zax
@@ -1,5 +1,4 @@
 section data vars at $1000
-  data
     idx: byte = 0
     idxw: word = 0
     arr: byte[64] = {}

--- a/examples/codegen-corpus/pr276_typed_call_preservation_matrix.zax
+++ b/examples/codegen-corpus/pr276_typed_call_preservation_matrix.zax
@@ -1,5 +1,4 @@
 section data vars at $1000
-  data
     out: word = 0
 end
 

--- a/examples/codegen-corpus/pr283_local_arg_global_access_matrix.zax
+++ b/examples/codegen-corpus/pr283_local_arg_global_access_matrix.zax
@@ -1,5 +1,4 @@
 section data vars at $1000
-  data
     gword: word = 0
     gbyte: byte = 0
 end

--- a/examples/hello.zax
+++ b/examples/hello.zax
@@ -13,7 +13,6 @@ end
 const MsgLen = 10
 
 section data vars at $1000
-  data
   msg: byte[10] = "HELLO, ZAX"
 end
 

--- a/examples/language-tour/03_globals_and_aliases.d8dbg.json
+++ b/examples/language-tour/03_globals_and_aliases.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 6,
+          "lstLine": 5,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,63 +24,63 @@
         {
           "start": 267,
           "end": 270,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 270,
           "end": 278,
-          "lstLine": 6,
+          "lstLine": 5,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 278,
           "end": 290,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 290,
           "end": 300,
-          "lstLine": 11,
+          "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 300,
           "end": 309,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 309,
           "end": 321,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 321,
           "end": 330,
-          "lstLine": 19,
+          "lstLine": 18,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 330,
           "end": 333,
-          "lstLine": 20,
+          "lstLine": 19,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 333,
           "end": 342,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
@@ -97,49 +97,49 @@
           "name": "read_counter",
           "kind": "label",
           "address": 256,
-          "line": 6,
+          "line": 5,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 270,
-          "line": 6,
+          "line": 5,
           "scope": "local"
         },
         {
           "name": "write_counter",
           "kind": "label",
           "address": 278,
-          "line": 10,
+          "line": 9,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 300,
-          "line": 10,
+          "line": 9,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 309,
-          "line": 14,
+          "line": 13,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_2",
           "kind": "label",
           "address": 333,
-          "line": 14,
+          "line": 13,
           "scope": "local"
         },
         {
           "name": "counter",
           "kind": "data",
           "address": 4096,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -170,7 +170,7 @@
       "kind": "label",
       "address": 256,
       "file": "03_globals_and_aliases.zax",
-      "line": 6,
+      "line": 5,
       "scope": "global"
     },
     {
@@ -178,7 +178,7 @@
       "kind": "label",
       "address": 270,
       "file": "03_globals_and_aliases.zax",
-      "line": 6,
+      "line": 5,
       "scope": "local"
     },
     {
@@ -186,7 +186,7 @@
       "kind": "label",
       "address": 278,
       "file": "03_globals_and_aliases.zax",
-      "line": 10,
+      "line": 9,
       "scope": "global"
     },
     {
@@ -194,7 +194,7 @@
       "kind": "label",
       "address": 300,
       "file": "03_globals_and_aliases.zax",
-      "line": 10,
+      "line": 9,
       "scope": "local"
     },
     {
@@ -202,7 +202,7 @@
       "kind": "label",
       "address": 309,
       "file": "03_globals_and_aliases.zax",
-      "line": 14,
+      "line": 13,
       "scope": "global"
     },
     {
@@ -210,7 +210,7 @@
       "kind": "label",
       "address": 333,
       "file": "03_globals_and_aliases.zax",
-      "line": 14,
+      "line": 13,
       "scope": "local"
     },
     {
@@ -218,7 +218,7 @@
       "kind": "data",
       "address": 4096,
       "file": "03_globals_and_aliases.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/03_globals_and_aliases.zax
+++ b/examples/language-tour/03_globals_and_aliases.zax
@@ -1,5 +1,4 @@
 section data vars at $1000
-  data
   counter: word = 0
 end
 

--- a/examples/language-tour/10_arrays_and_indexing.d8dbg.json
+++ b/examples/language-tour/10_arrays_and_indexing.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,91 +24,91 @@
         {
           "start": 267,
           "end": 270,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 270,
           "end": 271,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 271,
           "end": 273,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 273,
           "end": 281,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 281,
           "end": 292,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 292,
           "end": 312,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 312,
           "end": 320,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 320,
           "end": 328,
-          "lstLine": 17,
+          "lstLine": 16,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 328,
           "end": 333,
-          "lstLine": 19,
+          "lstLine": 18,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 333,
           "end": 337,
-          "lstLine": 17,
+          "lstLine": 16,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 337,
           "end": 340,
-          "lstLine": 22,
+          "lstLine": 21,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 340,
           "end": 354,
-          "lstLine": 23,
+          "lstLine": 22,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 354,
           "end": 363,
-          "lstLine": 17,
+          "lstLine": 16,
           "kind": "code",
           "confidence": "high"
         },
@@ -125,56 +125,56 @@
           "name": "first_byte",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 273,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "read_word_at",
           "kind": "label",
           "address": 281,
-          "line": 13,
+          "line": 12,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 312,
-          "line": 13,
+          "line": 12,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 320,
-          "line": 17,
+          "line": 16,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_2",
           "kind": "label",
           "address": 354,
-          "line": 17,
+          "line": 16,
           "scope": "local"
         },
         {
           "name": "bytes10",
           "kind": "data",
           "address": 4096,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
           "name": "words4",
           "kind": "data",
           "address": 4112,
-          "line": 4,
+          "line": 3,
           "scope": "global"
         },
         {
@@ -205,7 +205,7 @@
       "kind": "label",
       "address": 256,
       "file": "10_arrays_and_indexing.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -213,7 +213,7 @@
       "kind": "label",
       "address": 273,
       "file": "10_arrays_and_indexing.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -221,7 +221,7 @@
       "kind": "label",
       "address": 281,
       "file": "10_arrays_and_indexing.zax",
-      "line": 13,
+      "line": 12,
       "scope": "global"
     },
     {
@@ -229,7 +229,7 @@
       "kind": "label",
       "address": 312,
       "file": "10_arrays_and_indexing.zax",
-      "line": 13,
+      "line": 12,
       "scope": "local"
     },
     {
@@ -237,7 +237,7 @@
       "kind": "label",
       "address": 320,
       "file": "10_arrays_and_indexing.zax",
-      "line": 17,
+      "line": 16,
       "scope": "global"
     },
     {
@@ -245,7 +245,7 @@
       "kind": "label",
       "address": 354,
       "file": "10_arrays_and_indexing.zax",
-      "line": 17,
+      "line": 16,
       "scope": "local"
     },
     {
@@ -253,7 +253,7 @@
       "kind": "data",
       "address": 4096,
       "file": "10_arrays_and_indexing.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {
@@ -261,7 +261,7 @@
       "kind": "data",
       "address": 4112,
       "file": "10_arrays_and_indexing.zax",
-      "line": 4,
+      "line": 3,
       "scope": "global"
     },
     {

--- a/examples/language-tour/10_arrays_and_indexing.zax
+++ b/examples/language-tour/10_arrays_and_indexing.zax
@@ -1,5 +1,4 @@
 section data vars at $1000
-  data
   bytes10: byte[10] = { 1,2,3,4,5,6,7,8,9,10 }
   words4: word[4] = { 100, 200, 300, 400 }
 end

--- a/examples/language-tour/11_records_and_fields.d8dbg.json
+++ b/examples/language-tour/11_records_and_fields.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 268,
-          "lstLine": 11,
+          "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,84 +24,84 @@
         {
           "start": 268,
           "end": 295,
-          "lstLine": 12,
+          "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 295,
           "end": 322,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 322,
           "end": 331,
-          "lstLine": 11,
+          "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 331,
           "end": 342,
-          "lstLine": 16,
+          "lstLine": 15,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 342,
           "end": 348,
-          "lstLine": 17,
+          "lstLine": 16,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 348,
           "end": 361,
-          "lstLine": 18,
+          "lstLine": 17,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 361,
           "end": 369,
-          "lstLine": 16,
+          "lstLine": 15,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 369,
           "end": 381,
-          "lstLine": 21,
+          "lstLine": 20,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 381,
           "end": 396,
-          "lstLine": 26,
+          "lstLine": 25,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 396,
           "end": 399,
-          "lstLine": 27,
+          "lstLine": 26,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 399,
           "end": 402,
-          "lstLine": 28,
+          "lstLine": 27,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 402,
           "end": 411,
-          "lstLine": 21,
+          "lstLine": 20,
           "kind": "code",
           "confidence": "high"
         },
@@ -118,49 +118,49 @@
           "name": "write_pair",
           "kind": "label",
           "address": 256,
-          "line": 11,
+          "line": 10,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 322,
-          "line": 11,
+          "line": 10,
           "scope": "local"
         },
         {
           "name": "read_pair_word",
           "kind": "label",
           "address": 331,
-          "line": 16,
+          "line": 15,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 361,
-          "line": 16,
+          "line": 15,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 369,
-          "line": 21,
+          "line": 20,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_2",
           "kind": "label",
           "address": 402,
-          "line": 21,
+          "line": 20,
           "scope": "local"
         },
         {
           "name": "pair_buf",
           "kind": "data",
           "address": 4096,
-          "line": 8,
+          "line": 7,
           "scope": "global"
         },
         {
@@ -191,7 +191,7 @@
       "kind": "label",
       "address": 256,
       "file": "11_records_and_fields.zax",
-      "line": 11,
+      "line": 10,
       "scope": "global"
     },
     {
@@ -199,7 +199,7 @@
       "kind": "label",
       "address": 322,
       "file": "11_records_and_fields.zax",
-      "line": 11,
+      "line": 10,
       "scope": "local"
     },
     {
@@ -207,7 +207,7 @@
       "kind": "label",
       "address": 331,
       "file": "11_records_and_fields.zax",
-      "line": 16,
+      "line": 15,
       "scope": "global"
     },
     {
@@ -215,7 +215,7 @@
       "kind": "label",
       "address": 361,
       "file": "11_records_and_fields.zax",
-      "line": 16,
+      "line": 15,
       "scope": "local"
     },
     {
@@ -223,7 +223,7 @@
       "kind": "label",
       "address": 369,
       "file": "11_records_and_fields.zax",
-      "line": 21,
+      "line": 20,
       "scope": "global"
     },
     {
@@ -231,7 +231,7 @@
       "kind": "label",
       "address": 402,
       "file": "11_records_and_fields.zax",
-      "line": 21,
+      "line": 20,
       "scope": "local"
     },
     {
@@ -239,7 +239,7 @@
       "kind": "data",
       "address": 4096,
       "file": "11_records_and_fields.zax",
-      "line": 8,
+      "line": 7,
       "scope": "global"
     },
     {

--- a/examples/language-tour/11_records_and_fields.zax
+++ b/examples/language-tour/11_records_and_fields.zax
@@ -4,7 +4,6 @@ type Pair
 end
 
 section data vars at $1000
-  data
   pair_buf: Pair = { lo: 0, hi: 0 }
 end
 

--- a/examples/language-tour/12_args_with_arrays_records.d8dbg.json
+++ b/examples/language-tour/12_args_with_arrays_records.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,77 +24,77 @@
         {
           "start": 267,
           "end": 286,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 286,
           "end": 287,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 287,
           "end": 289,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 289,
           "end": 297,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 297,
           "end": 308,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 308,
           "end": 328,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 328,
           "end": 336,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 336,
           "end": 348,
-          "lstLine": 17,
+          "lstLine": 16,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 348,
           "end": 357,
-          "lstLine": 18,
+          "lstLine": 17,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 357,
           "end": 366,
-          "lstLine": 19,
+          "lstLine": 18,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 366,
           "end": 375,
-          "lstLine": 17,
+          "lstLine": 16,
           "kind": "code",
           "confidence": "high"
         },
@@ -111,56 +111,56 @@
           "name": "read_byte_at",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 289,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "read_word_at",
           "kind": "label",
           "address": 297,
-          "line": 13,
+          "line": 12,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 328,
-          "line": 13,
+          "line": 12,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 336,
-          "line": 17,
+          "line": 16,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_2",
           "kind": "label",
           "address": 366,
-          "line": 17,
+          "line": 16,
           "scope": "local"
         },
         {
           "name": "sample_bytes",
           "kind": "data",
           "address": 4096,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
           "name": "sample_words",
           "kind": "data",
           "address": 4112,
-          "line": 4,
+          "line": 3,
           "scope": "global"
         },
         {
@@ -191,7 +191,7 @@
       "kind": "label",
       "address": 256,
       "file": "12_args_with_arrays_records.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -199,7 +199,7 @@
       "kind": "label",
       "address": 289,
       "file": "12_args_with_arrays_records.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -207,7 +207,7 @@
       "kind": "label",
       "address": 297,
       "file": "12_args_with_arrays_records.zax",
-      "line": 13,
+      "line": 12,
       "scope": "global"
     },
     {
@@ -215,7 +215,7 @@
       "kind": "label",
       "address": 328,
       "file": "12_args_with_arrays_records.zax",
-      "line": 13,
+      "line": 12,
       "scope": "local"
     },
     {
@@ -223,7 +223,7 @@
       "kind": "label",
       "address": 336,
       "file": "12_args_with_arrays_records.zax",
-      "line": 17,
+      "line": 16,
       "scope": "global"
     },
     {
@@ -231,7 +231,7 @@
       "kind": "label",
       "address": 366,
       "file": "12_args_with_arrays_records.zax",
-      "line": 17,
+      "line": 16,
       "scope": "local"
     },
     {
@@ -239,7 +239,7 @@
       "kind": "data",
       "address": 4096,
       "file": "12_args_with_arrays_records.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {
@@ -247,7 +247,7 @@
       "kind": "data",
       "address": 4112,
       "file": "12_args_with_arrays_records.zax",
-      "line": 4,
+      "line": 3,
       "scope": "global"
     },
     {

--- a/examples/language-tour/12_args_with_arrays_records.zax
+++ b/examples/language-tour/12_args_with_arrays_records.zax
@@ -1,5 +1,4 @@
 section data vars at $1000
-  data
   sample_bytes: byte[10] = { 1,2,3,4,5,6,7,8,9,10 }
   sample_words: word[4] = { 100, 200, 300, 400 }
 end

--- a/examples/language-tour/13_structured_control_flow.d8dbg.json
+++ b/examples/language-tour/13_structured_control_flow.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 268,
-          "lstLine": 6,
+          "lstLine": 5,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,175 +24,175 @@
         {
           "start": 268,
           "end": 271,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 271,
           "end": 272,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 272,
           "end": 275,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 275,
           "end": 277,
-          "lstLine": 11,
+          "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 277,
           "end": 280,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 280,
           "end": 282,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 282,
           "end": 285,
-          "lstLine": 16,
+          "lstLine": 15,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 285,
           "end": 286,
-          "lstLine": 17,
+          "lstLine": 16,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 286,
           "end": 289,
-          "lstLine": 16,
+          "lstLine": 15,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 289,
           "end": 291,
-          "lstLine": 20,
+          "lstLine": 19,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 291,
           "end": 292,
-          "lstLine": 22,
+          "lstLine": 21,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 292,
           "end": 295,
-          "lstLine": 21,
+          "lstLine": 20,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 295,
           "end": 298,
-          "lstLine": 25,
+          "lstLine": 24,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 298,
           "end": 301,
-          "lstLine": 26,
+          "lstLine": 25,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 301,
           "end": 303,
-          "lstLine": 28,
+          "lstLine": 27,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 303,
           "end": 306,
-          "lstLine": 26,
+          "lstLine": 25,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 306,
           "end": 308,
-          "lstLine": 30,
+          "lstLine": 29,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 308,
           "end": 311,
-          "lstLine": 26,
+          "lstLine": 25,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 311,
           "end": 313,
-          "lstLine": 32,
+          "lstLine": 31,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 313,
           "end": 343,
-          "lstLine": 26,
+          "lstLine": 25,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 343,
           "end": 346,
-          "lstLine": 35,
+          "lstLine": 34,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 346,
           "end": 355,
-          "lstLine": 6,
+          "lstLine": 5,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 355,
           "end": 367,
-          "lstLine": 38,
+          "lstLine": 37,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 367,
           "end": 370,
-          "lstLine": 39,
+          "lstLine": 38,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 370,
           "end": 379,
-          "lstLine": 38,
+          "lstLine": 37,
           "kind": "code",
           "confidence": "high"
         },
@@ -209,119 +209,119 @@
           "name": "run_once",
           "kind": "label",
           "address": 256,
-          "line": 6,
+          "line": 5,
           "scope": "global"
         },
         {
           "name": "__zax_if_else_1",
           "kind": "label",
           "address": 280,
-          "line": 12,
+          "line": 11,
           "scope": "local"
         },
         {
           "name": "__zax_if_end_2",
           "kind": "label",
           "address": 282,
-          "line": 14,
+          "line": 13,
           "scope": "local"
         },
         {
           "name": "__zax_while_cond_3",
           "kind": "label",
           "address": 282,
-          "line": 16,
+          "line": 15,
           "scope": "local"
         },
         {
           "name": "__zax_while_end_4",
           "kind": "label",
           "address": 289,
-          "line": 18,
+          "line": 17,
           "scope": "local"
         },
         {
           "name": "__zax_repeat_body_5",
           "kind": "label",
           "address": 291,
-          "line": 21,
+          "line": 20,
           "scope": "local"
         },
         {
           "name": "__zax_case_8",
           "kind": "label",
           "address": 301,
-          "line": 27,
+          "line": 26,
           "scope": "local"
         },
         {
           "name": "__zax_case_9",
           "kind": "label",
           "address": 306,
-          "line": 29,
+          "line": 28,
           "scope": "local"
         },
         {
           "name": "__zax_select_else_10",
           "kind": "label",
           "address": 311,
-          "line": 31,
+          "line": 30,
           "scope": "local"
         },
         {
           "name": "__zax_select_dispatch_6",
           "kind": "label",
           "address": 316,
-          "line": 33,
+          "line": 32,
           "scope": "local"
         },
         {
           "name": "__zax_select_next_11",
           "kind": "label",
           "address": 330,
-          "line": 27,
+          "line": 26,
           "scope": "local"
         },
         {
           "name": "__zax_select_next_12",
           "kind": "label",
           "address": 339,
-          "line": 29,
+          "line": 28,
           "scope": "local"
         },
         {
           "name": "__zax_select_end_7",
           "kind": "label",
           "address": 343,
-          "line": 33,
+          "line": 32,
           "scope": "local"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 346,
-          "line": 6,
+          "line": 5,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 355,
-          "line": 38,
+          "line": 37,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_13",
           "kind": "label",
           "address": 370,
-          "line": 38,
+          "line": 37,
           "scope": "local"
         },
         {
           "name": "mode_value",
           "kind": "data",
           "address": 4096,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -352,7 +352,7 @@
       "kind": "label",
       "address": 256,
       "file": "13_structured_control_flow.zax",
-      "line": 6,
+      "line": 5,
       "scope": "global"
     },
     {
@@ -360,7 +360,7 @@
       "kind": "label",
       "address": 280,
       "file": "13_structured_control_flow.zax",
-      "line": 12,
+      "line": 11,
       "scope": "local"
     },
     {
@@ -368,7 +368,7 @@
       "kind": "label",
       "address": 282,
       "file": "13_structured_control_flow.zax",
-      "line": 14,
+      "line": 13,
       "scope": "local"
     },
     {
@@ -376,7 +376,7 @@
       "kind": "label",
       "address": 282,
       "file": "13_structured_control_flow.zax",
-      "line": 16,
+      "line": 15,
       "scope": "local"
     },
     {
@@ -384,7 +384,7 @@
       "kind": "label",
       "address": 289,
       "file": "13_structured_control_flow.zax",
-      "line": 18,
+      "line": 17,
       "scope": "local"
     },
     {
@@ -392,7 +392,7 @@
       "kind": "label",
       "address": 291,
       "file": "13_structured_control_flow.zax",
-      "line": 21,
+      "line": 20,
       "scope": "local"
     },
     {
@@ -400,7 +400,7 @@
       "kind": "label",
       "address": 301,
       "file": "13_structured_control_flow.zax",
-      "line": 27,
+      "line": 26,
       "scope": "local"
     },
     {
@@ -408,7 +408,7 @@
       "kind": "label",
       "address": 306,
       "file": "13_structured_control_flow.zax",
-      "line": 29,
+      "line": 28,
       "scope": "local"
     },
     {
@@ -416,7 +416,7 @@
       "kind": "label",
       "address": 311,
       "file": "13_structured_control_flow.zax",
-      "line": 31,
+      "line": 30,
       "scope": "local"
     },
     {
@@ -424,7 +424,7 @@
       "kind": "label",
       "address": 316,
       "file": "13_structured_control_flow.zax",
-      "line": 33,
+      "line": 32,
       "scope": "local"
     },
     {
@@ -432,7 +432,7 @@
       "kind": "label",
       "address": 330,
       "file": "13_structured_control_flow.zax",
-      "line": 27,
+      "line": 26,
       "scope": "local"
     },
     {
@@ -440,7 +440,7 @@
       "kind": "label",
       "address": 339,
       "file": "13_structured_control_flow.zax",
-      "line": 29,
+      "line": 28,
       "scope": "local"
     },
     {
@@ -448,7 +448,7 @@
       "kind": "label",
       "address": 343,
       "file": "13_structured_control_flow.zax",
-      "line": 33,
+      "line": 32,
       "scope": "local"
     },
     {
@@ -456,7 +456,7 @@
       "kind": "label",
       "address": 346,
       "file": "13_structured_control_flow.zax",
-      "line": 6,
+      "line": 5,
       "scope": "local"
     },
     {
@@ -464,7 +464,7 @@
       "kind": "label",
       "address": 355,
       "file": "13_structured_control_flow.zax",
-      "line": 38,
+      "line": 37,
       "scope": "global"
     },
     {
@@ -472,7 +472,7 @@
       "kind": "label",
       "address": 370,
       "file": "13_structured_control_flow.zax",
-      "line": 38,
+      "line": 37,
       "scope": "local"
     },
     {
@@ -480,7 +480,7 @@
       "kind": "data",
       "address": 4096,
       "file": "13_structured_control_flow.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/13_structured_control_flow.zax
+++ b/examples/language-tour/13_structured_control_flow.zax
@@ -1,5 +1,4 @@
 section data vars at $1000
-  data
   mode_value: byte = 0
 end
 

--- a/examples/language-tour/14_ops_and_calls.d8dbg.json
+++ b/examples/language-tour/14_ops_and_calls.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 20,
+          "lstLine": 19,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,77 +24,77 @@
         {
           "start": 267,
           "end": 270,
-          "lstLine": 21,
+          "lstLine": 20,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 270,
           "end": 276,
-          "lstLine": 22,
+          "lstLine": 21,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 276,
           "end": 279,
-          "lstLine": 23,
+          "lstLine": 22,
           "kind": "macro",
           "confidence": "high"
         },
         {
           "start": 279,
           "end": 287,
-          "lstLine": 20,
+          "lstLine": 19,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 287,
           "end": 295,
-          "lstLine": 26,
+          "lstLine": 25,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 295,
           "end": 300,
-          "lstLine": 28,
+          "lstLine": 27,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 300,
           "end": 304,
-          "lstLine": 26,
+          "lstLine": 25,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 304,
           "end": 307,
-          "lstLine": 31,
+          "lstLine": 30,
           "kind": "macro",
           "confidence": "high"
         },
         {
           "start": 307,
           "end": 316,
-          "lstLine": 32,
+          "lstLine": 31,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 316,
           "end": 324,
-          "lstLine": 33,
+          "lstLine": 32,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 324,
           "end": 333,
-          "lstLine": 26,
+          "lstLine": 25,
           "kind": "code",
           "confidence": "high"
         },
@@ -111,42 +111,42 @@
           "name": "add_to_sample",
           "kind": "label",
           "address": 256,
-          "line": 20,
+          "line": 19,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 279,
-          "line": 20,
+          "line": 19,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 287,
-          "line": 26,
+          "line": 25,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 324,
-          "line": 26,
+          "line": 25,
           "scope": "local"
         },
         {
           "name": "sample_byte",
           "kind": "data",
           "address": 4096,
-          "line": 16,
+          "line": 15,
           "scope": "global"
         },
         {
           "name": "sample_word",
           "kind": "data",
           "address": 4097,
-          "line": 17,
+          "line": 16,
           "scope": "global"
         },
         {
@@ -177,7 +177,7 @@
       "kind": "label",
       "address": 256,
       "file": "14_ops_and_calls.zax",
-      "line": 20,
+      "line": 19,
       "scope": "global"
     },
     {
@@ -185,7 +185,7 @@
       "kind": "label",
       "address": 279,
       "file": "14_ops_and_calls.zax",
-      "line": 20,
+      "line": 19,
       "scope": "local"
     },
     {
@@ -193,7 +193,7 @@
       "kind": "label",
       "address": 287,
       "file": "14_ops_and_calls.zax",
-      "line": 26,
+      "line": 25,
       "scope": "global"
     },
     {
@@ -201,7 +201,7 @@
       "kind": "label",
       "address": 324,
       "file": "14_ops_and_calls.zax",
-      "line": 26,
+      "line": 25,
       "scope": "local"
     },
     {
@@ -209,7 +209,7 @@
       "kind": "data",
       "address": 4096,
       "file": "14_ops_and_calls.zax",
-      "line": 16,
+      "line": 15,
       "scope": "global"
     },
     {
@@ -217,7 +217,7 @@
       "kind": "data",
       "address": 4097,
       "file": "14_ops_and_calls.zax",
-      "line": 17,
+      "line": 16,
       "scope": "global"
     },
     {

--- a/examples/language-tour/14_ops_and_calls.zax
+++ b/examples/language-tour/14_ops_and_calls.zax
@@ -12,7 +12,6 @@ op read_byte(dst: reg8, source_mem: mem8)
 end
 
 section data vars at $1000
-  data
   sample_byte: byte = 7
   sample_word: word = 100
 end

--- a/examples/language-tour/30_scalar_byte_glob.d8dbg.json
+++ b/examples/language-tour/30_scalar_byte_glob.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,56 +24,56 @@
         {
           "start": 267,
           "end": 270,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 270,
           "end": 273,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 273,
           "end": 275,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 275,
           "end": 276,
-          "lstLine": 11,
+          "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 276,
           "end": 284,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 284,
           "end": 296,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 296,
           "end": 299,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 299,
           "end": 308,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
@@ -90,35 +90,35 @@
           "name": "touch_scalar_byte_glob",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 276,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 284,
-          "line": 14,
+          "line": 13,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 299,
-          "line": 14,
+          "line": 13,
           "scope": "local"
         },
         {
           "name": "glob_b",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -149,7 +149,7 @@
       "kind": "label",
       "address": 256,
       "file": "30_scalar_byte_glob.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -157,7 +157,7 @@
       "kind": "label",
       "address": 276,
       "file": "30_scalar_byte_glob.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -165,7 +165,7 @@
       "kind": "label",
       "address": 284,
       "file": "30_scalar_byte_glob.zax",
-      "line": 14,
+      "line": 13,
       "scope": "global"
     },
     {
@@ -173,7 +173,7 @@
       "kind": "label",
       "address": 299,
       "file": "30_scalar_byte_glob.zax",
-      "line": 14,
+      "line": 13,
       "scope": "local"
     },
     {
@@ -181,7 +181,7 @@
       "kind": "data",
       "address": 8192,
       "file": "30_scalar_byte_glob.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/30_scalar_byte_glob.zax
+++ b/examples/language-tour/30_scalar_byte_glob.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_b: byte = $AA
 end
 

--- a/examples/language-tour/31_scalar_byte_frame.d8dbg.json
+++ b/examples/language-tour/31_scalar_byte_frame.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,56 +24,56 @@
         {
           "start": 267,
           "end": 270,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 270,
           "end": 273,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 273,
           "end": 275,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 275,
           "end": 276,
-          "lstLine": 11,
+          "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 276,
           "end": 284,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 284,
           "end": 296,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 296,
           "end": 305,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 305,
           "end": 314,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
@@ -90,35 +90,35 @@
           "name": "touch_scalar_byte_frame",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 276,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 284,
-          "line": 14,
+          "line": 13,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 305,
-          "line": 14,
+          "line": 13,
           "scope": "local"
         },
         {
           "name": "dummy",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -149,7 +149,7 @@
       "kind": "label",
       "address": 256,
       "file": "31_scalar_byte_frame.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -157,7 +157,7 @@
       "kind": "label",
       "address": 276,
       "file": "31_scalar_byte_frame.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -165,7 +165,7 @@
       "kind": "label",
       "address": 284,
       "file": "31_scalar_byte_frame.zax",
-      "line": 14,
+      "line": 13,
       "scope": "global"
     },
     {
@@ -173,7 +173,7 @@
       "kind": "label",
       "address": 305,
       "file": "31_scalar_byte_frame.zax",
-      "line": 14,
+      "line": 13,
       "scope": "local"
     },
     {
@@ -181,7 +181,7 @@
       "kind": "data",
       "address": 8192,
       "file": "31_scalar_byte_frame.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/31_scalar_byte_frame.zax
+++ b/examples/language-tour/31_scalar_byte_frame.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     dummy: byte = 0
 end
 

--- a/examples/language-tour/32_scalar_word_glob.d8dbg.json
+++ b/examples/language-tour/32_scalar_word_glob.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,42 +24,42 @@
         {
           "start": 267,
           "end": 270,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 270,
           "end": 273,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 273,
           "end": 281,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 281,
           "end": 293,
-          "lstLine": 12,
+          "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 293,
           "end": 296,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 296,
           "end": 305,
-          "lstLine": 12,
+          "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
@@ -76,35 +76,35 @@
           "name": "touch_scalar_word_glob",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 273,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 281,
-          "line": 12,
+          "line": 11,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 296,
-          "line": 12,
+          "line": 11,
           "scope": "local"
         },
         {
           "name": "glob_w",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -135,7 +135,7 @@
       "kind": "label",
       "address": 256,
       "file": "32_scalar_word_glob.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -143,7 +143,7 @@
       "kind": "label",
       "address": 273,
       "file": "32_scalar_word_glob.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -151,7 +151,7 @@
       "kind": "label",
       "address": 281,
       "file": "32_scalar_word_glob.zax",
-      "line": 12,
+      "line": 11,
       "scope": "global"
     },
     {
@@ -159,7 +159,7 @@
       "kind": "label",
       "address": 296,
       "file": "32_scalar_word_glob.zax",
-      "line": 12,
+      "line": 11,
       "scope": "local"
     },
     {
@@ -167,7 +167,7 @@
       "kind": "data",
       "address": 8192,
       "file": "32_scalar_word_glob.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/32_scalar_word_glob.zax
+++ b/examples/language-tour/32_scalar_word_glob.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_w: word = $BEEF
 end
 

--- a/examples/language-tour/33_scalar_word_frame.d8dbg.json
+++ b/examples/language-tour/33_scalar_word_frame.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,49 +24,49 @@
         {
           "start": 267,
           "end": 273,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 273,
           "end": 279,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 279,
           "end": 280,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 280,
           "end": 288,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 288,
           "end": 300,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 300,
           "end": 309,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 309,
           "end": 318,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
@@ -83,35 +83,35 @@
           "name": "touch_scalar_word_frame",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 280,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 288,
-          "line": 13,
+          "line": 12,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 309,
-          "line": 13,
+          "line": 12,
           "scope": "local"
         },
         {
           "name": "dummy",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -142,7 +142,7 @@
       "kind": "label",
       "address": 256,
       "file": "33_scalar_word_frame.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -150,7 +150,7 @@
       "kind": "label",
       "address": 280,
       "file": "33_scalar_word_frame.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -158,7 +158,7 @@
       "kind": "label",
       "address": 288,
       "file": "33_scalar_word_frame.zax",
-      "line": 13,
+      "line": 12,
       "scope": "global"
     },
     {
@@ -166,7 +166,7 @@
       "kind": "label",
       "address": 309,
       "file": "33_scalar_word_frame.zax",
-      "line": 13,
+      "line": 12,
       "scope": "local"
     },
     {
@@ -174,7 +174,7 @@
       "kind": "data",
       "address": 8192,
       "file": "33_scalar_word_frame.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/33_scalar_word_frame.zax
+++ b/examples/language-tour/33_scalar_word_frame.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     dummy: word = 0
 end
 

--- a/examples/language-tour/34_byte_glob_const.d8dbg.json
+++ b/examples/language-tour/34_byte_glob_const.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,56 +24,56 @@
         {
           "start": 267,
           "end": 270,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 270,
           "end": 273,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 273,
           "end": 275,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 275,
           "end": 276,
-          "lstLine": 11,
+          "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 276,
           "end": 284,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 284,
           "end": 296,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 296,
           "end": 299,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 299,
           "end": 308,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
@@ -90,35 +90,35 @@
           "name": "byte_glob_const",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 276,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 284,
-          "line": 14,
+          "line": 13,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 299,
-          "line": 14,
+          "line": 13,
           "scope": "local"
         },
         {
           "name": "glob_bytes",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -149,7 +149,7 @@
       "kind": "label",
       "address": 256,
       "file": "34_byte_glob_const.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -157,7 +157,7 @@
       "kind": "label",
       "address": 276,
       "file": "34_byte_glob_const.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -165,7 +165,7 @@
       "kind": "label",
       "address": 284,
       "file": "34_byte_glob_const.zax",
-      "line": 14,
+      "line": 13,
       "scope": "global"
     },
     {
@@ -173,7 +173,7 @@
       "kind": "label",
       "address": 299,
       "file": "34_byte_glob_const.zax",
-      "line": 14,
+      "line": 13,
       "scope": "local"
     },
     {
@@ -181,7 +181,7 @@
       "kind": "data",
       "address": 8192,
       "file": "34_byte_glob_const.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/34_byte_glob_const.zax
+++ b/examples/language-tour/34_byte_glob_const.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_bytes: byte[8] = { 0,1,2,3,4,5,6,7 }
 end
 

--- a/examples/language-tour/35_byte_glob_reg8.d8dbg.json
+++ b/examples/language-tour/35_byte_glob_reg8.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,56 +24,56 @@
         {
           "start": 267,
           "end": 286,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 286,
           "end": 305,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 305,
           "end": 307,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 307,
           "end": 308,
-          "lstLine": 11,
+          "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 308,
           "end": 316,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 316,
           "end": 328,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 328,
           "end": 337,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 337,
           "end": 346,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
@@ -90,35 +90,35 @@
           "name": "byte_glob_reg",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 308,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 316,
-          "line": 14,
+          "line": 13,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 337,
-          "line": 14,
+          "line": 13,
           "scope": "local"
         },
         {
           "name": "glob_bytes",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -149,7 +149,7 @@
       "kind": "label",
       "address": 256,
       "file": "35_byte_glob_reg8.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -157,7 +157,7 @@
       "kind": "label",
       "address": 308,
       "file": "35_byte_glob_reg8.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -165,7 +165,7 @@
       "kind": "label",
       "address": 316,
       "file": "35_byte_glob_reg8.zax",
-      "line": 14,
+      "line": 13,
       "scope": "global"
     },
     {
@@ -173,7 +173,7 @@
       "kind": "label",
       "address": 337,
       "file": "35_byte_glob_reg8.zax",
-      "line": 14,
+      "line": 13,
       "scope": "local"
     },
     {
@@ -181,7 +181,7 @@
       "kind": "data",
       "address": 8192,
       "file": "35_byte_glob_reg8.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/35_byte_glob_reg8.zax
+++ b/examples/language-tour/35_byte_glob_reg8.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_bytes: byte[8] = { 0,1,2,3,4,5,6,7 }
 end
 

--- a/examples/language-tour/36_byte_glob_reg16.d8dbg.json
+++ b/examples/language-tour/36_byte_glob_reg16.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,63 +24,63 @@
         {
           "start": 267,
           "end": 275,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 275,
           "end": 284,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 284,
           "end": 293,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 293,
           "end": 295,
-          "lstLine": 11,
+          "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 295,
           "end": 296,
-          "lstLine": 12,
+          "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 296,
           "end": 304,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 304,
           "end": 316,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 316,
           "end": 325,
-          "lstLine": 16,
+          "lstLine": 15,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 325,
           "end": 334,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
@@ -97,35 +97,35 @@
           "name": "byte_glob_reg16",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 296,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 304,
-          "line": 15,
+          "line": 14,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 325,
-          "line": 15,
+          "line": 14,
           "scope": "local"
         },
         {
           "name": "glob_bytes",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -156,7 +156,7 @@
       "kind": "label",
       "address": 256,
       "file": "36_byte_glob_reg16.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -164,7 +164,7 @@
       "kind": "label",
       "address": 296,
       "file": "36_byte_glob_reg16.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -172,7 +172,7 @@
       "kind": "label",
       "address": 304,
       "file": "36_byte_glob_reg16.zax",
-      "line": 15,
+      "line": 14,
       "scope": "global"
     },
     {
@@ -180,7 +180,7 @@
       "kind": "label",
       "address": 325,
       "file": "36_byte_glob_reg16.zax",
-      "line": 15,
+      "line": 14,
       "scope": "local"
     },
     {
@@ -188,7 +188,7 @@
       "kind": "data",
       "address": 8192,
       "file": "36_byte_glob_reg16.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/36_byte_glob_reg16.zax
+++ b/examples/language-tour/36_byte_glob_reg16.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_bytes: byte[8] = { 0,1,2,3,4,5,6,7 }
 end
 

--- a/examples/language-tour/37_byte_fvar_const.d8dbg.json
+++ b/examples/language-tour/37_byte_fvar_const.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,56 +24,56 @@
         {
           "start": 267,
           "end": 270,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 270,
           "end": 273,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 273,
           "end": 275,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 275,
           "end": 276,
-          "lstLine": 11,
+          "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 276,
           "end": 284,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 284,
           "end": 296,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 296,
           "end": 305,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 305,
           "end": 314,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
@@ -90,35 +90,35 @@
           "name": "byte_fvar_const",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 276,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 284,
-          "line": 14,
+          "line": 13,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 305,
-          "line": 14,
+          "line": 13,
           "scope": "local"
         },
         {
           "name": "glob_bytes",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -149,7 +149,7 @@
       "kind": "label",
       "address": 256,
       "file": "37_byte_fvar_const.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -157,7 +157,7 @@
       "kind": "label",
       "address": 276,
       "file": "37_byte_fvar_const.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -165,7 +165,7 @@
       "kind": "label",
       "address": 284,
       "file": "37_byte_fvar_const.zax",
-      "line": 14,
+      "line": 13,
       "scope": "global"
     },
     {
@@ -173,7 +173,7 @@
       "kind": "label",
       "address": 305,
       "file": "37_byte_fvar_const.zax",
-      "line": 14,
+      "line": 13,
       "scope": "local"
     },
     {
@@ -181,7 +181,7 @@
       "kind": "data",
       "address": 8192,
       "file": "37_byte_fvar_const.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/37_byte_fvar_const.zax
+++ b/examples/language-tour/37_byte_fvar_const.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_bytes: byte[8] = { 0,1,2,3,4,5,6,7 }
 end
 

--- a/examples/language-tour/38_byte_fvar_reg8.d8dbg.json
+++ b/examples/language-tour/38_byte_fvar_reg8.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,56 +24,56 @@
         {
           "start": 267,
           "end": 292,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 292,
           "end": 317,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 317,
           "end": 319,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 319,
           "end": 320,
-          "lstLine": 11,
+          "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 320,
           "end": 328,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 328,
           "end": 340,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 340,
           "end": 355,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 355,
           "end": 364,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
@@ -90,35 +90,35 @@
           "name": "byte_fvar_reg",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 320,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 328,
-          "line": 14,
+          "line": 13,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 355,
-          "line": 14,
+          "line": 13,
           "scope": "local"
         },
         {
           "name": "glob_bytes",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -149,7 +149,7 @@
       "kind": "label",
       "address": 256,
       "file": "38_byte_fvar_reg8.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -157,7 +157,7 @@
       "kind": "label",
       "address": 320,
       "file": "38_byte_fvar_reg8.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -165,7 +165,7 @@
       "kind": "label",
       "address": 328,
       "file": "38_byte_fvar_reg8.zax",
-      "line": 14,
+      "line": 13,
       "scope": "global"
     },
     {
@@ -173,7 +173,7 @@
       "kind": "label",
       "address": 355,
       "file": "38_byte_fvar_reg8.zax",
-      "line": 14,
+      "line": 13,
       "scope": "local"
     },
     {
@@ -181,7 +181,7 @@
       "kind": "data",
       "address": 8192,
       "file": "38_byte_fvar_reg8.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/38_byte_fvar_reg8.zax
+++ b/examples/language-tour/38_byte_fvar_reg8.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_bytes: byte[8] = { 0,1,2,3,4,5,6,7 }
 end
 

--- a/examples/language-tour/39_byte_fvar_reg16.d8dbg.json
+++ b/examples/language-tour/39_byte_fvar_reg16.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,63 +24,63 @@
         {
           "start": 267,
           "end": 275,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 275,
           "end": 287,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 287,
           "end": 299,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 299,
           "end": 301,
-          "lstLine": 11,
+          "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 301,
           "end": 302,
-          "lstLine": 12,
+          "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 302,
           "end": 310,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 310,
           "end": 322,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 322,
           "end": 337,
-          "lstLine": 16,
+          "lstLine": 15,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 337,
           "end": 346,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
@@ -97,35 +97,35 @@
           "name": "byte_fvar_reg16",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 302,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 310,
-          "line": 15,
+          "line": 14,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 337,
-          "line": 15,
+          "line": 14,
           "scope": "local"
         },
         {
           "name": "glob_bytes",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -156,7 +156,7 @@
       "kind": "label",
       "address": 256,
       "file": "39_byte_fvar_reg16.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -164,7 +164,7 @@
       "kind": "label",
       "address": 302,
       "file": "39_byte_fvar_reg16.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -172,7 +172,7 @@
       "kind": "label",
       "address": 310,
       "file": "39_byte_fvar_reg16.zax",
-      "line": 15,
+      "line": 14,
       "scope": "global"
     },
     {
@@ -180,7 +180,7 @@
       "kind": "label",
       "address": 337,
       "file": "39_byte_fvar_reg16.zax",
-      "line": 15,
+      "line": 14,
       "scope": "local"
     },
     {
@@ -188,7 +188,7 @@
       "kind": "data",
       "address": 8192,
       "file": "39_byte_fvar_reg16.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/39_byte_fvar_reg16.zax
+++ b/examples/language-tour/39_byte_fvar_reg16.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_bytes: byte[8] = { 0,1,2,3,4,5,6,7 }
 end
 

--- a/examples/language-tour/40_byte_glob_fvar.d8dbg.json
+++ b/examples/language-tour/40_byte_glob_fvar.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,56 +24,56 @@
         {
           "start": 267,
           "end": 286,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 286,
           "end": 307,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 307,
           "end": 309,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 309,
           "end": 310,
-          "lstLine": 11,
+          "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 310,
           "end": 318,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 318,
           "end": 330,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 330,
           "end": 339,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 339,
           "end": 348,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
@@ -90,35 +90,35 @@
           "name": "byte_glob_fvar",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 310,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 318,
-          "line": 14,
+          "line": 13,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 339,
-          "line": 14,
+          "line": 13,
           "scope": "local"
         },
         {
           "name": "glob_bytes",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -149,7 +149,7 @@
       "kind": "label",
       "address": 256,
       "file": "40_byte_glob_fvar.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -157,7 +157,7 @@
       "kind": "label",
       "address": 310,
       "file": "40_byte_glob_fvar.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -165,7 +165,7 @@
       "kind": "label",
       "address": 318,
       "file": "40_byte_glob_fvar.zax",
-      "line": 14,
+      "line": 13,
       "scope": "global"
     },
     {
@@ -173,7 +173,7 @@
       "kind": "label",
       "address": 339,
       "file": "40_byte_glob_fvar.zax",
-      "line": 14,
+      "line": 13,
       "scope": "local"
     },
     {
@@ -181,7 +181,7 @@
       "kind": "data",
       "address": 8192,
       "file": "40_byte_glob_fvar.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/40_byte_glob_fvar.zax
+++ b/examples/language-tour/40_byte_glob_fvar.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_bytes: byte[8] = { 0,1,2,3,4,5,6,7 }
 end
 

--- a/examples/language-tour/41_byte_fvar_fvar.d8dbg.json
+++ b/examples/language-tour/41_byte_fvar_fvar.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,56 +24,56 @@
         {
           "start": 267,
           "end": 292,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 292,
           "end": 319,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 319,
           "end": 321,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 321,
           "end": 322,
-          "lstLine": 11,
+          "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 322,
           "end": 330,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 330,
           "end": 342,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 342,
           "end": 357,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 357,
           "end": 366,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
@@ -90,35 +90,35 @@
           "name": "byte_fvar_fvar",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 322,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 330,
-          "line": 14,
+          "line": 13,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 357,
-          "line": 14,
+          "line": 13,
           "scope": "local"
         },
         {
           "name": "glob_bytes",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -149,7 +149,7 @@
       "kind": "label",
       "address": 256,
       "file": "41_byte_fvar_fvar.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -157,7 +157,7 @@
       "kind": "label",
       "address": 322,
       "file": "41_byte_fvar_fvar.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -165,7 +165,7 @@
       "kind": "label",
       "address": 330,
       "file": "41_byte_fvar_fvar.zax",
-      "line": 14,
+      "line": 13,
       "scope": "global"
     },
     {
@@ -173,7 +173,7 @@
       "kind": "label",
       "address": 357,
       "file": "41_byte_fvar_fvar.zax",
-      "line": 14,
+      "line": 13,
       "scope": "local"
     },
     {
@@ -181,7 +181,7 @@
       "kind": "data",
       "address": 8192,
       "file": "41_byte_fvar_fvar.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/41_byte_fvar_fvar.zax
+++ b/examples/language-tour/41_byte_fvar_fvar.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_bytes: byte[8] = { 0,1,2,3,4,5,6,7 }
 end
 

--- a/examples/language-tour/42_byte_fvar_glob.d8dbg.json
+++ b/examples/language-tour/42_byte_fvar_glob.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,56 +24,56 @@
         {
           "start": 267,
           "end": 287,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 287,
           "end": 309,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 309,
           "end": 311,
-          "lstLine": 11,
+          "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 311,
           "end": 312,
-          "lstLine": 12,
+          "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 312,
           "end": 320,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 320,
           "end": 332,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 332,
           "end": 341,
-          "lstLine": 16,
+          "lstLine": 15,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 341,
           "end": 350,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
@@ -90,42 +90,42 @@
           "name": "byte_fvar_glob",
           "kind": "label",
           "address": 256,
-          "line": 8,
+          "line": 7,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 312,
-          "line": 8,
+          "line": 7,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 320,
-          "line": 15,
+          "line": 14,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 341,
-          "line": 15,
+          "line": 14,
           "scope": "local"
         },
         {
           "name": "glob_bytes",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
           "name": "glob_idx_word",
           "kind": "data",
           "address": 8200,
-          "line": 4,
+          "line": 3,
           "scope": "global"
         },
         {
@@ -156,7 +156,7 @@
       "kind": "label",
       "address": 256,
       "file": "42_byte_fvar_glob.zax",
-      "line": 8,
+      "line": 7,
       "scope": "global"
     },
     {
@@ -164,7 +164,7 @@
       "kind": "label",
       "address": 312,
       "file": "42_byte_fvar_glob.zax",
-      "line": 8,
+      "line": 7,
       "scope": "local"
     },
     {
@@ -172,7 +172,7 @@
       "kind": "label",
       "address": 320,
       "file": "42_byte_fvar_glob.zax",
-      "line": 15,
+      "line": 14,
       "scope": "global"
     },
     {
@@ -180,7 +180,7 @@
       "kind": "label",
       "address": 341,
       "file": "42_byte_fvar_glob.zax",
-      "line": 15,
+      "line": 14,
       "scope": "local"
     },
     {
@@ -188,7 +188,7 @@
       "kind": "data",
       "address": 8192,
       "file": "42_byte_fvar_glob.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {
@@ -196,7 +196,7 @@
       "kind": "data",
       "address": 8200,
       "file": "42_byte_fvar_glob.zax",
-      "line": 4,
+      "line": 3,
       "scope": "global"
     },
     {

--- a/examples/language-tour/42_byte_fvar_glob.zax
+++ b/examples/language-tour/42_byte_fvar_glob.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_bytes: byte[8] = { 0,1,2,3,4,5,6,7 }
     glob_idx_word: word = 6
 end

--- a/examples/language-tour/43_byte_glob_glob.d8dbg.json
+++ b/examples/language-tour/43_byte_glob_glob.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,56 +24,56 @@
         {
           "start": 267,
           "end": 281,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 281,
           "end": 297,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 297,
           "end": 299,
-          "lstLine": 11,
+          "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 299,
           "end": 300,
-          "lstLine": 12,
+          "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 300,
           "end": 308,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 308,
           "end": 320,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 320,
           "end": 323,
-          "lstLine": 16,
+          "lstLine": 15,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 323,
           "end": 332,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
@@ -90,42 +90,42 @@
           "name": "byte_glob_glob",
           "kind": "label",
           "address": 256,
-          "line": 8,
+          "line": 7,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 300,
-          "line": 8,
+          "line": 7,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 308,
-          "line": 15,
+          "line": 14,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 323,
-          "line": 15,
+          "line": 14,
           "scope": "local"
         },
         {
           "name": "glob_bytes",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
           "name": "glob_idx_word",
           "kind": "data",
           "address": 8200,
-          "line": 4,
+          "line": 3,
           "scope": "global"
         },
         {
@@ -156,7 +156,7 @@
       "kind": "label",
       "address": 256,
       "file": "43_byte_glob_glob.zax",
-      "line": 8,
+      "line": 7,
       "scope": "global"
     },
     {
@@ -164,7 +164,7 @@
       "kind": "label",
       "address": 300,
       "file": "43_byte_glob_glob.zax",
-      "line": 8,
+      "line": 7,
       "scope": "local"
     },
     {
@@ -172,7 +172,7 @@
       "kind": "label",
       "address": 308,
       "file": "43_byte_glob_glob.zax",
-      "line": 15,
+      "line": 14,
       "scope": "global"
     },
     {
@@ -180,7 +180,7 @@
       "kind": "label",
       "address": 323,
       "file": "43_byte_glob_glob.zax",
-      "line": 15,
+      "line": 14,
       "scope": "local"
     },
     {
@@ -188,7 +188,7 @@
       "kind": "data",
       "address": 8192,
       "file": "43_byte_glob_glob.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {
@@ -196,7 +196,7 @@
       "kind": "data",
       "address": 8200,
       "file": "43_byte_glob_glob.zax",
-      "line": 4,
+      "line": 3,
       "scope": "global"
     },
     {

--- a/examples/language-tour/43_byte_glob_glob.zax
+++ b/examples/language-tour/43_byte_glob_glob.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_bytes: byte[8] = { 0,1,2,3,4,5,6,7 }
     glob_idx_word: word = 4
 end

--- a/examples/language-tour/60_word_glob_const.d8dbg.json
+++ b/examples/language-tour/60_word_glob_const.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,42 +24,42 @@
         {
           "start": 267,
           "end": 270,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 270,
           "end": 285,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 285,
           "end": 293,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 293,
           "end": 305,
-          "lstLine": 12,
+          "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 305,
           "end": 308,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 308,
           "end": 317,
-          "lstLine": 12,
+          "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
@@ -76,35 +76,35 @@
           "name": "word_glob_const",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 285,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 293,
-          "line": 12,
+          "line": 11,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 308,
-          "line": 12,
+          "line": 11,
           "scope": "local"
         },
         {
           "name": "glob_words",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -135,7 +135,7 @@
       "kind": "label",
       "address": 256,
       "file": "60_word_glob_const.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -143,7 +143,7 @@
       "kind": "label",
       "address": 285,
       "file": "60_word_glob_const.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -151,7 +151,7 @@
       "kind": "label",
       "address": 293,
       "file": "60_word_glob_const.zax",
-      "line": 12,
+      "line": 11,
       "scope": "global"
     },
     {
@@ -159,7 +159,7 @@
       "kind": "label",
       "address": 308,
       "file": "60_word_glob_const.zax",
-      "line": 12,
+      "line": 11,
       "scope": "local"
     },
     {
@@ -167,7 +167,7 @@
       "kind": "data",
       "address": 8192,
       "file": "60_word_glob_const.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/60_word_glob_const.zax
+++ b/examples/language-tour/60_word_glob_const.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_words: word[8] = { $1001,$1002,$1003,$1004,$1005,$1006,$1007,$1008 }
 end
 

--- a/examples/language-tour/61_word_glob_reg8.d8dbg.json
+++ b/examples/language-tour/61_word_glob_reg8.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,42 +24,42 @@
         {
           "start": 267,
           "end": 287,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 287,
           "end": 307,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 307,
           "end": 315,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 315,
           "end": 327,
-          "lstLine": 12,
+          "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 327,
           "end": 336,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 336,
           "end": 345,
-          "lstLine": 12,
+          "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
@@ -76,35 +76,35 @@
           "name": "word_glob_reg",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 307,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 315,
-          "line": 12,
+          "line": 11,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 336,
-          "line": 12,
+          "line": 11,
           "scope": "local"
         },
         {
           "name": "glob_words",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -135,7 +135,7 @@
       "kind": "label",
       "address": 256,
       "file": "61_word_glob_reg8.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -143,7 +143,7 @@
       "kind": "label",
       "address": 307,
       "file": "61_word_glob_reg8.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -151,7 +151,7 @@
       "kind": "label",
       "address": 315,
       "file": "61_word_glob_reg8.zax",
-      "line": 12,
+      "line": 11,
       "scope": "global"
     },
     {
@@ -159,7 +159,7 @@
       "kind": "label",
       "address": 336,
       "file": "61_word_glob_reg8.zax",
-      "line": 12,
+      "line": 11,
       "scope": "local"
     },
     {
@@ -167,7 +167,7 @@
       "kind": "data",
       "address": 8192,
       "file": "61_word_glob_reg8.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/61_word_glob_reg8.zax
+++ b/examples/language-tour/61_word_glob_reg8.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_words: word[8] = { $2001,$2002,$2003,$2004,$2005,$2006,$2007,$2008 }
 end
 

--- a/examples/language-tour/62_word_glob_reg16.d8dbg.json
+++ b/examples/language-tour/62_word_glob_reg16.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,56 +24,56 @@
         {
           "start": 267,
           "end": 275,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 275,
           "end": 288,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 288,
           "end": 300,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 300,
           "end": 301,
-          "lstLine": 11,
+          "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 301,
           "end": 309,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 309,
           "end": 321,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 321,
           "end": 330,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 330,
           "end": 339,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
@@ -90,35 +90,35 @@
           "name": "word_glob_reg16",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 301,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 309,
-          "line": 14,
+          "line": 13,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 330,
-          "line": 14,
+          "line": 13,
           "scope": "local"
         },
         {
           "name": "glob_words",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -149,7 +149,7 @@
       "kind": "label",
       "address": 256,
       "file": "62_word_glob_reg16.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -157,7 +157,7 @@
       "kind": "label",
       "address": 301,
       "file": "62_word_glob_reg16.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -165,7 +165,7 @@
       "kind": "label",
       "address": 309,
       "file": "62_word_glob_reg16.zax",
-      "line": 14,
+      "line": 13,
       "scope": "global"
     },
     {
@@ -173,7 +173,7 @@
       "kind": "label",
       "address": 330,
       "file": "62_word_glob_reg16.zax",
-      "line": 14,
+      "line": 13,
       "scope": "local"
     },
     {
@@ -181,7 +181,7 @@
       "kind": "data",
       "address": 8192,
       "file": "62_word_glob_reg16.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/62_word_glob_reg16.zax
+++ b/examples/language-tour/62_word_glob_reg16.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_words: word[8] = { $3001,$3002,$3003,$3004,$3005,$3006,$3007,$3008 }
 end
 

--- a/examples/language-tour/63_word_fvar_const.d8dbg.json
+++ b/examples/language-tour/63_word_fvar_const.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,42 +24,42 @@
         {
           "start": 267,
           "end": 275,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 275,
           "end": 293,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 293,
           "end": 301,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 301,
           "end": 313,
-          "lstLine": 12,
+          "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 313,
           "end": 322,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 322,
           "end": 331,
-          "lstLine": 12,
+          "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
@@ -76,35 +76,35 @@
           "name": "word_fvar_const",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 293,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 301,
-          "line": 12,
+          "line": 11,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 322,
-          "line": 12,
+          "line": 11,
           "scope": "local"
         },
         {
           "name": "glob_words",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -135,7 +135,7 @@
       "kind": "label",
       "address": 256,
       "file": "63_word_fvar_const.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -143,7 +143,7 @@
       "kind": "label",
       "address": 293,
       "file": "63_word_fvar_const.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -151,7 +151,7 @@
       "kind": "label",
       "address": 301,
       "file": "63_word_fvar_const.zax",
-      "line": 12,
+      "line": 11,
       "scope": "global"
     },
     {
@@ -159,7 +159,7 @@
       "kind": "label",
       "address": 322,
       "file": "63_word_fvar_const.zax",
-      "line": 12,
+      "line": 11,
       "scope": "local"
     },
     {
@@ -167,7 +167,7 @@
       "kind": "data",
       "address": 8192,
       "file": "63_word_fvar_const.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/63_word_fvar_const.zax
+++ b/examples/language-tour/63_word_fvar_const.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_words: word[8] = { $4001,$4002,$4003,$4004,$4005,$4006,$4007,$4008 }
 end
 

--- a/examples/language-tour/64_word_fvar_reg8.d8dbg.json
+++ b/examples/language-tour/64_word_fvar_reg8.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,49 +24,49 @@
         {
           "start": 267,
           "end": 291,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 291,
           "end": 314,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 314,
           "end": 315,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 315,
           "end": 323,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 323,
           "end": 335,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 335,
           "end": 350,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 350,
           "end": 359,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
@@ -83,35 +83,35 @@
           "name": "word_fvar_reg",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 315,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 323,
-          "line": 13,
+          "line": 12,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 350,
-          "line": 13,
+          "line": 12,
           "scope": "local"
         },
         {
           "name": "glob_words",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -142,7 +142,7 @@
       "kind": "label",
       "address": 256,
       "file": "64_word_fvar_reg8.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -150,7 +150,7 @@
       "kind": "label",
       "address": 315,
       "file": "64_word_fvar_reg8.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -158,7 +158,7 @@
       "kind": "label",
       "address": 323,
       "file": "64_word_fvar_reg8.zax",
-      "line": 13,
+      "line": 12,
       "scope": "global"
     },
     {
@@ -166,7 +166,7 @@
       "kind": "label",
       "address": 350,
       "file": "64_word_fvar_reg8.zax",
-      "line": 13,
+      "line": 12,
       "scope": "local"
     },
     {
@@ -174,7 +174,7 @@
       "kind": "data",
       "address": 8192,
       "file": "64_word_fvar_reg8.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/64_word_fvar_reg8.zax
+++ b/examples/language-tour/64_word_fvar_reg8.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_words: word[8] = { $5001,$5002,$5003,$5004,$5005,$5006,$5007,$5008 }
 end
 

--- a/examples/language-tour/65_word_fvar_reg16.d8dbg.json
+++ b/examples/language-tour/65_word_fvar_reg16.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,63 +24,63 @@
         {
           "start": 267,
           "end": 275,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 275,
           "end": 294,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 294,
           "end": 311,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 311,
           "end": 312,
-          "lstLine": 11,
+          "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 312,
           "end": 313,
-          "lstLine": 12,
+          "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 313,
           "end": 321,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 321,
           "end": 333,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 333,
           "end": 348,
-          "lstLine": 16,
+          "lstLine": 15,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 348,
           "end": 357,
-          "lstLine": 15,
+          "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
@@ -97,35 +97,35 @@
           "name": "word_fvar_reg16",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 313,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 321,
-          "line": 15,
+          "line": 14,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 348,
-          "line": 15,
+          "line": 14,
           "scope": "local"
         },
         {
           "name": "glob_words",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -156,7 +156,7 @@
       "kind": "label",
       "address": 256,
       "file": "65_word_fvar_reg16.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -164,7 +164,7 @@
       "kind": "label",
       "address": 313,
       "file": "65_word_fvar_reg16.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -172,7 +172,7 @@
       "kind": "label",
       "address": 321,
       "file": "65_word_fvar_reg16.zax",
-      "line": 15,
+      "line": 14,
       "scope": "global"
     },
     {
@@ -180,7 +180,7 @@
       "kind": "label",
       "address": 348,
       "file": "65_word_fvar_reg16.zax",
-      "line": 15,
+      "line": 14,
       "scope": "local"
     },
     {
@@ -188,7 +188,7 @@
       "kind": "data",
       "address": 8192,
       "file": "65_word_fvar_reg16.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/65_word_fvar_reg16.zax
+++ b/examples/language-tour/65_word_fvar_reg16.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_words: word[8] = { $6001,$6002,$6003,$6004,$6005,$6006,$6007,$6008 }
 end
 

--- a/examples/language-tour/66_word_glob_fvar.d8dbg.json
+++ b/examples/language-tour/66_word_glob_fvar.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,42 +24,42 @@
         {
           "start": 267,
           "end": 287,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 287,
           "end": 307,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 307,
           "end": 315,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 315,
           "end": 327,
-          "lstLine": 12,
+          "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 327,
           "end": 336,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 336,
           "end": 345,
-          "lstLine": 12,
+          "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
@@ -76,35 +76,35 @@
           "name": "word_glob_fvar",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 307,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 315,
-          "line": 12,
+          "line": 11,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 336,
-          "line": 12,
+          "line": 11,
           "scope": "local"
         },
         {
           "name": "glob_words",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -135,7 +135,7 @@
       "kind": "label",
       "address": 256,
       "file": "66_word_glob_fvar.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -143,7 +143,7 @@
       "kind": "label",
       "address": 307,
       "file": "66_word_glob_fvar.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -151,7 +151,7 @@
       "kind": "label",
       "address": 315,
       "file": "66_word_glob_fvar.zax",
-      "line": 12,
+      "line": 11,
       "scope": "global"
     },
     {
@@ -159,7 +159,7 @@
       "kind": "label",
       "address": 336,
       "file": "66_word_glob_fvar.zax",
-      "line": 12,
+      "line": 11,
       "scope": "local"
     },
     {
@@ -167,7 +167,7 @@
       "kind": "data",
       "address": 8192,
       "file": "66_word_glob_fvar.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/66_word_glob_fvar.zax
+++ b/examples/language-tour/66_word_glob_fvar.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_words: word[8] = { $7001,$7002,$7003,$7004,$7005,$7006,$7007,$7008 }
 end
 

--- a/examples/language-tour/67_word_fvar_fvar.d8dbg.json
+++ b/examples/language-tour/67_word_fvar_fvar.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,49 +24,49 @@
         {
           "start": 267,
           "end": 291,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 291,
           "end": 314,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 314,
           "end": 315,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 315,
           "end": 323,
-          "lstLine": 7,
+          "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 323,
           "end": 335,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 335,
           "end": 350,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 350,
           "end": 359,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
@@ -83,35 +83,35 @@
           "name": "word_fvar_fvar",
           "kind": "label",
           "address": 256,
-          "line": 7,
+          "line": 6,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 315,
-          "line": 7,
+          "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 323,
-          "line": 13,
+          "line": 12,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 350,
-          "line": 13,
+          "line": 12,
           "scope": "local"
         },
         {
           "name": "glob_words",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
@@ -142,7 +142,7 @@
       "kind": "label",
       "address": 256,
       "file": "67_word_fvar_fvar.zax",
-      "line": 7,
+      "line": 6,
       "scope": "global"
     },
     {
@@ -150,7 +150,7 @@
       "kind": "label",
       "address": 315,
       "file": "67_word_fvar_fvar.zax",
-      "line": 7,
+      "line": 6,
       "scope": "local"
     },
     {
@@ -158,7 +158,7 @@
       "kind": "label",
       "address": 323,
       "file": "67_word_fvar_fvar.zax",
-      "line": 13,
+      "line": 12,
       "scope": "global"
     },
     {
@@ -166,7 +166,7 @@
       "kind": "label",
       "address": 350,
       "file": "67_word_fvar_fvar.zax",
-      "line": 13,
+      "line": 12,
       "scope": "local"
     },
     {
@@ -174,7 +174,7 @@
       "kind": "data",
       "address": 8192,
       "file": "67_word_fvar_fvar.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {

--- a/examples/language-tour/67_word_fvar_fvar.zax
+++ b/examples/language-tour/67_word_fvar_fvar.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_words: word[8] = { $8001,$8002,$8003,$8004,$8005,$8006,$8007,$8008 }
 end
 

--- a/examples/language-tour/68_word_fvar_glob.d8dbg.json
+++ b/examples/language-tour/68_word_fvar_glob.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,42 +24,42 @@
         {
           "start": 267,
           "end": 285,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 285,
           "end": 303,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 303,
           "end": 311,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 311,
           "end": 323,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 323,
           "end": 332,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 332,
           "end": 341,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
@@ -76,42 +76,42 @@
           "name": "word_fvar_glob",
           "kind": "label",
           "address": 256,
-          "line": 8,
+          "line": 7,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 303,
-          "line": 8,
+          "line": 7,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 311,
-          "line": 13,
+          "line": 12,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 332,
-          "line": 13,
+          "line": 12,
           "scope": "local"
         },
         {
           "name": "glob_words",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
           "name": "glob_idx_word",
           "kind": "data",
           "address": 8208,
-          "line": 4,
+          "line": 3,
           "scope": "global"
         },
         {
@@ -142,7 +142,7 @@
       "kind": "label",
       "address": 256,
       "file": "68_word_fvar_glob.zax",
-      "line": 8,
+      "line": 7,
       "scope": "global"
     },
     {
@@ -150,7 +150,7 @@
       "kind": "label",
       "address": 303,
       "file": "68_word_fvar_glob.zax",
-      "line": 8,
+      "line": 7,
       "scope": "local"
     },
     {
@@ -158,7 +158,7 @@
       "kind": "label",
       "address": 311,
       "file": "68_word_fvar_glob.zax",
-      "line": 13,
+      "line": 12,
       "scope": "global"
     },
     {
@@ -166,7 +166,7 @@
       "kind": "label",
       "address": 332,
       "file": "68_word_fvar_glob.zax",
-      "line": 13,
+      "line": 12,
       "scope": "local"
     },
     {
@@ -174,7 +174,7 @@
       "kind": "data",
       "address": 8192,
       "file": "68_word_fvar_glob.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {
@@ -182,7 +182,7 @@
       "kind": "data",
       "address": 8208,
       "file": "68_word_fvar_glob.zax",
-      "line": 4,
+      "line": 3,
       "scope": "global"
     },
     {

--- a/examples/language-tour/68_word_fvar_glob.zax
+++ b/examples/language-tour/68_word_fvar_glob.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_words: word[8] = { $9001,$9002,$9003,$9004,$9005,$9006,$9007,$9008 }
     glob_idx_word: word = 6
 end

--- a/examples/language-tour/69_word_glob_glob.d8dbg.json
+++ b/examples/language-tour/69_word_glob_glob.d8dbg.json
@@ -10,7 +10,7 @@
         {
           "start": 256,
           "end": 267,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
@@ -24,42 +24,42 @@
         {
           "start": 267,
           "end": 282,
-          "lstLine": 9,
+          "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 282,
           "end": 297,
-          "lstLine": 10,
+          "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 297,
           "end": 305,
-          "lstLine": 8,
+          "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 305,
           "end": 317,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 317,
           "end": 320,
-          "lstLine": 14,
+          "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
           "start": 320,
           "end": 329,
-          "lstLine": 13,
+          "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
@@ -76,42 +76,42 @@
           "name": "word_glob_glob",
           "kind": "label",
           "address": 256,
-          "line": 8,
+          "line": 7,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
           "address": 297,
-          "line": 8,
+          "line": 7,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
           "address": 305,
-          "line": 13,
+          "line": 12,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
           "address": 320,
-          "line": 13,
+          "line": 12,
           "scope": "local"
         },
         {
           "name": "glob_words",
           "kind": "data",
           "address": 8192,
-          "line": 3,
+          "line": 2,
           "scope": "global"
         },
         {
           "name": "glob_idx_word",
           "kind": "data",
           "address": 8208,
-          "line": 4,
+          "line": 3,
           "scope": "global"
         },
         {
@@ -142,7 +142,7 @@
       "kind": "label",
       "address": 256,
       "file": "69_word_glob_glob.zax",
-      "line": 8,
+      "line": 7,
       "scope": "global"
     },
     {
@@ -150,7 +150,7 @@
       "kind": "label",
       "address": 297,
       "file": "69_word_glob_glob.zax",
-      "line": 8,
+      "line": 7,
       "scope": "local"
     },
     {
@@ -158,7 +158,7 @@
       "kind": "label",
       "address": 305,
       "file": "69_word_glob_glob.zax",
-      "line": 13,
+      "line": 12,
       "scope": "global"
     },
     {
@@ -166,7 +166,7 @@
       "kind": "label",
       "address": 320,
       "file": "69_word_glob_glob.zax",
-      "line": 13,
+      "line": 12,
       "scope": "local"
     },
     {
@@ -174,7 +174,7 @@
       "kind": "data",
       "address": 8192,
       "file": "69_word_glob_glob.zax",
-      "line": 3,
+      "line": 2,
       "scope": "global"
     },
     {
@@ -182,7 +182,7 @@
       "kind": "data",
       "address": 8208,
       "file": "69_word_glob_glob.zax",
-      "line": 4,
+      "line": 3,
       "scope": "global"
     },
     {

--- a/examples/language-tour/69_word_glob_glob.zax
+++ b/examples/language-tour/69_word_glob_glob.zax
@@ -1,5 +1,4 @@
 section data vars at $2000
-  data
     glob_words: word[8] = { $A001,$A002,$A003,$A004,$A005,$A006,$A007,$A008 }
     glob_idx_word: word = 4
 end

--- a/examples/stack_and_structs.zax
+++ b/examples/stack_and_structs.zax
@@ -13,7 +13,6 @@ type Sprite
 end
 
 section data vars at $1000
-  data
   sprites: Sprite[4] = {}
 end
 


### PR DESCRIPTION
## Summary\n- remove section-internal bare  marker lines across \n- regenerate language-tour  artifacts after source line changes\n- keep generated asm shape stable while updating source/trace line mappings\n\n## Why\n- stacks on #611 parser enforcement so examples compile under hard-cut syntax\n- unblocks smoke/example suites that compile language-tour and codegen corpus sources\n\n## Validation\n- 
> zax@0.0.0 typecheck
> tsc -p tsconfig.json --noEmit\n- 
> zax@0.0.0 pretest
> mkdir -p coverage/.tmp


> zax@0.0.0 test
> vitest run --run test/examples_compile.test.ts test/smoke_language_tour_compile.test.ts test/pr374_addressing_modes_mini_suite.test.ts test/pr303_codegen_corpus_expansion.test.ts test/pr312_expected_trace_corpus.test.ts test/pr406_word_eaw_matrix.test.ts


 RUN  v2.1.9 /Users/johnhardy/.codex/worktrees/ce14/ZAX

 ✓ test/pr406_word_eaw_matrix.test.ts (4 tests) 363ms
 ✓ test/pr312_expected_trace_corpus.test.ts (3 tests) 474ms
 ✓ test/examples_compile.test.ts (2 tests) 554ms
 ✓ test/pr303_codegen_corpus_expansion.test.ts (2 tests) 599ms
   ✓ PR303: curated codegen corpus expansion > keeps regenerated asm and hex in sync with the expanded curated manifest 530ms
 ✓ test/smoke_language_tour_compile.test.ts (33 tests) 1060ms
 ✓ test/pr374_addressing_modes_mini_suite.test.ts (24 tests) 1086ms

 Test Files  6 passed (6)
      Tests  68 passed (68)
   Start at  14:41:27
   Duration  6.34s (transform 1.97s, setup 0ms, collect 15.16s, tests 4.14s, environment 2ms, prepare 2.44s)\n\nCloses #612