### PR TITLE
#654 docs CI: stabilize docs-fast formatting checks to changed paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,28 @@ jobs:
           node-version: '20'
           cache: npm
 
+      - name: Collect changed files
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+            head_sha="${{ github.event.pull_request.head.sha }}"
+            git diff --name-only "$base_sha" "$head_sha" > changed_files.txt
+          else
+            before_sha="${{ github.event.before }}"
+            head_sha="${{ github.sha }}"
+            if [[ "$before_sha" == "0000000000000000000000000000000000000000" ]]; then
+              git ls-files > changed_files.txt
+            else
+              git diff --name-only "$before_sha" "$head_sha" > changed_files.txt
+            fi
+          fi
+
       - name: Install
         run: npm ci
 
       - name: Docs format check
-        run: npx prettier -c "**/*.md" ".github/ISSUE_TEMPLATE/*.yml"
+        run: node ./scripts/ci/docs-prettier-check.js < changed_files.txt
 
   test:
     name: test (${{ matrix.os }})

--- a/docs/zax-dev-playbook.md
+++ b/docs/zax-dev-playbook.md
@@ -166,6 +166,14 @@ Historical material should either:
 - live in the version closeout / planning docs, or
 - be removed rather than copied forward into active workflow guides
 
+### Docs formatting workflow
+
+- CI `docs (fast)` checks only docs paths changed by the PR/push (`*.md`, `docs/**`, `.github/ISSUE_TEMPLATE/**`).
+- This keeps docs-only CI strict for touched content while avoiding unrelated baseline drift failures.
+- If baseline drift appears, run one-time normalization in a dedicated docs PR:
+  - `npx prettier -w "**/*.md" ".github/ISSUE_TEMPLATE/*.yml"`
+- After normalization, keep strict changed-path docs checks enabled in CI.
+
 ## Current Focus
 
 The current active workstream is defined in:

--- a/scripts/ci/docs-prettier-check.js
+++ b/scripts/ci/docs-prettier-check.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import { createInterface } from 'node:readline';
+import { stdin as input } from 'node:process';
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+import { classifyChangedPaths } from './change-classifier.js';
+
+async function readPathsFromStdin() {
+  const rl = createInterface({ input, crlfDelay: Infinity });
+  const values = [];
+  for await (const line of rl) values.push(line);
+  return values;
+}
+
+async function main() {
+  const paths = await readPathsFromStdin();
+  const { docsPaths } = classifyChangedPaths(paths);
+  const existingDocsPaths = docsPaths.filter((p) => existsSync(p));
+  const deletedDocsPaths = docsPaths.filter((p) => !existsSync(p));
+
+  if (deletedDocsPaths.length > 0) {
+    console.log(`[docs-fast] skipping deleted docs paths: ${deletedDocsPaths.join(', ')}`);
+  }
+
+  if (existingDocsPaths.length === 0) {
+    console.log('[docs-fast] no existing docs paths changed; skipping prettier check');
+    return;
+  }
+
+  const result = spawnSync('npx', ['prettier', '-c', ...existingDocsPaths], {
+    stdio: 'inherit',
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}
+
+await main();


### PR DESCRIPTION
## Summary
- change `docs (fast)` CI to run prettier checks only on docs paths changed by the PR/push
- add `scripts/ci/docs-prettier-check.js` to classify changed paths and check only existing docs files (skips deleted docs paths)
- document docs formatting workflow in the dev playbook, including one-time repo-wide normalization command when baseline drift appears

## Why
- prevents docs-only PR failures caused by unrelated baseline formatting drift while keeping strict checks for touched docs content

## Verification
- baseline check: `npx prettier -c "**/*.md" ".github/ISSUE_TEMPLATE/*.yml"` (clean in current repo)
- script check (changed docs path): `printf "docs/zax-dev-playbook.md\n" | node ./scripts/ci/docs-prettier-check.js`
- script check (deleted docs path): `printf "docs/does-not-exist.md\n" | node ./scripts/ci/docs-prettier-check.js`
- `npm run typecheck`

Closes #654