### PR TITLE
#681: stabilize CI timeouts by partitioning slow test slice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       SKIP_LANGUAGE_TOUR: '1'
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -118,12 +118,15 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
-      - name: Test
-        id: coverage_tests
-        run: npm run test:coverage
+      - name: Test (coverage core)
+        id: coverage_core_tests
+        run: npm run test:ci:coverage-core
+
+      - name: Test (slow reliability partition)
+        run: npm run test:ci:slow-reliability
 
       - name: Upload coverage artifact
-        if: always() && steps.coverage_tests.outcome != 'skipped' && hashFiles('coverage/**') != ''
+        if: always() && steps.coverage_core_tests.outcome != 'skipped' && hashFiles('coverage/**') != ''
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "pretest": "mkdir -p coverage/.tmp",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:ci:coverage-core": "vitest run --coverage --exclude 'test/cli_*.test.ts' --exclude 'test/pr312_expected_trace_corpus.test.ts'",
+    "test:ci:slow-reliability": "vitest run --no-file-parallelism --maxWorkers=1 --minWorkers=1 --testTimeout=20000 --hookTimeout=300000 test/cli_*.test.ts test/pr312_expected_trace_corpus.test.ts",
     "test:watch": "vitest",
     "format": "prettier -w .",
     "format:check": "prettier -c .",


### PR DESCRIPTION
## Summary
- Split CI test execution into two steps per OS: coverage core and slow reliability partition.
- Keep reliability-sensitive CLI/trace suites in a serialized partition with explicit timeout budget (`--no-file-parallelism`, `--maxWorkers=1`, `--testTimeout=20000`, `--hookTimeout=300000`).
- Increase CI test job timeout from 10 to 15 minutes for partitioned execution headroom.

## Scope Check
- CI/test reliability only.
- No compiler semantics changes in `src/**`.

## Changed Files
- `.github/workflows/ci.yml`
- `package.json`

## Local Verification
- `npm run typecheck` ✅
- `npm run test:ci:coverage-core` ✅
- `npm run test:ci:slow-reliability` ✅

## Before/After Timing Impact (local, isolated runs)
- Before (monolithic slow slice under coverage):
  - `npx vitest run --coverage test/cli_*.test.ts test/pr312_expected_trace_corpus.test.ts`
  - elapsed: `2:17.65`
- After (partitioned):
  - `npm run test:ci:coverage-core` elapsed: `1:03.56`
  - `npm run test:ci:slow-reliability` elapsed: `0:34.04`
  - combined elapsed: `1:37.60`

Refs #681
