### PR TITLE
#712: use packed sizes for record field layout

### DIFF
--- a/src/lowering/eaResolution.ts
+++ b/src/lowering/eaResolution.ts
@@ -1,6 +1,7 @@
 import type { Diagnostic } from '../diagnostics/types.js';
 import type { EaExprNode, SourceSpan, TypeExprNode } from '../frontend/ast.js';
 import type { CompileEnv } from '../semantics/env.js';
+import { preRoundSizeOfTypeExpr } from '../semantics/layout.js';
 
 export type EaResolution =
   | { kind: 'abs'; baseLower: string; addend: number; typeExpr?: TypeExprNode }
@@ -100,7 +101,7 @@ export function createEaResolutionHelpers(ctx: EaResolutionContext) {
               };
             }
             if (agg.kind === 'record') {
-              const sz = ctx.sizeOfTypeExpr(f.typeExpr);
+              const sz = preRoundSizeOfTypeExpr(f.typeExpr, ctx.env, ctx.diagnostics);
               if (sz === undefined) return undefined;
               off += sz;
             }

--- a/src/lowering/programLowering.ts
+++ b/src/lowering/programLowering.ts
@@ -37,6 +37,7 @@ import type {
   SectionKind,
 } from './loweringTypes.js';
 import type { AggregateType, ScalarKind } from './typeResolution.js';
+import { preRoundSizeOfTypeExpr } from '../semantics/layout.js';
 import { lowerDataBlock } from './programLoweringData.js';
 
 // Program lowering owns module-wide declaration traversal and the final
@@ -306,7 +307,7 @@ export function lowerProgramDeclarations(ctx: Context, _prescan: PrescanResult):
   const lowerVarBlock = (varBlock: VarBlockNode): void => {
     for (const decl of varBlock.decls) {
       if (decl.form !== 'typed') continue;
-      const size = ctx.sizeOfTypeExpr(decl.typeExpr, ctx.env, ctx.diagnostics);
+      const size = preRoundSizeOfTypeExpr(decl.typeExpr, ctx.env, ctx.diagnostics);
       if (size === undefined) continue;
       if (ctx.env.consts.has(decl.name)) {
         ctx.diag(ctx.diagnostics, decl.span.file, `Var name "${decl.name}" collides with a const.`);

--- a/src/lowering/programLoweringData.ts
+++ b/src/lowering/programLoweringData.ts
@@ -2,6 +2,7 @@ import type { DataBlockNode, ImmExprNode } from '../frontend/ast.js';
 import type { StartupInitAction } from './sectionContributions.js';
 import type { PendingSymbol } from './loweringTypes.js';
 import type { Context } from './programLowering.js';
+import { preRoundSizeOfTypeExpr } from '../semantics/layout.js';
 
 export function lowerDataBlock(
   ctx: Context,
@@ -71,7 +72,7 @@ export function lowerDataBlock(
     if (recordType?.kind === 'record') {
       if (init.kind === 'InitZero') {
         const zeroStart = target.offsetRef.current;
-        const storageBytes = ctx.sizeOfTypeExpr(type, ctx.env, ctx.diagnostics);
+        const storageBytes = preRoundSizeOfTypeExpr(type, ctx.env, ctx.diagnostics);
         if (storageBytes === undefined) continue;
         for (let pad = 0; pad < storageBytes; pad++) emitByte(0);
         recordStartupInit('zero', zeroStart, storageBytes);
@@ -148,7 +149,7 @@ export function lowerDataBlock(
           emitted += 2;
         }
       }
-      const storageBytes = ctx.sizeOfTypeExpr(type, ctx.env, ctx.diagnostics);
+      const storageBytes = preRoundSizeOfTypeExpr(type, ctx.env, ctx.diagnostics);
       if (storageBytes === undefined) continue;
       recordStartupInit('copy', copyStart, emitted);
       const zeroStart = target.offsetRef.current;
@@ -164,7 +165,7 @@ export function lowerDataBlock(
 
     if (init.kind === 'InitZero') {
       const zeroStart = target.offsetRef.current;
-      const storageBytes = ctx.sizeOfTypeExpr(type, ctx.env, ctx.diagnostics);
+      const storageBytes = preRoundSizeOfTypeExpr(type, ctx.env, ctx.diagnostics);
       if (storageBytes === undefined) continue;
       for (let pad = 0; pad < storageBytes; pad++) emitByte(0);
       recordStartupInit('zero', zeroStart, storageBytes);

--- a/src/semantics/env.ts
+++ b/src/semantics/env.ts
@@ -14,7 +14,11 @@ import type {
 } from '../frontend/ast.js';
 import { canonicalModuleId } from '../moduleIdentity.js';
 import { resolveVisibleConst, resolveVisibleEnum } from '../moduleVisibility.js';
-import { offsetOfPathInTypeExpr, sizeOfTypeExpr, storageInfoForTypeDecl } from './layout.js';
+import {
+  offsetOfPathInTypeExpr,
+  preRoundSizeOfTypeExpr,
+  storageInfoForTypeDecl,
+} from './layout.js';
 import { visitDeclTree } from './declVisitor.js';
 
 /**
@@ -101,7 +105,7 @@ export function evalImmExpr(
       return undefined;
     }
     case 'ImmSizeof': {
-      return sizeOfTypeExpr(expr.typeExpr, env, diagnostics);
+      return preRoundSizeOfTypeExpr(expr.typeExpr, env, diagnostics);
     }
     case 'ImmOffsetof': {
       return offsetOfPathInTypeExpr(

--- a/src/semantics/layout.ts
+++ b/src/semantics/layout.ts
@@ -89,7 +89,7 @@ function typeStorageInfoForDecl(
     for (const f of te.fields) {
       const fs = resolveTypeExpr(f.typeExpr);
       if (!fs) return undefined;
-      sum += fs.storageSize;
+      sum += fs.preRoundSize;
     }
     return { preRoundSize: sum, storageSize: nextPow2(sum) };
   }
@@ -140,7 +140,7 @@ export function storageInfoForTypeExpr(
         for (const f of te.fields) {
           const fs = sizeOf(f.typeExpr);
           if (!fs) return undefined;
-          sum += fs.storageSize;
+          sum += fs.preRoundSize;
         }
         return { preRoundSize: sum, storageSize: nextPow2(sum) };
       }
@@ -165,11 +165,19 @@ export function storageInfoForTypeDecl(
 }
 
 /**
- * Compute the packed size (in bytes) of a type expression.
- *
- * PR3 implementation note:
- * - Supports scalar types (`byte`, `word`, `addr`), arrays, and record types.
- * - Named types are resolved via `env.types`.
+ * Compute the packed (pre-rounded) size in bytes of a type expression.
+ */
+export function preRoundSizeOfTypeExpr(
+  typeExpr: TypeExprNode,
+  env: CompileEnv,
+  diagnostics?: Diagnostic[],
+): number | undefined {
+  const info = storageInfoForTypeExpr(typeExpr, env, diagnostics);
+  return info?.preRoundSize;
+}
+
+/**
+ * Compute the storage (rounded) size in bytes of a type expression.
  */
 export function sizeOfTypeExpr(
   typeExpr: TypeExprNode,
@@ -239,7 +247,7 @@ export function offsetOfPathInTypeExpr(
     let offsetBefore = 0;
     for (const f of fields) {
       if (f.name === fieldName) return { field: f, offsetBefore };
-      const fs = sizeOfTypeExpr(f.typeExpr, env, diagnostics);
+      const fs = preRoundSizeOfTypeExpr(f.typeExpr, env, diagnostics);
       if (fs === undefined) return undefined;
       offsetBefore += fs;
     }

--- a/test/semantics_layout_extra.test.ts
+++ b/test/semantics_layout_extra.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { CompileEnv } from '../src/semantics/env.js';
 import {
   offsetOfPathInTypeExpr,
+  preRoundSizeOfTypeExpr,
   sizeOfTypeExpr,
   storageInfoForTypeExpr,
 } from '../src/semantics/layout.js';
@@ -52,6 +53,18 @@ describe('semantics/layout', () => {
     expect(unionInfo).toEqual({ preRoundSize: 2, storageSize: 2 });
   });
 
+  it('computes packed sizes for records via preRoundSizeOfTypeExpr', () => {
+    const rec: TypeExprNode = {
+      kind: 'RecordType',
+      span,
+      fields: [recordField('x', byteType), recordField('y', wordType)],
+    };
+    const packed = preRoundSizeOfTypeExpr(rec, emptyEnv);
+    expect(packed).toBe(3);
+    const storage = sizeOfTypeExpr(rec, emptyEnv);
+    expect(storage).toBe(4);
+  });
+
   it('rejects inferred-length arrays without initializer', () => {
     const arr: TypeExprNode = { kind: 'ArrayType', span, element: byteType };
     const diagnostics: any[] = [];
@@ -96,5 +109,92 @@ describe('semantics/layout', () => {
       () => 0,
     );
     expect(offset).toBe(1); // byte field x (1) before y
+  });
+
+  it('uses packed record fields and rounded array stride in offsetof', () => {
+    const inner: TypeDeclNode = {
+      kind: 'TypeDecl',
+      span,
+      name: 'Inner',
+      exported: false,
+      typeExpr: {
+        kind: 'RecordType',
+        span,
+        fields: [recordField('a', byteType), recordField('b', wordType)],
+      },
+    };
+    const outer: TypeDeclNode = {
+      kind: 'TypeDecl',
+      span,
+      name: 'Outer',
+      exported: false,
+      typeExpr: {
+        kind: 'RecordType',
+        span,
+        fields: [
+          recordField('lead', byteType),
+          recordField('inner', { kind: 'TypeName', span, name: 'Inner' }),
+          recordField('tail', byteType),
+        ],
+      },
+    };
+    const table: TypeDeclNode = {
+      kind: 'TypeDecl',
+      span,
+      name: 'Table',
+      exported: false,
+      typeExpr: {
+        kind: 'RecordType',
+        span,
+        fields: [
+          recordField('rows', {
+            kind: 'ArrayType',
+            span,
+            element: { kind: 'TypeName', span, name: 'Inner' },
+            length: 2,
+          }),
+        ],
+      },
+    };
+    const env: CompileEnv = {
+      ...emptyEnv,
+      types: new Map([
+        ['Inner', inner],
+        ['Outer', outer],
+        ['Table', table],
+      ]),
+    };
+    const evalImm = (expr: ImmExprNode) =>
+      expr.kind === 'ImmLiteral' ? expr.value : undefined;
+    const diagnostics: any[] = [];
+
+    const tailPath: OffsetofPathNode = { kind: 'OffsetofPath', span, base: 'tail', steps: [] };
+    const tailOffset = offsetOfPathInTypeExpr(
+      { kind: 'TypeName', span, name: 'Outer' },
+      tailPath,
+      env,
+      evalImm,
+      diagnostics,
+    );
+    expect(tailOffset).toBe(4); // lead (1) + inner packed (3)
+
+    const rowsPath: OffsetofPathNode = {
+      kind: 'OffsetofPath',
+      span,
+      base: 'rows',
+      steps: [
+        { kind: 'OffsetofIndex', span, expr: { kind: 'ImmLiteral', span, value: 1 } },
+        { kind: 'OffsetofField', span, name: 'b' },
+      ],
+    };
+    const rowsOffset = offsetOfPathInTypeExpr(
+      { kind: 'TypeName', span, name: 'Table' },
+      rowsPath,
+      env,
+      evalImm,
+      diagnostics,
+    );
+    expect(rowsOffset).toBe(5); // stride 4 + field b offset 1
+    expect(diagnostics).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Introduced `preRoundSizeOfTypeExpr(...)` and wired record field accumulation/offsetof to use packed (pre-round) sizes.
- Kept array element stride on rounded sizes by leaving `sizeOfTypeExpr` as storage size while routing record field offsets through `preRoundSizeOfTypeExpr`.
- Switched sizeof/record layout consumers to the packed size path.
- Added focused layout/offsetof regression coverage.

## Scope Check
- Issue #712 only.
- No emission module changes.

## Files Changed
- `src/semantics/layout.ts`
- `src/semantics/env.ts`
- `src/lowering/programLowering.ts`
- `src/lowering/programLoweringData.ts`
- `src/lowering/eaResolution.ts`
- `test/semantics_layout_extra.test.ts`

## Verification
- `npm run typecheck`
- `npm test -- --run test/semantics_layout_extra.test.ts test/semantics_layout.test.ts test/pr8_sizeof.test.ts`

Refs #712
