### PR TITLE
[v0.6-quality] #636 centralize parser diagnostics helpers

### DIFF
--- a/src/frontend/parseAsmStatements.ts
+++ b/src/frontend/parseAsmStatements.ts
@@ -1,23 +1,8 @@
 import type { AsmItemNode, ImmExprNode, SourceSpan } from './ast.js';
 import type { Diagnostic } from '../diagnostics/types.js';
-import { DiagnosticIds } from '../diagnostics/types.js';
+import { parseDiag as diag } from './parseDiagnostics.js';
 import { immLiteral, parseImmExprFromText } from './parseImm.js';
 import { parseAsmInstruction, parseAsmOperand } from './parseOperands.js';
-
-function diag(
-  diagnostics: Diagnostic[],
-  file: string,
-  message: string,
-  where?: { line: number; column: number },
-): void {
-  diagnostics.push({
-    id: DiagnosticIds.ParseError,
-    severity: 'error',
-    message,
-    file,
-    ...(where ? { line: where.line, column: where.column } : {}),
-  });
-}
 
 function canonicalConditionToken(token: string): string {
   return token.toLowerCase();

--- a/src/frontend/parseData.ts
+++ b/src/frontend/parseData.ts
@@ -2,7 +2,7 @@ import type { DataBlockNode, DataDeclNode, DataRecordFieldInitNode, ImmExprNode 
 import type { SourceFile } from './source.js';
 import { span } from './source.js';
 import type { Diagnostic } from '../diagnostics/types.js';
-import { DiagnosticIds } from '../diagnostics/types.js';
+import { parseDiag as diag } from './parseDiagnostics.js';
 import { parseImmExprFromText, parseTypeExprFromText } from './parseImm.js';
 import {
   TOP_LEVEL_KEYWORDS,
@@ -11,21 +11,6 @@ import {
   isTopLevelStart,
   looksLikeKeywordBodyDeclLine,
 } from './parseModuleCommon.js';
-
-function diag(
-  diagnostics: Diagnostic[],
-  file: string,
-  message: string,
-  where?: { line: number; column: number },
-): void {
-  diagnostics.push({
-    id: DiagnosticIds.ParseError,
-    severity: 'error',
-    message,
-    file,
-    ...(where ? { line: where.line, column: where.column } : {}),
-  });
-}
 
 function stripComment(line: string): string {
   const semi = line.indexOf(';');

--- a/src/frontend/parseDiagnostics.ts
+++ b/src/frontend/parseDiagnostics.ts
@@ -1,0 +1,43 @@
+import type { Diagnostic, DiagnosticId, DiagnosticSeverity } from '../diagnostics/types.js';
+import { DiagnosticIds } from '../diagnostics/types.js';
+
+export type ParseDiagLocation = {
+  line: number;
+  column: number;
+};
+
+export function parseDiag(
+  diagnostics: Diagnostic[],
+  file: string,
+  message: string,
+  where?: ParseDiagLocation,
+): void {
+  parseDiagAtWithId(diagnostics, file, DiagnosticIds.ParseError, 'error', message, where);
+}
+
+export function parseDiagAt(
+  diagnostics: Diagnostic[],
+  file: string,
+  message: string,
+  line: number,
+  column: number,
+): void {
+  parseDiag(diagnostics, file, message, { line, column });
+}
+
+export function parseDiagAtWithId(
+  diagnostics: Diagnostic[],
+  file: string,
+  id: DiagnosticId,
+  severity: DiagnosticSeverity,
+  message: string,
+  where?: ParseDiagLocation,
+): void {
+  diagnostics.push({
+    id,
+    severity,
+    message,
+    file,
+    ...(where ? { line: where.line, column: where.column } : {}),
+  });
+}

--- a/src/frontend/parseEnum.ts
+++ b/src/frontend/parseEnum.ts
@@ -1,22 +1,7 @@
 import type { EnumDeclNode, SourceSpan } from './ast.js';
 import type { Diagnostic } from '../diagnostics/types.js';
-import { DiagnosticIds } from '../diagnostics/types.js';
+import { parseDiag as diag } from './parseDiagnostics.js';
 import { diagInvalidHeaderLine, formatIdentifierToken } from './parseModuleCommon.js';
-
-function diag(
-  diagnostics: Diagnostic[],
-  file: string,
-  message: string,
-  where?: { line: number; column: number },
-): void {
-  diagnostics.push({
-    id: DiagnosticIds.ParseError,
-    severity: 'error',
-    message,
-    file,
-    ...(where ? { line: where.line, column: where.column } : {}),
-  });
-}
 
 type ParseEnumContext = {
   diagnostics: Diagnostic[];

--- a/src/frontend/parseExtern.ts
+++ b/src/frontend/parseExtern.ts
@@ -1,6 +1,6 @@
 import type { ExternFuncNode, ParamNode, SourceSpan } from './ast.js';
 import type { Diagnostic } from '../diagnostics/types.js';
-import { DiagnosticIds } from '../diagnostics/types.js';
+import { parseDiag as diag } from './parseDiagnostics.js';
 import { parseImmExprFromText } from './parseImm.js';
 import {
   diagInvalidHeaderLine,
@@ -8,21 +8,6 @@ import {
   parseReturnRegsFromText,
 } from './parseModuleCommon.js';
 import type { ParseParamsContext } from './parseParams.js';
-
-function diag(
-  diagnostics: Diagnostic[],
-  file: string,
-  message: string,
-  where?: { line: number; column: number },
-): void {
-  diagnostics.push({
-    id: DiagnosticIds.ParseError,
-    severity: 'error',
-    message,
-    file,
-    ...(where ? { line: where.line, column: where.column } : {}),
-  });
-}
 
 type ParseExternFuncContext = {
   diagnostics: Diagnostic[];

--- a/src/frontend/parseExternBlock.ts
+++ b/src/frontend/parseExternBlock.ts
@@ -2,7 +2,7 @@ import type { ExternDeclNode, ExternFuncNode, ParamNode, SourceSpan } from './as
 import type { SourceFile } from './source.js';
 import { span } from './source.js';
 import type { Diagnostic } from '../diagnostics/types.js';
-import { DiagnosticIds } from '../diagnostics/types.js';
+import { parseDiag as diag } from './parseDiagnostics.js';
 import { consumeKeywordPrefix } from './parseModuleCommon.js';
 import {
   diagInvalidBlockLine,
@@ -13,21 +13,6 @@ import {
 } from './parseModuleCommon.js';
 import { parseExternFuncFromTail } from './parseExtern.js';
 import type { ParseParamsContext } from './parseParams.js';
-
-function diag(
-  diagnostics: Diagnostic[],
-  file: string,
-  message: string,
-  where?: { line: number; column: number },
-): void {
-  diagnostics.push({
-    id: DiagnosticIds.ParseError,
-    severity: 'error',
-    message,
-    file,
-    ...(where ? { line: where.line, column: where.column } : {}),
-  });
-}
 
 function stripComment(line: string): string {
   const semi = line.indexOf(';');

--- a/src/frontend/parseFunc.ts
+++ b/src/frontend/parseFunc.ts
@@ -11,7 +11,7 @@ import type {
 import type { SourceFile } from './source.js';
 import { span } from './source.js';
 import type { Diagnostic } from '../diagnostics/types.js';
-import { DiagnosticIds } from '../diagnostics/types.js';
+import { parseDiag as diag } from './parseDiagnostics.js';
 import {
   appendParsedAsmStatement,
   isRecoverOnlyControlFrame,
@@ -28,21 +28,6 @@ import {
   topLevelStartKeyword,
 } from './parseModuleCommon.js';
 import type { ParseParamsContext } from './parseParams.js';
-
-function diag(
-  diagnostics: Diagnostic[],
-  file: string,
-  message: string,
-  where?: { line: number; column: number },
-): void {
-  diagnostics.push({
-    id: DiagnosticIds.ParseError,
-    severity: 'error',
-    message,
-    file,
-    ...(where ? { line: where.line, column: where.column } : {}),
-  });
-}
 
 function stripComment(line: string): string {
   const semi = line.indexOf(';');

--- a/src/frontend/parseGlobals.ts
+++ b/src/frontend/parseGlobals.ts
@@ -2,7 +2,7 @@ import type { VarBlockNode, VarDeclNode } from './ast.js';
 import type { SourceFile } from './source.js';
 import { span } from './source.js';
 import type { Diagnostic } from '../diagnostics/types.js';
-import { DiagnosticIds } from '../diagnostics/types.js';
+import { parseDiag as diag } from './parseDiagnostics.js';
 import {
   TOP_LEVEL_KEYWORDS,
   diagInvalidBlockLine,
@@ -10,21 +10,6 @@ import {
   looksLikeKeywordBodyDeclLine,
   parseVarDeclLine,
 } from './parseModuleCommon.js';
-
-function diag(
-  diagnostics: Diagnostic[],
-  file: string,
-  message: string,
-  where?: { line: number; column: number },
-): void {
-  diagnostics.push({
-    id: DiagnosticIds.ParseError,
-    severity: 'error',
-    message,
-    file,
-    ...(where ? { line: where.line, column: where.column } : {}),
-  });
-}
 
 function stripComment(line: string): string {
   const semi = line.indexOf(';');

--- a/src/frontend/parseImm.ts
+++ b/src/frontend/parseImm.ts
@@ -1,25 +1,10 @@
 import type { ImmExprNode, OffsetofPathNode, SourceSpan, TypeExprNode } from './ast.js';
 import type { Diagnostic } from '../diagnostics/types.js';
-import { DiagnosticIds } from '../diagnostics/types.js';
+import { parseDiag as diag } from './parseDiagnostics.js';
 
 type ImmUnaryOp = Extract<ImmExprNode, { kind: 'ImmUnary' }>['op'];
 type ImmBinaryOp = Extract<ImmExprNode, { kind: 'ImmBinary' }>['op'];
 type ImmOpToken = ImmUnaryOp | ImmBinaryOp;
-
-function diag(
-  diagnostics: Diagnostic[],
-  file: string,
-  message: string,
-  where?: { line: number; column: number },
-): void {
-  diagnostics.push({
-    id: DiagnosticIds.ParseError,
-    severity: 'error',
-    message,
-    file,
-    ...(where ? { line: where.line, column: where.column } : {}),
-  });
-}
 
 export function immLiteral(filePath: string, s: SourceSpan, value: number): ImmExprNode {
   return { kind: 'ImmLiteral', span: { ...s, file: filePath }, value };

--- a/src/frontend/parseModuleCommon.ts
+++ b/src/frontend/parseModuleCommon.ts
@@ -1,27 +1,12 @@
 import type { SourceSpan, VarDeclInitializerNode, VarDeclNode } from './ast.js';
 import type { Diagnostic } from '../diagnostics/types.js';
-import { DiagnosticIds } from '../diagnostics/types.js';
+import { parseDiag as diag } from './parseDiagnostics.js';
 import {
   diagIfInferredArrayLengthNotAllowed,
   parseImmExprFromText,
   parseTypeExprFromText,
 } from './parseImm.js';
 import { parseEaExprFromText } from './parseOperands.js';
-
-function diag(
-  diagnostics: Diagnostic[],
-  file: string,
-  message: string,
-  where?: { line: number; column: number },
-): void {
-  diagnostics.push({
-    id: DiagnosticIds.ParseError,
-    severity: 'error',
-    message,
-    file,
-    ...(where ? { line: where.line, column: where.column } : {}),
-  });
-}
 
 export const TOP_LEVEL_KEYWORDS = new Set([
   'func',

--- a/src/frontend/parseOp.ts
+++ b/src/frontend/parseOp.ts
@@ -2,7 +2,7 @@ import type { AsmBlockNode, AsmItemNode, OpDeclNode, OpParamNode, SourceSpan } f
 import type { SourceFile } from './source.js';
 import { span } from './source.js';
 import type { Diagnostic } from '../diagnostics/types.js';
-import { DiagnosticIds } from '../diagnostics/types.js';
+import { parseDiag as diag } from './parseDiagnostics.js';
 import {
   appendParsedAsmStatement,
   isRecoverOnlyControlFrame,
@@ -16,21 +16,6 @@ import {
   topLevelStartKeyword,
 } from './parseModuleCommon.js';
 import type { ParseParamsContext } from './parseParams.js';
-
-function diag(
-  diagnostics: Diagnostic[],
-  file: string,
-  message: string,
-  where?: { line: number; column: number },
-): void {
-  diagnostics.push({
-    id: DiagnosticIds.ParseError,
-    severity: 'error',
-    message,
-    file,
-    ...(where ? { line: where.line, column: where.column } : {}),
-  });
-}
 
 function stripComment(line: string): string {
   const semi = line.indexOf(';');

--- a/src/frontend/parseOperands.ts
+++ b/src/frontend/parseOperands.ts
@@ -8,21 +8,7 @@ import type {
 import type { Diagnostic } from '../diagnostics/types.js';
 import { DiagnosticIds } from '../diagnostics/types.js';
 import { immLiteral, parseImmExprFromText, parseNumberLiteral } from './parseImm.js';
-
-function diag(
-  diagnostics: Diagnostic[],
-  file: string,
-  message: string,
-  where?: { line: number; column: number },
-): void {
-  diagnostics.push({
-    id: DiagnosticIds.ParseError,
-    severity: 'error',
-    message,
-    file,
-    ...(where ? { line: where.line, column: where.column } : {}),
-  });
-}
+import { parseDiag as diag, parseDiagAtWithId } from './parseDiagnostics.js';
 
 function parseBalancedBracketContent(text: string): { inside: string; rest: string } | undefined {
   if (!text.startsWith('[')) return undefined;
@@ -81,14 +67,14 @@ export function parseEaIndexFromText(
     if (!/[A-Za-z_]/.test(inner)) {
       const grouped = parseImmExprFromText(filePath, inner, indexSpan, diagnostics, false);
       if (grouped) {
-        diagnostics.push({
-          id: DiagnosticIds.IndexParenRedundant,
-          severity: 'warning',
-          message: `Redundant outer parentheses in constant index expression "${t}".`,
-          file: indexSpan.file,
-          line: indexSpan.start.line,
-          column: indexSpan.start.column,
-        });
+        parseDiagAtWithId(
+          diagnostics,
+          indexSpan.file,
+          DiagnosticIds.IndexParenRedundant,
+          'warning',
+          `Redundant outer parentheses in constant index expression "${t}".`,
+          { line: indexSpan.start.line, column: indexSpan.start.column },
+        );
       }
     }
   }

--- a/src/frontend/parseParams.ts
+++ b/src/frontend/parseParams.ts
@@ -1,22 +1,7 @@
 import type { OpMatcherNode, OpParamNode, ParamNode, SourceSpan, TypeExprNode } from './ast.js';
 import type { Diagnostic } from '../diagnostics/types.js';
-import { DiagnosticIds } from '../diagnostics/types.js';
+import { parseDiag as diag } from './parseDiagnostics.js';
 import { parseTypeExprFromText } from './parseImm.js';
-
-function diag(
-  diagnostics: Diagnostic[],
-  file: string,
-  message: string,
-  where?: { line: number; column: number },
-): void {
-  diagnostics.push({
-    id: DiagnosticIds.ParseError,
-    severity: 'error',
-    message,
-    file,
-    ...(where ? { line: where.line, column: where.column } : {}),
-  });
-}
 
 export type ParseParamsContext = {
   isReservedTopLevelName: (name: string) => boolean;

--- a/src/frontend/parseParserShared.ts
+++ b/src/frontend/parseParserShared.ts
@@ -1,6 +1,3 @@
-import type { Diagnostic } from '../diagnostics/types.js';
-import { DiagnosticIds } from '../diagnostics/types.js';
-
 const RESERVED_TOP_LEVEL_KEYWORDS = new Set([
   'func',
   'const',
@@ -21,21 +18,6 @@ const RESERVED_TOP_LEVEL_KEYWORDS = new Set([
 
 export function isReservedTopLevelDeclName(name: string): boolean {
   return RESERVED_TOP_LEVEL_KEYWORDS.has(name.toLowerCase());
-}
-
-export function pushParseError(
-  diagnostics: Diagnostic[],
-  file: string,
-  message: string,
-  where?: { line: number; column: number },
-): void {
-  diagnostics.push({
-    id: DiagnosticIds.ParseError,
-    severity: 'error',
-    message,
-    file,
-    ...(where ? { line: where.line, column: where.column } : {}),
-  });
 }
 
 export function stripLineComment(line: string): string {

--- a/src/frontend/parseTopLevelSimple.ts
+++ b/src/frontend/parseTopLevelSimple.ts
@@ -8,24 +8,9 @@ import type {
   SourceSpan,
 } from './ast.js';
 import type { Diagnostic } from '../diagnostics/types.js';
-import { DiagnosticIds } from '../diagnostics/types.js';
+import { parseDiag as diag } from './parseDiagnostics.js';
 import { parseImmExprFromText } from './parseImm.js';
 import { diagInvalidHeaderLine, formatIdentifierToken } from './parseModuleCommon.js';
-
-function diag(
-  diagnostics: Diagnostic[],
-  file: string,
-  message: string,
-  where?: { line: number; column: number },
-): void {
-  diagnostics.push({
-    id: DiagnosticIds.ParseError,
-    severity: 'error',
-    message,
-    file,
-    ...(where ? { line: where.line, column: where.column } : {}),
-  });
-}
 
 type SimpleTopLevelContext = {
   diagnostics: Diagnostic[];

--- a/src/frontend/parseTypes.ts
+++ b/src/frontend/parseTypes.ts
@@ -2,7 +2,7 @@ import type { RecordFieldNode, SourceSpan, TypeDeclNode, UnionDeclNode } from '.
 import type { SourceFile } from './source.js';
 import { span } from './source.js';
 import type { Diagnostic } from '../diagnostics/types.js';
-import { DiagnosticIds } from '../diagnostics/types.js';
+import { parseDiag as diag } from './parseDiagnostics.js';
 import { diagIfInferredArrayLengthNotAllowed, parseTypeExprFromText } from './parseImm.js';
 import {
   diagInvalidBlockLine,
@@ -11,21 +11,6 @@ import {
   looksLikeKeywordBodyDeclLine,
   topLevelStartKeyword,
 } from './parseModuleCommon.js';
-
-function diag(
-  diagnostics: Diagnostic[],
-  file: string,
-  message: string,
-  where?: { line: number; column: number },
-): void {
-  diagnostics.push({
-    id: DiagnosticIds.ParseError,
-    severity: 'error',
-    message,
-    file,
-    ...(where ? { line: where.line, column: where.column } : {}),
-  });
-}
 
 function stripComment(line: string): string {
   const semi = line.indexOf(';');

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -41,9 +41,9 @@ import { parseDataBlock, parseDataDeclLine } from './parseData.js';
 import { canonicalModuleId } from '../moduleIdentity.js';
 import {
   isReservedTopLevelDeclName,
-  pushParseError as diag,
   stripLineComment as stripComment,
 } from './parseParserShared.js';
+import { parseDiag as diag } from './parseDiagnostics.js';
 
 /**
  * Parse a single `.zax` module file from an in-memory source string.

--- a/test/pr636_parse_diagnostics_helpers.test.ts
+++ b/test/pr636_parse_diagnostics_helpers.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { DiagnosticIds } from '../src/diagnostics/types.js';
+import { parseDiag, parseDiagAt, parseDiagAtWithId } from '../src/frontend/parseDiagnostics.js';
+
+describe('PR636 parser diagnostics helpers', () => {
+  it('emits parse errors with default parse ID/severity', () => {
+    const diagnostics: Diagnostic[] = [];
+    parseDiag(diagnostics, 'pr636.zax', 'broken thing');
+
+    expect(diagnostics).toEqual([
+      {
+        id: DiagnosticIds.ParseError,
+        severity: 'error',
+        message: 'broken thing',
+        file: 'pr636.zax',
+      },
+    ]);
+  });
+
+  it('emits parse errors at explicit locations', () => {
+    const diagnostics: Diagnostic[] = [];
+    parseDiagAt(diagnostics, 'pr636.zax', 'broken thing', 12, 7);
+
+    expect(diagnostics).toEqual([
+      {
+        id: DiagnosticIds.ParseError,
+        severity: 'error',
+        message: 'broken thing',
+        file: 'pr636.zax',
+        line: 12,
+        column: 7,
+      },
+    ]);
+  });
+
+  it('supports explicit IDs and severities', () => {
+    const diagnostics: Diagnostic[] = [];
+    parseDiagAtWithId(
+      diagnostics,
+      'pr636.zax',
+      DiagnosticIds.IndexParenRedundant,
+      'warning',
+      'redundant parens',
+      { line: 3, column: 9 },
+    );
+
+    expect(diagnostics).toEqual([
+      {
+        id: DiagnosticIds.IndexParenRedundant,
+        severity: 'warning',
+        message: 'redundant parens',
+        file: 'pr636.zax',
+        line: 3,
+        column: 9,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `src/frontend/parseDiagnostics.ts` with shared `parseDiag`, `parseDiagAt`, and `parseDiagAtWithId` helpers
- remove private `diag(...)` helper copies across frontend parse modules
- switch parser warning emission in `parseOperands.ts` to the shared helper path
- add focused helper coverage in `test/pr636_parse_diagnostics_helpers.test.ts`

## Verification
- `npm run typecheck`
- `npm test -- --run test/pr636_parse_diagnostics_helpers.test.ts test/pr476_parse_imm_helpers.test.ts test/pr476_parse_operands_helpers.test.ts test/pr476_parse_data_helpers.test.ts test/pr476_parse_func_helpers.test.ts test/pr476_parse_module_common_helpers.test.ts test/pr277_index_redundant_paren_warning.test.ts test/pr611_parser_data_marker_enforcement.test.ts`

Closes #636
