### PR TITLE
Unify parser dispatch path and callable header parsing

### DIFF
--- a/src/frontend/parseCallableHeader.ts
+++ b/src/frontend/parseCallableHeader.ts
@@ -1,0 +1,80 @@
+import type { SourceSpan } from './ast.js';
+import type { Diagnostic } from '../diagnostics/types.js';
+import { parseDiag as diag } from './parseDiagnostics.js';
+import { diagInvalidHeaderLine, formatIdentifierToken } from './parseModuleCommon.js';
+
+export type ParsedCallableHeader<TParam> = {
+  name: string;
+  params: TParam[];
+  trailing: string;
+};
+
+type ParseCallableHeaderOptions<TParam> = {
+  kind: 'func' | 'op';
+  header: string;
+  stmtText: string;
+  stmtSpan: SourceSpan;
+  lineNo: number;
+  diagnostics: Diagnostic[];
+  modulePath: string;
+  expectedHeader: string;
+  isReservedTopLevelName: (name: string) => boolean;
+  parseParams: (paramsText: string) => TParam[] | undefined;
+};
+
+export function parseCallableHeader<TParam>(
+  options: ParseCallableHeaderOptions<TParam>,
+): ParsedCallableHeader<TParam> | undefined {
+  const {
+    kind,
+    header,
+    stmtText,
+    stmtSpan,
+    lineNo,
+    diagnostics,
+    modulePath,
+    expectedHeader,
+    isReservedTopLevelName,
+    parseParams,
+  } = options;
+
+  const openParen = header.indexOf('(');
+  const closeParen = header.lastIndexOf(')');
+  if (openParen < 0 || closeParen < openParen) {
+    diagInvalidHeaderLine(diagnostics, modulePath, `${kind} header`, stmtText, expectedHeader, lineNo);
+    return undefined;
+  }
+
+  const name = header.slice(0, openParen).trim();
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    diag(
+      diagnostics,
+      modulePath,
+      `Invalid ${kind} name ${formatIdentifierToken(name)}: expected <identifier>.`,
+      { line: lineNo, column: 1 },
+    );
+    return undefined;
+  }
+  if (isReservedTopLevelName(name)) {
+    diag(
+      diagnostics,
+      modulePath,
+      `Invalid ${kind} name "${name}": collides with a top-level keyword.`,
+      {
+        line: lineNo,
+        column: 1,
+      },
+    );
+    return undefined;
+  }
+
+  const paramsText = header.slice(openParen + 1, closeParen);
+  const params = parseParams(paramsText);
+  if (!params) return undefined;
+
+  return {
+    name,
+    params,
+    trailing: header.slice(closeParen + 1).trimStart(),
+  };
+}

--- a/src/frontend/parseFunc.ts
+++ b/src/frontend/parseFunc.ts
@@ -20,14 +20,13 @@ import {
 } from './parseAsmStatements.js';
 import {
   diagInvalidBlockLine,
-  diagInvalidHeaderLine,
-  formatIdentifierToken,
   looksLikeKeywordBodyDeclLine,
   parseReturnRegsFromText,
   parseVarDeclLine,
   topLevelStartKeyword,
 } from './parseModuleCommon.js';
 import type { ParseParamsContext } from './parseParams.js';
+import { parseCallableHeader } from './parseCallableHeader.js';
 
 function stripComment(line: string): string {
   const semi = line.indexOf(';');
@@ -78,46 +77,29 @@ export function parseTopLevelFuncDecl(
     isReservedTopLevelName,
     parseParamsFromText,
   } = ctx;
-  const header = funcTail;
-  const openParen = header.indexOf('(');
-  const closeParen = header.lastIndexOf(')');
-  if (openParen < 0 || closeParen < openParen) {
-    diagInvalidHeaderLine(
-      diagnostics,
-      modulePath,
-      'func header',
-      stmtText,
-      '<name>(...): <retType>',
-      lineNo,
-    );
+  const parsedHeader = parseCallableHeader({
+    kind: 'func',
+    header: funcTail,
+    stmtText,
+    stmtSpan,
+    lineNo,
+    diagnostics,
+    modulePath,
+    expectedHeader: '<name>(...): <retType>',
+    isReservedTopLevelName,
+    parseParams: (paramsText) =>
+      parseParamsFromText(modulePath, paramsText, stmtSpan, diagnostics, {
+        isReservedTopLevelName,
+      }),
+  });
+  if (!parsedHeader) {
     return { nextIndex: startIndex + 1 };
   }
 
-  const name = header.slice(0, openParen).trim();
-  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
-    diag(
-      diagnostics,
-      modulePath,
-      `Invalid func name ${formatIdentifierToken(name)}: expected <identifier>.`,
-      { line: lineNo, column: 1 },
-    );
-    return { nextIndex: startIndex + 1 };
-  }
-  if (isReservedTopLevelName(name)) {
-    diag(
-      diagnostics,
-      modulePath,
-      `Invalid func name "${name}": collides with a top-level keyword.`,
-      {
-        line: lineNo,
-        column: 1,
-      },
-    );
-    return { nextIndex: startIndex + 1 };
-  }
-
+  const name = parsedHeader.name;
+  const params = parsedHeader.params;
   const funcStartOffset = stmtSpan.start.offset;
-  const afterClose = header.slice(closeParen + 1).trimStart();
+  const afterClose = parsedHeader.trailing;
   let returnRegs: string[] = [];
   if (afterClose.length !== 0) {
     const retMatch = /^:\s*(.+)$/.exec(afterClose);
@@ -138,12 +120,6 @@ export function parseTopLevelFuncDecl(
     if (!parsedRegs) return { nextIndex: startIndex + 1 };
     returnRegs = parsedRegs.regs;
   }
-
-  const paramsText = header.slice(openParen + 1, closeParen);
-  const params = parseParamsFromText(modulePath, paramsText, stmtSpan, diagnostics, {
-    isReservedTopLevelName,
-  });
-  if (!params) return { nextIndex: startIndex + 1 };
 
   let index = startIndex + 1;
 

--- a/src/frontend/parseOp.ts
+++ b/src/frontend/parseOp.ts
@@ -10,12 +10,10 @@ import {
   type AsmControlFrame,
 } from './parseAsmStatements.js';
 import {
-  diagInvalidHeaderLine,
-  formatIdentifierToken,
-  parseReturnRegsFromText,
   topLevelStartKeyword,
 } from './parseModuleCommon.js';
 import type { ParseParamsContext } from './parseParams.js';
+import { parseCallableHeader } from './parseCallableHeader.js';
 
 function stripComment(line: string): string {
   const semi = line.indexOf(';');
@@ -66,33 +64,28 @@ export function parseTopLevelOpDecl(
     isReservedTopLevelName,
     parseOpParamsFromText,
   } = ctx;
-  const header = opTail;
-  const openParen = header.indexOf('(');
-  const closeParen = header.lastIndexOf(')');
-  if (openParen < 0 || closeParen < openParen) {
-    diagInvalidHeaderLine(diagnostics, modulePath, 'op header', stmtText, '<name>(...)', lineNo);
+  const parsedHeader = parseCallableHeader({
+    kind: 'op',
+    header: opTail,
+    stmtText,
+    stmtSpan,
+    lineNo,
+    diagnostics,
+    modulePath,
+    expectedHeader: '<name>(...)',
+    isReservedTopLevelName,
+    parseParams: (paramsText) =>
+      parseOpParamsFromText(modulePath, paramsText, stmtSpan, diagnostics, {
+        isReservedTopLevelName,
+      }),
+  });
+  if (!parsedHeader) {
     return undefined;
   }
 
-  const name = header.slice(0, openParen).trim();
-  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
-    diag(
-      diagnostics,
-      modulePath,
-      `Invalid op name ${formatIdentifierToken(name)}: expected <identifier>.`,
-      { line: lineNo, column: 1 },
-    );
-    return undefined;
-  }
-  if (isReservedTopLevelName(name)) {
-    diag(diagnostics, modulePath, `Invalid op name "${name}": collides with a top-level keyword.`, {
-      line: lineNo,
-      column: 1,
-    });
-    return undefined;
-  }
-
-  const trailing = header.slice(closeParen + 1).trim();
+  const name = parsedHeader.name;
+  const params = parsedHeader.params;
+  const trailing = parsedHeader.trailing.trim();
   if (trailing.length > 0) {
     diag(diagnostics, modulePath, `Invalid op header: unexpected trailing tokens`, {
       line: lineNo,
@@ -102,11 +95,6 @@ export function parseTopLevelOpDecl(
   }
 
   const opStartOffset = stmtSpan.start.offset;
-  const paramsText = header.slice(openParen + 1, closeParen);
-  const params = parseOpParamsFromText(modulePath, paramsText, stmtSpan, diagnostics, {
-    isReservedTopLevelName,
-  });
-  if (!params) return undefined;
 
   let index = startIndex + 1;
   const bodyItems: AsmItemNode[] = [];

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -212,7 +212,7 @@ export function parseModuleFile(
     sectionClosed?: boolean;
   };
 
-  function parseItemAt(index: number, ctx: ParseItemContext): ParseItemResult {
+  function parseModuleItem(index: number, ctx: ParseItemContext): ParseItemResult {
     const { raw, startOffset: lineStartOffset, endOffset: lineEndOffset } = getRawLine(index);
     const text = stripComment(raw).trim();
     const lineNo = index + 1;
@@ -593,7 +593,7 @@ export function parseModuleFile(
     let index = startIndex;
 
     while (index < lineCount) {
-      const parsed = parseItemAt(index, {
+      const parsed = parseModuleItem(index, {
         scope: 'section',
         sectionKind,
         directDeclNamesLower,
@@ -614,7 +614,7 @@ export function parseModuleFile(
 
   let i = 0;
   while (i < lineCount) {
-    const parsed = parseItemAt(i, { scope: 'module' });
+    const parsed = parseModuleItem(i, { scope: 'module' });
     if (parsed.node) items.push(parsed.node as ModuleItemNode);
     i = parsed.nextIndex;
   }

--- a/test/pr689_callable_header_parser.test.ts
+++ b/test/pr689_callable_header_parser.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { parseCallableHeader } from '../src/frontend/parseCallableHeader.js';
+import { makeSourceFile, span } from '../src/frontend/source.js';
+
+describe('PR689 callable header parser primitive', () => {
+  it('parses shared callable header shape and params', () => {
+    const file = makeSourceFile('pr689_callable_header_parser.zax', 'func add(lhs: word, rhs: word): HL');
+    const diagnostics: Diagnostic[] = [];
+    const stmtSpan = span(file, 0, file.text.length);
+    const parsed = parseCallableHeader({
+      kind: 'func',
+      header: 'add(lhs: word, rhs: word): HL',
+      stmtText: 'func add(lhs: word, rhs: word): HL',
+      stmtSpan,
+      lineNo: 1,
+      diagnostics,
+      modulePath: file.path,
+      expectedHeader: '<name>(...): <retType>',
+      isReservedTopLevelName: () => false,
+      parseParams: (paramsText) => paramsText.split(',').map((part) => part.trim()),
+    });
+
+    expect(diagnostics).toEqual([]);
+    expect(parsed).toEqual({
+      name: 'add',
+      params: ['lhs: word', 'rhs: word'],
+      trailing: ': HL',
+    });
+  });
+
+  it('preserves callable-kind-specific diagnostics for invalid names', () => {
+    const file = makeSourceFile('pr689_callable_header_invalid.zax', 'op 1bad()');
+    const diagnostics: Diagnostic[] = [];
+    const stmtSpan = span(file, 0, file.text.length);
+    const parsed = parseCallableHeader({
+      kind: 'op',
+      header: '1bad()',
+      stmtText: 'op 1bad()',
+      stmtSpan,
+      lineNo: 1,
+      diagnostics,
+      modulePath: file.path,
+      expectedHeader: '<name>(...)',
+      isReservedTopLevelName: () => false,
+      parseParams: () => [],
+    });
+
+    expect(parsed).toBeUndefined();
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      message: 'Invalid op name "1bad": expected <identifier>.',
+      line: 1,
+      column: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add shared `parseCallableHeader(...)` primitive for callable name/paren/param parsing
- route both `parseTopLevelFuncDecl(...)` and `parseTopLevelOpDecl(...)` through the shared header parser
- keep module/section parsing on the single context-driven `parseModuleItem(...)` dispatch path in `parser.ts`
- add targeted parser test coverage for the shared callable-header primitive

Closes #689

## Verification
- `npm run typecheck`
- `npm test -- --run test/pr689_callable_header_parser.test.ts test/pr476_parse_func_helpers.test.ts test/pr476_parse_op_helpers.test.ts test/pr572_named_sections_parser.test.ts test/pr196_parser_control_interruption_matrix.test.ts test/pr170_block_termination_recovery_matrix.test.ts test/smoke_language_tour_compile.test.ts`
