### PR TITLE
[v0.4-quality] #618 lowering slice: remove unsafe any casts

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -376,8 +376,9 @@ export function emitProgram(
 
   const emitInstr = (head: string, operands: AsmOperandNode[], span: SourceSpan) => {
     const start = getCurrentCodeOffset();
+    const syntheticInstruction: AsmInstructionNode = { kind: 'AsmInstruction', span, head, operands };
     const encoded = encodeInstruction(
-      { kind: 'AsmInstruction', span, head, operands } as any,
+      syntheticInstruction,
       env,
       diagnostics,
     );

--- a/src/lowering/functionCallLowering.ts
+++ b/src/lowering/functionCallLowering.ts
@@ -6,6 +6,7 @@ import type {
   AsmOperandNode,
   EaExprNode,
   ImmExprNode,
+  OpMatcherNode,
   OpDeclNode,
   ParamNode,
   SourceSpan,
@@ -90,7 +91,7 @@ type Context = {
     id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds],
     message: string,
   ) => void;
-  matcherMatchesOperand: (matcher: any, operand: AsmOperandNode) => boolean;
+  matcherMatchesOperand: (matcher: OpMatcherNode, operand: AsmOperandNode) => boolean;
   formatOpSignature: (op: OpDeclNode) => string;
   formatAsmOperandForOpDiag: (operand: AsmOperandNode) => string;
   firstOpOverloadMismatchReason: (op: OpDeclNode, args: AsmOperandNode[]) => string | undefined;

--- a/src/lowering/opSubstitution.ts
+++ b/src/lowering/opSubstitution.ts
@@ -1,5 +1,12 @@
 import type { Diagnostic } from '../diagnostics/types.js';
-import type { AsmOperandNode, EaExprNode, ImmExprNode, SourceSpan } from '../frontend/ast.js';
+import type {
+  AsmOperandNode,
+  EaExprNode,
+  ImmExprNode,
+  OffsetofPathNode,
+  OffsetofPathStepNode,
+  SourceSpan,
+} from '../frontend/ast.js';
 import type { CompileEnv } from '../semantics/env.js';
 
 type OpSubstitutionContext = {
@@ -16,6 +23,18 @@ type OpSubstitutionContext = {
 };
 
 export function createOpSubstitutionHelpers(ctx: OpSubstitutionContext) {
+  const substituteOffsetofPath = (
+    path: OffsetofPathNode,
+    substituteImmExpr: (expr: ImmExprNode) => ImmExprNode,
+  ): OffsetofPathNode => ({
+    ...path,
+    steps: path.steps.map((step): OffsetofPathStepNode =>
+      step.kind === 'OffsetofIndex'
+        ? { ...step, expr: substituteImmExpr(step.expr) }
+        : { ...step },
+    ),
+  });
+
   const bindingAsImmExpr = (
     bound: AsmOperandNode | undefined,
     span: SourceSpan,
@@ -29,14 +48,6 @@ export function createOpSubstitutionHelpers(ctx: OpSubstitutionContext) {
   };
 
   const substituteImm = (expr: ImmExprNode): ImmExprNode => {
-    const substituteOffsetofPath = (path: any): any => ({
-      ...path,
-      steps: path.steps.map((step: any) =>
-        step.kind === 'OffsetofIndex'
-          ? { ...step, expr: substituteImm(step.expr) }
-          : { ...step },
-      ),
-    });
     if (expr.kind === 'ImmName') {
       const bound = ctx.bindings.get(expr.name.toLowerCase());
       const immBound = bindingAsImmExpr(bound, expr.span);
@@ -44,7 +55,7 @@ export function createOpSubstitutionHelpers(ctx: OpSubstitutionContext) {
       return { ...expr };
     }
     if (expr.kind === 'ImmOffsetof') {
-      return { ...expr, path: substituteOffsetofPath(expr.path) as typeof expr.path };
+      return { ...expr, path: substituteOffsetofPath(expr.path, substituteImm) };
     }
     if (expr.kind === 'ImmUnary') return { ...expr, expr: substituteImm(expr.expr) };
     if (expr.kind === 'ImmBinary') {
@@ -90,14 +101,6 @@ export function createOpSubstitutionHelpers(ctx: OpSubstitutionContext) {
     expr: ImmExprNode,
     localLabelMap: Map<string, string>,
   ): ImmExprNode => {
-    const substituteOffsetofPath = (path: any): any => ({
-      ...path,
-      steps: path.steps.map((step: any) =>
-        step.kind === 'OffsetofIndex'
-          ? { ...step, expr: substituteImmWithOpLabels(step.expr, localLabelMap) }
-          : { ...step },
-      ),
-    });
     if (expr.kind === 'ImmName') {
       const bound = ctx.bindings.get(expr.name.toLowerCase());
       const immBound = bindingAsImmExpr(bound, expr.span);
@@ -107,7 +110,12 @@ export function createOpSubstitutionHelpers(ctx: OpSubstitutionContext) {
       return { ...expr };
     }
     if (expr.kind === 'ImmOffsetof') {
-      return { ...expr, path: substituteOffsetofPath(expr.path) as typeof expr.path };
+      return {
+        ...expr,
+        path: substituteOffsetofPath(expr.path, (inner) =>
+          substituteImmWithOpLabels(inner, localLabelMap),
+        ),
+      };
     }
     if (expr.kind === 'ImmUnary') {
       return { ...expr, expr: substituteImmWithOpLabels(expr.expr, localLabelMap) };


### PR DESCRIPTION
## Summary
First slice for #618, constrained to lowering-only type safety cleanup.

- remove unsafe `any`/`as any` usage from selected `src/lowering/*` boundaries
- keep behavior unchanged (type tightening only)
- no frontend/docs/CI-script changes

## Scope (this slice)
- `src/lowering/opSubstitution.ts`
- `src/lowering/functionCallLowering.ts`
- `src/lowering/emit.ts`

## What changed
- `opSubstitution.ts`
  - replaced `path: any` / `step: any` offset-of substitution helpers with concrete `OffsetofPathNode`/`OffsetofPathStepNode` typing.
- `functionCallLowering.ts`
  - tightened `matcherMatchesOperand` callback type from `any` to `OpMatcherNode`.
- `emit.ts`
  - removed `as any` synthetic instruction handoff by constructing typed `AsmInstructionNode` directly.

## Boundary confirmation
- No `src/frontend/*` changes.
- No docs changes.
- No `scripts/ci/*` changes.

## Verification
- `npm run typecheck` ✅
- `npm test -- --run test/pr510_op_substitution_helpers.test.ts test/pr510_op_expansion_orchestration_helpers.test.ts test/pr510_op_expansion_execution_helpers.test.ts test/pr544_program_lowering_integration.test.ts test/examples_compile.test.ts` ✅

Part of #618.
