### PR TITLE
[v0.6-quality] #638 disambiguate FuncDecl returnRegs representation

### DIFF
--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -292,7 +292,7 @@ export interface FuncDeclNode extends BaseNode {
   name: string;
   exported: boolean;
   params: ParamNode[];
-  returnRegs?: string[];
+  returnRegs: string[];
   locals?: VarBlockNode;
   asm: AsmBlockNode;
 }

--- a/src/frontend/parseFunc.ts
+++ b/src/frontend/parseFunc.ts
@@ -118,10 +118,8 @@ export function parseTopLevelFuncDecl(
 
   const funcStartOffset = stmtSpan.start.offset;
   const afterClose = header.slice(closeParen + 1).trimStart();
-  let returnRegs: string[] | undefined;
-  if (afterClose.length === 0) {
-    returnRegs = [];
-  } else {
+  let returnRegs: string[] = [];
+  if (afterClose.length !== 0) {
     const retMatch = /^:\s*(.+)$/.exec(afterClose);
     if (!retMatch) {
       diag(diagnostics, modulePath, `Invalid func header: expected ": <return registers>"`, {
@@ -339,7 +337,7 @@ export function parseTopLevelFuncDecl(
           name,
           exported,
           params,
-          ...(returnRegs ? { returnRegs } : {}),
+          returnRegs,
           ...(locals ? { locals } : {}),
           asm,
         },

--- a/src/lowering/functionLowering.ts
+++ b/src/lowering/functionLowering.ts
@@ -199,7 +199,7 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
   localAliasTargets.clear();
 
   const localDecls = item.locals?.decls ?? [];
-  const returnRegs = (item.returnRegs ?? []).map((r: string) => r.toUpperCase());
+  const returnRegs = item.returnRegs.map((r: string) => r.toUpperCase());
   const basePreserveOrder: string[] = ['AF', 'BC', 'DE', 'HL'];
   let preserveSet = basePreserveOrder.filter((r) => !returnRegs.includes(r));
   const preserveBytes = preserveSet.length * 2;

--- a/test/pr638_return_regs_canonicalization.test.ts
+++ b/test/pr638_return_regs_canonicalization.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { parseProgram } from '../src/frontend/parser.js';
+
+describe('PR638 return register representation', () => {
+  it('keeps FuncDecl returnRegs canonical as [] when omitted', () => {
+    const diagnostics: Diagnostic[] = [];
+    const program = parseProgram('pr638_func_return_regs.zax', ['func main()', 'end', ''].join('\n'), diagnostics);
+
+    expect(diagnostics).toEqual([]);
+    const fn = program.files[0]?.items[0];
+    expect(fn).toMatchObject({ kind: 'FuncDecl', name: 'main', returnRegs: [] });
+  });
+});


### PR DESCRIPTION
## Summary
- make `FuncDeclNode.returnRegs` required (`string[]`) in `src/frontend/ast.ts`
- canonicalize parser output in `src/frontend/parseFunc.ts` so omitted return registers are represented as `[]`
- remove fallback handling in lowering consumer `src/lowering/functionLowering.ts`
- add focused regression coverage in `test/pr638_return_regs_canonicalization.test.ts`

## Verification
- `npm run typecheck`
- `npm test -- --run test/pr638_return_regs_canonicalization.test.ts test/pr476_parse_func_helpers.test.ts test/pr543_function_lowering_integration.test.ts test/pr511_asm_body_orchestration_helpers.test.ts test/smoke_language_tour_compile.test.ts`

Closes #638
