### PR TITLE
[v0.6-quality] #646 introduce single declaration-tree visitor in semantics

### DIFF
--- a/src/semantics/declVisitor.ts
+++ b/src/semantics/declVisitor.ts
@@ -1,0 +1,34 @@
+import type {
+  ModuleItemNode,
+  NamedSectionNode,
+  SectionItemNode,
+} from '../frontend/ast.js';
+
+type DeclNode = Exclude<ModuleItemNode | SectionItemNode, NamedSectionNode>;
+
+export type DeclVisitContext = {
+  inNamedSection: boolean;
+  section?: NamedSectionNode;
+};
+
+export function visitDeclTree(
+  items: ModuleItemNode[],
+  visit: (item: DeclNode, ctx: DeclVisitContext) => void,
+): void {
+  const walkEntry = (
+    entry: ModuleItemNode | SectionItemNode,
+    ctx: DeclVisitContext,
+  ): void => {
+    if (entry.kind === 'NamedSection') {
+      for (const sectionItem of entry.items) {
+        walkEntry(sectionItem, { inNamedSection: true, section: entry });
+      }
+      return;
+    }
+    visit(entry as DeclNode, ctx);
+  };
+
+  for (const item of items) {
+    walkEntry(item, { inNamedSection: false });
+  }
+}

--- a/src/semantics/env.ts
+++ b/src/semantics/env.ts
@@ -8,15 +8,14 @@ import type {
   FuncDeclNode,
   ImportNode,
   ImmExprNode,
-  ModuleItemNode,
   ProgramNode,
-  SectionItemNode,
   TypeDeclNode,
   UnionDeclNode,
 } from '../frontend/ast.js';
 import { canonicalModuleId } from '../moduleIdentity.js';
 import { resolveVisibleConst, resolveVisibleEnum } from '../moduleVisibility.js';
 import { offsetOfPathInTypeExpr, sizeOfTypeExpr, storageInfoForTypeDecl } from './layout.js';
+import { visitDeclTree } from './declVisitor.js';
 
 /**
  * Immutable compilation environment for PR2: resolved constant and enum member values.
@@ -180,37 +179,6 @@ export function evalImmExpr(
   }
 }
 
-function collectEnumMembers(items: ModuleItemNode[]): EnumDeclNode[] {
-  const enums: EnumDeclNode[] = [];
-  const visit = (entry: ModuleItemNode | SectionItemNode): void => {
-    if (entry.kind === 'NamedSection') {
-      for (const item of entry.items) visit(item);
-      return;
-    }
-    if (entry.kind === 'EnumDecl') enums.push(entry);
-  };
-  for (const item of items) visit(item);
-  return enums;
-}
-
-function forEachDeclItem(
-  items: ModuleItemNode[],
-  visit: (item: ModuleItemNode | SectionItemNode) => void,
-): void {
-  const walk = (entry: ModuleItemNode | SectionItemNode): void => {
-    if (entry.kind === 'NamedSection') {
-      for (const item of entry.items) walk(item);
-      return;
-    }
-    visit(entry);
-  };
-  for (const item of items) walk(item);
-}
-
-function directImports(items: ModuleItemNode[]): ImportNode[] {
-  return items.filter((item): item is ImportNode => item.kind === 'Import');
-}
-
 type BuildEnvOptions = {
   typePaddingWarnings?: boolean;
   moduleIdRootDir?: string;
@@ -228,9 +196,17 @@ function importedModuleIdsForFile(
     if (!resolvedTargets) return new Set();
     return new Set(resolvedTargets.map((targetPath) => canonicalModuleId(targetPath, moduleIdRootDir)));
   }
+  const imports: ImportNode[] = [];
+  visitDeclTree(moduleFile.items, (item, ctx) => {
+    if (ctx.inNamedSection || item.kind !== 'Import') return;
+    imports.push(item);
+  });
   return new Set(
-    directImports(moduleFile.items).map((item) => {
-      const target = item.form === 'path' ? resolve(dirname(moduleFile.path), item.specifier) : item.specifier;
+    imports.map((importNode) => {
+      const target =
+        importNode.form === 'path'
+          ? resolve(dirname(moduleFile.path), importNode.specifier)
+          : importNode.specifier;
       return canonicalModuleId(target, moduleIdRootDir);
     }),
   );
@@ -281,7 +257,7 @@ export function buildEnv(
   };
 
   for (const mf of program.files) {
-    forEachDeclItem(mf.items, (item) => {
+    visitDeclTree(mf.items, (item) => {
       if (item.kind !== 'TypeDecl' && item.kind !== 'UnionDecl') return;
       const kind = item.kind === 'TypeDecl' ? 'type' : 'union';
       const name = item.name;
@@ -297,7 +273,7 @@ export function buildEnv(
   }
 
   for (const mf of program.files) {
-    forEachDeclItem(mf.items, (item) => {
+    visitDeclTree(mf.items, (item) => {
       if (item.kind === 'FuncDecl') {
         const f = item as FuncDeclNode;
         claim('func', f.name, f.span.file);
@@ -311,7 +287,9 @@ export function buildEnv(
   }
 
   for (const mf of program.files) {
-    for (const e of collectEnumMembers(mf.items)) {
+    visitDeclTree(mf.items, (item) => {
+      if (item.kind !== 'EnumDecl') return;
+      const e = item as EnumDeclNode;
       // Note: enum names are tracked for collision purposes even though PR4 does not use them.
       claim('enum', e.name, e.span.file);
 
@@ -326,7 +304,7 @@ export function buildEnv(
           visibleEnums.set(exportedName, idx);
         }
       }
-    }
+    });
   }
 
   const env: CompileEnv = {
@@ -342,7 +320,7 @@ export function buildEnv(
 
   if (options?.typePaddingWarnings === true) {
     for (const mf of program.files) {
-      forEachDeclItem(mf.items, (item) => {
+      visitDeclTree(mf.items, (item) => {
         if (item.kind !== 'TypeDecl' && item.kind !== 'UnionDecl') return;
         const info = storageInfoForTypeDecl(item, env, diagnostics);
         if (!info) return;
@@ -364,7 +342,7 @@ export function buildEnv(
   }
 
   for (const mf of program.files) {
-    forEachDeclItem(mf.items, (item) => {
+    visitDeclTree(mf.items, (item) => {
       if (item.kind !== 'ConstDecl') return;
       if (types.has(item.name)) {
         diag(diagnostics, item.span.file, `Const name "${item.name}" collides with a type name.`);

--- a/test/pr646_decl_visitor.test.ts
+++ b/test/pr646_decl_visitor.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  ImportNode,
+  ModuleItemNode,
+  NamedSectionNode,
+  SourceSpan,
+} from '../src/frontend/ast.js';
+import { visitDeclTree } from '../src/semantics/declVisitor.js';
+
+const span: SourceSpan = {
+  file: 'pr646.zax',
+  start: { line: 1, column: 1, offset: 0 },
+  end: { line: 1, column: 1, offset: 0 },
+};
+
+describe('PR646 declaration-tree visitor', () => {
+  it('walks module and named-section declarations with context', () => {
+    const importNode: ImportNode = {
+      kind: 'Import',
+      span,
+      specifier: 'dep',
+      form: 'moduleId',
+    };
+    const sectionNode: NamedSectionNode = {
+      kind: 'NamedSection',
+      span,
+      section: 'code',
+      name: 'boot',
+      items: [
+        {
+          kind: 'ConstDecl',
+          span,
+          name: 'Inside',
+          exported: false,
+          value: { kind: 'ImmLiteral', span, value: 1 },
+        },
+      ],
+    };
+
+    const items: ModuleItemNode[] = [
+      importNode,
+      sectionNode,
+      {
+        kind: 'ConstDecl',
+        span,
+        name: 'Top',
+        exported: false,
+        value: { kind: 'ImmLiteral', span, value: 2 },
+      },
+    ];
+
+    const visited: Array<{ kind: string; inNamedSection: boolean; section?: string }> = [];
+    visitDeclTree(items, (item, ctx) => {
+      visited.push({
+        kind: item.kind,
+        inNamedSection: ctx.inNamedSection,
+        ...(ctx.section ? { section: ctx.section.name } : {}),
+      });
+    });
+
+    expect(visited).toEqual([
+      { kind: 'Import', inNamedSection: false },
+      { kind: 'ConstDecl', inNamedSection: true, section: 'boot' },
+      { kind: 'ConstDecl', inNamedSection: false },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a single declaration-tree visitor utility in `src/semantics/declVisitor.ts`
- remove parallel traversal helpers in `src/semantics/env.ts` (`collectEnumMembers`, `forEachDeclItem`, `directImports`)
- migrate semantics collection passes to use one visitor path for module/section declaration walking
- keep import-module-id collection restricted to direct module-scope imports using visitor context
- add focused visitor coverage in `test/pr646_decl_visitor.test.ts`

## Verification
- `npm run typecheck`
- `npm test -- --run test/pr646_decl_visitor.test.ts test/pr575_module_visibility_scaffolding.test.ts test/pr575_callable_visibility.test.ts test/pr582_named_section_semantics_integration.test.ts test/semantics_layout.test.ts test/semantics_layout_extra.test.ts test/smoke_language_tour_compile.test.ts`

Closes #646
