### PR TITLE
chore: relicense to public domain (The Unlicense)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the software
+to the public domain. We make this dedication for the benefit of the
+public at large and to the detriment of our heirs and successors. We
+intend this dedication to be an overt act of relinquishment in
+perpetuity of all present and future rights to this software under
+copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/README.md
+++ b/README.md
@@ -332,4 +332,4 @@ Tests are organized by spec section and PR scope under `test/`. Golden-file comp
 
 ## License
 
-GPL-3.0-or-later. See [LICENSE](LICENSE).
+Public domain. See [LICENSE](LICENSE) ([The Unlicense](https://unlicense.org)).


### PR DESCRIPTION
## Summary

- Replaces the GPL-3.0 `LICENSE` file with [The Unlicense](https://unlicense.org) — a public domain dedication that GitHub natively recognises and labels correctly on the repository page.
- Updates the `README.md` license line from `GPL-3.0-or-later` to `Public domain. See LICENSE (The Unlicense)`.

## Why The Unlicense

GitHub's license detector recognises The Unlicense out of the box and displays the "Unlicense" badge on the repo page. CC0 is also detected but is aimed at creative works; The Unlicense is purpose-built for software and is the standard choice for putting code into the public domain.

## Test plan

- [ ] Confirm GitHub repo page shows "Unlicense" under the license field after merge
- [ ] Verify `LICENSE` file contents match https://unlicense.org verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)