### PR TITLE
[v0.6-quality] #639 make section anchor bounds unrepresentable as invalid state

### DIFF
--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -120,14 +120,18 @@ export interface SectionDirectiveNode extends BaseNode {
   at?: ImmExprNode;
 }
 
+export type AnchorBoundNode =
+  | { kind: 'none' }
+  | { kind: 'size'; size: ImmExprNode }
+  | { kind: 'end'; end: ImmExprNode };
+
 /**
  * Optional anchor attached to a named section declaration.
  */
 export interface SectionAnchorNode extends BaseNode {
   kind: 'SectionAnchor';
   at: ImmExprNode;
-  size?: ImmExprNode;
-  end?: ImmExprNode;
+  bound: AnchorBoundNode;
 }
 
 /**

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -101,10 +101,12 @@ export function parseModuleFile(
     if (atText) {
       const at = parseImmExprFromText(modulePath, atText, sectionSpan, diagnostics);
       if (!at) return undefined;
+      let bound: SectionAnchorNode['bound'] = { kind: 'none' };
       anchor = {
         kind: 'SectionAnchor',
         span: sectionSpan,
         at,
+        bound,
       };
       if (rangeKeyword && rangeExprText) {
         const rangeExpr = parseAlignDirectiveDecl(
@@ -120,8 +122,8 @@ export function parseModuleFile(
           },
         )?.value;
         if (!rangeExpr) return undefined;
-        if (rangeKeyword === 'size') anchor.size = rangeExpr;
-        else anchor.end = rangeExpr;
+        bound = rangeKeyword === 'size' ? { kind: 'size', size: rangeExpr } : { kind: 'end', end: rangeExpr };
+        anchor.bound = bound;
       }
     }
 

--- a/src/lowering/sectionPlacement.ts
+++ b/src/lowering/sectionPlacement.ts
@@ -95,70 +95,73 @@ function evaluateCapacity(
 ): number | undefined {
   const anchor = sink.anchor.node.anchor;
   if (!anchor) return undefined;
-  if (anchor.size) {
-    const size = ctx.evalImmExpr(anchor.size, ctx.env, ctx.diagnostics);
-    if (size === undefined) {
-      const where = startOf(sink);
-      diagAt(
-        ctx.diagnostics,
-        where.file,
-        where.line,
-        where.column,
-        `Failed to evaluate anchor size for section "${formatKey(sink)}".`,
-      );
+  switch (anchor.bound.kind) {
+    case 'none':
       return undefined;
+    case 'size': {
+      const size = ctx.evalImmExpr(anchor.bound.size, ctx.env, ctx.diagnostics);
+      if (size === undefined) {
+        const where = startOf(sink);
+        diagAt(
+          ctx.diagnostics,
+          where.file,
+          where.line,
+          where.column,
+          `Failed to evaluate anchor size for section "${formatKey(sink)}".`,
+        );
+        return undefined;
+      }
+      if (size < 0) {
+        const where = startOf(sink);
+        diagAt(
+          ctx.diagnostics,
+          where.file,
+          where.line,
+          where.column,
+          `Anchor size must be non-negative for section "${formatKey(sink)}".`,
+        );
+        return undefined;
+      }
+      return size;
     }
-    if (size < 0) {
-      const where = startOf(sink);
-      diagAt(
-        ctx.diagnostics,
-        where.file,
-        where.line,
-        where.column,
-        `Anchor size must be non-negative for section "${formatKey(sink)}".`,
-      );
-      return undefined;
+    case 'end': {
+      const end = ctx.evalImmExpr(anchor.bound.end, ctx.env, ctx.diagnostics);
+      if (end === undefined) {
+        const where = startOf(sink);
+        diagAt(
+          ctx.diagnostics,
+          where.file,
+          where.line,
+          where.column,
+          `Failed to evaluate anchor end for section "${formatKey(sink)}".`,
+        );
+        return undefined;
+      }
+      if (end < baseAddress) {
+        const where = startOf(sink);
+        diagAt(
+          ctx.diagnostics,
+          where.file,
+          where.line,
+          where.column,
+          `Anchor end must be greater than or equal to the base for section "${formatKey(sink)}".`,
+        );
+        return undefined;
+      }
+      if (end > 0xffff) {
+        const where = startOf(sink);
+        diagAt(
+          ctx.diagnostics,
+          where.file,
+          where.line,
+          where.column,
+          `Anchor end out of range for section "${formatKey(sink)}": ${end}.`,
+        );
+        return undefined;
+      }
+      return end - baseAddress + 1;
     }
-    return size;
   }
-  if (anchor.end) {
-    const end = ctx.evalImmExpr(anchor.end, ctx.env, ctx.diagnostics);
-    if (end === undefined) {
-      const where = startOf(sink);
-      diagAt(
-        ctx.diagnostics,
-        where.file,
-        where.line,
-        where.column,
-        `Failed to evaluate anchor end for section "${formatKey(sink)}".`,
-      );
-      return undefined;
-    }
-    if (end < baseAddress) {
-      const where = startOf(sink);
-      diagAt(
-        ctx.diagnostics,
-        where.file,
-        where.line,
-        where.column,
-        `Anchor end must be greater than or equal to the base for section "${formatKey(sink)}".`,
-      );
-      return undefined;
-    }
-    if (end > 0xffff) {
-      const where = startOf(sink);
-      diagAt(
-        ctx.diagnostics,
-        where.file,
-        where.line,
-        where.column,
-        `Anchor end out of range for section "${formatKey(sink)}": ${end}.`,
-      );
-      return undefined;
-    }
-    return end - baseAddress + 1;
-  }
-  return undefined;
 }
 
 export function placeNonBankedSectionContributions(

--- a/test/pr572_named_sections_parser.test.ts
+++ b/test/pr572_named_sections_parser.test.ts
@@ -27,7 +27,7 @@ describe('PR572 named section parser scaffolding', () => {
       anchor: {
         kind: 'SectionAnchor',
         at: { kind: 'ImmLiteral', value: 0x1000 },
-        size: { kind: 'ImmLiteral', value: 0x40 },
+        bound: { kind: 'size', size: { kind: 'ImmLiteral', value: 0x40 } },
       },
     });
     if (!section || section.kind !== 'NamedSection') {
@@ -41,6 +41,27 @@ describe('PR572 named section parser scaffolding', () => {
       exported: true,
     });
     expect(section.items[2]).toMatchObject({ kind: 'DataDecl', name: 'message' });
+  });
+
+  it('parses named-section anchors with end bounds', () => {
+    const diagnostics: Diagnostic[] = [];
+    const program = parseProgram(
+      'pr639_named_section_end_anchor.zax',
+      ['section code boot at $2000 end $20ff', 'end'].join('\n'),
+      diagnostics,
+    );
+
+    expect(diagnostics).toEqual([]);
+    expect(program.files[0]?.items[0]).toMatchObject({
+      kind: 'NamedSection',
+      section: 'code',
+      name: 'boot',
+      anchor: {
+        kind: 'SectionAnchor',
+        at: { kind: 'ImmLiteral', value: 0x2000 },
+        bound: { kind: 'end', end: { kind: 'ImmLiteral', value: 0x20ff } },
+      },
+    });
   });
 
   it('keeps imports module-scoped and rejects legacy section directives', () => {

--- a/test/pr583_section_placement_helpers.test.ts
+++ b/test/pr583_section_placement_helpers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Diagnostic } from '../src/diagnostics/types.js';
-import type { NamedSectionNode } from '../src/frontend/ast.js';
+import type { AnchorBoundNode, NamedSectionNode } from '../src/frontend/ast.js';
 import { parseProgram } from '../src/frontend/parser.js';
 import { emitProgram } from '../src/lowering/emit.js';
 import { placeNonBankedSectionContributions } from '../src/lowering/sectionPlacement.js';
@@ -14,6 +14,7 @@ function makeSink(
   name: string,
   at: number,
   offset: number,
+  bound: AnchorBoundNode = { kind: 'none' },
 ): NamedSectionContributionSink {
   const span = {
     file: `${name}.zax`,
@@ -32,6 +33,7 @@ function makeSink(
         value: at,
         span,
       },
+      bound,
     },
     items: [],
     span,
@@ -116,5 +118,31 @@ describe('PR583 section placement helpers', () => {
     expect(diagnostics).toEqual([]);
     expect(map.bytes.get(0)).toBe(0xc9);
     expect(map.bytes.get(0x1000)).toBe(0xc9);
+  });
+
+  it('handles end-bounded anchors when computing capacity', () => {
+    const diagnostics: Diagnostic[] = [];
+    const endSpan = {
+      file: 'boot.zax',
+      start: { line: 1, column: 1, offset: 0 },
+      end: { line: 1, column: 1, offset: 0 },
+    };
+    const sinks = [makeSink('code', 'boot', 0x1000, 2, {
+      kind: 'end',
+      end: { kind: 'ImmLiteral', value: 0x1000, span: endSpan },
+    })];
+
+    placeNonBankedSectionContributions(sinks, {
+      diagnostics,
+      env: {} as never,
+      evalImmExpr: (expr) => (expr.kind === 'ImmLiteral' ? expr.value : undefined),
+    });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      id: 'ZAX300',
+      severity: 'error',
+    });
+    expect(diagnostics[0]?.message).toContain('Section "code boot" exceeds its anchored capacity');
   });
 });


### PR DESCRIPTION
## Summary
- refactor `SectionAnchorNode` in `src/frontend/ast.ts` to use a discriminated bound union:
  - `{ kind: 'none' }`
  - `{ kind: 'size'; size: ImmExprNode }`
  - `{ kind: 'end'; end: ImmExprNode }`
- update named-section header parsing in `src/frontend/parser.ts` to construct `anchor.bound` explicitly
- update placement capacity handling in `src/lowering/sectionPlacement.ts` to switch on `anchor.bound.kind`
- update named-section parser and placement tests for bound representation and add end-bound coverage

## Verification
- `npm run typecheck`
- `npm test -- --run test/pr572_named_sections_parser.test.ts test/pr583_section_placement_helpers.test.ts test/pr582_section_contribution_sinks.test.ts test/pr585_named_section_layout_integration.test.ts test/smoke_language_tour_compile.test.ts`

Closes #639
