### PR TITLE
[#653] Introduce typed lowering phase handoff structs

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -127,6 +127,8 @@ import {
   lowerProgramDeclarations,
   preScanProgramDeclarations,
   type Context as ProgramLoweringContext,
+  type LoweringResult as ProgramLoweringResult,
+  type PrescanResult as ProgramPrescanResult,
 } from './programLowering.js';
 import { finalizeEmitProgram } from './emitFinalization.js';
 import {
@@ -157,6 +159,19 @@ import {
   toHexWord,
 } from './traceFormat.js';
 import { createTypeResolutionHelpers } from './typeResolution.js';
+
+type ProgramLoweringPhaseResult = {
+  prescan: ProgramPrescanResult;
+  lowered: ProgramLoweringResult;
+};
+
+function runProgramLoweringPhases(
+  programLoweringContext: ProgramLoweringContext,
+): ProgramLoweringPhaseResult {
+  const prescan = preScanProgramDeclarations(programLoweringContext);
+  const lowered = lowerProgramDeclarations(programLoweringContext, prescan);
+  return { prescan, lowered };
+}
 
 /**
  * Emit machine-code bytes for a parsed program into an address->byte map.
@@ -906,8 +921,7 @@ export function emitProgram(
     },
   };
 
-  preScanProgramDeclarations(programLoweringContext);
-  lowerProgramDeclarations(programLoweringContext);
+  const { lowered } = runProgramLoweringPhases(programLoweringContext);
 
   return finalizeEmitProgram({
     namedSectionSinks,
@@ -918,18 +932,18 @@ export function emitProgram(
     baseExprs,
     evalImmExpr,
     env,
-    codeOffset,
-    dataOffset,
-    varOffset,
-    pending,
-    symbols,
-    absoluteSymbols,
-    deferredExterns,
+    codeOffset: lowered.codeOffset,
+    dataOffset: lowered.dataOffset,
+    varOffset: lowered.varOffset,
+    pending: lowered.pending,
+    symbols: lowered.symbols,
+    absoluteSymbols: lowered.absoluteSymbols,
+    deferredExterns: lowered.deferredExterns,
     fixups,
     rel8Fixups,
-    codeBytes,
-    dataBytes,
-    hexBytes,
+    codeBytes: lowered.codeBytes,
+    dataBytes: lowered.dataBytes,
+    hexBytes: lowered.hexBytes,
     bytes,
     codeSourceSegments,
     codeAsmTrace,

--- a/src/lowering/programLowering.ts
+++ b/src/lowering/programLowering.ts
@@ -96,6 +96,32 @@ export type Context = FunctionLoweringSharedContext & {
   withNamedSectionSink: <T>(sink: NamedSectionContributionSink, fn: () => T) => T;
 };
 
+export type PrescanResult = {
+  localCallablesByFile: Context['localCallablesByFile'];
+  visibleCallables: Context['visibleCallables'];
+  localOpsByFile: Context['localOpsByFile'];
+  visibleOpsByName: Context['visibleOpsByName'];
+  declaredOpNames: Context['declaredOpNames'];
+  declaredBinNames: Context['declaredBinNames'];
+  storageTypes: Context['storageTypes'];
+  moduleAliasTargets: Context['moduleAliasTargets'];
+  moduleAliasDecls: Context['moduleAliasDecls'];
+  rawAddressSymbols: Context['rawAddressSymbols'];
+};
+
+export type LoweringResult = {
+  codeOffset: number;
+  dataOffset: number;
+  varOffset: number;
+  pending: Context['pending'];
+  symbols: Context['symbols'];
+  absoluteSymbols: Context['absoluteSymbols'];
+  deferredExterns: Context['deferredExterns'];
+  codeBytes: Context['codeBytes'];
+  dataBytes: Context['dataBytes'];
+  hexBytes: Context['hexBytes'];
+};
+
 export type FinalizationContext = {
   diagnostics: Diagnostic[];
   diag: (diagnostics: Diagnostic[], file: string, message: string) => void;
@@ -145,7 +171,7 @@ export type FinalizationContext = {
   rebaseAsmTrace: (codeBase: number, trace: EmittedAsmTraceEntry[]) => EmittedAsmTraceEntry[];
 };
 
-export function preScanProgramDeclarations(ctx: Context): void {
+export function preScanProgramDeclarations(ctx: Context): PrescanResult {
   const preScanItem = (
     item: ModuleItemNode | SectionItemNode,
     namedSection?: NamedSectionNode,
@@ -250,9 +276,22 @@ export function preScanProgramDeclarations(ctx: Context): void {
   for (const module of ctx.program.files) {
     for (const item of module.items) preScanItem(item);
   }
+
+  return {
+    localCallablesByFile: ctx.localCallablesByFile,
+    visibleCallables: ctx.visibleCallables,
+    localOpsByFile: ctx.localOpsByFile,
+    visibleOpsByName: ctx.visibleOpsByName,
+    declaredOpNames: ctx.declaredOpNames,
+    declaredBinNames: ctx.declaredBinNames,
+    storageTypes: ctx.storageTypes,
+    moduleAliasTargets: ctx.moduleAliasTargets,
+    moduleAliasDecls: ctx.moduleAliasDecls,
+    rawAddressSymbols: ctx.rawAddressSymbols,
+  };
 }
 
-export function lowerProgramDeclarations(ctx: Context): void {
+export function lowerProgramDeclarations(ctx: Context, _prescan: PrescanResult): LoweringResult {
   const sinkOffsetRef = (sink: NamedSectionContributionSink) => ({
     get current() {
       return sink.offset;
@@ -627,6 +666,19 @@ export function lowerProgramDeclarations(ctx: Context): void {
     ctx.activeSectionRef.current = 'code';
     for (const item of module.items) lowerItem(item);
   }
+
+  return {
+    codeOffset: ctx.codeOffsetRef.current,
+    dataOffset: ctx.dataOffsetRef.current,
+    varOffset: ctx.varOffsetRef.current,
+    pending: ctx.pending,
+    symbols: ctx.symbols,
+    absoluteSymbols: ctx.absoluteSymbols,
+    deferredExterns: ctx.deferredExterns,
+    codeBytes: ctx.codeBytes,
+    dataBytes: ctx.dataBytes,
+    hexBytes: ctx.hexBytes,
+  };
 }
 
 export { finalizeProgramEmission } from './programLoweringFinalize.js';


### PR DESCRIPTION
## Summary
- introduce explicit typed handoff structs for lowering phases in `programLowering.ts`
  - `PrescanResult`
  - `LoweringResult`
- make prescan and lower phases return typed results
  - `preScanProgramDeclarations(ctx) -> PrescanResult`
  - `lowerProgramDeclarations(ctx, prescan) -> LoweringResult`
- wire `emit.ts` through a typed phase pipeline helper (`runProgramLoweringPhases`) and pass lowered phase output into finalization

## Scope
- compile/lowering boundary lane only
- lowering files only:
  - `src/lowering/programLowering.ts`
  - `src/lowering/emit.ts`

## Verification
- `npm run typecheck`
- `npm run check:source-file-sizes`
- `npm test -- --run test/pr582_program_prescan_named_section_rules.test.ts test/pr622_direct_data_decl_prescan.test.ts test/pr544_program_lowering_integration.test.ts test/examples_compile.test.ts`
- `npm test -- --run test/pr576_unified_data_sections.test.ts test/pr584_named_section_fixups_integration.test.ts test/pr585_named_section_layout_integration.test.ts test/pr652_startup_init_semantic_routine.test.ts`

## Note on full local suite
- `npm test -- --run` in this environment hit existing timeout failures in long-running suites (`cli_*` hooks and `pr312_expected_trace_corpus`) while targeted compile/lowering suites passed.

Closes #653
