### PR TITLE
Roll out lowering capability interfaces

### DIFF
--- a/src/lowering/capabilities.ts
+++ b/src/lowering/capabilities.ts
@@ -1,0 +1,86 @@
+import type { Diagnostic, DiagnosticId } from '../diagnostics/types.js';
+import type {
+  AsmItemNode,
+  AsmOperandNode,
+  EaExprNode,
+  ImmExprNode,
+  OpDeclNode,
+  SourceSpan,
+} from '../frontend/ast.js';
+import type { CompileEnv } from '../semantics/env.js';
+import type { OpOverloadSelection } from './opMatching.js';
+import type { OpStackSummary } from './opStackAnalysis.js';
+
+export interface LoweringDiagnosticsCapability {
+  diagnostics: Diagnostic[];
+  diagAt: (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
+}
+
+export interface LoweringDiagnosticsWithIdCapability extends LoweringDiagnosticsCapability {
+  diagAtWithId: (
+    diagnostics: Diagnostic[],
+    span: SourceSpan,
+    id: DiagnosticId,
+    message: string,
+  ) => void;
+}
+
+export interface LoweringDiagnosticsWithSeverityCapability extends LoweringDiagnosticsWithIdCapability {
+  diagAtWithSeverityAndId: (
+    diagnostics: Diagnostic[],
+    span: SourceSpan,
+    id: DiagnosticId,
+    severity: 'warning' | 'error',
+    message: string,
+  ) => void;
+}
+
+export interface CompileEnvCapability {
+  env: CompileEnv;
+}
+
+export interface AstCloneCapability {
+  cloneImmExpr: (expr: ImmExprNode) => ImmExprNode;
+  cloneEaExpr: (ea: EaExprNode) => EaExprNode;
+  cloneOperand: (operand: AsmOperandNode) => AsmOperandNode;
+}
+
+export interface DottedEaNameCapability {
+  flattenEaDottedName: (ea: EaExprNode) => string | undefined;
+}
+
+export interface FixedTokenNormalizationCapability {
+  normalizeFixedToken: (operand: AsmOperandNode) => string | undefined;
+}
+
+export interface InverseConditionCapability {
+  inverseConditionName: (name: string) => string | undefined;
+}
+
+export interface HiddenLabelCapability {
+  newHiddenLabel: (prefix: string) => string;
+}
+
+export interface AsmRangeLoweringCapability {
+  lowerAsmRange: (items: readonly AsmItemNode[], startIndex: number, stopKinds: Set<string>) => number;
+}
+
+export interface FlowSyncCapability {
+  syncToFlow: () => void;
+}
+
+export interface OpCandidateResolverCapability {
+  resolveOpCandidates: (name: string, file: string) => OpDeclNode[] | undefined;
+}
+
+export interface OpOperandFormattingCapability {
+  formatAsmOperandForOpDiag: (operand: AsmOperandNode) => string;
+}
+
+export interface OpOverloadSelectionCapability {
+  selectOpOverload: (overloads: OpDeclNode[], operands: AsmOperandNode[]) => OpOverloadSelection;
+}
+
+export interface OpStackSummaryCapability {
+  summarizeOpStackEffect: (opDecl: OpDeclNode) => OpStackSummary;
+}

--- a/src/lowering/opExpansionExecution.ts
+++ b/src/lowering/opExpansionExecution.ts
@@ -3,14 +3,15 @@ import type {
   AsmInstructionNode,
   OpDeclNode,
 } from '../frontend/ast.js';
-import type { Diagnostic } from '../diagnostics/types.js';
+import type {
+  AsmRangeLoweringCapability,
+  HiddenLabelCapability,
+  LoweringDiagnosticsCapability,
+} from './capabilities.js';
 
-type OpExpansionExecutionContext = {
-  diagnostics: Diagnostic[];
-  diagAt: (diagnostics: Diagnostic[], span: AsmInstructionNode['span'], message: string) => void;
-  newHiddenLabel: (prefix: string) => string;
-  lowerAsmRange: (items: AsmItemNode[], startIndex: number, stopKinds: Set<AsmItemNode['kind']>) => number;
-};
+type OpExpansionExecutionContext = LoweringDiagnosticsCapability &
+  HiddenLabelCapability &
+  AsmRangeLoweringCapability;
 
 type ExpandAndLowerArgs = {
   opDecl: OpDeclNode;

--- a/src/lowering/opExpansionOrchestration.ts
+++ b/src/lowering/opExpansionOrchestration.ts
@@ -1,16 +1,24 @@
-import { DiagnosticIds, type Diagnostic } from '../diagnostics/types.js';
+import { DiagnosticIds } from '../diagnostics/types.js';
 import type {
   AsmInstructionNode,
-  AsmItemNode,
   AsmOperandNode,
-  EaExprNode,
-  ImmExprNode,
-  OpDeclNode,
   SourceSpan,
 } from '../frontend/ast.js';
-import type { CompileEnv } from '../semantics/env.js';
-import type { OpOverloadSelection } from './opMatching.js';
-import type { OpStackSummary } from './opStackAnalysis.js';
+import type {
+  AsmRangeLoweringCapability,
+  AstCloneCapability,
+  CompileEnvCapability,
+  DottedEaNameCapability,
+  FixedTokenNormalizationCapability,
+  FlowSyncCapability,
+  HiddenLabelCapability,
+  InverseConditionCapability,
+  LoweringDiagnosticsWithSeverityCapability,
+  OpCandidateResolverCapability,
+  OpOperandFormattingCapability,
+  OpOverloadSelectionCapability,
+  OpStackSummaryCapability,
+} from './capabilities.js';
 import { createOpExpansionExecutionHelpers } from './opExpansionExecution.js';
 import { createOpSubstitutionHelpers } from './opSubstitution.js';
 
@@ -21,41 +29,22 @@ type OpExpansionStackEntry = {
   callSiteSpan: SourceSpan;
 };
 
-type CloneHelper<T> = (value: T) => T;
-
-type Context = {
-  resolveOpCandidates: (name: string, file: string) => OpDeclNode[] | undefined;
-  diagnostics: Diagnostic[];
-  env: CompileEnv;
+type Context = LoweringDiagnosticsWithSeverityCapability &
+  CompileEnvCapability &
+  OpCandidateResolverCapability &
+  OpOperandFormattingCapability &
+  OpOverloadSelectionCapability &
+  OpStackSummaryCapability &
+  AstCloneCapability &
+  DottedEaNameCapability &
+  FixedTokenNormalizationCapability &
+  InverseConditionCapability &
+  HiddenLabelCapability &
+  AsmRangeLoweringCapability &
+  FlowSyncCapability & {
   hasStackSlots: boolean;
   opStackPolicyMode: 'off' | 'warn' | 'error';
   opExpansionStack: OpExpansionStackEntry[];
-  diagAt: (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
-  diagAtWithId: (
-    diagnostics: Diagnostic[],
-    span: SourceSpan,
-    id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds],
-    message: string,
-  ) => void;
-  diagAtWithSeverityAndId: (
-    diagnostics: Diagnostic[],
-    span: SourceSpan,
-    id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds],
-    severity: 'warning' | 'error',
-    message: string,
-  ) => void;
-  formatAsmOperandForOpDiag: (operand: AsmOperandNode) => string;
-  selectOpOverload: (overloads: OpDeclNode[], operands: AsmOperandNode[]) => OpOverloadSelection;
-  summarizeOpStackEffect: (opDecl: OpDeclNode) => OpStackSummary;
-  cloneImmExpr: CloneHelper<ImmExprNode>;
-  cloneEaExpr: CloneHelper<EaExprNode>;
-  cloneOperand: CloneHelper<AsmOperandNode>;
-  flattenEaDottedName: (ea: EaExprNode) => string | undefined;
-  normalizeFixedToken: (operand: AsmOperandNode) => string | undefined;
-  inverseConditionName: (name: string) => string | undefined;
-  newHiddenLabel: (prefix: string) => string;
-  lowerAsmRange: (items: readonly AsmItemNode[], startIndex: number, stopKinds: Set<string>) => number;
-  syncToFlow: () => void;
 };
 
 export function createOpExpansionOrchestrationHelpers(ctx: Context) {

--- a/src/lowering/opSubstitution.ts
+++ b/src/lowering/opSubstitution.ts
@@ -1,4 +1,3 @@
-import type { Diagnostic } from '../diagnostics/types.js';
 import type {
   AsmOperandNode,
   EaExprNode,
@@ -7,19 +6,22 @@ import type {
   OffsetofPathStepNode,
   SourceSpan,
 } from '../frontend/ast.js';
-import type { CompileEnv } from '../semantics/env.js';
+import type {
+  AstCloneCapability,
+  CompileEnvCapability,
+  DottedEaNameCapability,
+  FixedTokenNormalizationCapability,
+  InverseConditionCapability,
+  LoweringDiagnosticsCapability,
+} from './capabilities.js';
 
-type OpSubstitutionContext = {
+type OpSubstitutionContext = LoweringDiagnosticsCapability &
+  CompileEnvCapability &
+  AstCloneCapability &
+  DottedEaNameCapability &
+  FixedTokenNormalizationCapability &
+  InverseConditionCapability & {
   bindings: Map<string, AsmOperandNode>;
-  env: CompileEnv;
-  diagnostics: Diagnostic[];
-  diagAt: (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
-  cloneImmExpr: (expr: ImmExprNode) => ImmExprNode;
-  cloneEaExpr: (ea: EaExprNode) => EaExprNode;
-  cloneOperand: (operand: AsmOperandNode) => AsmOperandNode;
-  flattenEaDottedName: (ea: EaExprNode) => string | undefined;
-  normalizeFixedToken: (operand: AsmOperandNode) => string | undefined;
-  inverseConditionName: (name: string) => string | undefined;
 };
 
 export function createOpSubstitutionHelpers(ctx: OpSubstitutionContext) {

--- a/test/pr510_op_expansion_execution_helpers.test.ts
+++ b/test/pr510_op_expansion_execution_helpers.test.ts
@@ -14,7 +14,7 @@ describe('#510 op expansion execution helpers', () => {
   it('keeps label mapping and lowering handoff stable', () => {
     const diagnostics: Diagnostic[] = [];
     let hiddenCounter = 0;
-    let loweredItems: AsmItemNode[] = [];
+    let loweredItems: readonly AsmItemNode[] = [];
 
     const opDecl: OpDeclNode = {
       kind: 'OpDecl',


### PR DESCRIPTION
## Summary
- add shared lowering capability interfaces for diagnostics, cloning, label generation, flow sync, and op resolution
- convert the op expansion/substitution helper cluster to capability-based signatures
- keep orchestration contexts broad only at the higher composition points

## Verification
- npm run typecheck
- npm test -- --run test/pr504_op_matching_helpers.test.ts test/pr510_op_expansion_execution_helpers.test.ts test/pr510_op_expansion_orchestration_helpers.test.ts test/pr230_lowering_rst_call_boundary_matrix.test.ts test/pr468_typed_step_integration.test.ts test/smoke_language_tour_compile.test.ts