### PR TITLE
#682 docs: consolidate canonical testing and verification guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,24 +331,23 @@ zax [options] <entry.zax>
 
 ## Development
 
-```sh
-npm run typecheck     # Type-check without emitting
-npm test              # Run test suite
-npm run format        # Format with Prettier
-```
+Use the canonical contributor verification guide:
 
-Tests are organized by spec section and PR scope under `test/`. Golden-file comparisons ensure output stability. The `examples/*.zax` files serve as end-to-end acceptance tests — they must compile without errors in CI.
+- `docs/testing-verification-guide.md`
+
+It defines the current local verification flow, fixture refresh commands, and CI expectations.
 
 ---
 
 ## Documentation
 
-| Document                        | Purpose                                                             |
-| ------------------------------- | ------------------------------------------------------------------- |
-| `docs/zax-spec.md`              | **Normative** language specification (includes CLI/op appendices)   |
-| `docs/ZAX-quick-guide.md`       | Practical quick guide for daily language usage (non-normative)      |
-| `docs/zax-dev-playbook.md`      | Consolidated implementation, roadmap, checklist, and workflow guide |
-| `docs/v02-codegen-reference.md` | Consolidated v0.2 codegen entry point and archive links             |
+| Document                             | Purpose                                                           |
+| ------------------------------------ | ----------------------------------------------------------------- |
+| `docs/zax-spec.md`                   | **Normative** language specification (includes CLI/op appendices) |
+| `docs/ZAX-quick-guide.md`            | Practical quick guide for daily language usage (non-normative)    |
+| `docs/testing-verification-guide.md` | Canonical testing/verification flow for contributors              |
+| `docs/zax-dev-playbook.md`           | Contributor workflow and review/merge hygiene                     |
+| `docs/v02-codegen-reference.md`      | Consolidated v0.2 codegen entry point and archive links           |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ This directory is intentionally constrained. Every file below has a unique purpo
 ## 3. Core Supporting References (Non-normative)
 
 - `zax-dev-playbook.md` — contributor workflow only (branching, review, refactor, merge hygiene); no roadmap history or semantic policy.
+- `testing-verification-guide.md` — canonical contributor testing, verification, fixture refresh, and CI expectations reference.
 - `v02-codegen-reference.md` — single-stop v0.2 codegen reference (what to read, invariants).
 - `v02-codegen-worked-examples.md` — worked `.zax` → `.asm` examples for frame/call behavior.
 - `v04-planning-track.md` — v0.4 code-quality planning record.
@@ -39,6 +40,7 @@ This directory is intentionally constrained. Every file below has a unique purpo
 - `v02-codegen-worked-examples.md`: executable worked examples and expected lowering shapes only.
 - `return-register-policy.md`: preservation matrix and HL-preserve swap guidance.
 - `zax-dev-playbook.md`: contributor workflow only; must not duplicate planning history, semantic policy, or version-status tracking.
+- `testing-verification-guide.md`: single source for contributor verification commands, fixture refresh flow, and CI testing expectations.
 - `source-overview.md`: non-normative architecture map of the current code layout and subsystem boundaries.
 - `modules.md`: non-normative but authoritative v0.5 design direction for the planned section/module model.
 - `v05-planning-track.md`: active staged implementation plan responding to `modules.md`.

--- a/docs/github-backlog-workflow.md
+++ b/docs/github-backlog-workflow.md
@@ -79,17 +79,9 @@ Issue close rule:
 
 ## CI Change Classification Rule
 
-Docs-only PRs are short-circuited in CI and must satisfy this path rule:
+Testing-path and CI verification expectations are maintained in:
 
-- docs-only set: all changed files are in `docs/**`, match `*.md`, or are under `.github/ISSUE_TEMPLATE/**`
-- docs-only result: run `docs (fast)` only, skip full `test (ubuntu/macos/windows)` matrix
-- any non-doc path in the change set: run full matrix
-
-Implementation anchors:
-
-- workflow: `.github/workflows/ci.yml` (`detect-changes` job)
-- classifier script: `scripts/ci/change-classifier.js`
-- classifier tests: `test/pr288_ci_docs_only_classifier.test.ts`
+- `docs/testing-verification-guide.md`
 
 ## Dependency Handling Without Project Views
 

--- a/docs/testing-verification-guide.md
+++ b/docs/testing-verification-guide.md
@@ -1,0 +1,88 @@
+# ZAX Testing and Verification Guide (Canonical)
+
+This is the single contributor reference for local verification flow, fixture refresh commands, and CI expectations.
+
+Normative language behavior remains defined only by `docs/zax-spec.md`.
+
+## Local verification flow
+
+Run from repo root:
+
+```sh
+npm ci
+npm run typecheck
+```
+
+For a focused change, run targeted tests first:
+
+```sh
+npm test -- --run test/<targeted-test-file>.test.ts
+```
+
+Run smoke compile coverage before opening a PR:
+
+```sh
+npm test -- --run test/smoke_language_tour_compile.test.ts
+```
+
+Run file-size guard for refactor slices:
+
+```sh
+npm run check:source-file-sizes
+```
+
+Run full suite when your slice touches broad behavior:
+
+```sh
+npm test
+```
+
+For docs-only changes, check changed docs paths with Prettier:
+
+```sh
+npx prettier -c <changed-doc-paths...>
+```
+
+## Fixture refresh commands
+
+Refresh language-tour generated artifacts:
+
+```sh
+npm run regen:language-tour
+```
+
+Refresh codegen corpus generated artifacts:
+
+```sh
+npm run regen:codegen-corpus
+```
+
+After running either refresh command:
+
+1. Re-run `npm run typecheck`.
+2. Run targeted tests touching the refreshed fixtures.
+3. Run `npm test -- --run test/smoke_language_tour_compile.test.ts`.
+
+## CI expectations
+
+- PRs to `main` run through `.github/workflows/ci.yml`.
+- Docs-only changes are detected by `scripts/ci/change-classifier.js`.
+- Docs-only path set:
+  - `docs/**`
+  - `*.md`
+  - `.github/ISSUE_TEMPLATE/**`
+- Docs-only result:
+  - run `docs (fast)`
+  - skip full `test (ubuntu/macos/windows)` matrix
+- Any non-doc path changed:
+  - run full platform matrix
+
+Do not merge while required CI jobs are pending or failing.
+
+## PR verification evidence
+
+In every PR body, include:
+
+1. Scope summary (what changed and what did not).
+2. Verification commands you ran.
+3. Current CI state (pending/green/failing) with the PR link.

--- a/docs/zax-dev-playbook.md
+++ b/docs/zax-dev-playbook.md
@@ -128,6 +128,12 @@ Preferred extraction order for oversized modules:
 
 ## Testing Expectations
 
+Canonical command reference:
+
+- `docs/testing-verification-guide.md`
+
+This playbook keeps workflow principles only. Keep concrete command lists and CI testing-path details in the testing guide.
+
 Use targeted tests to support refactors.
 
 Preferred order:


### PR DESCRIPTION
## Summary
- add a single canonical contributor testing/verification reference: `docs/testing-verification-guide.md`
- fold duplicate testing/CI guidance in README, dev playbook, and backlog workflow docs into links to the canonical guide
- keep scope docs-only

## Changed files
- `README.md`
- `docs/testing-verification-guide.md`
- `docs/README.md`
- `docs/zax-dev-playbook.md`
- `docs/github-backlog-workflow.md`

## Verification
- `npm run typecheck`
- `npm run check:source-file-sizes`
- `npm test -- --run test/smoke_language_tour_compile.test.ts`
- `npm run | rg -n "regen:language-tour|regen:codegen-corpus|typecheck|check:source-file-sizes|format:check"`
- `npx prettier -c README.md docs/README.md docs/zax-dev-playbook.md docs/github-backlog-workflow.md docs/testing-verification-guide.md`

Closes #682