### PR TITLE
[v0.6-quality] #647 consolidate visible symbol resolver helpers

### DIFF
--- a/src/moduleVisibility.ts
+++ b/src/moduleVisibility.ts
@@ -1,6 +1,18 @@
 import type { TypeDeclNode, UnionDeclNode } from './frontend/ast.js';
 import type { CompileEnv } from './semantics/env.js';
 
+function resolveVisibleSymbol<T>(
+  name: string,
+  file: string,
+  env: CompileEnv,
+  localMap: ReadonlyMap<string, T> | undefined,
+  visibleMap: ReadonlyMap<string, T> | undefined,
+): T | undefined {
+  if (!canAccessQualifiedName(name, file, env)) return undefined;
+  const qualifier = moduleQualifierOf(name);
+  return qualifier ? visibleMap?.get(name) : localMap?.get(name);
+}
+
 export function moduleQualifierOf(name: string): string | undefined {
   const dot = name.indexOf('.');
   if (dot <= 0) return undefined;
@@ -20,9 +32,7 @@ export function canAccessQualifiedName(name: string, file: string, env: CompileE
 }
 
 export function resolveVisibleConst(name: string, file: string, env: CompileEnv): number | undefined {
-  if (!canAccessQualifiedName(name, file, env)) return undefined;
-  const qualifier = moduleQualifierOf(name);
-  return qualifier ? env.visibleConsts?.get(name) : env.consts.get(name);
+  return resolveVisibleSymbol(name, file, env, env.consts, env.visibleConsts);
 }
 
 export function resolveVisibleEnum(name: string, file: string, env: CompileEnv): number | undefined {
@@ -30,11 +40,7 @@ export function resolveVisibleEnum(name: string, file: string, env: CompileEnv):
   // dotted name as a module-qualified export alias (e.g. dep.Mode.Value).
   const local = env.enums.get(name);
   if (local !== undefined) return local;
-
-  const qualifier = moduleQualifierOf(name);
-  if (!qualifier) return undefined;
-  if (!canAccessQualifiedName(name, file, env)) return undefined;
-  return env.visibleEnums?.get(name);
+  return resolveVisibleSymbol(name, file, env, undefined, env.visibleEnums);
 }
 
 export function resolveVisibleType(
@@ -42,7 +48,5 @@ export function resolveVisibleType(
   file: string,
   env: CompileEnv,
 ): TypeDeclNode | UnionDeclNode | undefined {
-  if (!canAccessQualifiedName(name, file, env)) return undefined;
-  const qualifier = moduleQualifierOf(name);
-  return qualifier ? env.visibleTypes?.get(name) : env.types.get(name);
+  return resolveVisibleSymbol(name, file, env, env.types, env.visibleTypes);
 }

--- a/test/pr647_visible_symbol_resolver.test.ts
+++ b/test/pr647_visible_symbol_resolver.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SourceSpan, TypeDeclNode, UnionDeclNode } from '../src/frontend/ast.js';
+import {
+  resolveVisibleConst,
+  resolveVisibleEnum,
+  resolveVisibleType,
+} from '../src/moduleVisibility.js';
+import type { CompileEnv } from '../src/semantics/env.js';
+
+const span: SourceSpan = {
+  file: 'pr647.zax',
+  start: { line: 1, column: 1, offset: 0 },
+  end: { line: 1, column: 1, offset: 0 },
+};
+
+const typeDecl: TypeDeclNode = {
+  kind: 'TypeDecl',
+  span,
+  name: 'LocalType',
+  exported: false,
+  typeExpr: { kind: 'TypeName', span, name: 'word' },
+};
+
+const unionDecl: UnionDeclNode = {
+  kind: 'UnionDecl',
+  span,
+  name: 'RemoteType',
+  exported: true,
+  fields: [],
+};
+
+function makeEnv(): CompileEnv {
+  return {
+    consts: new Map([['LOCAL', 1]]),
+    enums: new Map([['Mode.Value', 7]]),
+    types: new Map([['LocalType', typeDecl]]),
+    visibleConsts: new Map([['dep.REMOTE', 2]]),
+    visibleEnums: new Map([['dep.Mode.Value', 9], ['Mode.Value', 99]]),
+    visibleTypes: new Map([['dep.RemoteType', unionDecl]]),
+    moduleIds: new Map([['root.zax', 'root']]),
+    importedModuleIds: new Map([['root.zax', new Set(['dep'])]]),
+  };
+}
+
+describe('PR647 visible symbol resolver consolidation', () => {
+  it('resolves local and imported visible consts and types through shared path', () => {
+    const env = makeEnv();
+
+    expect(resolveVisibleConst('LOCAL', 'root.zax', env)).toBe(1);
+    expect(resolveVisibleConst('dep.REMOTE', 'root.zax', env)).toBe(2);
+    expect(resolveVisibleType('LocalType', 'root.zax', env)).toBe(typeDecl);
+    expect(resolveVisibleType('dep.RemoteType', 'root.zax', env)).toBe(unionDecl);
+  });
+
+  it('preserves enum local precedence over qualified-alias lookup', () => {
+    const env = makeEnv();
+
+    expect(resolveVisibleEnum('Mode.Value', 'root.zax', env)).toBe(7);
+    expect(resolveVisibleEnum('dep.Mode.Value', 'root.zax', env)).toBe(9);
+  });
+
+  it('fails closed for non-imported qualified access', () => {
+    const env = makeEnv();
+    env.importedModuleIds?.set('root.zax', new Set());
+
+    expect(resolveVisibleConst('dep.REMOTE', 'root.zax', env)).toBeUndefined();
+    expect(resolveVisibleType('dep.RemoteType', 'root.zax', env)).toBeUndefined();
+    expect(resolveVisibleEnum('dep.Mode.Value', 'root.zax', env)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add a generic internal resolver in `src/moduleVisibility.ts` to deduplicate visible symbol access logic
- refactor `resolveVisibleConst` and `resolveVisibleType` to use the shared resolver
- keep `resolveVisibleEnum` local-enum precedence unchanged, then route qualified alias lookup through the shared resolver
- add focused regression coverage in `test/pr647_visible_symbol_resolver.test.ts`

## Verification
- `npm run typecheck`
- `npm test -- --run test/pr647_visible_symbol_resolver.test.ts test/pr575_module_visibility_scaffolding.test.ts test/pr575_callable_visibility.test.ts test/smoke_language_tour_compile.test.ts`

Closes #647
