### PR TITLE
Stabilize CLI contract missing-value matrix timeout

### DIFF
--- a/test/cli_contract_matrix.test.ts
+++ b/test/cli_contract_matrix.test.ts
@@ -67,7 +67,7 @@ describe('cli contract matrix', () => {
     const opStackPolicyMissing = await runCli(['--op-stack-policy']);
     expect(opStackPolicyMissing.code).toBe(2);
     expect(opStackPolicyMissing.stderr).toContain('--op-stack-policy expects a value');
-  });
+  }, 20_000);
 
   it('rejects unsupported type tokens and output/type extension mismatches', async () => {
     const work = await mkdtemp(join(tmpdir(), 'zax-cli-type-'));


### PR DESCRIPTION
## Summary
- increase timeout for `cli contract matrix > rejects missing values for --output/--type/--include/--case-style/--op-stack-policy`
- keep assertion coverage unchanged; this only prevents intermittent timeout flakes under heavy concurrent CI load

## Verification
- `npm test -- --run test/cli_contract_matrix.test.ts`
