### PR TITLE
#694: add registry-driven encoder dispatch layer

### DIFF
--- a/src/z80/encode.ts
+++ b/src/z80/encode.ts
@@ -8,6 +8,8 @@ import type {
 } from '../frontend/ast.js';
 import type { CompileEnv } from '../semantics/env.js';
 import { evalImmExpr } from '../semantics/env.js';
+import type { EncoderFamily } from './encoderRegistry.js';
+import { getEncoderRegistryEntry } from './encoderRegistry.js';
 import { encodeAluInstruction } from './encodeAlu.js';
 import { encodeBitOpsInstruction } from './encodeBitOps.js';
 import { encodeControlInstruction } from './encodeControl.js';
@@ -348,176 +350,83 @@ function retConditionOpcode(name: string): number | undefined {
   }
 }
 
-function zeroOperandEdOpcode(head: string): number | undefined {
-  switch (head) {
-    case 'reti':
-      return 0x4d;
-    case 'retn':
-      return 0x45;
-    case 'neg':
-      return 0x44;
-    case 'rrd':
-      return 0x67;
-    case 'rld':
-      return 0x6f;
-    case 'ldi':
-      return 0xa0;
-    case 'ldir':
-      return 0xb0;
-    case 'ldd':
-      return 0xa8;
-    case 'lddr':
-      return 0xb8;
-    case 'cpi':
-      return 0xa1;
-    case 'cpir':
-      return 0xb1;
-    case 'cpd':
-      return 0xa9;
-    case 'cpdr':
-      return 0xb9;
-    case 'ini':
-      return 0xa2;
-    case 'inir':
-      return 0xb2;
-    case 'ind':
-      return 0xaa;
-    case 'indr':
-      return 0xba;
-    case 'outi':
-      return 0xa3;
-    case 'otir':
-      return 0xb3;
-    case 'outd':
-      return 0xab;
-    case 'otdr':
-      return 0xbb;
-    default:
-      return undefined;
-  }
-}
-
-function zeroOperandOpcode(head: string): Uint8Array | undefined {
-  switch (head) {
-    case 'nop':
-      return Uint8Array.of(0x00);
-    case 'halt':
-      return Uint8Array.of(0x76);
-    case 'di':
-      return Uint8Array.of(0xf3);
-    case 'ei':
-      return Uint8Array.of(0xfb);
-    case 'scf':
-      return Uint8Array.of(0x37);
-    case 'ccf':
-      return Uint8Array.of(0x3f);
-    case 'cpl':
-      return Uint8Array.of(0x2f);
-    case 'daa':
-      return Uint8Array.of(0x27);
-    case 'rlca':
-      return Uint8Array.of(0x07);
-    case 'rrca':
-      return Uint8Array.of(0x0f);
-    case 'rla':
-      return Uint8Array.of(0x17);
-    case 'rra':
-      return Uint8Array.of(0x1f);
-    case 'exx':
-      return Uint8Array.of(0xd9);
-    default: {
-      const edOpcode = zeroOperandEdOpcode(head);
-      return edOpcode === undefined ? undefined : Uint8Array.of(0xed, edOpcode);
-    }
-  }
-}
-
-function arityDiagnostic(head: string, operandCount: number): string | undefined {
-  switch (head) {
-    case 'add':
+function encodeFamilyInstruction(
+  family: EncoderFamily,
+  node: AsmInstructionNode,
+  env: CompileEnv,
+  diagnostics: Diagnostic[],
+): Uint8Array | undefined {
+  switch (family) {
+    case 'control':
+      return encodeControlInstruction(node, env, diagnostics, {
+        diag,
+        immValue,
+        registerTokenName,
+        conditionName,
+        symbolicImmBaseName,
+        fitsImm16,
+        isMemRegName,
+        retConditionOpcode,
+        callConditionOpcode,
+        jpConditionOpcode,
+        jrConditionOpcode,
+      });
+    case 'alu':
+      return encodeAluInstruction(node, env, diagnostics, {
+        diag,
+        regName,
+        immValue,
+        indexedReg8,
+        reg8Code,
+        fitsImm8,
+        isMemHL,
+        memIndexed,
+      });
+    case 'io':
+      return encodeIoInstruction(node, env, diagnostics, {
+        diag,
+        regName,
+        immValue,
+        portImmValue,
+        indexedReg8,
+        reg8Code,
+        fitsImm8,
+      });
     case 'ld':
-    case 'ex':
-      if (operandCount === 2) return undefined;
-      return `${head} expects two operands`;
-    case 'sub':
-    case 'cp':
-    case 'and':
-    case 'or':
-    case 'xor':
-      if (operandCount === 1 || operandCount === 2) return undefined;
-      return `${head} expects one operand, or two with destination A`;
-    case 'adc':
-    case 'sbc':
-      if (operandCount === 1 || operandCount === 2) return undefined;
-      return `${head} expects one operand, two with destination A, or HL,rr form`;
-    case 'inc':
-    case 'dec':
-    case 'push':
-    case 'pop':
-      if (operandCount === 1) return undefined;
-      return `${head} expects one operand`;
+      return encodeLdInstruction(node, env, diagnostics, {
+        diag,
+        regName,
+        immValue,
+        indexedReg8,
+        reg8Code,
+        fitsImm8,
+        fitsImm16,
+        memAbs16,
+        memIndexed,
+        isMemHL,
+        isMemRegName,
+        isReg16TransferName,
+        isLegacyHLReg8,
+      });
+    case 'core':
+      return encodeCoreOpsInstruction(node, env, diagnostics, {
+        diag,
+        regName,
+        indexedReg8,
+        reg8Code,
+        isMemHL,
+        memIndexed,
+      });
     case 'bit':
-      if (operandCount === 2) return undefined;
-      return `${head} expects two operands`;
-    case 'res':
-    case 'set':
-      if (operandCount === 2 || operandCount === 3) return undefined;
-      return `${head} expects two operands, or three with indexed source + reg8 destination`;
-    case 'rl':
-    case 'rr':
-    case 'sla':
-    case 'sra':
-    case 'srl':
-    case 'sll':
-    case 'rlc':
-    case 'rrc':
-      if (operandCount === 1 || operandCount === 2) return undefined;
-      return `${head} expects one operand, or two with indexed source + reg8 destination`;
-    default:
-      return undefined;
-  }
-}
-
-function isKnownInstructionHead(head: string): boolean {
-  const h = head.toLowerCase();
-  switch (h) {
-    case 'ret':
-    case 'add':
-    case 'call':
-    case 'djnz':
-    case 'rst':
-    case 'im':
-    case 'in':
-    case 'out':
-    case 'jp':
-    case 'jr':
-    case 'ld':
-    case 'inc':
-    case 'dec':
-    case 'push':
-    case 'pop':
-    case 'ex':
-    case 'sub':
-    case 'cp':
-    case 'and':
-    case 'or':
-    case 'xor':
-    case 'adc':
-    case 'sbc':
-    case 'bit':
-    case 'res':
-    case 'set':
-    case 'rl':
-    case 'rr':
-    case 'sla':
-    case 'sra':
-    case 'srl':
-    case 'sll':
-    case 'rlc':
-    case 'rrc':
-      return true;
-    default:
-      return zeroOperandOpcode(h) !== undefined;
+      return encodeBitOpsInstruction(node, env, diagnostics, {
+        diag,
+        regName,
+        immValue,
+        indexedReg8,
+        reg8Code,
+        isMemHL,
+        memIndexed,
+      });
   }
 }
 
@@ -534,151 +443,31 @@ export function encodeInstruction(
 ): Uint8Array | undefined {
   const diagnosticsBefore = diagnostics.length;
   const head = node.head.toLowerCase();
-  const ops = node.operands;
-
-  if (head === 'ret' || head === 'call' || head === 'djnz' || head === 'jp' || head === 'jr') {
-    return encodeControlInstruction(node, env, diagnostics, {
-      diag,
-      immValue,
-      registerTokenName,
-      conditionName,
-      symbolicImmBaseName,
-      fitsImm16,
-      isMemRegName,
-      retConditionOpcode,
-      callConditionOpcode,
-      jpConditionOpcode,
-      jrConditionOpcode,
-    });
+  const entry = getEncoderRegistryEntry(head);
+  if (!entry) {
+    diag(diagnostics, node, `Unsupported instruction: ${node.head}`);
+    return undefined;
   }
-  const zeroOpcode = zeroOperandOpcode(head);
-  if (zeroOpcode) {
-    if (ops.length === 0) return zeroOpcode;
+
+  if (entry.kind === 'zero') {
+    if (node.operands.length === 0) return entry.bytes;
     diag(diagnostics, node, `${head} expects no operands`);
     return undefined;
   }
 
-  if (
-    head === 'add' ||
-    head === 'sub' ||
-    head === 'cp' ||
-    head === 'and' ||
-    head === 'or' ||
-    head === 'xor' ||
-    head === 'adc' ||
-    head === 'sbc'
-  ) {
-    const encoded = encodeAluInstruction(node, env, diagnostics, {
-      diag,
-      regName,
-      immValue,
-      indexedReg8,
-      reg8Code,
-      fitsImm8,
-      isMemHL,
-      memIndexed,
-    });
-    if (encoded) return encoded;
-  }
+  const encoded = encodeFamilyInstruction(entry.family, node, env, diagnostics);
+  if (encoded) return encoded;
 
-  if (head === 'rst' || head === 'im' || head === 'in' || head === 'out') {
-    const encoded = encodeIoInstruction(node, env, diagnostics, {
-      diag,
-      regName,
-      immValue,
-      portImmValue,
-      indexedReg8,
-      reg8Code,
-      fitsImm8,
-    });
-    if (encoded) return encoded;
-  }
+  if (entry.fallback === 'none') return undefined;
+  if (diagnostics.length > diagnosticsBefore) return undefined;
 
-  if (head === 'ld') {
-    return encodeLdInstruction(node, env, diagnostics, {
-      diag,
-      regName,
-      immValue,
-      indexedReg8,
-      reg8Code,
-      fitsImm8,
-      fitsImm16,
-      memAbs16,
-      memIndexed,
-      isMemHL,
-      isMemRegName,
-      isReg16TransferName,
-      isLegacyHLReg8,
-    });
-  }
-
-  if (head === 'inc' || head === 'dec' || head === 'push' || head === 'pop' || head === 'ex') {
-    const encoded = encodeCoreOpsInstruction(node, env, diagnostics, {
-      diag,
-      regName,
-      indexedReg8,
-      reg8Code,
-      isMemHL,
-      memIndexed,
-    });
-    if (encoded) return encoded;
-  }
-
-  if (
-    head === 'bit' ||
-    head === 'res' ||
-    head === 'set' ||
-    head === 'rl' ||
-    head === 'rr' ||
-    head === 'sla' ||
-    head === 'sra' ||
-    head === 'srl' ||
-    head === 'sll' ||
-    head === 'rlc' ||
-    head === 'rrc'
-  ) {
-    const encoded = encodeBitOpsInstruction(node, env, diagnostics, {
-      diag,
-      regName,
-      immValue,
-      indexedReg8,
-      reg8Code,
-      isMemHL,
-      memIndexed,
-    });
-    if (encoded) return encoded;
-    if (
-      (head === 'bit' && ops.length === 2) ||
-      ((head === 'res' || head === 'set') && (ops.length === 2 || ops.length === 3)) ||
-      ((head === 'rl' ||
-        head === 'rr' ||
-        head === 'sla' ||
-        head === 'sra' ||
-        head === 'srl' ||
-        head === 'sll' ||
-        head === 'rlc' ||
-        head === 'rrc') &&
-        (ops.length === 1 || ops.length === 2))
-    ) {
-      return undefined;
-    }
-  }
-
-  if (isKnownInstructionHead(head) && diagnostics.length > diagnosticsBefore) {
-    return undefined;
-  }
-
-  const arityMessage = arityDiagnostic(head, ops.length);
+  const arityMessage = entry.arityDiagnostic(head, node.operands.length);
+  if (entry.fallback === 'arity-short-circuit' && arityMessage === undefined) return undefined;
   if (arityMessage !== undefined) {
     diag(diagnostics, node, arityMessage);
     return undefined;
   }
 
-  if (isKnownInstructionHead(head)) {
-    diag(diagnostics, node, `${head} has unsupported operand form`);
-    return undefined;
-  }
-
-  diag(diagnostics, node, `Unsupported instruction: ${node.head}`);
+  diag(diagnostics, node, `${head} has unsupported operand form`);
   return undefined;
 }

--- a/src/z80/encoderRegistry.ts
+++ b/src/z80/encoderRegistry.ts
@@ -1,0 +1,197 @@
+export type EncoderFamily = 'control' | 'alu' | 'io' | 'ld' | 'core' | 'bit';
+
+export type EncoderFallbackMode = 'none' | 'standard' | 'arity-short-circuit';
+
+export type EncoderRegistryEntry =
+  | {
+      kind: 'zero';
+      bytes: Uint8Array;
+    }
+  | {
+      kind: 'family';
+      family: EncoderFamily;
+      fallback: EncoderFallbackMode;
+      arityDiagnostic: (head: string, operandCount: number) => string | undefined;
+    };
+
+function expectOneOrTwoWithA(head: string, operandCount: number): string | undefined {
+  if (operandCount === 1 || operandCount === 2) return undefined;
+  return `${head} expects one operand, or two with destination A`;
+}
+
+function expectOneOrTwoWithAOrHl(head: string, operandCount: number): string | undefined {
+  if (operandCount === 1 || operandCount === 2) return undefined;
+  return `${head} expects one operand, two with destination A, or HL,rr form`;
+}
+
+function expectOne(head: string, operandCount: number): string | undefined {
+  if (operandCount === 1) return undefined;
+  return `${head} expects one operand`;
+}
+
+function expectTwo(head: string, operandCount: number): string | undefined {
+  if (operandCount === 2) return undefined;
+  return `${head} expects two operands`;
+}
+
+function expectTwoOrThreeIndexedToReg8(head: string, operandCount: number): string | undefined {
+  if (operandCount === 2 || operandCount === 3) return undefined;
+  return `${head} expects two operands, or three with indexed source + reg8 destination`;
+}
+
+function expectOneOrTwoIndexedToReg8(head: string, operandCount: number): string | undefined {
+  if (operandCount === 1 || operandCount === 2) return undefined;
+  return `${head} expects one operand, or two with indexed source + reg8 destination`;
+}
+
+function expectTwoOps(head: string, operandCount: number): string | undefined {
+  if (operandCount === 2) return undefined;
+  return `${head} expects two operands`;
+}
+
+const identityArity = (_head: string, _operandCount: number): string | undefined => undefined;
+
+type FamilySpec = {
+  heads: readonly string[];
+  family: EncoderFamily;
+  fallback: EncoderFallbackMode;
+  arityDiagnostic: (head: string, operandCount: number) => string | undefined;
+};
+
+const FAMILY_SPECS: readonly FamilySpec[] = [
+  {
+    heads: ['ret', 'call', 'djnz', 'jp', 'jr'],
+    family: 'control',
+    fallback: 'none',
+    arityDiagnostic: identityArity,
+  },
+  {
+    heads: ['add', 'sub', 'cp', 'and', 'or', 'xor', 'adc', 'sbc'],
+    family: 'alu',
+    fallback: 'standard',
+    arityDiagnostic: (head, operandCount) => {
+      switch (head) {
+        case 'add':
+          return expectTwoOps(head, operandCount);
+        case 'sub':
+        case 'cp':
+        case 'and':
+        case 'or':
+        case 'xor':
+          return expectOneOrTwoWithA(head, operandCount);
+        case 'adc':
+        case 'sbc':
+          return expectOneOrTwoWithAOrHl(head, operandCount);
+        default:
+          return undefined;
+      }
+    },
+  },
+  {
+    heads: ['rst', 'im', 'in', 'out'],
+    family: 'io',
+    fallback: 'standard',
+    arityDiagnostic: identityArity,
+  },
+  {
+    heads: ['ld'],
+    family: 'ld',
+    fallback: 'none',
+    arityDiagnostic: identityArity,
+  },
+  {
+    heads: ['inc', 'dec', 'push', 'pop', 'ex'],
+    family: 'core',
+    fallback: 'standard',
+    arityDiagnostic: (head, operandCount) => {
+      if (head === 'ex') return expectTwo(head, operandCount);
+      return expectOne(head, operandCount);
+    },
+  },
+  {
+    heads: ['bit', 'res', 'set', 'rl', 'rr', 'sla', 'sra', 'srl', 'sll', 'rlc', 'rrc'],
+    family: 'bit',
+    fallback: 'arity-short-circuit',
+    arityDiagnostic: (head, operandCount) => {
+      switch (head) {
+        case 'bit':
+          return expectTwo(head, operandCount);
+        case 'res':
+        case 'set':
+          return expectTwoOrThreeIndexedToReg8(head, operandCount);
+        case 'rl':
+        case 'rr':
+        case 'sla':
+        case 'sra':
+        case 'srl':
+        case 'sll':
+        case 'rlc':
+        case 'rrc':
+          return expectOneOrTwoIndexedToReg8(head, operandCount);
+        default:
+          return undefined;
+      }
+    },
+  },
+];
+
+const ZERO_OPCODE_REGISTRY: Readonly<Record<string, Uint8Array>> = {
+  nop: Uint8Array.of(0x00),
+  halt: Uint8Array.of(0x76),
+  di: Uint8Array.of(0xf3),
+  ei: Uint8Array.of(0xfb),
+  scf: Uint8Array.of(0x37),
+  ccf: Uint8Array.of(0x3f),
+  cpl: Uint8Array.of(0x2f),
+  daa: Uint8Array.of(0x27),
+  rlca: Uint8Array.of(0x07),
+  rrca: Uint8Array.of(0x0f),
+  rla: Uint8Array.of(0x17),
+  rra: Uint8Array.of(0x1f),
+  exx: Uint8Array.of(0xd9),
+  reti: Uint8Array.of(0xed, 0x4d),
+  retn: Uint8Array.of(0xed, 0x45),
+  neg: Uint8Array.of(0xed, 0x44),
+  rrd: Uint8Array.of(0xed, 0x67),
+  rld: Uint8Array.of(0xed, 0x6f),
+  ldi: Uint8Array.of(0xed, 0xa0),
+  ldir: Uint8Array.of(0xed, 0xb0),
+  ldd: Uint8Array.of(0xed, 0xa8),
+  lddr: Uint8Array.of(0xed, 0xb8),
+  cpi: Uint8Array.of(0xed, 0xa1),
+  cpir: Uint8Array.of(0xed, 0xb1),
+  cpd: Uint8Array.of(0xed, 0xa9),
+  cpdr: Uint8Array.of(0xed, 0xb9),
+  ini: Uint8Array.of(0xed, 0xa2),
+  inir: Uint8Array.of(0xed, 0xb2),
+  ind: Uint8Array.of(0xed, 0xaa),
+  indr: Uint8Array.of(0xed, 0xba),
+  outi: Uint8Array.of(0xed, 0xa3),
+  otir: Uint8Array.of(0xed, 0xb3),
+  outd: Uint8Array.of(0xed, 0xab),
+  otdr: Uint8Array.of(0xed, 0xbb),
+};
+
+const ENCODER_REGISTRY = new Map<string, EncoderRegistryEntry>();
+
+for (const [head, bytes] of Object.entries(ZERO_OPCODE_REGISTRY)) {
+  ENCODER_REGISTRY.set(head, {
+    kind: 'zero',
+    bytes,
+  });
+}
+
+for (const spec of FAMILY_SPECS) {
+  for (const head of spec.heads) {
+    ENCODER_REGISTRY.set(head, {
+      kind: 'family',
+      family: spec.family,
+      fallback: spec.fallback,
+      arityDiagnostic: spec.arityDiagnostic,
+    });
+  }
+}
+
+export function getEncoderRegistryEntry(head: string): EncoderRegistryEntry | undefined {
+  return ENCODER_REGISTRY.get(head.toLowerCase());
+}

--- a/test/pr694_encoder_registry_dispatch.test.ts
+++ b/test/pr694_encoder_registry_dispatch.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import type { AsmInstructionNode, AsmOperandNode, SourceSpan } from '../src/frontend/ast.js';
+import { getEncoderRegistryEntry } from '../src/z80/encoderRegistry.js';
+import { encodeInstruction } from '../src/z80/encode.js';
+
+const span: SourceSpan = {
+  file: 'pr694_encoder_registry_dispatch.zax',
+  start: { line: 1, column: 1, offset: 0 },
+  end: { line: 1, column: 1, offset: 0 },
+};
+
+const env = {
+  consts: new Map<string, number>(),
+  enums: new Map<string, number>(),
+  types: new Map(),
+};
+
+function instruction(head: string, operands: AsmOperandNode[]): AsmInstructionNode {
+  return { kind: 'AsmInstruction', span, head, operands };
+}
+
+function reg(name: string): AsmOperandNode {
+  return { kind: 'Reg', span, name };
+}
+
+function imm(value: number): AsmOperandNode {
+  return { kind: 'Imm', span, expr: { kind: 'ImmLiteral', span, value } };
+}
+
+describe('PR694 encoder registry dispatch', () => {
+  it('registers representative zero-op and family handlers by mnemonic', () => {
+    expect(getEncoderRegistryEntry('nop')).toMatchObject({
+      kind: 'zero',
+    });
+    expect(getEncoderRegistryEntry('add')).toMatchObject({
+      kind: 'family',
+      family: 'alu',
+      fallback: 'standard',
+    });
+    expect(getEncoderRegistryEntry('ld')).toMatchObject({
+      kind: 'family',
+      family: 'ld',
+      fallback: 'none',
+    });
+    expect(getEncoderRegistryEntry('bit')).toMatchObject({
+      kind: 'family',
+      family: 'bit',
+      fallback: 'arity-short-circuit',
+    });
+    expect(getEncoderRegistryEntry('totally_unknown')).toBeUndefined();
+  });
+
+  it('keeps registry fallback diagnostics stable for unknown, zero-op arity, and family arity', () => {
+    const diagnostics: Diagnostic[] = [];
+
+    const noOperandOpcode = encodeInstruction(instruction('ldi', []), env, diagnostics);
+    expect(Array.from(noOperandOpcode ?? [])).toEqual([0xed, 0xa0]);
+
+    const zeroArityError = encodeInstruction(instruction('ldi', [reg('A')]), env, diagnostics);
+    expect(zeroArityError).toBeUndefined();
+    expect(diagnostics[0]?.message).toBe('ldi expects no operands');
+
+    const familyArityError = encodeInstruction(
+      instruction('add', [reg('A'), reg('B'), reg('C')]),
+      env,
+      diagnostics,
+    );
+    expect(familyArityError).toBeUndefined();
+    expect(diagnostics[1]?.message).toBe('add expects two operands');
+
+    const unknown = encodeInstruction(instruction('bogus_op', [imm(1)]), env, diagnostics);
+    expect(unknown).toBeUndefined();
+    expect(diagnostics[2]?.message).toBe('Unsupported instruction: bogus_op');
+  });
+});


### PR DESCRIPTION
## Summary
- Added a central encoder registry (`src/z80/encoderRegistry.ts`) mapping instruction mnemonics to either:
  - zero-operand opcode handlers, or
  - encoder family handlers with explicit fallback policy.
- Replaced ad-hoc dispatcher branching in `encodeInstruction` with registry lookup + family dispatch.
- Kept existing family encoder modules (`encodeControl`, `encodeAlu`, `encodeIo`, `encodeLd`, `encodeCoreOps`, `encodeBitOps`) as implementation backends.
- Added focused regression coverage for registry mapping and fallback diagnostics.

## Scope Check
- Issue #694 only (L-04 encoder registry dispatch).
- No parser/semantics/lowering changes.
- No ISA expansion.

## Files Changed
- `src/z80/encoderRegistry.ts`
- `src/z80/encode.ts`
- `test/pr694_encoder_registry_dispatch.test.ts`

## Verification
- `npm run typecheck`
- `npm test -- --run test/pr694_encoder_registry_dispatch.test.ts test/pr468_encoder_dispatch_integration.test.ts test/pr477_encode_alu_family.test.ts test/pr477_encode_io_family.test.ts test/pr477_encode_ld_family.test.ts test/pr477_encode_core_ops_family.test.ts test/pr477_encode_bitops_family.test.ts test/pr477_encode_control_family.test.ts test/pr57_isa_im_rst.test.ts test/pr56_isa_misc.test.ts`

Refs #694
