### PR TITLE
Harden AST optional contracts for vars and function locals

### DIFF
--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -195,16 +195,29 @@ export interface VarBlockNode extends BaseNode {
 /**
  * Single variable declaration inside a `var` block.
  */
-export interface VarDeclNode extends BaseNode {
+export type VarDeclNode = VarDeclTypedNode | VarDeclAliasNode;
+
+export interface VarDeclTypedNode extends BaseNode {
   kind: 'VarDecl';
+  form: 'typed';
   name: string;
-  typeExpr?: TypeExprNode;
-  initializer?: VarDeclInitializerNode;
+  typeExpr: TypeExprNode;
+  initializer?: VarDeclValueInitializerNode;
+}
+
+export interface VarDeclAliasNode extends BaseNode {
+  kind: 'VarDecl';
+  form: 'alias';
+  name: string;
+  initializer: VarDeclAliasInitializerNode;
 }
 
 export type VarDeclInitializerNode =
-  | { kind: 'VarInitValue'; span: SourceSpan; expr: ImmExprNode }
-  | { kind: 'VarInitAlias'; span: SourceSpan; expr: EaExprNode };
+  | VarDeclValueInitializerNode
+  | VarDeclAliasInitializerNode;
+
+export type VarDeclValueInitializerNode = { kind: 'VarInitValue'; span: SourceSpan; expr: ImmExprNode };
+export type VarDeclAliasInitializerNode = { kind: 'VarInitAlias'; span: SourceSpan; expr: EaExprNode };
 
 /**
  * Data storage block (`data`) with initializers.
@@ -287,7 +300,7 @@ export interface FuncDeclNode extends BaseNode {
   exported: boolean;
   params: ParamNode[];
   returnRegs: string[];
-  locals?: VarBlockNode;
+  locals: VarBlockNode;
   asm: AsmBlockNode;
 }
 

--- a/src/frontend/parseFunc.ts
+++ b/src/frontend/parseFunc.ts
@@ -305,6 +305,14 @@ export function parseTopLevelFuncDecl(
       const funcSpan = span(file, funcStartOffset, funcEndOffset);
       const asmSpan = span(file, asmStartOffset, funcEndOffset);
       const asm: AsmBlockNode = { kind: 'AsmBlock', span: asmSpan, items: asmItems };
+      const localsNode: VarBlockNode =
+        locals ??
+        ({
+          kind: 'VarBlock',
+          span: span(file, funcStartOffset, funcStartOffset),
+          scope: 'function',
+          decls: [],
+        } satisfies VarBlockNode);
 
       return {
         node: {
@@ -314,7 +322,7 @@ export function parseTopLevelFuncDecl(
           exported,
           params,
           returnRegs,
-          ...(locals ? { locals } : {}),
+          locals: localsNode,
           asm,
         },
         nextIndex: index + 1,

--- a/src/frontend/parseModuleCommon.ts
+++ b/src/frontend/parseModuleCommon.ts
@@ -251,7 +251,7 @@ export function parseVarDeclLine(
       span: declSpan,
       expr: rhsEa,
     };
-    return { kind: 'VarDecl', span: declSpan, name, initializer };
+    return { kind: 'VarDecl', form: 'alias', span: declSpan, name, initializer };
   }
 
   const typedMatch = /^([^:]+)\s*:\s*(.+)$/.exec(raw);
@@ -301,7 +301,7 @@ export function parseVarDeclLine(
   }
 
   if (eqIdx < 0) {
-    return { kind: 'VarDecl', span: declSpan, name, typeExpr };
+    return { kind: 'VarDecl', form: 'typed', span: declSpan, name, typeExpr };
   }
 
   const aliasLike = parseEaExprFromText(modulePath, initText, declSpan, diagnostics);
@@ -326,5 +326,5 @@ export function parseVarDeclLine(
     span: declSpan,
     expr: valueExpr,
   };
-  return { kind: 'VarDecl', span: declSpan, name, typeExpr, initializer };
+  return { kind: 'VarDecl', form: 'typed', span: declSpan, name, typeExpr, initializer };
 }

--- a/src/lowering/functionLowering.ts
+++ b/src/lowering/functionLowering.ts
@@ -249,7 +249,7 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
   stackSlotTypes.clear();
   localAliasTargets.clear();
 
-  const localDecls = item.locals?.decls ?? [];
+  const localDecls = item.locals.decls;
   const returnRegs = item.returnRegs.map((r: string) => r.toUpperCase());
   const basePreserveOrder: string[] = ['AF', 'BC', 'DE', 'HL'];
   let preserveSet = basePreserveOrder.filter((r) => !returnRegs.includes(r));
@@ -266,7 +266,7 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
   for (let li = 0; li < localDecls.length; li++) {
     const decl = localDecls[li]!;
     const declLower = decl.name.toLowerCase();
-    if (decl.typeExpr) {
+    if (decl.form === 'typed') {
       const scalarKind = resolveScalarKind(decl.typeExpr);
       if (!scalarKind) {
         diagAt(
@@ -282,14 +282,6 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
       stackSlotTypes.set(declLower, decl.typeExpr);
       localSlotCount++;
       const init = decl.initializer;
-      if (init && init.kind !== 'VarInitValue') {
-        diagAt(
-          diagnostics,
-          decl.span,
-          `Unsupported typed alias form for "${decl.name}": use "${decl.name} = rhs" for alias initialization.`,
-        );
-        continue;
-      }
       localScalarInitializers.push({
         name: decl.name,
         ...(init ? { expr: init.expr } : {}),
@@ -299,14 +291,6 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
       continue;
     }
     const init = decl.initializer;
-    if (init?.kind !== 'VarInitAlias') {
-      diagAt(
-        diagnostics,
-        decl.span,
-        `Invalid local declaration "${decl.name}": expected typed storage or alias initializer.`,
-      );
-      continue;
-    }
     localAliasTargets.set(declLower, init.expr);
     const inferred = resolveEaTypeExpr(init.expr);
     if (!inferred) {

--- a/src/lowering/programLowering.ts
+++ b/src/lowering/programLowering.ts
@@ -236,11 +236,11 @@ export function preScanProgramDeclarations(ctx: Context): PrescanResult {
       const vb = item as VarBlockNode;
       for (const decl of vb.decls) {
         const lower = decl.name.toLowerCase();
-        if (decl.typeExpr) {
+        if (decl.form === 'typed') {
           ctx.storageTypes.set(lower, decl.typeExpr);
           continue;
         }
-        if (decl.initializer?.kind === 'VarInitAlias') {
+        if (decl.initializer.kind === 'VarInitAlias') {
           ctx.moduleAliasTargets.set(lower, decl.initializer.expr);
           ctx.moduleAliasDecls.set(lower, decl);
         }
@@ -305,7 +305,7 @@ export function lowerProgramDeclarations(ctx: Context, _prescan: PrescanResult):
   };
   const lowerVarBlock = (varBlock: VarBlockNode): void => {
     for (const decl of varBlock.decls) {
-      if (!decl.typeExpr) continue;
+      if (decl.form !== 'typed') continue;
       const size = ctx.sizeOfTypeExpr(decl.typeExpr, ctx.env, ctx.diagnostics);
       if (size === undefined) continue;
       if (ctx.env.consts.has(decl.name)) {

--- a/test/pr690_ast_optional_contracts.test.ts
+++ b/test/pr690_ast_optional_contracts.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { parseVarDeclLine } from '../src/frontend/parseModuleCommon.js';
+import { parseProgram } from '../src/frontend/parser.js';
+import { makeSourceFile, span } from '../src/frontend/source.js';
+
+describe('PR690 AST optional contract hardening', () => {
+  it('emits discriminated var decl forms for typed and alias declarations', () => {
+    const file = makeSourceFile('pr690_var_forms.zax', '');
+    const lineSpan = span(file, 0, 0);
+    const diagnostics: Diagnostic[] = [];
+
+    const typed = parseVarDeclLine('count: word = $12', lineSpan, 1, 'var', {
+      diagnostics,
+      modulePath: file.path,
+      isReservedTopLevelName: () => false,
+    });
+    const alias = parseVarDeclLine('slot = arr[idx]', lineSpan, 2, 'var', {
+      diagnostics,
+      modulePath: file.path,
+      isReservedTopLevelName: () => false,
+    });
+
+    expect(diagnostics).toEqual([]);
+    expect(typed).toMatchObject({
+      kind: 'VarDecl',
+      form: 'typed',
+      name: 'count',
+      typeExpr: { kind: 'TypeName', name: 'word' },
+      initializer: { kind: 'VarInitValue' },
+    });
+    expect(alias).toMatchObject({
+      kind: 'VarDecl',
+      form: 'alias',
+      name: 'slot',
+      initializer: { kind: 'VarInitAlias' },
+    });
+  });
+
+  it('always emits function locals block (empty when no locals declared)', () => {
+    const diagnostics: Diagnostic[] = [];
+    const program = parseProgram(
+      'pr690_func_locals.zax',
+      ['func main()', 'ret', 'end', ''].join('\n'),
+      diagnostics,
+    );
+
+    expect(diagnostics).toEqual([]);
+    const fn = program.files[0]?.items[0];
+    expect(fn).toMatchObject({
+      kind: 'FuncDecl',
+      name: 'main',
+      locals: { kind: 'VarBlock', scope: 'function', decls: [] },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- replace optional `VarDeclNode` contract with a discriminated union (`form: 'typed' | 'alias'`)
- make `FuncDeclNode.locals` required and emit an explicit empty function-local `VarBlock` when absent
- update parser and lowering consumers to use the stricter AST contracts
- add focused regression coverage for var-form discrimination and always-present function locals

Closes #690

## Verification
- `npm run typecheck`
- `npm test -- --run test/pr690_ast_optional_contracts.test.ts test/pr476_parse_module_common_helpers.test.ts test/pr476_parse_globals_helpers.test.ts test/pr476_parse_func_helpers.test.ts test/pr543_function_lowering_integration.test.ts test/pr285_alias_init_parser_semantics_matrix.test.ts test/smoke_language_tour_compile.test.ts`
