### PR TITLE
#650 lowering: split FunctionLoweringContext into narrow typed contexts

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -104,7 +104,22 @@ import {
   type FlowState,
   type OpExpansionFrame,
 } from './functionBodySetup.js';
-import { lowerFunctionDecl } from './functionLowering.js';
+import {
+  lowerFunctionDecl,
+  type FunctionLoweringAstUtilityContext,
+  type FunctionLoweringCallableResolutionContext,
+  type FunctionLoweringConditionContext,
+  type FunctionLoweringDiagnosticsContext,
+  type FunctionLoweringEmissionContext,
+  type FunctionLoweringMaterializationContext,
+  type FunctionLoweringOpOverloadContext,
+  type FunctionLoweringRegisterContext,
+  type FunctionLoweringSharedContext,
+  type FunctionLoweringSpTrackingContext,
+  type FunctionLoweringStorageContext,
+  type FunctionLoweringSymbolContext,
+  type FunctionLoweringTypeContext,
+} from './functionLowering.js';
 import {
   createNamedSectionContributionSinks,
   type NamedSectionContributionSink,
@@ -124,6 +139,7 @@ import {
   finalizeProgramEmission,
   lowerProgramDeclarations,
   preScanProgramDeclarations,
+  type Context as ProgramLoweringContext,
 } from './programLowering.js';
 import {
   diag,
@@ -732,26 +748,41 @@ export function emitProgram(
     },
   };
 
-  const programLoweringContext = {
+  const currentCodeSegmentTagRef: FunctionLoweringSymbolContext['currentCodeSegmentTagRef'] = {
+    get current() {
+      return currentCodeSegmentTag;
+    },
+    set current(value: SourceSegmentTag | undefined) {
+      currentCodeSegmentTag = value;
+      if (currentNamedSectionSink) currentNamedSectionSink.currentSourceTag = value;
+    },
+  };
+  const generatedLabelCounterRef: FunctionLoweringSymbolContext['generatedLabelCounterRef'] = {
+    get current() {
+      return generatedLabelCounter;
+    },
+    set current(value: number) {
+      generatedLabelCounter = value;
+    },
+  };
+
+  const functionLoweringDiagnosticsContext: FunctionLoweringDiagnosticsContext = {
     diagnostics,
     diag,
     diagAt,
     diagAtWithId,
     diagAtWithSeverityAndId,
     warnAt,
+  };
+  const functionLoweringSymbolContext: FunctionLoweringSymbolContext = {
     taken,
     pending,
     traceComment,
     traceLabel,
-    currentCodeSegmentTagRef: {
-      get current() {
-        return currentCodeSegmentTag;
-      },
-      set current(value: SourceSegmentTag | undefined) {
-        currentCodeSegmentTag = value;
-        if (currentNamedSectionSink) currentNamedSectionSink.currentSourceTag = value;
-      },
-    },
+    currentCodeSegmentTagRef,
+    generatedLabelCounterRef,
+  };
+  const functionLoweringSpTrackingContext: FunctionLoweringSpTrackingContext = {
     bindSpTracking: (
       callbacks?:
         | {
@@ -763,12 +794,16 @@ export function emitProgram(
       applySpTracking = callbacks?.applySpTracking;
       invalidateSpTracking = callbacks?.invalidateSpTracking;
     },
+  };
+  const functionLoweringEmissionContext: FunctionLoweringEmissionContext = {
     getCodeOffset: getCurrentCodeOffset,
     emitInstr,
     emitRawCodeBytes,
     emitAbs16Fixup,
     emitAbs16FixupPrefixed,
     emitRel8Fixup,
+  };
+  const functionLoweringConditionContext: FunctionLoweringConditionContext = {
     conditionOpcodeFromName,
     conditionNameFromOpcode,
     callConditionOpcodeFromName,
@@ -776,6 +811,8 @@ export function emitProgram(
     conditionOpcode,
     inverseConditionName,
     symbolicTargetFromExpr,
+  };
+  const functionLoweringTypeContext: FunctionLoweringTypeContext = {
     evalImmExpr,
     env,
     resolveScalarBinding,
@@ -783,6 +820,10 @@ export function emitProgram(
     resolveEaTypeExpr,
     resolveScalarTypeForEa,
     resolveArrayType,
+    typeDisplay,
+    sameTypeShape,
+  };
+  const functionLoweringMaterializationContext: FunctionLoweringMaterializationContext = {
     buildEaWordPipeline,
     enforceEaRuntimeAtomBudget,
     enforceDirectCallSiteEaBudget,
@@ -791,18 +832,22 @@ export function emitProgram(
     pushImm16,
     pushZeroExtendedReg8,
     loadImm16ToHL,
+    emitStepPipeline,
+    lowerLdWithEa,
+  };
+  const functionLoweringStorageContext: FunctionLoweringStorageContext = {
     stackSlotOffsets,
     stackSlotTypes,
     localAliasTargets,
     storageTypes,
     rawTypedCallWarningsEnabled,
-    localCallablesByFile,
-    visibleCallables,
-    localOpsByFile,
-    visibleOpsByName,
-    declaredOpNames,
-    deferredExterns,
+  };
+  const functionLoweringCallableResolutionContext: FunctionLoweringCallableResolutionContext = {
+    resolveCallable: resolveVisibleCallable,
+    resolveOpCandidates: resolveVisibleOpCandidates,
     opStackPolicyMode,
+  };
+  const functionLoweringOpOverloadContext: FunctionLoweringOpOverloadContext = {
     matcherMatchesOperand,
     formatOpSignature,
     formatAsmOperandForOpDiag,
@@ -810,31 +855,47 @@ export function emitProgram(
     formatOpDefinitionForDiag,
     selectMostSpecificOpOverload,
     summarizeOpStackEffect,
+  };
+  const functionLoweringAstUtilityContext: FunctionLoweringAstUtilityContext = {
     cloneImmExpr,
     cloneEaExpr,
     cloneOperand,
     flattenEaDottedName,
     normalizeFixedToken,
-    typeDisplay,
-    sameTypeShape,
-    emitStepPipeline,
-    lowerLdWithEa,
+  };
+  const functionLoweringRegisterContext: FunctionLoweringRegisterContext = {
     reg8,
     reg16,
-    generatedLabelCounterRef: {
-      get current() {
-        return generatedLabelCounter;
-      },
-      set current(value: number) {
-        generatedLabelCounter = value;
-      },
-    },
+  };
+  const functionLoweringSharedContext: FunctionLoweringSharedContext = {
+    ...functionLoweringDiagnosticsContext,
+    ...functionLoweringSymbolContext,
+    ...functionLoweringSpTrackingContext,
+    ...functionLoweringEmissionContext,
+    ...functionLoweringConditionContext,
+    ...functionLoweringTypeContext,
+    ...functionLoweringMaterializationContext,
+    ...functionLoweringStorageContext,
+    ...functionLoweringCallableResolutionContext,
+    ...functionLoweringOpOverloadContext,
+    ...functionLoweringAstUtilityContext,
+    ...functionLoweringRegisterContext,
+  };
+
+  const programLoweringContext: ProgramLoweringContext = {
+    ...functionLoweringSharedContext,
     program,
     includeDirs,
+    localCallablesByFile,
+    visibleCallables,
+    localOpsByFile,
+    visibleOpsByName,
+    declaredOpNames,
     declaredBinNames,
-    rawAddressSymbols,
+    deferredExterns,
     moduleAliasTargets,
     moduleAliasDecls,
+    rawAddressSymbols,
     absoluteSymbols,
     symbols,
     dataBytes,
@@ -853,8 +914,6 @@ export function emitProgram(
     resolveAggregateType,
     sizeOfTypeExpr,
     lowerFunctionDecl,
-    resolveCallable: resolveVisibleCallable,
-    resolveOpCandidates: resolveVisibleOpCandidates,
     namedSectionSinksByNode,
     withNamedSectionSink: <T>(sink: NamedSectionContributionSink, fn: () => T): T => {
       const prevSink = currentNamedSectionSink;

--- a/src/lowering/functionLowering.ts
+++ b/src/lowering/functionLowering.ts
@@ -36,8 +36,11 @@ import { createFunctionCallLoweringHelpers } from './functionCallLowering.js';
 // function-local helpers, state, and diagnostics around the extracted
 // body-setup and call-lowering submodules.
 type ResolvedArrayType = { element: TypeExprNode; length?: number };
-export type FunctionLoweringContext = {
+export type FunctionLoweringItemContext = {
   item: FuncDeclNode;
+};
+
+export type FunctionLoweringDiagnosticsContext = {
   diagnostics: Diagnostic[];
   diag: (diagnostics: Diagnostic[], file: string, message: string) => void;
   diagAt: (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
@@ -55,11 +58,18 @@ export type FunctionLoweringContext = {
     message: string,
   ) => void;
   warnAt: (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
+};
+
+export type FunctionLoweringSymbolContext = {
   taken: Set<string>;
   pending: PendingSymbol[];
   traceComment: (offset: number, text: string) => void;
   traceLabel: (offset: number, name: string) => void;
   currentCodeSegmentTagRef: { current: SourceSegmentTag | undefined };
+  generatedLabelCounterRef: { current: number };
+};
+
+export type FunctionLoweringSpTrackingContext = {
   bindSpTracking: (
     callbacks?:
       | {
@@ -68,6 +78,9 @@ export type FunctionLoweringContext = {
         }
       | undefined,
   ) => void;
+};
+
+export type FunctionLoweringEmissionContext = {
   getCodeOffset: () => number;
   emitInstr: (head: string, operands: AsmOperandNode[], span: SourceSpan) => boolean;
   emitRawCodeBytes: (bs: Uint8Array, file: string, traceText: string) => void;
@@ -93,6 +106,9 @@ export type FunctionLoweringContext = {
     span: SourceSpan,
     mnemonic: string,
   ) => void;
+};
+
+export type FunctionLoweringConditionContext = {
   conditionOpcodeFromName: (name: string) => number | undefined;
   conditionNameFromOpcode: (opcode: number) => string | undefined;
   callConditionOpcodeFromName: (name: string) => number | undefined;
@@ -102,6 +118,9 @@ export type FunctionLoweringContext = {
   symbolicTargetFromExpr: (
     expr: ImmExprNode,
   ) => { baseLower: string; addend: number } | undefined;
+};
+
+export type FunctionLoweringTypeContext = {
   evalImmExpr: (
     expr: ImmExprNode,
     env: CompileEnv,
@@ -113,6 +132,11 @@ export type FunctionLoweringContext = {
   resolveEaTypeExpr: (ea: EaExprNode) => TypeExprNode | undefined;
   resolveScalarTypeForEa: (ea: EaExprNode) => ScalarKind | undefined;
   resolveArrayType: (typeExpr: TypeExprNode, env?: CompileEnv) => ResolvedArrayType | undefined;
+  typeDisplay: (typeExpr: TypeExprNode) => string;
+  sameTypeShape: (left: TypeExprNode, right: TypeExprNode) => boolean;
+};
+
+export type FunctionLoweringMaterializationContext = {
   buildEaWordPipeline: (ea: EaExprNode, span: SourceSpan) => StepPipeline | null;
   enforceEaRuntimeAtomBudget: (operand: AsmOperandNode, context: string) => boolean;
   enforceDirectCallSiteEaBudget: (operand: AsmOperandNode, calleeName: string) => boolean;
@@ -121,14 +145,25 @@ export type FunctionLoweringContext = {
   pushImm16: (value: number, span: SourceSpan) => boolean;
   pushZeroExtendedReg8: (regName: string, span: SourceSpan) => boolean;
   loadImm16ToHL: (value: number, span: SourceSpan) => boolean;
+  emitStepPipeline: (pipe: StepPipeline, span: SourceSpan) => boolean;
+  lowerLdWithEa: (asmItem: AsmInstructionNode) => boolean;
+};
+
+export type FunctionLoweringStorageContext = {
   stackSlotOffsets: Map<string, number>;
   stackSlotTypes: Map<string, TypeExprNode>;
   localAliasTargets: Map<string, EaExprNode>;
   storageTypes: Map<string, TypeExprNode>;
   rawTypedCallWarningsEnabled: boolean;
+};
+
+export type FunctionLoweringCallableResolutionContext = {
   resolveCallable: (name: string, file: string) => Callable | undefined;
   resolveOpCandidates: (name: string, file: string) => OpDeclNode[] | undefined;
   opStackPolicyMode: OpStackPolicyMode;
+};
+
+export type FunctionLoweringOpOverloadContext = {
   matcherMatchesOperand: (matcher: OpMatcherNode, operand: AsmOperandNode) => boolean;
   formatOpSignature: (op: OpDeclNode) => string;
   formatAsmOperandForOpDiag: (operand: AsmOperandNode) => string;
@@ -142,19 +177,35 @@ export type FunctionLoweringContext = {
     args: AsmOperandNode[],
   ) => OpDeclNode | undefined;
   summarizeOpStackEffect: (op: OpDeclNode) => OpStackSummary;
+};
+
+export type FunctionLoweringAstUtilityContext = {
   cloneImmExpr: (expr: ImmExprNode) => ImmExprNode;
   cloneEaExpr: (expr: EaExprNode) => EaExprNode;
   cloneOperand: (operand: AsmOperandNode) => AsmOperandNode;
   flattenEaDottedName: (ea: EaExprNode) => string | undefined;
   normalizeFixedToken: (operand: AsmOperandNode) => string | undefined;
-  typeDisplay: (typeExpr: TypeExprNode) => string;
-  sameTypeShape: (left: TypeExprNode, right: TypeExprNode) => boolean;
-  emitStepPipeline: (pipe: StepPipeline, span: SourceSpan) => boolean;
-  lowerLdWithEa: (asmItem: AsmInstructionNode) => boolean;
+};
+
+export type FunctionLoweringRegisterContext = {
   reg8: Set<string>;
   reg16: Set<string>;
-  generatedLabelCounterRef: { current: number };
 };
+
+export type FunctionLoweringSharedContext = FunctionLoweringDiagnosticsContext &
+  FunctionLoweringSymbolContext &
+  FunctionLoweringSpTrackingContext &
+  FunctionLoweringEmissionContext &
+  FunctionLoweringConditionContext &
+  FunctionLoweringTypeContext &
+  FunctionLoweringMaterializationContext &
+  FunctionLoweringStorageContext &
+  FunctionLoweringCallableResolutionContext &
+  FunctionLoweringOpOverloadContext &
+  FunctionLoweringAstUtilityContext &
+  FunctionLoweringRegisterContext;
+
+export type FunctionLoweringContext = FunctionLoweringItemContext & FunctionLoweringSharedContext;
 
 export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
   const { item, diagnostics, diag, diagAt, diagAtWithId, diagAtWithSeverityAndId, warnAt } = ctx;

--- a/src/lowering/programLowering.ts
+++ b/src/lowering/programLowering.ts
@@ -30,7 +30,7 @@ import type {
   SymbolEntry,
 } from '../formats/types.js';
 import type { CompileEnv } from '../semantics/env.js';
-import type { FunctionLoweringContext } from './functionLowering.js';
+import type { FunctionLoweringContext, FunctionLoweringSharedContext } from './functionLowering.js';
 import type { NamedSectionContributionSink } from './sectionContributions.js';
 import type {
   Callable,
@@ -42,7 +42,7 @@ import { lowerDataBlock } from './programLoweringData.js';
 
 // Program lowering owns module-wide declaration traversal and the final
 // emission/fixup passes after all symbols and section bases are known.
-export type Context = Omit<FunctionLoweringContext, 'item'> & {
+export type Context = FunctionLoweringSharedContext & {
   program: ProgramNode;
   includeDirs: string[];
   localCallablesByFile: Map<string, Map<string, Callable>>;


### PR DESCRIPTION
## Summary
- split `FunctionLoweringContext` into concern-specific interfaces in `functionLowering.ts` (diagnostics/symbol/emission/type/materialization/storage/callable/op/ast/register)
- introduce `FunctionLoweringSharedContext` and define `FunctionLoweringContext` as `item + shared`
- switch `programLowering.Context` from `Omit<FunctionLoweringContext, "item">` to `FunctionLoweringSharedContext`
- in `emit.ts`, build typed context slices and compose them into `FunctionLoweringSharedContext` before creating `ProgramLoweringContext`

## Scope
- lowering-only changes (`src/lowering/*`)
- no parser or semantics changes

## Verification
- `npm run typecheck`
- `npm test -- --run test/pr543_function_lowering_integration.test.ts test/pr544_program_lowering_integration.test.ts test/pr511_asm_range_lowering_integration.test.ts test/pr532_asm_instruction_lowering_integration.test.ts test/pr102_lowering_frame_invariants.test.ts test/pr92_lowering_interactions.test.ts test/smoke_language_tour_compile.test.ts`

Closes #650