### PR TITLE
[#643] Build visibility import graph from resolved module edges

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -91,6 +91,7 @@ type LoadedProgram = {
   program: ProgramNode;
   sourceTexts: Map<string, string>;
   moduleTraversal: string[];
+  resolvedImportGraph: Map<string, string[]>;
 };
 
 async function loadProgram(
@@ -287,6 +288,9 @@ async function loadProgram(
     program: { kind: 'Program', span: entryModule.span, entryFile: entryPath, files: moduleFiles },
     sourceTexts,
     moduleTraversal,
+    resolvedImportGraph: new Map(
+      Array.from(edges.entries(), ([modulePath, moduleEdges]) => [modulePath, Array.from(moduleEdges.keys())]),
+    ),
   };
 }
 
@@ -307,7 +311,7 @@ export const compile: CompileFn = async (
   const diagnostics: Diagnostic[] = [];
   const loaded = await loadProgram(entryPath, diagnostics, options);
   if (!loaded) return { diagnostics, artifacts: [] };
-  const { program, sourceTexts, moduleTraversal } = loaded;
+  const { program, sourceTexts, moduleTraversal, resolvedImportGraph } = loaded;
 
   if (hasErrors(diagnostics)) {
     return { diagnostics, artifacts: [] };
@@ -351,6 +355,7 @@ export const compile: CompileFn = async (
 
   const env = buildEnv(program, diagnostics, {
     typePaddingWarnings: options.typePaddingWarnings ?? false,
+    resolvedImportGraph,
   });
   if (hasErrors(diagnostics)) {
     return { diagnostics, artifacts: [] };

--- a/src/semantics/env.ts
+++ b/src/semantics/env.ts
@@ -210,6 +210,21 @@ function directImports(items: ModuleItemNode[]): ImportNode[] {
   return items.filter((item): item is ImportNode => item.kind === 'Import');
 }
 
+type BuildEnvOptions = {
+  typePaddingWarnings?: boolean;
+  resolvedImportGraph?: ReadonlyMap<string, ReadonlyArray<string>>;
+};
+
+function importedModuleIdsForFile(moduleFile: ProgramNode['files'][number], options?: BuildEnvOptions): Set<string> {
+  const graph = options?.resolvedImportGraph;
+  if (!graph) {
+    return new Set(directImports(moduleFile.items).map((item) => canonicalModuleId(item.specifier)));
+  }
+  const resolvedTargets = graph.get(moduleFile.path);
+  if (!resolvedTargets) return new Set();
+  return new Set(resolvedTargets.map((targetPath) => canonicalModuleId(targetPath)));
+}
+
 /**
  * Build the PR2 compile environment by resolving module-scope `enum` and `const` declarations.
  *
@@ -220,7 +235,7 @@ function directImports(items: ModuleItemNode[]): ImportNode[] {
 export function buildEnv(
   program: ProgramNode,
   diagnostics: Diagnostic[],
-  options?: { typePaddingWarnings?: boolean },
+  options?: BuildEnvOptions,
 ): CompileEnv {
   const consts = new Map<string, number>();
   const enums = new Map<string, number>();
@@ -238,10 +253,7 @@ export function buildEnv(
 
   for (const mf of program.files) {
     moduleIds.set(mf.path, mf.moduleId || canonicalModuleId(mf.path));
-    importedModuleIds.set(
-      mf.path,
-      new Set(directImports(mf.items).map((item) => canonicalModuleId(item.specifier))),
-    );
+    importedModuleIds.set(mf.path, importedModuleIdsForFile(mf, options));
   }
 
   const globalLower = new Map<string, { kind: string; name: string; file: string }>();

--- a/test/pr575_module_visibility_scaffolding.test.ts
+++ b/test/pr575_module_visibility_scaffolding.test.ts
@@ -163,4 +163,66 @@ describe('PR575 module visibility scaffolding', () => {
     expect(sizeOfTypeExpr({ kind: 'TypeName', span: root.span, name: 'dep.Word' }, env, diagnostics)).toBeUndefined();
     expect(diagnostics.some((d) => d.message === 'Unknown type "dep.Word".')).toBe(true);
   });
+
+  it('uses resolved path-form import edges to determine visibility', () => {
+    const diagnostics: any[] = [];
+    const dep = parseModuleFile(
+      '/workspace/libs/dep.zax',
+      ['export const FOO = 7', 'export type Word word'].join('\n'),
+      diagnostics,
+    );
+    const root = parseModuleFile(
+      '/workspace/root.zax',
+      ['import "../vendor/alias_dep.zax"', 'const LOCAL = dep.FOO'].join('\n'),
+      diagnostics,
+    );
+
+    const program = {
+      kind: 'Program',
+      span: root.span,
+      entryFile: root.path,
+      files: [dep, root],
+    } as ProgramNode;
+
+    const env = buildEnv(program, diagnostics, {
+      typePaddingWarnings: false,
+      resolvedImportGraph: new Map([
+        [dep.path, []],
+        [root.path, [dep.path]],
+      ]),
+    });
+
+    expect(diagnostics).toEqual([]);
+    expect(env.importedModuleIds!.get(root.path)).toEqual(new Set([dep.moduleId]));
+    expect(env.consts.get('LOCAL')).toBe(7);
+  });
+
+  it('uses resolved module-id-form import edges to determine visibility', () => {
+    const diagnostics: any[] = [];
+    const dep = parseModuleFile('/workspace/libs/dep.zax', ['export const FOO = 7'].join('\n'), diagnostics);
+    const root = parseModuleFile(
+      '/workspace/root.zax',
+      ['import aliasdep', 'const LOCAL = dep.FOO'].join('\n'),
+      diagnostics,
+    );
+
+    const program = {
+      kind: 'Program',
+      span: root.span,
+      entryFile: root.path,
+      files: [dep, root],
+    } as ProgramNode;
+
+    const env = buildEnv(program, diagnostics, {
+      typePaddingWarnings: false,
+      resolvedImportGraph: new Map([
+        [dep.path, []],
+        [root.path, [dep.path]],
+      ]),
+    });
+
+    expect(diagnostics).toEqual([]);
+    expect(env.importedModuleIds!.get(root.path)).toEqual(new Set([dep.moduleId]));
+    expect(env.consts.get('LOCAL')).toBe(7);
+  });
 });


### PR DESCRIPTION
## Summary
- emit a resolved import graph from `loadProgram` and thread it into semantics env construction
- build `importedModuleIds` from resolved module-edge targets (not raw import specifier text)
- add focused visibility tests covering both path-form and module-id-form imports using resolved edges

## Files changed
- `src/compile.ts`
- `src/semantics/env.ts`
- `test/pr575_module_visibility_scaffolding.test.ts`

## Verification
- `npm run typecheck`
- `npm test -- --run test/pr575_module_visibility_scaffolding.test.ts test/pr575_callable_visibility.test.ts`
- `npm test -- --run test/examples_compile.test.ts`

Closes #643
