### PR TITLE
[v0.6-quality] #642 remove dead legacy section-directive AST/lowering path

### DIFF
--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -67,7 +67,6 @@ export type ModuleItemNode =
   | BinDeclNode
   | HexDeclNode
   | OpDeclNode
-  | SectionDirectiveNode
   | AlignDirectiveNode
   | UnimplementedNode;
 
@@ -109,15 +108,6 @@ export interface ImportNode extends BaseNode {
   kind: 'Import';
   specifier: string;
   form: 'moduleId' | 'path';
-}
-
-/**
- * Section selection directive.
- */
-export interface SectionDirectiveNode extends BaseNode {
-  kind: 'Section';
-  section: 'code' | 'data' | 'var';
-  at?: ImmExprNode;
 }
 
 export type AnchorBoundNode =

--- a/src/frontend/parseTopLevelSimple.ts
+++ b/src/frontend/parseTopLevelSimple.ts
@@ -4,7 +4,6 @@ import type {
   ConstDeclNode,
   HexDeclNode,
   ImportNode,
-  SectionDirectiveNode,
   SourceSpan,
 } from './ast.js';
 import type { Diagnostic } from '../diagnostics/types.js';
@@ -58,7 +57,7 @@ export function parseSectionDirectiveDecl(
   rest: string,
   sectionTail: string | undefined,
   ctx: SimpleTopLevelContext,
-): SectionDirectiveNode | undefined {
+): void {
   const { diagnostics, modulePath, lineNo, text, span } = ctx;
   const decl = rest === 'section' ? '' : (sectionTail ?? '');
   const m = /^(code|data|var)(?:\s+at\s+(.+))?$/.exec(decl);
@@ -74,7 +73,7 @@ export function parseSectionDirectiveDecl(
     return undefined;
   }
 
-  const section = m[1]! as SectionDirectiveNode['section'];
+  const section = m[1]! as 'code' | 'data' | 'var';
   const atText = m[2]?.trim();
   diag(
     diagnostics,

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -430,7 +430,7 @@ export function parseModuleFile(
         return { nextIndex: parsedSection.nextIndex, node: sectionNode };
       }
 
-      const sectionNode = parseSectionDirectiveDecl(rest, sectionTail, {
+      parseSectionDirectiveDecl(rest, sectionTail, {
         diagnostics,
         modulePath,
         lineNo,
@@ -438,7 +438,7 @@ export function parseModuleFile(
         span: stmtSpan,
         isReservedTopLevelName,
       });
-      return { nextIndex: index + 1, ...(sectionNode ? { node: sectionNode } : {}) };
+      return { nextIndex: index + 1 };
     }
 
     const alignTail = consumeTopKeyword(rest, 'align');

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -68,7 +68,6 @@ import type {
   OpMatcherNode,
   ParamNode,
   ProgramNode,
-  SectionDirectiveNode,
   SourceSpan,
   TypeExprNode,
   VarBlockNode,
@@ -664,15 +663,7 @@ export function emitProgram(
   let dataOffset = 0;
   let varOffset = 0;
 
-  const baseExprs: Partial<Record<SectionKind, SectionDirectiveNode['at']>> = {};
-
-  const setBaseExpr = (kind: SectionKind, at: SectionDirectiveNode['at'], file: string) => {
-    if (baseExprs[kind]) {
-      diag(diagnostics, file, `Section "${kind}" base address may be set at most once.`);
-      return;
-    }
-    baseExprs[kind] = at;
-  };
+  const baseExprs: Partial<Record<SectionKind, ImmExprNode>> = {};
 
   const advanceAlign = (a: number) => {
     switch (activeSection) {
@@ -834,7 +825,6 @@ export function emitProgram(
     dataOffsetRef,
     varOffsetRef,
     baseExprs,
-    setBaseExpr,
     advanceAlign,
     alignTo,
     loadBinInput,

--- a/src/lowering/programLowering.ts
+++ b/src/lowering/programLowering.ts
@@ -16,7 +16,6 @@ import type {
   OpDeclNode,
   ProgramNode,
   SectionItemNode,
-  SectionDirectiveNode,
   SourceSpan,
   TypeExprNode,
   VarBlockNode,
@@ -71,8 +70,7 @@ export type Context = Omit<FunctionLoweringContext, 'item'> & {
   codeOffsetRef: { current: number };
   dataOffsetRef: { current: number };
   varOffsetRef: { current: number };
-  baseExprs: Partial<Record<SectionKind, SectionDirectiveNode['at']>>;
-  setBaseExpr: (kind: SectionKind, at: SectionDirectiveNode['at'], file: string) => void;
+  baseExprs: Partial<Record<SectionKind, ImmExprNode>>;
   advanceAlign: (a: number) => void;
   alignTo: (n: number, alignment: number) => number;
   loadBinInput: (
@@ -102,7 +100,7 @@ export type FinalizationContext = {
   diagnostics: Diagnostic[];
   diag: (diagnostics: Diagnostic[], file: string, message: string) => void;
   primaryFile: string;
-  baseExprs: Partial<Record<SectionKind, SectionDirectiveNode['at']>>;
+  baseExprs: Partial<Record<SectionKind, ImmExprNode>>;
   evalImmExpr: (
     expr: ImmExprNode,
     env: CompileEnv,
@@ -471,13 +469,6 @@ export function lowerProgramDeclarations(ctx: Context): void {
           scope: 'global',
         });
       }
-      return;
-    }
-
-    if (item.kind === 'Section') {
-      const s = item as SectionDirectiveNode;
-      ctx.activeSectionRef.current = s.section;
-      if (s.at) ctx.setBaseExpr(s.section, s.at, s.span.file);
       return;
     }
 


### PR DESCRIPTION
## Summary
- remove `SectionDirectiveNode` from the frontend AST public surface (`src/frontend/ast.ts`)
- keep hard-cut legacy syntax rejection via parser diagnostics, but remove the AST/lowering construct path for legacy section directives
- update parser handling to treat legacy `section code|data|var ...` only as rejected syntax (no node production)
- remove dead lowering references to section-directive node types in `src/lowering/emit.ts` and `src/lowering/programLowering.ts`

## Verification
- `npm run typecheck`
- `npm test -- --run test/pr9_sections_align.test.ts test/pr476_parse_top_level_simple_helpers.test.ts test/pr157_export_malformed_matrix.test.ts test/pr572_named_sections_parser.test.ts test/pr578_legacy_syntax_warnings.test.ts test/pr583_section_placement_helpers.test.ts test/smoke_language_tour_compile.test.ts`

Closes #642
