### PR TITLE
Unify visible symbol resolution algorithm and precedence

### DIFF
--- a/src/moduleVisibility.ts
+++ b/src/moduleVisibility.ts
@@ -1,16 +1,69 @@
 import type { TypeDeclNode, UnionDeclNode } from './frontend/ast.js';
 import type { CompileEnv } from './semantics/env.js';
 
-function resolveVisibleSymbol<T>(
+export type VisibleSymbolKind = 'const' | 'enum' | 'type';
+
+type ResolutionMaps<T> = {
+  localMap: ReadonlyMap<string, T> | undefined;
+  visibleMap: ReadonlyMap<string, T> | undefined;
+};
+
+function resolveVisibleSymbolWithMaps<T>(
   name: string,
   file: string,
   env: CompileEnv,
-  localMap: ReadonlyMap<string, T> | undefined,
-  visibleMap: ReadonlyMap<string, T> | undefined,
+  maps: ResolutionMaps<T>,
 ): T | undefined {
-  if (!canAccessQualifiedName(name, file, env)) return undefined;
+  const local = maps.localMap?.get(name);
+  if (local !== undefined) return local;
+
   const qualifier = moduleQualifierOf(name);
-  return qualifier ? visibleMap?.get(name) : localMap?.get(name);
+  if (!qualifier) return undefined;
+  if (!canAccessQualifiedName(name, file, env)) return undefined;
+  return maps.visibleMap?.get(name);
+}
+
+export function resolveVisibleSymbol(
+  kind: 'const',
+  name: string,
+  file: string,
+  env: CompileEnv,
+): number | undefined;
+export function resolveVisibleSymbol(
+  kind: 'enum',
+  name: string,
+  file: string,
+  env: CompileEnv,
+): number | undefined;
+export function resolveVisibleSymbol(
+  kind: 'type',
+  name: string,
+  file: string,
+  env: CompileEnv,
+): TypeDeclNode | UnionDeclNode | undefined;
+export function resolveVisibleSymbol(
+  kind: VisibleSymbolKind,
+  name: string,
+  file: string,
+  env: CompileEnv,
+): number | TypeDeclNode | UnionDeclNode | undefined {
+  switch (kind) {
+    case 'const':
+      return resolveVisibleSymbolWithMaps(name, file, env, {
+        localMap: env.consts,
+        visibleMap: env.visibleConsts,
+      });
+    case 'enum':
+      return resolveVisibleSymbolWithMaps(name, file, env, {
+        localMap: env.enums,
+        visibleMap: env.visibleEnums,
+      });
+    case 'type':
+      return resolveVisibleSymbolWithMaps(name, file, env, {
+        localMap: env.types,
+        visibleMap: env.visibleTypes,
+      });
+  }
 }
 
 export function moduleQualifierOf(name: string): string | undefined {
@@ -32,15 +85,11 @@ export function canAccessQualifiedName(name: string, file: string, env: CompileE
 }
 
 export function resolveVisibleConst(name: string, file: string, env: CompileEnv): number | undefined {
-  return resolveVisibleSymbol(name, file, env, env.consts, env.visibleConsts);
+  return resolveVisibleSymbol('const', name, file, env);
 }
 
 export function resolveVisibleEnum(name: string, file: string, env: CompileEnv): number | undefined {
-  // Preserve ordinary enum-member lookup (e.g. Mode.Value) before treating a
-  // dotted name as a module-qualified export alias (e.g. dep.Mode.Value).
-  const local = env.enums.get(name);
-  if (local !== undefined) return local;
-  return resolveVisibleSymbol(name, file, env, undefined, env.visibleEnums);
+  return resolveVisibleSymbol('enum', name, file, env);
 }
 
 export function resolveVisibleType(
@@ -48,5 +97,5 @@ export function resolveVisibleType(
   file: string,
   env: CompileEnv,
 ): TypeDeclNode | UnionDeclNode | undefined {
-  return resolveVisibleSymbol(name, file, env, env.types, env.visibleTypes);
+  return resolveVisibleSymbol('type', name, file, env);
 }

--- a/test/pr647_visible_symbol_resolver.test.ts
+++ b/test/pr647_visible_symbol_resolver.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { SourceSpan, TypeDeclNode, UnionDeclNode } from '../src/frontend/ast.js';
 import {
+  resolveVisibleSymbol,
   resolveVisibleConst,
   resolveVisibleEnum,
   resolveVisibleType,
@@ -58,6 +59,18 @@ describe('PR647 visible symbol resolver consolidation', () => {
 
     expect(resolveVisibleEnum('Mode.Value', 'root.zax', env)).toBe(7);
     expect(resolveVisibleEnum('dep.Mode.Value', 'root.zax', env)).toBe(9);
+  });
+
+  it('applies one shared precedence rule: local first, then imported qualified alias', () => {
+    const env = makeEnv();
+
+    expect(resolveVisibleSymbol('const', 'LOCAL', 'root.zax', env)).toBe(1);
+    expect(resolveVisibleSymbol('enum', 'Mode.Value', 'root.zax', env)).toBe(7);
+    expect(resolveVisibleSymbol('type', 'LocalType', 'root.zax', env)).toBe(typeDecl);
+
+    expect(resolveVisibleSymbol('const', 'dep.REMOTE', 'root.zax', env)).toBe(2);
+    expect(resolveVisibleSymbol('enum', 'dep.Mode.Value', 'root.zax', env)).toBe(9);
+    expect(resolveVisibleSymbol('type', 'dep.RemoteType', 'root.zax', env)).toBe(unionDecl);
   });
 
   it('fails closed for non-imported qualified access', () => {


### PR DESCRIPTION
## Summary
- unify const/enum/type visibility lookup behind one shared `resolveVisibleSymbol(...)` entry point
- apply one explicit precedence rule across all kinds: local first, then imported qualified alias
- remove the enum-specific ad hoc lookup path and lock the precedence rule with focused resolver tests

Closes #691

## Verification
- `npm run typecheck`
- `npm test -- --run test/pr647_visible_symbol_resolver.test.ts test/pr575_module_visibility_scaffolding.test.ts test/semantics_layout.test.ts test/semantics_layout_extra.test.ts test/smoke_language_tour_compile.test.ts`
