### PR TITLE
fix: pack top-level array data emission (#713)

### DIFF
--- a/src/lowering/programLoweringData.ts
+++ b/src/lowering/programLoweringData.ts
@@ -48,12 +48,6 @@ export function lowerDataBlock(
       emitByte(w & 0xff);
       emitByte((w >> 8) & 0xff);
     };
-    const nextPow2 = (value: number): number => {
-      if (value <= 1) return value;
-      let pow = 1;
-      while (pow < value) pow <<= 1;
-      return pow;
-    };
     const recordStartupInit = (
       kind: 'copy' | 'zero',
       offset: number,
@@ -195,13 +189,6 @@ export function lowerDataBlock(
       for (let idx = 0; idx < init.value.length; idx++) emitByte(init.value.charCodeAt(idx));
       actualLength = init.value.length;
       recordStartupInit('copy', copyStart, actualLength);
-      if (type.kind === 'ArrayType') {
-        const emittedBytes = actualLength * elementSize;
-        const storageBytes = nextPow2(emittedBytes);
-        const zeroStart = target.offsetRef.current;
-        for (let pad = emittedBytes; pad < storageBytes; pad++) emitByte(0);
-        recordStartupInit('zero', zeroStart, storageBytes - emittedBytes);
-      }
       continue;
     }
 
@@ -227,12 +214,5 @@ export function lowerDataBlock(
     }
     actualLength = type.kind === 'ArrayType' ? values.length : 1;
     recordStartupInit('copy', copyStart, actualLength * elementSize);
-    if (type.kind === 'ArrayType') {
-      const emittedBytes = actualLength * elementSize;
-      const storageBytes = nextPow2(emittedBytes);
-      const zeroStart = target.offsetRef.current;
-      for (let pad = emittedBytes; pad < storageBytes; pad++) emitByte(0);
-      recordStartupInit('zero', zeroStart, storageBytes - emittedBytes);
-    }
   }
 }

--- a/test/fixtures/pr713_packed_top_level_arrays.zax
+++ b/test/fixtures/pr713_packed_top_level_arrays.zax
@@ -1,0 +1,12 @@
+section data vars at $4000 size $20
+  bytes: byte[3] = [1, 2, 3]
+  flag: word = 1
+  words: word[2] = [17, 34]
+  tail: byte = 5
+end
+
+section code boot at $4020 size $20
+  func main()
+    ret
+  end
+end

--- a/test/pr576_unified_data_sections.test.ts
+++ b/test/pr576_unified_data_sections.test.ts
@@ -59,6 +59,6 @@ describe('PR576 unified data declarations inside data sections', () => {
     const symbols = d8m!.json.symbols as Array<{ name: string; address: number }>;
     expect(symbols.find((s) => s.name === 'counter')?.address).toBe(0x4000);
     expect(symbols.find((s) => s.name === 'message')?.address).toBe(0x4001);
-    expect(symbols.find((s) => s.name === 'flag')?.address).toBe(0x4005);
+    expect(symbols.find((s) => s.name === 'flag')?.address).toBe(0x4004);
   });
 });

--- a/test/pr577_startup_init_region.test.ts
+++ b/test/pr577_startup_init_region.test.ts
@@ -108,7 +108,7 @@ describe('PR577 startup init region', () => {
     expect(bin).toBeDefined();
     expect(d8m).toBeDefined();
     const bytes = Array.from(bin!.bytes);
-    expect(bytes.slice(0, 7)).toEqual([0x00, 0x61, 0x62, 0x63, 0x00, 0x01, 0x00]);
+    expect(bytes.slice(0, 6)).toEqual([0x00, 0x61, 0x62, 0x63, 0x01, 0x00]);
 
     const generator = d8m!.json.generator as { entrySymbol?: string; entryAddress?: number };
     expect(generator.entrySymbol).toBe('__zax_startup');
@@ -116,13 +116,12 @@ describe('PR577 startup init region', () => {
     const entryOffset = (generator.entryAddress ?? 0) - 0x4000;
     expect(bytes[entryOffset]).toBe(0x21);
 
-    expect(bytes.slice(-28)).toEqual([
+    expect(bytes.slice(-24)).toEqual([
       0x02, 0x00,
       0x01, 0x40, 0x00, 0x00, 0x03, 0x00,
-      0x05, 0x40, 0x03, 0x00, 0x02, 0x00,
-      0x02, 0x00,
+      0x04, 0x40, 0x03, 0x00, 0x02, 0x00,
+      0x01, 0x00,
       0x00, 0x40, 0x01, 0x00,
-      0x04, 0x40, 0x01, 0x00,
       0x61, 0x62, 0x63, 0x01,
     ]);
   });

--- a/test/pr713_packed_top_level_arrays.test.ts
+++ b/test/pr713_packed_top_level_arrays.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { D8mArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR713 packed top-level array emission', () => {
+  it('does not round top-level array initializers up before following symbols', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr713_packed_top_level_arrays.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+
+    const d8m = res.artifacts.find((a): a is D8mArtifact => a.kind === 'd8m');
+    expect(d8m).toBeDefined();
+
+    const symbols = d8m!.json.symbols as Array<{ name: string; address: number }>;
+    expect(symbols.find((s) => s.name === 'bytes')?.address).toBe(0x4000);
+    expect(symbols.find((s) => s.name === 'flag')?.address).toBe(0x4003);
+    expect(symbols.find((s) => s.name === 'words')?.address).toBe(0x4005);
+    expect(symbols.find((s) => s.name === 'tail')?.address).toBe(0x4009);
+  });
+});


### PR DESCRIPTION
Changed files:
- src/lowering/programLoweringData.ts
- test/pr576_unified_data_sections.test.ts
- test/pr577_startup_init_region.test.ts
- test/pr713_packed_top_level_arrays.test.ts
- test/fixtures/pr713_packed_top_level_arrays.zax

Verification:
- npm run typecheck
- npm test -- --run test/pr576_unified_data_sections.test.ts test/pr577_startup_init_region.test.ts test/pr713_packed_top_level_arrays.test.ts test/pr51_data_inferred_array_len.test.ts test/semantics_layout_extra.test.ts
- npm test -- --run test/examples_compile.test.ts
