### PR TITLE
Flatten op matching overload selection

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -475,12 +475,8 @@ export function emitProgram(
   };
 
   const {
-    matcherMatchesOperand,
-    selectMostSpecificOpOverload,
+    selectOpOverload,
     formatAsmOperandForOpDiag,
-    formatOpSignature,
-    formatOpDefinitionForDiag,
-    firstOpOverloadMismatchReason,
   } = createOpMatchingHelpers({
     reg8,
     isIxIyIndexedMem,
@@ -843,12 +839,8 @@ export function emitProgram(
     opStackPolicyMode,
   };
   const functionLoweringOpOverloadContext: FunctionLoweringOpOverloadContext = {
-    matcherMatchesOperand,
-    formatOpSignature,
     formatAsmOperandForOpDiag,
-    firstOpOverloadMismatchReason,
-    formatOpDefinitionForDiag,
-    selectMostSpecificOpOverload,
+    selectOpOverload,
     summarizeOpStackEffect,
   };
   const functionLoweringAstUtilityContext: FunctionLoweringAstUtilityContext = {

--- a/src/lowering/functionCallLowering.ts
+++ b/src/lowering/functionCallLowering.ts
@@ -6,7 +6,6 @@ import type {
   AsmOperandNode,
   EaExprNode,
   ImmExprNode,
-  OpMatcherNode,
   OpDeclNode,
   ParamNode,
   SourceSpan,
@@ -16,6 +15,7 @@ import type { CompileEnv } from '../semantics/env.js';
 import type { StepPipeline } from '../addressing/steps.js';
 import type { OpStackPolicyMode } from '../pipeline.js';
 import type { Callable, SourceSegmentTag } from './loweringTypes.js';
+import type { OpOverloadSelection } from './opMatching.js';
 import type { OpStackSummary } from './opStackAnalysis.js';
 import type { ScalarKind } from './typeResolution.js';
 import type { FlowState, OpExpansionFrame } from './functionBodySetup.js';
@@ -91,12 +91,8 @@ type Context = {
     id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds],
     message: string,
   ) => void;
-  matcherMatchesOperand: (matcher: OpMatcherNode, operand: AsmOperandNode) => boolean;
-  formatOpSignature: (op: OpDeclNode) => string;
   formatAsmOperandForOpDiag: (operand: AsmOperandNode) => string;
-  firstOpOverloadMismatchReason: (op: OpDeclNode, args: AsmOperandNode[]) => string | undefined;
-  formatOpDefinitionForDiag: (op: OpDeclNode) => string;
-  selectMostSpecificOpOverload: (candidates: OpDeclNode[], args: AsmOperandNode[]) => OpDeclNode | undefined;
+  selectOpOverload: (overloads: OpDeclNode[], operands: AsmOperandNode[]) => OpOverloadSelection;
   summarizeOpStackEffect: (op: OpDeclNode) => OpStackSummary;
   cloneImmExpr: (expr: ImmExprNode) => ImmExprNode;
   cloneEaExpr: (expr: EaExprNode) => EaExprNode;
@@ -405,12 +401,8 @@ export function createFunctionCallLoweringHelpers(ctx: Context) {
         diagAt: ctx.diagAt,
         diagAtWithId: ctx.diagAtWithId,
         diagAtWithSeverityAndId: ctx.diagAtWithSeverityAndId,
-        matcherMatchesOperand: ctx.matcherMatchesOperand,
-        formatOpSignature: ctx.formatOpSignature,
         formatAsmOperandForOpDiag: ctx.formatAsmOperandForOpDiag,
-        firstOpOverloadMismatchReason: ctx.firstOpOverloadMismatchReason,
-        formatOpDefinitionForDiag: ctx.formatOpDefinitionForDiag,
-        selectMostSpecificOpOverload: ctx.selectMostSpecificOpOverload,
+        selectOpOverload: ctx.selectOpOverload,
         summarizeOpStackEffect: ctx.summarizeOpStackEffect,
         cloneImmExpr: ctx.cloneImmExpr,
         cloneEaExpr: ctx.cloneEaExpr,

--- a/src/lowering/functionLowering.ts
+++ b/src/lowering/functionLowering.ts
@@ -9,7 +9,6 @@ import type {
   FuncDeclNode,
   ImmExprNode,
   OpDeclNode,
-  OpMatcherNode,
   ParamNode,
   SourceSpan,
   TypeExprNode,
@@ -21,6 +20,7 @@ import type {
   PendingSymbol,
   SourceSegmentTag,
 } from './loweringTypes.js';
+import type { OpOverloadSelection } from './opMatching.js';
 import type { OpStackSummary } from './opStackAnalysis.js';
 import type { ScalarKind } from './typeResolution.js';
 import { createAsmInstructionLoweringHelpers } from './asmInstructionLowering.js';
@@ -164,18 +164,8 @@ export type FunctionLoweringCallableResolutionContext = {
 };
 
 export type FunctionLoweringOpOverloadContext = {
-  matcherMatchesOperand: (matcher: OpMatcherNode, operand: AsmOperandNode) => boolean;
-  formatOpSignature: (op: OpDeclNode) => string;
   formatAsmOperandForOpDiag: (operand: AsmOperandNode) => string;
-  firstOpOverloadMismatchReason: (
-    op: OpDeclNode,
-    args: AsmOperandNode[],
-  ) => string | undefined;
-  formatOpDefinitionForDiag: (op: OpDeclNode) => string;
-  selectMostSpecificOpOverload: (
-    candidates: OpDeclNode[],
-    args: AsmOperandNode[],
-  ) => OpDeclNode | undefined;
+  selectOpOverload: (overloads: OpDeclNode[], operands: AsmOperandNode[]) => OpOverloadSelection;
   summarizeOpStackEffect: (op: OpDeclNode) => OpStackSummary;
 };
 
@@ -233,9 +223,8 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
   const { pushEaAddress, pushMemValue, pushImm16, pushZeroExtendedReg8, loadImm16ToHL } = ctx;
   const { stackSlotOffsets, stackSlotTypes, localAliasTargets, storageTypes } = ctx;
   const { rawTypedCallWarningsEnabled, resolveCallable, resolveOpCandidates, opStackPolicyMode } = ctx;
-  const { matcherMatchesOperand, formatOpSignature, formatAsmOperandForOpDiag } = ctx;
-  const { firstOpOverloadMismatchReason, formatOpDefinitionForDiag, selectMostSpecificOpOverload } = ctx;
-  const { summarizeOpStackEffect, cloneImmExpr, cloneEaExpr, cloneOperand } = ctx;
+  const { formatAsmOperandForOpDiag, selectOpOverload, summarizeOpStackEffect } = ctx;
+  const { cloneImmExpr, cloneEaExpr, cloneOperand } = ctx;
   const { flattenEaDottedName, normalizeFixedToken, reg8, reg16, generatedLabelCounterRef } = ctx;
   const { typeDisplay, sameTypeShape, emitStepPipeline, lowerLdWithEa } = ctx;
   let currentCodeSegmentTag = currentCodeSegmentTagRef.current;
@@ -723,12 +712,8 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
     opStackPolicyMode,
     opExpansionStack,
     diagAtWithId,
-    matcherMatchesOperand,
-    formatOpSignature,
     formatAsmOperandForOpDiag: (operand) => formatAsmOperandForOpDiag(operand) ?? '?',
-    firstOpOverloadMismatchReason,
-    formatOpDefinitionForDiag,
-    selectMostSpecificOpOverload,
+    selectOpOverload,
     summarizeOpStackEffect,
     cloneImmExpr,
     cloneEaExpr,

--- a/src/lowering/opExpansionOrchestration.ts
+++ b/src/lowering/opExpansionOrchestration.ts
@@ -6,10 +6,10 @@ import type {
   EaExprNode,
   ImmExprNode,
   OpDeclNode,
-  OpMatcherNode,
   SourceSpan,
 } from '../frontend/ast.js';
 import type { CompileEnv } from '../semantics/env.js';
+import type { OpOverloadSelection } from './opMatching.js';
 import type { OpStackSummary } from './opStackAnalysis.js';
 import { createOpExpansionExecutionHelpers } from './opExpansionExecution.js';
 import { createOpSubstitutionHelpers } from './opSubstitution.js';
@@ -44,12 +44,8 @@ type Context = {
     severity: 'warning' | 'error',
     message: string,
   ) => void;
-  matcherMatchesOperand: (matcher: OpMatcherNode, operand: AsmOperandNode) => boolean;
-  formatOpSignature: (opDecl: OpDeclNode) => string;
   formatAsmOperandForOpDiag: (operand: AsmOperandNode) => string;
-  firstOpOverloadMismatchReason: (opDecl: OpDeclNode, operands: AsmOperandNode[]) => string | undefined;
-  formatOpDefinitionForDiag: (opDecl: OpDeclNode) => string;
-  selectMostSpecificOpOverload: (matches: OpDeclNode[], operands: AsmOperandNode[]) => OpDeclNode | undefined;
+  selectOpOverload: (overloads: OpDeclNode[], operands: AsmOperandNode[]) => OpOverloadSelection;
   summarizeOpStackEffect: (opDecl: OpDeclNode) => OpStackSummary;
   cloneImmExpr: CloneHelper<ImmExprNode>;
   cloneEaExpr: CloneHelper<EaExprNode>;
@@ -67,11 +63,9 @@ export function createOpExpansionOrchestrationHelpers(ctx: Context) {
     const opCandidates = ctx.resolveOpCandidates(asmItem.head, asmItem.span.file);
     if (!opCandidates || opCandidates.length === 0) return false;
 
-    const arityMatches = opCandidates.filter(
-      (candidate) => candidate.params.length === asmItem.operands.length,
-    );
-    if (arityMatches.length === 0) {
-      const available = opCandidates.map((candidate) => `  - ${ctx.formatOpSignature(candidate)}`).join('\n');
+    const selection = ctx.selectOpOverload(opCandidates, asmItem.operands);
+    if (selection.kind === 'arity_mismatch') {
+      const available = selection.signatures.map((signature) => `  - ${signature}`).join('\n');
       ctx.diagAtWithId(
         ctx.diagnostics,
         asmItem.span,
@@ -82,23 +76,9 @@ export function createOpExpansionOrchestrationHelpers(ctx: Context) {
       return true;
     }
 
-    const matches = arityMatches.filter((candidate) => {
-      if (candidate.params.length !== asmItem.operands.length) return false;
-      for (let idx = 0; idx < candidate.params.length; idx++) {
-        const param = candidate.params[idx]!;
-        const arg = asmItem.operands[idx]!;
-        if (!ctx.matcherMatchesOperand(param.matcher, arg)) return false;
-      }
-      return true;
-    });
-    if (matches.length === 0) {
+    if (selection.kind === 'no_match') {
       const operandSummary = asmItem.operands.map(ctx.formatAsmOperandForOpDiag).join(', ');
-      const available = arityMatches
-        .map((candidate) => {
-          const reason = ctx.firstOpOverloadMismatchReason(candidate, asmItem.operands);
-          return `  - ${ctx.formatOpDefinitionForDiag(candidate)}${reason ? ` ; ${reason}` : ''}`;
-        })
-        .join('\n');
+      const available = selection.mismatchDetails.map((detail) => `  - ${detail}`).join('\n');
       ctx.diagAtWithId(
         ctx.diagnostics,
         asmItem.span,
@@ -110,24 +90,21 @@ export function createOpExpansionOrchestrationHelpers(ctx: Context) {
       return true;
     }
 
-    const selected = ctx.selectMostSpecificOpOverload(matches, asmItem.operands);
-    if (!selected) {
+    if (selection.kind === 'ambiguous') {
       const operandSummary = asmItem.operands.map(ctx.formatAsmOperandForOpDiag).join(', ');
-      const equallySpecific = matches
-        .map((candidate) => `  - ${ctx.formatOpDefinitionForDiag(candidate)}`)
-        .join('\n');
+      const equallySpecific = selection.definitions.map((definition) => `  - ${definition}`).join('\n');
       ctx.diagAtWithId(
         ctx.diagnostics,
         asmItem.span,
         DiagnosticIds.OpAmbiguousOverload,
-        `Ambiguous op overload for "${asmItem.head}" (${matches.length} matches).\n` +
+        `Ambiguous op overload for "${asmItem.head}" (${selection.overloads.length} matches).\n` +
           `call-site operands: (${operandSummary})\n` +
           `equally specific candidates:\n${equallySpecific}`,
       );
       return true;
     }
 
-    const opDecl = selected;
+    const opDecl = selection.overload;
     if (ctx.opStackPolicyMode !== 'off' && ctx.hasStackSlots) {
       const summary = ctx.summarizeOpStackEffect(opDecl);
       const severity = ctx.opStackPolicyMode === 'error' ? 'error' : 'warning';

--- a/src/lowering/opMatching.ts
+++ b/src/lowering/opMatching.ts
@@ -14,6 +14,12 @@ type Context = {
 type MatcherSpecificity = 'x_more_specific' | 'y_more_specific' | 'equal';
 type OverloadSpecificity = 'x_wins' | 'y_wins' | 'equal' | 'incomparable';
 
+export type OpOverloadSelection =
+  | { kind: 'arity_mismatch'; overloads: OpDeclNode[]; signatures: string[] }
+  | { kind: 'no_match'; overloads: OpDeclNode[]; mismatchDetails: string[] }
+  | { kind: 'ambiguous'; overloads: OpDeclNode[]; definitions: string[] }
+  | { kind: 'selected'; overload: OpDeclNode };
+
 const fitsImm8 = (value: number): boolean => value >= -0x80 && value <= 0xff;
 const fitsImm16 = (value: number): boolean => value >= -0x8000 && value <= 0xffff;
 
@@ -366,9 +372,55 @@ export function createOpMatchingHelpers(ctx: Context) {
     return undefined;
   };
 
+  const selectOpOverload = (
+    overloads: OpDeclNode[],
+    operands: AsmOperandNode[],
+  ): OpOverloadSelection => {
+    const arityMatches = overloads.filter((candidate) => candidate.params.length === operands.length);
+    if (arityMatches.length === 0) {
+      return {
+        kind: 'arity_mismatch',
+        overloads,
+        signatures: overloads.map((candidate) => formatOpSignature(candidate)),
+      };
+    }
+
+    const matches = arityMatches.filter((candidate) => {
+      if (candidate.params.length !== operands.length) return false;
+      for (let idx = 0; idx < candidate.params.length; idx++) {
+        const param = candidate.params[idx]!;
+        const arg = operands[idx]!;
+        if (!matcherMatchesOperand(param.matcher, arg)) return false;
+      }
+      return true;
+    });
+    if (matches.length === 0) {
+      return {
+        kind: 'no_match',
+        overloads: arityMatches,
+        mismatchDetails: arityMatches.map((candidate) => {
+          const reason = firstOpOverloadMismatchReason(candidate, operands);
+          return `${formatOpDefinitionForDiag(candidate)}${reason ? ` ; ${reason}` : ''}`;
+        }),
+      };
+    }
+
+    const selected = selectMostSpecificOpOverload(matches, operands);
+    if (!selected) {
+      return {
+        kind: 'ambiguous',
+        overloads: matches,
+        definitions: matches.map((candidate) => formatOpDefinitionForDiag(candidate)),
+      };
+    }
+
+    return { kind: 'selected', overload: selected };
+  };
+
   return {
     matcherMatchesOperand,
     selectMostSpecificOpOverload,
+    selectOpOverload,
     formatAsmOperandForOpDiag,
     formatOpSignature,
     formatOpDefinitionForDiag,

--- a/test/pr504_op_matching_helpers.test.ts
+++ b/test/pr504_op_matching_helpers.test.ts
@@ -43,7 +43,39 @@ describe('#504 op matching helpers', () => {
 
     expect(helpers.matcherMatchesOperand(fixed.params[0]!.matcher, reg('A'))).toBe(true);
     expect(helpers.selectMostSpecificOpOverload([general, fixed], [reg('A')])).toBe(fixed);
+    expect(helpers.selectOpOverload([general, fixed], [reg('A')])).toEqual({
+      kind: 'selected',
+      overload: fixed,
+    });
     expect(helpers.formatOpSignature(fixed)).toBe('my_op(arg: A)');
     expect(helpers.firstOpOverloadMismatchReason(fixed, [reg('B')])).toBe('arg: expects A, got B');
+  });
+
+  it('reports mismatch details through the shared overload selection result', () => {
+    const helpers = createOpMatchingHelpers({
+      reg8: new Set(['A', 'B', 'C', 'D', 'E', 'H', 'L']),
+      isIxIyIndexedMem: () => false,
+      flattenEaDottedName: () => undefined,
+      isEnumName: () => false,
+      normalizeFixedToken: (operand) => (operand.kind === 'Reg' ? operand.name.toUpperCase() : undefined),
+      conditionOpcodeFromName: () => undefined,
+      evalImmNoDiag: () => undefined,
+      inferMemWidth: () => undefined,
+    });
+
+    const fixed = {
+      kind: 'OpDecl',
+      span,
+      name: 'my_op',
+      params: [{ name: 'arg', matcher: { kind: 'MatcherFixed', span, token: 'A' } }],
+      body: { kind: 'AsmBlock', span, items: [] },
+      stackPolicy: 'default',
+    } as unknown as OpDeclNode;
+
+    expect(helpers.selectOpOverload([fixed], [reg('B')])).toEqual({
+      kind: 'no_match',
+      overloads: [fixed],
+      mismatchDetails: ['my_op(arg: A) (test.zax:1) ; arg: expects A, got B'],
+    });
   });
 });

--- a/test/pr510_op_expansion_orchestration_helpers.test.ts
+++ b/test/pr510_op_expansion_orchestration_helpers.test.ts
@@ -44,12 +44,12 @@ describe('#510 op expansion orchestration helpers', () => {
       diagAtWithSeverityAndId: (list, sourceSpan, id, severity, message) => {
         list.push({ id, severity, file: sourceSpan.file, message });
       },
-      matcherMatchesOperand: () => true,
-      formatOpSignature: (decl) => `${decl.name}(arg)`,
       formatAsmOperandForOpDiag: () => 'arg',
-      firstOpOverloadMismatchReason: () => undefined,
-      formatOpDefinitionForDiag: (decl) => decl.name,
-      selectMostSpecificOpOverload: () => opDecl,
+      selectOpOverload: () => ({
+        kind: 'arity_mismatch',
+        overloads: [opDecl],
+        signatures: [`${opDecl.name}(arg)`],
+      }),
       summarizeOpStackEffect: () => ({
         kind: 'known',
         delta: 0,


### PR DESCRIPTION
## Summary
- collapse op overload selection into a single typed selection result
- thread the flattened selection contract through function call/op expansion lowering
- extend helper coverage for the shared selection path

## Verification
- npm run typecheck
- npm test -- --run test/pr504_op_matching_helpers.test.ts test/pr510_op_expansion_orchestration_helpers.test.ts test/pr230_lowering_rst_call_boundary_matrix.test.ts test/pr468_typed_step_integration.test.ts test/smoke_language_tour_compile.test.ts