### PR TITLE
[v0.6-quality] #637 make exported field consistent on AST decl nodes

### DIFF
--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -155,7 +155,7 @@ export interface AlignDirectiveNode extends BaseNode {
 export interface TypeDeclNode extends BaseNode {
   kind: 'TypeDecl';
   name: string;
-  exported?: boolean;
+  exported: boolean;
   typeExpr: TypeExprNode;
 }
 
@@ -165,7 +165,7 @@ export interface TypeDeclNode extends BaseNode {
 export interface UnionDeclNode extends BaseNode {
   kind: 'UnionDecl';
   name: string;
-  exported?: boolean;
+  exported: boolean;
   fields: RecordFieldNode[];
 }
 
@@ -175,7 +175,7 @@ export interface UnionDeclNode extends BaseNode {
 export interface EnumDeclNode extends BaseNode {
   kind: 'EnumDecl';
   name: string;
-  exported?: boolean;
+  exported: boolean;
   members: string[];
 }
 

--- a/test/semantics_layout.test.ts
+++ b/test/semantics_layout.test.ts
@@ -29,6 +29,7 @@ const typeDecl = (name: string, typeExpr: TypeExprNode): TypeDeclNode => ({
   kind: 'TypeDecl',
   span: s(),
   name,
+  exported: false,
   typeExpr,
 });
 
@@ -36,6 +37,7 @@ const unionDecl = (name: string, fields: RecordFieldNode[]): UnionDeclNode => ({
   kind: 'UnionDecl',
   span: s(),
   name,
+  exported: false,
   fields,
 });
 

--- a/test/semantics_layout_extra.test.ts
+++ b/test/semantics_layout_extra.test.ts
@@ -44,6 +44,7 @@ describe('semantics/layout', () => {
       kind: 'UnionDecl',
       span,
       name: 'U',
+      exported: false,
       fields: [recordField('a', byteType), recordField('b', wordType)],
     };
     const env: CompileEnv = { ...emptyEnv, types: new Map([['U', unionDecl]]) };
@@ -64,6 +65,7 @@ describe('semantics/layout', () => {
       kind: 'TypeDecl',
       span,
       name: 'Self',
+      exported: false,
       typeExpr: { kind: 'TypeName', span, name: 'Self' },
     };
     const env: CompileEnv = { ...emptyEnv, types: new Map([['Self', selfDecl]]) };
@@ -78,6 +80,7 @@ describe('semantics/layout', () => {
       kind: 'TypeDecl',
       span,
       name: 'Point',
+      exported: false,
       typeExpr: {
         kind: 'RecordType',
         span,


### PR DESCRIPTION
## Summary
- make `TypeDeclNode.exported`, `UnionDeclNode.exported`, and `EnumDeclNode.exported` required booleans in `src/frontend/ast.ts`
- preserve parser construction behavior (all parse sites already pass explicit boolean)
- update semantic layout test fixtures that construct AST nodes directly to set `exported: false`

## Verification
- `npm run typecheck`
- `npm test -- --run test/pr476_parse_types_helpers.test.ts test/pr476_parse_enum_helpers.test.ts test/pr575_module_visibility_scaffolding.test.ts test/semantics_layout.test.ts test/semantics_layout_extra.test.ts test/smoke_language_tour_compile.test.ts`

Closes #637
