### PR TITLE
Complete indirect EA consumer audit

### DIFF
--- a/examples/language-tour/37_byte_fvar_const.asm
+++ b/examples/language-tour/37_byte_fvar_const.asm
@@ -9,24 +9,24 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-push DE                        ; 010B: D5
-push HL                        ; 010C: E5
-ld E, (IX + $0006)             ; 010D: DD 5E 06
-ld D, (IX + $0007)             ; 0110: DD 56 07
-ld HL, $0000                   ; 0113: 21 00 00
-add HL, DE                     ; 0116: 19
-ld A, (HL)                     ; 0117: 7E
-pop HL                         ; 0118: E1
-pop DE                         ; 0119: D1
-push DE                        ; 011A: D5
-push HL                        ; 011B: E5
-ld E, (IX + $0007)             ; 011C: DD 5E 07
-ld D, (IX + $0008)             ; 011F: DD 56 08
-ld HL, $0000                   ; 0122: 21 00 00
-add HL, DE                     ; 0125: 19
-ld (HL), A                     ; 0126: 77
-pop HL                         ; 0127: E1
-pop DE                         ; 0128: D1
+ld E, (IX + $0004)             ; 010B: DD 5E 04
+ld D, (IX + $0005)             ; 010E: DD 56 05
+ex DE, HL                      ; 0111: EB
+ld DE, $0002                   ; 0112: 11 02 00
+add HL, DE                     ; 0115: 19
+push HL                        ; 0116: E5
+pop HL                         ; 0117: E1
+ld A, (hl)                     ; 0118: 7E
+push AF                        ; 0119: F5
+ld E, (IX + $0004)             ; 011A: DD 5E 04
+ld D, (IX + $0005)             ; 011D: DD 56 05
+ex DE, HL                      ; 0120: EB
+ld DE, $0003                   ; 0121: 11 03 00
+add HL, DE                     ; 0124: 19
+push HL                        ; 0125: E5
+pop HL                         ; 0126: E1
+ld (hl), A                     ; 0127: 77
+pop AF                         ; 0128: F1
 ld H, $0000                    ; 0129: 26 00
 ld L, A                        ; 012B: 6F
 __zax_epilogue_0:

--- a/examples/language-tour/37_byte_fvar_const.d8dbg.json
+++ b/examples/language-tour/37_byte_fvar_const.d8dbg.json
@@ -23,13 +23,13 @@
         },
         {
           "start": 267,
-          "end": 282,
+          "end": 281,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 282,
+          "start": 281,
           "end": 297,
           "lstLine": 8,
           "kind": "code",

--- a/examples/language-tour/38_byte_fvar_reg8.asm
+++ b/examples/language-tour/38_byte_fvar_reg8.asm
@@ -9,72 +9,78 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-push DE                        ; 010B: D5
-push HL                        ; 010C: E5
-ld E, (IX + $0004)             ; 010D: DD 5E 04
-ld D, (IX + $0005)             ; 0110: DD 56 05
-ex DE, HL                      ; 0113: EB
-ld E, (IX + $0006)             ; 0114: DD 5E 06
-ld D, (IX + $0007)             ; 0117: DD 56 07
-ex DE, HL                      ; 011A: EB
-add HL, DE                     ; 011B: 19
-ld B, (HL)                     ; 011C: 46
-pop HL                         ; 011D: E1
-pop DE                         ; 011E: D1
-push DE                        ; 011F: D5
-push HL                        ; 0120: E5
-ld E, (IX + $0004)             ; 0121: DD 5E 04
-ld D, (IX + $0005)             ; 0124: DD 56 05
-ex DE, HL                      ; 0127: EB
-ld E, (IX + $0006)             ; 0128: DD 5E 06
-ld D, (IX + $0007)             ; 012B: DD 56 07
-ex DE, HL                      ; 012E: EB
-add HL, DE                     ; 012F: 19
-ld (HL), B                     ; 0130: 70
-pop HL                         ; 0131: E1
-pop DE                         ; 0132: D1
-ld H, $0000                    ; 0133: 26 00
-ld L, B                        ; 0135: 68
+ex DE, HL                      ; 010B: EB
+ld E, (IX + $0006)             ; 010C: DD 5E 06
+ld D, (IX + $0007)             ; 010F: DD 56 07
+ex DE, HL                      ; 0112: EB
+push HL                        ; 0113: E5
+pop HL                         ; 0114: E1
+push HL                        ; 0115: E5
+ld E, (IX + $0004)             ; 0116: DD 5E 04
+ld D, (IX + $0005)             ; 0119: DD 56 05
+ex DE, HL                      ; 011C: EB
+pop DE                         ; 011D: D1
+add HL, DE                     ; 011E: 19
+push HL                        ; 011F: E5
+pop HL                         ; 0120: E1
+ld B, (hl)                     ; 0121: 46
+ex DE, HL                      ; 0122: EB
+ld E, (IX + $0006)             ; 0123: DD 5E 06
+ld D, (IX + $0007)             ; 0126: DD 56 07
+ex DE, HL                      ; 0129: EB
+push HL                        ; 012A: E5
+pop HL                         ; 012B: E1
+push HL                        ; 012C: E5
+ld E, (IX + $0004)             ; 012D: DD 5E 04
+ld D, (IX + $0005)             ; 0130: DD 56 05
+ex DE, HL                      ; 0133: EB
+pop DE                         ; 0134: D1
+add HL, DE                     ; 0135: 19
+push HL                        ; 0136: E5
+pop HL                         ; 0137: E1
+ld (hl), B                     ; 0138: 70
+ld H, $0000                    ; 0139: 26 00
+ld L, B                        ; 013B: 68
 __zax_epilogue_0:
-pop DE                         ; 0136: D1
-pop BC                         ; 0137: C1
-pop AF                         ; 0138: F1
-ld SP, IX                      ; 0139: DD F9
-pop IX                         ; 013B: DD E1
-ret                            ; 013D: C9
+pop DE                         ; 013C: D1
+pop BC                         ; 013D: C1
+pop AF                         ; 013E: F1
+ld SP, IX                      ; 013F: DD F9
+pop IX                         ; 0141: DD E1
+ret                            ; 0143: C9
 ; func byte_fvar_reg end
 ; func main begin
 main:
-push IX                        ; 013E: DD E5
-ld IX, $0000                   ; 0140: DD 21 00 00
-add IX, SP                     ; 0144: DD 39
-push AF                        ; 0146: F5
-push BC                        ; 0147: C5
-push DE                        ; 0148: D5
-push HL                        ; 0149: E5
-ld HL, $0001                   ; 014A: 21 01 00
-push HL                        ; 014D: E5
-ld HL, glob_bytes              ; 014E: 21 00 00
-push HL                        ; 0151: E5
-call byte_fvar_reg             ; 0152: CD 00 00
-inc SP                         ; 0155: 33
-inc SP                         ; 0156: 33
-inc SP                         ; 0157: 33
-inc SP                         ; 0158: 33
+push IX                        ; 0144: DD E5
+ld IX, $0000                   ; 0146: DD 21 00 00
+add IX, SP                     ; 014A: DD 39
+push AF                        ; 014C: F5
+push BC                        ; 014D: C5
+push DE                        ; 014E: D5
+push HL                        ; 014F: E5
+ld HL, $0001                   ; 0150: 21 01 00
+push HL                        ; 0153: E5
+ld HL, glob_bytes              ; 0154: 21 00 00
+push HL                        ; 0157: E5
+call byte_fvar_reg             ; 0158: CD 00 00
+inc SP                         ; 015B: 33
+inc SP                         ; 015C: 33
+inc SP                         ; 015D: 33
+inc SP                         ; 015E: 33
 __zax_epilogue_1:
-pop HL                         ; 0159: E1
-pop DE                         ; 015A: D1
-pop BC                         ; 015B: C1
-pop AF                         ; 015C: F1
-ld SP, IX                      ; 015D: DD F9
-pop IX                         ; 015F: DD E1
-ret                            ; 0161: C9
+pop HL                         ; 015F: E1
+pop DE                         ; 0160: D1
+pop BC                         ; 0161: C1
+pop AF                         ; 0162: F1
+ld SP, IX                      ; 0163: DD F9
+pop IX                         ; 0165: DD E1
+ret                            ; 0167: C9
 ; func main end
 
 ; symbols:
 ; label byte_fvar_reg = $0100
-; label __zax_epilogue_0 = $0136
-; label main = $013E
-; label __zax_epilogue_1 = $0159
+; label __zax_epilogue_0 = $013C
+; label main = $0144
+; label __zax_epilogue_1 = $015F
 ; data glob_bytes = $2000
 ; label __zax_startup = $2008

--- a/examples/language-tour/38_byte_fvar_reg8.d8dbg.json
+++ b/examples/language-tour/38_byte_fvar_reg8.d8dbg.json
@@ -16,63 +16,63 @@
         },
         {
           "start": 256,
-          "end": 354,
+          "end": 360,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
         },
         {
           "start": 267,
-          "end": 287,
+          "end": 290,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 287,
-          "end": 307,
+          "start": 290,
+          "end": 313,
           "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 307,
-          "end": 309,
+          "start": 313,
+          "end": 315,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 309,
-          "end": 310,
+          "start": 315,
+          "end": 316,
           "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 310,
-          "end": 318,
+          "start": 316,
+          "end": 324,
           "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 318,
-          "end": 330,
+          "start": 324,
+          "end": 336,
           "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 330,
-          "end": 345,
+          "start": 336,
+          "end": 351,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 345,
-          "end": 354,
+          "start": 351,
+          "end": 360,
           "lstLine": 13,
           "kind": "code",
           "confidence": "high"
@@ -96,21 +96,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 310,
+          "address": 316,
           "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 318,
+          "address": 324,
           "line": 13,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 345,
+          "address": 351,
           "line": 13,
           "scope": "local"
         },
@@ -133,7 +133,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 354
+      "end": 360
     },
     {
       "start": 8192,
@@ -155,7 +155,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 310,
+      "address": 316,
       "file": "38_byte_fvar_reg8.zax",
       "line": 6,
       "scope": "local"
@@ -163,7 +163,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 318,
+      "address": 324,
       "file": "38_byte_fvar_reg8.zax",
       "line": 13,
       "scope": "global"
@@ -171,7 +171,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 345,
+      "address": 351,
       "file": "38_byte_fvar_reg8.zax",
       "line": 13,
       "scope": "local"

--- a/examples/language-tour/39_byte_fvar_reg16.asm
+++ b/examples/language-tour/39_byte_fvar_reg16.asm
@@ -13,64 +13,72 @@ ex DE, HL                      ; 010B: EB
 ld E, (IX + $0006)             ; 010C: DD 5E 06
 ld D, (IX + $0007)             ; 010F: DD 56 07
 ex DE, HL                      ; 0112: EB
-push DE                        ; 0113: D5
-push HL                        ; 0114: E5
-ld E, (IX + $0004)             ; 0115: DD 5E 04
-ld D, (IX + $0005)             ; 0118: DD 56 05
+ex DE, HL                      ; 0113: EB
+push DE                        ; 0114: D5
+push IX                        ; 0115: DD E5
+pop HL                         ; 0117: E1
+ld DE, $0004                   ; 0118: 11 04 00
 add HL, DE                     ; 011B: 19
-ld A, (HL)                     ; 011C: 7E
-pop HL                         ; 011D: E1
-pop DE                         ; 011E: D1
-push DE                        ; 011F: D5
-push HL                        ; 0120: E5
-ld E, (IX + $0004)             ; 0121: DD 5E 04
-ld D, (IX + $0005)             ; 0124: DD 56 05
-add HL, DE                     ; 0127: 19
-ld (HL), A                     ; 0128: 77
-pop HL                         ; 0129: E1
-pop DE                         ; 012A: D1
-ld H, $0000                    ; 012B: 26 00
-ld L, A                        ; 012D: 6F
-__zax_epilogue_0:
-pop DE                         ; 012E: D1
-pop BC                         ; 012F: C1
+pop DE                         ; 011C: D1
+add HL, DE                     ; 011D: 19
+push HL                        ; 011E: E5
+pop HL                         ; 011F: E1
+ld A, (hl)                     ; 0120: 7E
+push AF                        ; 0121: F5
+ex DE, HL                      ; 0122: EB
+push DE                        ; 0123: D5
+push IX                        ; 0124: DD E5
+pop HL                         ; 0126: E1
+ld DE, $0004                   ; 0127: 11 04 00
+add HL, DE                     ; 012A: 19
+pop DE                         ; 012B: D1
+add HL, DE                     ; 012C: 19
+push HL                        ; 012D: E5
+pop HL                         ; 012E: E1
+ld (hl), A                     ; 012F: 77
 pop AF                         ; 0130: F1
-ld SP, IX                      ; 0131: DD F9
-pop IX                         ; 0133: DD E1
-ret                            ; 0135: C9
+ld H, $0000                    ; 0131: 26 00
+ld L, A                        ; 0133: 6F
+__zax_epilogue_0:
+pop DE                         ; 0134: D1
+pop BC                         ; 0135: C1
+pop AF                         ; 0136: F1
+ld SP, IX                      ; 0137: DD F9
+pop IX                         ; 0139: DD E1
+ret                            ; 013B: C9
 ; func byte_fvar_reg16 end
 ; func main begin
 main:
-push IX                        ; 0136: DD E5
-ld IX, $0000                   ; 0138: DD 21 00 00
-add IX, SP                     ; 013C: DD 39
-push AF                        ; 013E: F5
-push BC                        ; 013F: C5
-push DE                        ; 0140: D5
-push HL                        ; 0141: E5
-ld HL, $0006                   ; 0142: 21 06 00
-push HL                        ; 0145: E5
-ld HL, glob_bytes              ; 0146: 21 00 00
-push HL                        ; 0149: E5
-call byte_fvar_reg16           ; 014A: CD 00 00
-inc SP                         ; 014D: 33
-inc SP                         ; 014E: 33
-inc SP                         ; 014F: 33
-inc SP                         ; 0150: 33
+push IX                        ; 013C: DD E5
+ld IX, $0000                   ; 013E: DD 21 00 00
+add IX, SP                     ; 0142: DD 39
+push AF                        ; 0144: F5
+push BC                        ; 0145: C5
+push DE                        ; 0146: D5
+push HL                        ; 0147: E5
+ld HL, $0006                   ; 0148: 21 06 00
+push HL                        ; 014B: E5
+ld HL, glob_bytes              ; 014C: 21 00 00
+push HL                        ; 014F: E5
+call byte_fvar_reg16           ; 0150: CD 00 00
+inc SP                         ; 0153: 33
+inc SP                         ; 0154: 33
+inc SP                         ; 0155: 33
+inc SP                         ; 0156: 33
 __zax_epilogue_1:
-pop HL                         ; 0151: E1
-pop DE                         ; 0152: D1
-pop BC                         ; 0153: C1
-pop AF                         ; 0154: F1
-ld SP, IX                      ; 0155: DD F9
-pop IX                         ; 0157: DD E1
-ret                            ; 0159: C9
+pop HL                         ; 0157: E1
+pop DE                         ; 0158: D1
+pop BC                         ; 0159: C1
+pop AF                         ; 015A: F1
+ld SP, IX                      ; 015B: DD F9
+pop IX                         ; 015D: DD E1
+ret                            ; 015F: C9
 ; func main end
 
 ; symbols:
 ; label byte_fvar_reg16 = $0100
-; label __zax_epilogue_0 = $012E
-; label main = $0136
-; label __zax_epilogue_1 = $0151
+; label __zax_epilogue_0 = $0134
+; label main = $013C
+; label __zax_epilogue_1 = $0157
 ; data glob_bytes = $2000
 ; label __zax_startup = $2008

--- a/examples/language-tour/39_byte_fvar_reg16.d8dbg.json
+++ b/examples/language-tour/39_byte_fvar_reg16.d8dbg.json
@@ -16,7 +16,7 @@
         },
         {
           "start": 256,
-          "end": 346,
+          "end": 352,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
@@ -30,56 +30,56 @@
         },
         {
           "start": 275,
-          "end": 287,
+          "end": 289,
           "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 287,
-          "end": 299,
+          "start": 289,
+          "end": 305,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 299,
-          "end": 301,
+          "start": 305,
+          "end": 307,
           "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 301,
-          "end": 302,
+          "start": 307,
+          "end": 308,
           "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 302,
-          "end": 310,
+          "start": 308,
+          "end": 316,
           "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 310,
-          "end": 322,
+          "start": 316,
+          "end": 328,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 322,
-          "end": 337,
+          "start": 328,
+          "end": 343,
           "lstLine": 15,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 337,
-          "end": 346,
+          "start": 343,
+          "end": 352,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
@@ -103,21 +103,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 302,
+          "address": 308,
           "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 310,
+          "address": 316,
           "line": 14,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 337,
+          "address": 343,
           "line": 14,
           "scope": "local"
         },
@@ -140,7 +140,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 346
+      "end": 352
     },
     {
       "start": 8192,
@@ -162,7 +162,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 302,
+      "address": 308,
       "file": "39_byte_fvar_reg16.zax",
       "line": 6,
       "scope": "local"
@@ -170,7 +170,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 310,
+      "address": 316,
       "file": "39_byte_fvar_reg16.zax",
       "line": 14,
       "scope": "global"
@@ -178,7 +178,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 337,
+      "address": 343,
       "file": "39_byte_fvar_reg16.zax",
       "line": 14,
       "scope": "local"

--- a/examples/language-tour/41_byte_fvar_fvar.asm
+++ b/examples/language-tour/41_byte_fvar_fvar.asm
@@ -9,72 +9,80 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-push DE                        ; 010B: D5
-push HL                        ; 010C: E5
-ld E, (IX + $0004)             ; 010D: DD 5E 04
-ld D, (IX + $0005)             ; 0110: DD 56 05
-ex DE, HL                      ; 0113: EB
-ld E, (IX + $0006)             ; 0114: DD 5E 06
-ld D, (IX + $0007)             ; 0117: DD 56 07
-ex DE, HL                      ; 011A: EB
-add HL, DE                     ; 011B: 19
-ld A, (HL)                     ; 011C: 7E
-pop HL                         ; 011D: E1
-pop DE                         ; 011E: D1
-push DE                        ; 011F: D5
-push HL                        ; 0120: E5
-ld E, (IX + $0004)             ; 0121: DD 5E 04
-ld D, (IX + $0005)             ; 0124: DD 56 05
-ex DE, HL                      ; 0127: EB
-ld E, (IX + $0006)             ; 0128: DD 5E 06
-ld D, (IX + $0007)             ; 012B: DD 56 07
-ex DE, HL                      ; 012E: EB
-add HL, DE                     ; 012F: 19
-ld (HL), A                     ; 0130: 77
-pop HL                         ; 0131: E1
-pop DE                         ; 0132: D1
-ld H, $0000                    ; 0133: 26 00
-ld L, A                        ; 0135: 6F
+ex DE, HL                      ; 010B: EB
+ld E, (IX + $0006)             ; 010C: DD 5E 06
+ld D, (IX + $0007)             ; 010F: DD 56 07
+ex DE, HL                      ; 0112: EB
+push HL                        ; 0113: E5
+pop HL                         ; 0114: E1
+push HL                        ; 0115: E5
+ld E, (IX + $0004)             ; 0116: DD 5E 04
+ld D, (IX + $0005)             ; 0119: DD 56 05
+ex DE, HL                      ; 011C: EB
+pop DE                         ; 011D: D1
+add HL, DE                     ; 011E: 19
+push HL                        ; 011F: E5
+pop HL                         ; 0120: E1
+ld A, (hl)                     ; 0121: 7E
+push AF                        ; 0122: F5
+ex DE, HL                      ; 0123: EB
+ld E, (IX + $0006)             ; 0124: DD 5E 06
+ld D, (IX + $0007)             ; 0127: DD 56 07
+ex DE, HL                      ; 012A: EB
+push HL                        ; 012B: E5
+pop HL                         ; 012C: E1
+push HL                        ; 012D: E5
+ld E, (IX + $0004)             ; 012E: DD 5E 04
+ld D, (IX + $0005)             ; 0131: DD 56 05
+ex DE, HL                      ; 0134: EB
+pop DE                         ; 0135: D1
+add HL, DE                     ; 0136: 19
+push HL                        ; 0137: E5
+pop HL                         ; 0138: E1
+ld (hl), A                     ; 0139: 77
+pop AF                         ; 013A: F1
+ld H, $0000                    ; 013B: 26 00
+ld L, A                        ; 013D: 6F
 __zax_epilogue_0:
-pop DE                         ; 0136: D1
-pop BC                         ; 0137: C1
-pop AF                         ; 0138: F1
-ld SP, IX                      ; 0139: DD F9
-pop IX                         ; 013B: DD E1
-ret                            ; 013D: C9
+pop DE                         ; 013E: D1
+pop BC                         ; 013F: C1
+pop AF                         ; 0140: F1
+ld SP, IX                      ; 0141: DD F9
+pop IX                         ; 0143: DD E1
+ret                            ; 0145: C9
 ; func byte_fvar_fvar end
 ; func main begin
 main:
-push IX                        ; 013E: DD E5
-ld IX, $0000                   ; 0140: DD 21 00 00
-add IX, SP                     ; 0144: DD 39
-push AF                        ; 0146: F5
-push BC                        ; 0147: C5
-push DE                        ; 0148: D5
-push HL                        ; 0149: E5
-ld HL, $0005                   ; 014A: 21 05 00
-push HL                        ; 014D: E5
-ld HL, glob_bytes              ; 014E: 21 00 00
+push IX                        ; 0146: DD E5
+ld IX, $0000                   ; 0148: DD 21 00 00
+add IX, SP                     ; 014C: DD 39
+push AF                        ; 014E: F5
+push BC                        ; 014F: C5
+push DE                        ; 0150: D5
 push HL                        ; 0151: E5
-call byte_fvar_fvar            ; 0152: CD 00 00
-inc SP                         ; 0155: 33
-inc SP                         ; 0156: 33
-inc SP                         ; 0157: 33
-inc SP                         ; 0158: 33
+ld HL, $0005                   ; 0152: 21 05 00
+push HL                        ; 0155: E5
+ld HL, glob_bytes              ; 0156: 21 00 00
+push HL                        ; 0159: E5
+call byte_fvar_fvar            ; 015A: CD 00 00
+inc SP                         ; 015D: 33
+inc SP                         ; 015E: 33
+inc SP                         ; 015F: 33
+inc SP                         ; 0160: 33
 __zax_epilogue_1:
-pop HL                         ; 0159: E1
-pop DE                         ; 015A: D1
-pop BC                         ; 015B: C1
-pop AF                         ; 015C: F1
-ld SP, IX                      ; 015D: DD F9
-pop IX                         ; 015F: DD E1
-ret                            ; 0161: C9
+pop HL                         ; 0161: E1
+pop DE                         ; 0162: D1
+pop BC                         ; 0163: C1
+pop AF                         ; 0164: F1
+ld SP, IX                      ; 0165: DD F9
+pop IX                         ; 0167: DD E1
+ret                            ; 0169: C9
 ; func main end
 
 ; symbols:
 ; label byte_fvar_fvar = $0100
-; label __zax_epilogue_0 = $0136
-; label main = $013E
-; label __zax_epilogue_1 = $0159
+; label __zax_epilogue_0 = $013E
+; label main = $0146
+; label __zax_epilogue_1 = $0161
 ; data glob_bytes = $2000
 ; label __zax_startup = $2008

--- a/examples/language-tour/41_byte_fvar_fvar.d8dbg.json
+++ b/examples/language-tour/41_byte_fvar_fvar.d8dbg.json
@@ -16,63 +16,63 @@
         },
         {
           "start": 256,
-          "end": 354,
+          "end": 362,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
         },
         {
           "start": 267,
-          "end": 287,
+          "end": 290,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 287,
-          "end": 307,
+          "start": 290,
+          "end": 315,
           "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 307,
-          "end": 309,
+          "start": 315,
+          "end": 317,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 309,
-          "end": 310,
+          "start": 317,
+          "end": 318,
           "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 310,
-          "end": 318,
+          "start": 318,
+          "end": 326,
           "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 318,
-          "end": 330,
+          "start": 326,
+          "end": 338,
           "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 330,
-          "end": 345,
+          "start": 338,
+          "end": 353,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 345,
-          "end": 354,
+          "start": 353,
+          "end": 362,
           "lstLine": 13,
           "kind": "code",
           "confidence": "high"
@@ -96,21 +96,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 310,
+          "address": 318,
           "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 318,
+          "address": 326,
           "line": 13,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 345,
+          "address": 353,
           "line": 13,
           "scope": "local"
         },
@@ -133,7 +133,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 354
+      "end": 362
     },
     {
       "start": 8192,
@@ -155,7 +155,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 310,
+      "address": 318,
       "file": "41_byte_fvar_fvar.zax",
       "line": 6,
       "scope": "local"
@@ -163,7 +163,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 318,
+      "address": 326,
       "file": "41_byte_fvar_fvar.zax",
       "line": 13,
       "scope": "global"
@@ -171,7 +171,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 345,
+      "address": 353,
       "file": "41_byte_fvar_fvar.zax",
       "line": 13,
       "scope": "local"

--- a/examples/language-tour/42_byte_fvar_glob.asm
+++ b/examples/language-tour/42_byte_fvar_glob.asm
@@ -9,63 +9,71 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-push DE                        ; 010B: D5
-push HL                        ; 010C: E5
-ld E, (IX + $0004)             ; 010D: DD 5E 04
-ld D, (IX + $0005)             ; 0110: DD 56 05
-ld hl, (glob_idx_word)         ; 0113: 2A 00 00
-add HL, DE                     ; 0116: 19
-ld A, (HL)                     ; 0117: 7E
-pop HL                         ; 0118: E1
-pop DE                         ; 0119: D1
-push DE                        ; 011A: D5
-push HL                        ; 011B: E5
-ld E, (IX + $0004)             ; 011C: DD 5E 04
-ld D, (IX + $0005)             ; 011F: DD 56 05
-ld hl, (glob_idx_word)         ; 0122: 2A 00 00
-add HL, DE                     ; 0125: 19
-ld (HL), A                     ; 0126: 77
-pop HL                         ; 0127: E1
-pop DE                         ; 0128: D1
-ld H, $0000                    ; 0129: 26 00
-ld L, A                        ; 012B: 6F
+ld hl, (glob_idx_word)         ; 010B: 2A 00 00
+push HL                        ; 010E: E5
+pop HL                         ; 010F: E1
+push HL                        ; 0110: E5
+ld E, (IX + $0004)             ; 0111: DD 5E 04
+ld D, (IX + $0005)             ; 0114: DD 56 05
+ex DE, HL                      ; 0117: EB
+pop DE                         ; 0118: D1
+add HL, DE                     ; 0119: 19
+push HL                        ; 011A: E5
+pop HL                         ; 011B: E1
+ld A, (hl)                     ; 011C: 7E
+push AF                        ; 011D: F5
+ld hl, (glob_idx_word)         ; 011E: 2A 00 00
+push HL                        ; 0121: E5
+pop HL                         ; 0122: E1
+push HL                        ; 0123: E5
+ld E, (IX + $0004)             ; 0124: DD 5E 04
+ld D, (IX + $0005)             ; 0127: DD 56 05
+ex DE, HL                      ; 012A: EB
+pop DE                         ; 012B: D1
+add HL, DE                     ; 012C: 19
+push HL                        ; 012D: E5
+pop HL                         ; 012E: E1
+ld (hl), A                     ; 012F: 77
+pop AF                         ; 0130: F1
+ld H, $0000                    ; 0131: 26 00
+ld L, A                        ; 0133: 6F
 __zax_epilogue_0:
-pop DE                         ; 012C: D1
-pop BC                         ; 012D: C1
-pop AF                         ; 012E: F1
-ld SP, IX                      ; 012F: DD F9
-pop IX                         ; 0131: DD E1
-ret                            ; 0133: C9
+pop DE                         ; 0134: D1
+pop BC                         ; 0135: C1
+pop AF                         ; 0136: F1
+ld SP, IX                      ; 0137: DD F9
+pop IX                         ; 0139: DD E1
+ret                            ; 013B: C9
 ; func byte_fvar_glob end
 ; func main begin
 main:
-push IX                        ; 0134: DD E5
-ld IX, $0000                   ; 0136: DD 21 00 00
-add IX, SP                     ; 013A: DD 39
-push AF                        ; 013C: F5
-push BC                        ; 013D: C5
-push DE                        ; 013E: D5
-push HL                        ; 013F: E5
-ld HL, glob_bytes              ; 0140: 21 00 00
-push HL                        ; 0143: E5
-call byte_fvar_glob            ; 0144: CD 00 00
-inc SP                         ; 0147: 33
-inc SP                         ; 0148: 33
+push IX                        ; 013C: DD E5
+ld IX, $0000                   ; 013E: DD 21 00 00
+add IX, SP                     ; 0142: DD 39
+push AF                        ; 0144: F5
+push BC                        ; 0145: C5
+push DE                        ; 0146: D5
+push HL                        ; 0147: E5
+ld HL, glob_bytes              ; 0148: 21 00 00
+push HL                        ; 014B: E5
+call byte_fvar_glob            ; 014C: CD 00 00
+inc SP                         ; 014F: 33
+inc SP                         ; 0150: 33
 __zax_epilogue_1:
-pop HL                         ; 0149: E1
-pop DE                         ; 014A: D1
-pop BC                         ; 014B: C1
-pop AF                         ; 014C: F1
-ld SP, IX                      ; 014D: DD F9
-pop IX                         ; 014F: DD E1
-ret                            ; 0151: C9
+pop HL                         ; 0151: E1
+pop DE                         ; 0152: D1
+pop BC                         ; 0153: C1
+pop AF                         ; 0154: F1
+ld SP, IX                      ; 0155: DD F9
+pop IX                         ; 0157: DD E1
+ret                            ; 0159: C9
 ; func main end
 
 ; symbols:
 ; label byte_fvar_glob = $0100
-; label __zax_epilogue_0 = $012C
-; label main = $0134
-; label __zax_epilogue_1 = $0149
+; label __zax_epilogue_0 = $0134
+; label main = $013C
+; label __zax_epilogue_1 = $0151
 ; data glob_bytes = $2000
 ; data glob_idx_word = $2008
 ; label __zax_startup = $200A

--- a/examples/language-tour/42_byte_fvar_glob.d8dbg.json
+++ b/examples/language-tour/42_byte_fvar_glob.d8dbg.json
@@ -16,63 +16,63 @@
         },
         {
           "start": 256,
-          "end": 338,
+          "end": 346,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
         },
         {
           "start": 267,
-          "end": 282,
+          "end": 285,
           "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 282,
-          "end": 297,
+          "start": 285,
+          "end": 305,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 297,
-          "end": 299,
+          "start": 305,
+          "end": 307,
           "lstLine": 10,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 299,
-          "end": 300,
+          "start": 307,
+          "end": 308,
           "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 300,
-          "end": 308,
+          "start": 308,
+          "end": 316,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 308,
-          "end": 320,
+          "start": 316,
+          "end": 328,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 320,
-          "end": 329,
+          "start": 328,
+          "end": 337,
           "lstLine": 15,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 329,
-          "end": 338,
+          "start": 337,
+          "end": 346,
           "lstLine": 14,
           "kind": "code",
           "confidence": "high"
@@ -96,21 +96,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 300,
+          "address": 308,
           "line": 7,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 308,
+          "address": 316,
           "line": 14,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 329,
+          "address": 337,
           "line": 14,
           "scope": "local"
         },
@@ -140,7 +140,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 338
+      "end": 346
     },
     {
       "start": 8192,
@@ -162,7 +162,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 300,
+      "address": 308,
       "file": "42_byte_fvar_glob.zax",
       "line": 7,
       "scope": "local"
@@ -170,7 +170,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 308,
+      "address": 316,
       "file": "42_byte_fvar_glob.zax",
       "line": 14,
       "scope": "global"
@@ -178,7 +178,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 329,
+      "address": 337,
       "file": "42_byte_fvar_glob.zax",
       "line": 14,
       "scope": "local"

--- a/examples/language-tour/63_word_fvar_const.asm
+++ b/examples/language-tour/63_word_fvar_const.asm
@@ -9,66 +9,70 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-push DE                        ; 010B: D5
-ld E, (IX + $0008)             ; 010C: DD 5E 08
-ld D, (IX + $0009)             ; 010F: DD 56 09
-ld HL, $0000                   ; 0112: 21 00 00
-add HL, HL                     ; 0115: 29
-add HL, DE                     ; 0116: 19
-ld E, (HL)                     ; 0117: 5E
-inc HL                         ; 0118: 23
-ld D, (HL)                     ; 0119: 56
-ld L, E                        ; 011A: 6B
-ld H, D                        ; 011B: 62
-pop DE                         ; 011C: D1
-push DE                        ; 011D: D5
-push HL                        ; 011E: E5
-ld E, (IX + $000A)             ; 011F: DD 5E 0A
-ld D, (IX + $000B)             ; 0122: DD 56 0B
-ld HL, $0000                   ; 0125: 21 00 00
-add HL, HL                     ; 0128: 29
-add HL, DE                     ; 0129: 19
-pop DE                         ; 012A: D1
-ld (HL), E                     ; 012B: 73
-inc HL                         ; 012C: 23
-ld (HL), D                     ; 012D: 72
+ld E, (IX + $0004)             ; 010B: DD 5E 04
+ld D, (IX + $0005)             ; 010E: DD 56 05
+ex DE, HL                      ; 0111: EB
+ld DE, $0004                   ; 0112: 11 04 00
+add HL, DE                     ; 0115: 19
+push HL                        ; 0116: E5
+pop HL                         ; 0117: E1
+push DE                        ; 0118: D5
+ld E, (HL)                     ; 0119: 5E
+inc HL                         ; 011A: 23
+ld D, (HL)                     ; 011B: 56
+ld L, E                        ; 011C: 6B
+ld H, D                        ; 011D: 62
+pop DE                         ; 011E: D1
+push DE                        ; 011F: D5
+push HL                        ; 0120: E5
+ld E, (IX + $0004)             ; 0121: DD 5E 04
+ld D, (IX + $0005)             ; 0124: DD 56 05
+ex DE, HL                      ; 0127: EB
+ld DE, $0006                   ; 0128: 11 06 00
+add HL, DE                     ; 012B: 19
+push HL                        ; 012C: E5
+pop HL                         ; 012D: E1
 pop DE                         ; 012E: D1
+ld (HL), E                     ; 012F: 73
+inc HL                         ; 0130: 23
+ld (HL), D                     ; 0131: 72
+pop DE                         ; 0132: D1
 __zax_epilogue_0:
-pop DE                         ; 012F: D1
-pop BC                         ; 0130: C1
-pop AF                         ; 0131: F1
-ld SP, IX                      ; 0132: DD F9
-pop IX                         ; 0134: DD E1
-ret                            ; 0136: C9
+pop DE                         ; 0133: D1
+pop BC                         ; 0134: C1
+pop AF                         ; 0135: F1
+ld SP, IX                      ; 0136: DD F9
+pop IX                         ; 0138: DD E1
+ret                            ; 013A: C9
 ; func main begin
 ; func word_fvar_const end
 main:
-push IX                        ; 0137: DD E5
-ld IX, $0000                   ; 0139: DD 21 00 00
-add IX, SP                     ; 013D: DD 39
-push AF                        ; 013F: F5
-push BC                        ; 0140: C5
-push DE                        ; 0141: D5
-push HL                        ; 0142: E5
-ld HL, glob_words              ; 0143: 21 00 00
+push IX                        ; 013B: DD E5
+ld IX, $0000                   ; 013D: DD 21 00 00
+add IX, SP                     ; 0141: DD 39
+push AF                        ; 0143: F5
+push BC                        ; 0144: C5
+push DE                        ; 0145: D5
 push HL                        ; 0146: E5
-call word_fvar_const           ; 0147: CD 00 00
-inc SP                         ; 014A: 33
-inc SP                         ; 014B: 33
+ld HL, glob_words              ; 0147: 21 00 00
+push HL                        ; 014A: E5
+call word_fvar_const           ; 014B: CD 00 00
+inc SP                         ; 014E: 33
+inc SP                         ; 014F: 33
 __zax_epilogue_1:
-pop HL                         ; 014C: E1
-pop DE                         ; 014D: D1
-pop BC                         ; 014E: C1
-pop AF                         ; 014F: F1
-ld SP, IX                      ; 0150: DD F9
-pop IX                         ; 0152: DD E1
-ret                            ; 0154: C9
+pop HL                         ; 0150: E1
+pop DE                         ; 0151: D1
+pop BC                         ; 0152: C1
+pop AF                         ; 0153: F1
+ld SP, IX                      ; 0154: DD F9
+pop IX                         ; 0156: DD E1
+ret                            ; 0158: C9
 ; func main end
 
 ; symbols:
 ; label word_fvar_const = $0100
-; label __zax_epilogue_0 = $012F
-; label main = $0137
-; label __zax_epilogue_1 = $014C
+; label __zax_epilogue_0 = $0133
+; label main = $013B
+; label __zax_epilogue_1 = $0150
 ; data glob_words = $2000
 ; label __zax_startup = $2010

--- a/examples/language-tour/63_word_fvar_const.d8dbg.json
+++ b/examples/language-tour/63_word_fvar_const.d8dbg.json
@@ -16,49 +16,49 @@
         },
         {
           "start": 256,
-          "end": 341,
+          "end": 345,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
         },
         {
           "start": 267,
-          "end": 285,
+          "end": 287,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 285,
-          "end": 303,
+          "start": 287,
+          "end": 307,
           "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 303,
-          "end": 311,
+          "start": 307,
+          "end": 315,
           "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 311,
-          "end": 323,
+          "start": 315,
+          "end": 327,
           "lstLine": 11,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 323,
-          "end": 332,
+          "start": 327,
+          "end": 336,
           "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 332,
-          "end": 341,
+          "start": 336,
+          "end": 345,
           "lstLine": 11,
           "kind": "code",
           "confidence": "high"
@@ -82,21 +82,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 303,
+          "address": 307,
           "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 311,
+          "address": 315,
           "line": 11,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 332,
+          "address": 336,
           "line": 11,
           "scope": "local"
         },
@@ -119,7 +119,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 341
+      "end": 345
     },
     {
       "start": 8192,
@@ -141,7 +141,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 303,
+      "address": 307,
       "file": "63_word_fvar_const.zax",
       "line": 6,
       "scope": "local"
@@ -149,7 +149,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 311,
+      "address": 315,
       "file": "63_word_fvar_const.zax",
       "line": 11,
       "scope": "global"
@@ -157,7 +157,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 332,
+      "address": 336,
       "file": "63_word_fvar_const.zax",
       "line": 11,
       "scope": "local"

--- a/examples/language-tour/64_word_fvar_reg8.asm
+++ b/examples/language-tour/64_word_fvar_reg8.asm
@@ -9,78 +9,85 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-push HL                        ; 010B: E5
-ld E, (IX + $0004)             ; 010C: DD 5E 04
-ld D, (IX + $0005)             ; 010F: DD 56 05
+ex DE, HL                      ; 010B: EB
+ld E, (IX + $0006)             ; 010C: DD 5E 06
+ld D, (IX + $0007)             ; 010F: DD 56 07
 ex DE, HL                      ; 0112: EB
-ld E, (IX + $0006)             ; 0113: DD 5E 06
-ld D, (IX + $0007)             ; 0116: DD 56 07
-ex DE, HL                      ; 0119: EB
-add HL, HL                     ; 011A: 29
-add HL, DE                     ; 011B: 19
-ld E, (HL)                     ; 011C: 5E
-inc HL                         ; 011D: 23
-ld D, (HL)                     ; 011E: 56
-ld L, E                        ; 011F: 6B
-ld H, D                        ; 0120: 62
-ex DE, HL                      ; 0121: EB
-pop HL                         ; 0122: E1
-push HL                        ; 0123: E5
-push DE                        ; 0124: D5
-ld E, (IX + $0004)             ; 0125: DD 5E 04
-ld D, (IX + $0005)             ; 0128: DD 56 05
-ex DE, HL                      ; 012B: EB
-ld E, (IX + $0006)             ; 012C: DD 5E 06
-ld D, (IX + $0007)             ; 012F: DD 56 07
-ex DE, HL                      ; 0132: EB
-add HL, HL                     ; 0133: 29
-add HL, DE                     ; 0134: 19
-pop DE                         ; 0135: D1
-ld (HL), E                     ; 0136: 73
-inc HL                         ; 0137: 23
-ld (HL), D                     ; 0138: 72
-pop HL                         ; 0139: E1
-ex DE, HL                      ; 013A: EB
+push HL                        ; 0113: E5
+pop HL                         ; 0114: E1
+add HL, HL                     ; 0115: 29
+push HL                        ; 0116: E5
+ld E, (IX + $0004)             ; 0117: DD 5E 04
+ld D, (IX + $0005)             ; 011A: DD 56 05
+ex DE, HL                      ; 011D: EB
+pop DE                         ; 011E: D1
+add HL, DE                     ; 011F: 19
+push HL                        ; 0120: E5
+pop HL                         ; 0121: E1
+ld E, (HL)                     ; 0122: 5E
+inc HL                         ; 0123: 23
+ld D, (HL)                     ; 0124: 56
+ld E, E                        ; 0125: 5B
+ld D, D                        ; 0126: 52
+ex DE, HL                      ; 0127: EB
+ld E, (IX + $0006)             ; 0128: DD 5E 06
+ld D, (IX + $0007)             ; 012B: DD 56 07
+ex DE, HL                      ; 012E: EB
+push HL                        ; 012F: E5
+pop HL                         ; 0130: E1
+add HL, HL                     ; 0131: 29
+push HL                        ; 0132: E5
+ld E, (IX + $0004)             ; 0133: DD 5E 04
+ld D, (IX + $0005)             ; 0136: DD 56 05
+ex DE, HL                      ; 0139: EB
+pop DE                         ; 013A: D1
+add HL, DE                     ; 013B: 19
+push HL                        ; 013C: E5
+pop HL                         ; 013D: E1
+ld (HL), E                     ; 013E: 73
+inc HL                         ; 013F: 23
+ld (HL), D                     ; 0140: 72
+ex DE, HL                      ; 0141: EB
 __zax_epilogue_0:
-pop DE                         ; 013B: D1
-pop BC                         ; 013C: C1
-pop AF                         ; 013D: F1
-ld SP, IX                      ; 013E: DD F9
-pop IX                         ; 0140: DD E1
-ret                            ; 0142: C9
+pop DE                         ; 0142: D1
+pop BC                         ; 0143: C1
+pop AF                         ; 0144: F1
+ld SP, IX                      ; 0145: DD F9
+pop IX                         ; 0147: DD E1
+ret                            ; 0149: C9
 ; func main begin
 ; func word_fvar_reg end
 main:
-push IX                        ; 0143: DD E5
-ld IX, $0000                   ; 0145: DD 21 00 00
-add IX, SP                     ; 0149: DD 39
-push AF                        ; 014B: F5
-push BC                        ; 014C: C5
-push DE                        ; 014D: D5
-push HL                        ; 014E: E5
-ld HL, $0001                   ; 014F: 21 01 00
-push HL                        ; 0152: E5
-ld HL, glob_words              ; 0153: 21 00 00
-push HL                        ; 0156: E5
-call word_fvar_reg             ; 0157: CD 00 00
-inc SP                         ; 015A: 33
-inc SP                         ; 015B: 33
-inc SP                         ; 015C: 33
-inc SP                         ; 015D: 33
+push IX                        ; 014A: DD E5
+ld IX, $0000                   ; 014C: DD 21 00 00
+add IX, SP                     ; 0150: DD 39
+push AF                        ; 0152: F5
+push BC                        ; 0153: C5
+push DE                        ; 0154: D5
+push HL                        ; 0155: E5
+ld HL, $0001                   ; 0156: 21 01 00
+push HL                        ; 0159: E5
+ld HL, glob_words              ; 015A: 21 00 00
+push HL                        ; 015D: E5
+call word_fvar_reg             ; 015E: CD 00 00
+inc SP                         ; 0161: 33
+inc SP                         ; 0162: 33
+inc SP                         ; 0163: 33
+inc SP                         ; 0164: 33
 __zax_epilogue_1:
-pop HL                         ; 015E: E1
-pop DE                         ; 015F: D1
-pop BC                         ; 0160: C1
-pop AF                         ; 0161: F1
-ld SP, IX                      ; 0162: DD F9
-pop IX                         ; 0164: DD E1
-ret                            ; 0166: C9
+pop HL                         ; 0165: E1
+pop DE                         ; 0166: D1
+pop BC                         ; 0167: C1
+pop AF                         ; 0168: F1
+ld SP, IX                      ; 0169: DD F9
+pop IX                         ; 016B: DD E1
+ret                            ; 016D: C9
 ; func main end
 
 ; symbols:
 ; label word_fvar_reg = $0100
-; label __zax_epilogue_0 = $013B
-; label main = $0143
-; label __zax_epilogue_1 = $015E
+; label __zax_epilogue_0 = $0142
+; label main = $014A
+; label __zax_epilogue_1 = $0165
 ; data glob_words = $2000
 ; label __zax_startup = $2010

--- a/examples/language-tour/64_word_fvar_reg8.d8dbg.json
+++ b/examples/language-tour/64_word_fvar_reg8.d8dbg.json
@@ -16,56 +16,56 @@
         },
         {
           "start": 256,
-          "end": 359,
+          "end": 366,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
         },
         {
           "start": 267,
-          "end": 291,
+          "end": 295,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 291,
-          "end": 314,
+          "start": 295,
+          "end": 321,
           "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 314,
-          "end": 315,
+          "start": 321,
+          "end": 322,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 315,
-          "end": 323,
+          "start": 322,
+          "end": 330,
           "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 323,
-          "end": 335,
+          "start": 330,
+          "end": 342,
           "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 335,
-          "end": 350,
+          "start": 342,
+          "end": 357,
           "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 350,
-          "end": 359,
+          "start": 357,
+          "end": 366,
           "lstLine": 12,
           "kind": "code",
           "confidence": "high"
@@ -89,21 +89,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 315,
+          "address": 322,
           "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 323,
+          "address": 330,
           "line": 12,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 350,
+          "address": 357,
           "line": 12,
           "scope": "local"
         },
@@ -126,7 +126,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 359
+      "end": 366
     },
     {
       "start": 8192,
@@ -148,7 +148,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 315,
+      "address": 322,
       "file": "64_word_fvar_reg8.zax",
       "line": 6,
       "scope": "local"
@@ -156,7 +156,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 323,
+      "address": 330,
       "file": "64_word_fvar_reg8.zax",
       "line": 12,
       "scope": "global"
@@ -164,7 +164,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 350,
+      "address": 357,
       "file": "64_word_fvar_reg8.zax",
       "line": 12,
       "scope": "local"

--- a/examples/language-tour/67_word_fvar_fvar.asm
+++ b/examples/language-tour/67_word_fvar_fvar.asm
@@ -9,78 +9,85 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-push HL                        ; 010B: E5
-ld E, (IX + $0004)             ; 010C: DD 5E 04
-ld D, (IX + $0005)             ; 010F: DD 56 05
+ex DE, HL                      ; 010B: EB
+ld E, (IX + $0006)             ; 010C: DD 5E 06
+ld D, (IX + $0007)             ; 010F: DD 56 07
 ex DE, HL                      ; 0112: EB
-ld E, (IX + $0006)             ; 0113: DD 5E 06
-ld D, (IX + $0007)             ; 0116: DD 56 07
-ex DE, HL                      ; 0119: EB
-add HL, HL                     ; 011A: 29
-add HL, DE                     ; 011B: 19
-ld E, (HL)                     ; 011C: 5E
-inc HL                         ; 011D: 23
-ld D, (HL)                     ; 011E: 56
-ld L, E                        ; 011F: 6B
-ld H, D                        ; 0120: 62
-ex DE, HL                      ; 0121: EB
-pop HL                         ; 0122: E1
-push HL                        ; 0123: E5
-push DE                        ; 0124: D5
-ld E, (IX + $0004)             ; 0125: DD 5E 04
-ld D, (IX + $0005)             ; 0128: DD 56 05
-ex DE, HL                      ; 012B: EB
-ld E, (IX + $0006)             ; 012C: DD 5E 06
-ld D, (IX + $0007)             ; 012F: DD 56 07
-ex DE, HL                      ; 0132: EB
-add HL, HL                     ; 0133: 29
-add HL, DE                     ; 0134: 19
-pop DE                         ; 0135: D1
-ld (HL), E                     ; 0136: 73
-inc HL                         ; 0137: 23
-ld (HL), D                     ; 0138: 72
-pop HL                         ; 0139: E1
-ex DE, HL                      ; 013A: EB
+push HL                        ; 0113: E5
+pop HL                         ; 0114: E1
+add HL, HL                     ; 0115: 29
+push HL                        ; 0116: E5
+ld E, (IX + $0004)             ; 0117: DD 5E 04
+ld D, (IX + $0005)             ; 011A: DD 56 05
+ex DE, HL                      ; 011D: EB
+pop DE                         ; 011E: D1
+add HL, DE                     ; 011F: 19
+push HL                        ; 0120: E5
+pop HL                         ; 0121: E1
+ld E, (HL)                     ; 0122: 5E
+inc HL                         ; 0123: 23
+ld D, (HL)                     ; 0124: 56
+ld E, E                        ; 0125: 5B
+ld D, D                        ; 0126: 52
+ex DE, HL                      ; 0127: EB
+ld E, (IX + $0006)             ; 0128: DD 5E 06
+ld D, (IX + $0007)             ; 012B: DD 56 07
+ex DE, HL                      ; 012E: EB
+push HL                        ; 012F: E5
+pop HL                         ; 0130: E1
+add HL, HL                     ; 0131: 29
+push HL                        ; 0132: E5
+ld E, (IX + $0004)             ; 0133: DD 5E 04
+ld D, (IX + $0005)             ; 0136: DD 56 05
+ex DE, HL                      ; 0139: EB
+pop DE                         ; 013A: D1
+add HL, DE                     ; 013B: 19
+push HL                        ; 013C: E5
+pop HL                         ; 013D: E1
+ld (HL), E                     ; 013E: 73
+inc HL                         ; 013F: 23
+ld (HL), D                     ; 0140: 72
+ex DE, HL                      ; 0141: EB
 __zax_epilogue_0:
-pop DE                         ; 013B: D1
-pop BC                         ; 013C: C1
-pop AF                         ; 013D: F1
-ld SP, IX                      ; 013E: DD F9
-pop IX                         ; 0140: DD E1
-ret                            ; 0142: C9
+pop DE                         ; 0142: D1
+pop BC                         ; 0143: C1
+pop AF                         ; 0144: F1
+ld SP, IX                      ; 0145: DD F9
+pop IX                         ; 0147: DD E1
+ret                            ; 0149: C9
 ; func main begin
 ; func word_fvar_fvar end
 main:
-push IX                        ; 0143: DD E5
-ld IX, $0000                   ; 0145: DD 21 00 00
-add IX, SP                     ; 0149: DD 39
-push AF                        ; 014B: F5
-push BC                        ; 014C: C5
-push DE                        ; 014D: D5
-push HL                        ; 014E: E5
-ld HL, $0005                   ; 014F: 21 05 00
-push HL                        ; 0152: E5
-ld HL, glob_words              ; 0153: 21 00 00
-push HL                        ; 0156: E5
-call word_fvar_fvar            ; 0157: CD 00 00
-inc SP                         ; 015A: 33
-inc SP                         ; 015B: 33
-inc SP                         ; 015C: 33
-inc SP                         ; 015D: 33
+push IX                        ; 014A: DD E5
+ld IX, $0000                   ; 014C: DD 21 00 00
+add IX, SP                     ; 0150: DD 39
+push AF                        ; 0152: F5
+push BC                        ; 0153: C5
+push DE                        ; 0154: D5
+push HL                        ; 0155: E5
+ld HL, $0005                   ; 0156: 21 05 00
+push HL                        ; 0159: E5
+ld HL, glob_words              ; 015A: 21 00 00
+push HL                        ; 015D: E5
+call word_fvar_fvar            ; 015E: CD 00 00
+inc SP                         ; 0161: 33
+inc SP                         ; 0162: 33
+inc SP                         ; 0163: 33
+inc SP                         ; 0164: 33
 __zax_epilogue_1:
-pop HL                         ; 015E: E1
-pop DE                         ; 015F: D1
-pop BC                         ; 0160: C1
-pop AF                         ; 0161: F1
-ld SP, IX                      ; 0162: DD F9
-pop IX                         ; 0164: DD E1
-ret                            ; 0166: C9
+pop HL                         ; 0165: E1
+pop DE                         ; 0166: D1
+pop BC                         ; 0167: C1
+pop AF                         ; 0168: F1
+ld SP, IX                      ; 0169: DD F9
+pop IX                         ; 016B: DD E1
+ret                            ; 016D: C9
 ; func main end
 
 ; symbols:
 ; label word_fvar_fvar = $0100
-; label __zax_epilogue_0 = $013B
-; label main = $0143
-; label __zax_epilogue_1 = $015E
+; label __zax_epilogue_0 = $0142
+; label main = $014A
+; label __zax_epilogue_1 = $0165
 ; data glob_words = $2000
 ; label __zax_startup = $2010

--- a/examples/language-tour/67_word_fvar_fvar.d8dbg.json
+++ b/examples/language-tour/67_word_fvar_fvar.d8dbg.json
@@ -16,56 +16,56 @@
         },
         {
           "start": 256,
-          "end": 359,
+          "end": 366,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
         },
         {
           "start": 267,
-          "end": 291,
+          "end": 295,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 291,
-          "end": 314,
+          "start": 295,
+          "end": 321,
           "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 314,
-          "end": 315,
+          "start": 321,
+          "end": 322,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 315,
-          "end": 323,
+          "start": 322,
+          "end": 330,
           "lstLine": 6,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 323,
-          "end": 335,
+          "start": 330,
+          "end": 342,
           "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 335,
-          "end": 350,
+          "start": 342,
+          "end": 357,
           "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 350,
-          "end": 359,
+          "start": 357,
+          "end": 366,
           "lstLine": 12,
           "kind": "code",
           "confidence": "high"
@@ -89,21 +89,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 315,
+          "address": 322,
           "line": 6,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 323,
+          "address": 330,
           "line": 12,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 350,
+          "address": 357,
           "line": 12,
           "scope": "local"
         },
@@ -126,7 +126,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 359
+      "end": 366
     },
     {
       "start": 8192,
@@ -148,7 +148,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 315,
+      "address": 322,
       "file": "67_word_fvar_fvar.zax",
       "line": 6,
       "scope": "local"
@@ -156,7 +156,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 323,
+      "address": 330,
       "file": "67_word_fvar_fvar.zax",
       "line": 12,
       "scope": "global"
@@ -164,7 +164,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 350,
+      "address": 357,
       "file": "67_word_fvar_fvar.zax",
       "line": 12,
       "scope": "local"

--- a/examples/language-tour/68_word_fvar_glob.asm
+++ b/examples/language-tour/68_word_fvar_glob.asm
@@ -9,67 +9,81 @@ add IX, SP                     ; 0106: DD 39
 push AF                        ; 0108: F5
 push BC                        ; 0109: C5
 push DE                        ; 010A: D5
-push DE                        ; 010B: D5
-ld E, (IX + $0004)             ; 010C: DD 5E 04
-ld D, (IX + $0005)             ; 010F: DD 56 05
-ld hl, (glob_idx_word)         ; 0112: 2A 00 00
-add HL, HL                     ; 0115: 29
-add HL, DE                     ; 0116: 19
-ld E, (HL)                     ; 0117: 5E
-inc HL                         ; 0118: 23
-ld D, (HL)                     ; 0119: 56
-ld L, E                        ; 011A: 6B
-ld H, D                        ; 011B: 62
-pop DE                         ; 011C: D1
+ld hl, (glob_idx_word)         ; 010B: 2A 00 00
+push HL                        ; 010E: E5
+pop HL                         ; 010F: E1
+add HL, HL                     ; 0110: 29
+push HL                        ; 0111: E5
+ld E, (IX + $0004)             ; 0112: DD 5E 04
+ld D, (IX + $0005)             ; 0115: DD 56 05
+ex DE, HL                      ; 0118: EB
+pop DE                         ; 0119: D1
+add HL, DE                     ; 011A: 19
+push HL                        ; 011B: E5
+pop HL                         ; 011C: E1
 push DE                        ; 011D: D5
-push HL                        ; 011E: E5
-ld E, (IX + $0004)             ; 011F: DD 5E 04
-ld D, (IX + $0005)             ; 0122: DD 56 05
-ld hl, (glob_idx_word)         ; 0125: 2A 00 00
-add HL, HL                     ; 0128: 29
-add HL, DE                     ; 0129: 19
-pop DE                         ; 012A: D1
-ld (HL), E                     ; 012B: 73
-inc HL                         ; 012C: 23
-ld (HL), D                     ; 012D: 72
-pop DE                         ; 012E: D1
+ld E, (HL)                     ; 011E: 5E
+inc HL                         ; 011F: 23
+ld D, (HL)                     ; 0120: 56
+ld L, E                        ; 0121: 6B
+ld H, D                        ; 0122: 62
+pop DE                         ; 0123: D1
+push DE                        ; 0124: D5
+push HL                        ; 0125: E5
+ld hl, (glob_idx_word)         ; 0126: 2A 00 00
+push HL                        ; 0129: E5
+pop HL                         ; 012A: E1
+add HL, HL                     ; 012B: 29
+push HL                        ; 012C: E5
+ld E, (IX + $0004)             ; 012D: DD 5E 04
+ld D, (IX + $0005)             ; 0130: DD 56 05
+ex DE, HL                      ; 0133: EB
+pop DE                         ; 0134: D1
+add HL, DE                     ; 0135: 19
+push HL                        ; 0136: E5
+pop HL                         ; 0137: E1
+pop DE                         ; 0138: D1
+ld (HL), E                     ; 0139: 73
+inc HL                         ; 013A: 23
+ld (HL), D                     ; 013B: 72
+pop DE                         ; 013C: D1
 __zax_epilogue_0:
-pop DE                         ; 012F: D1
-pop BC                         ; 0130: C1
-pop AF                         ; 0131: F1
-ld SP, IX                      ; 0132: DD F9
-pop IX                         ; 0134: DD E1
-ret                            ; 0136: C9
+pop DE                         ; 013D: D1
+pop BC                         ; 013E: C1
+pop AF                         ; 013F: F1
+ld SP, IX                      ; 0140: DD F9
+pop IX                         ; 0142: DD E1
+ret                            ; 0144: C9
 ; func main begin
 ; func word_fvar_glob end
 main:
-push IX                        ; 0137: DD E5
-ld IX, $0000                   ; 0139: DD 21 00 00
-add IX, SP                     ; 013D: DD 39
-push AF                        ; 013F: F5
-push BC                        ; 0140: C5
-push DE                        ; 0141: D5
-push HL                        ; 0142: E5
-ld HL, glob_words              ; 0143: 21 00 00
-push HL                        ; 0146: E5
-call word_fvar_glob            ; 0147: CD 00 00
-inc SP                         ; 014A: 33
-inc SP                         ; 014B: 33
+push IX                        ; 0145: DD E5
+ld IX, $0000                   ; 0147: DD 21 00 00
+add IX, SP                     ; 014B: DD 39
+push AF                        ; 014D: F5
+push BC                        ; 014E: C5
+push DE                        ; 014F: D5
+push HL                        ; 0150: E5
+ld HL, glob_words              ; 0151: 21 00 00
+push HL                        ; 0154: E5
+call word_fvar_glob            ; 0155: CD 00 00
+inc SP                         ; 0158: 33
+inc SP                         ; 0159: 33
 __zax_epilogue_1:
-pop HL                         ; 014C: E1
-pop DE                         ; 014D: D1
-pop BC                         ; 014E: C1
-pop AF                         ; 014F: F1
-ld SP, IX                      ; 0150: DD F9
-pop IX                         ; 0152: DD E1
-ret                            ; 0154: C9
+pop HL                         ; 015A: E1
+pop DE                         ; 015B: D1
+pop BC                         ; 015C: C1
+pop AF                         ; 015D: F1
+ld SP, IX                      ; 015E: DD F9
+pop IX                         ; 0160: DD E1
+ret                            ; 0162: C9
 ; func main end
 
 ; symbols:
 ; label word_fvar_glob = $0100
-; label __zax_epilogue_0 = $012F
-; label main = $0137
-; label __zax_epilogue_1 = $014C
+; label __zax_epilogue_0 = $013D
+; label main = $0145
+; label __zax_epilogue_1 = $015A
 ; data glob_words = $2000
 ; data glob_idx_word = $2010
 ; label __zax_startup = $2012

--- a/examples/language-tour/68_word_fvar_glob.d8dbg.json
+++ b/examples/language-tour/68_word_fvar_glob.d8dbg.json
@@ -16,49 +16,49 @@
         },
         {
           "start": 256,
-          "end": 341,
+          "end": 355,
           "lstLine": 0,
           "kind": "unknown",
           "confidence": "low"
         },
         {
           "start": 267,
-          "end": 285,
+          "end": 292,
           "lstLine": 8,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 285,
-          "end": 303,
+          "start": 292,
+          "end": 317,
           "lstLine": 9,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 303,
-          "end": 311,
+          "start": 317,
+          "end": 325,
           "lstLine": 7,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 311,
-          "end": 323,
+          "start": 325,
+          "end": 337,
           "lstLine": 12,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 323,
-          "end": 332,
+          "start": 337,
+          "end": 346,
           "lstLine": 13,
           "kind": "code",
           "confidence": "high"
         },
         {
-          "start": 332,
-          "end": 341,
+          "start": 346,
+          "end": 355,
           "lstLine": 12,
           "kind": "code",
           "confidence": "high"
@@ -82,21 +82,21 @@
         {
           "name": "__zax_epilogue_0",
           "kind": "label",
-          "address": 303,
+          "address": 317,
           "line": 7,
           "scope": "local"
         },
         {
           "name": "main",
           "kind": "label",
-          "address": 311,
+          "address": 325,
           "line": 12,
           "scope": "global"
         },
         {
           "name": "__zax_epilogue_1",
           "kind": "label",
-          "address": 332,
+          "address": 346,
           "line": 12,
           "scope": "local"
         },
@@ -126,7 +126,7 @@
   "segments": [
     {
       "start": 256,
-      "end": 341
+      "end": 355
     },
     {
       "start": 8192,
@@ -148,7 +148,7 @@
     {
       "name": "__zax_epilogue_0",
       "kind": "label",
-      "address": 303,
+      "address": 317,
       "file": "68_word_fvar_glob.zax",
       "line": 7,
       "scope": "local"
@@ -156,7 +156,7 @@
     {
       "name": "main",
       "kind": "label",
-      "address": 311,
+      "address": 325,
       "file": "68_word_fvar_glob.zax",
       "line": 12,
       "scope": "global"
@@ -164,7 +164,7 @@
     {
       "name": "__zax_epilogue_1",
       "kind": "label",
-      "address": 332,
+      "address": 346,
       "file": "68_word_fvar_glob.zax",
       "line": 12,
       "scope": "local"

--- a/src/lowering/addressingPipelines.ts
+++ b/src/lowering/addressingPipelines.ts
@@ -61,6 +61,7 @@ export function createAddressingPipelineBuilders(ctx: AddressingPipelineContext)
       const baseResolved = ctx.resolveEa(ea.base, span);
       const baseType = ctx.resolveEaTypeExpr(ea.base);
       if (!baseResolved || !baseType || baseType.kind !== 'ArrayType') return null;
+      if (baseResolved.kind === 'indirect') return null;
       const elemSize = ctx.sizeOfTypeExpr(baseType.element);
       if (elemSize !== 1) return null;
 
@@ -148,6 +149,7 @@ export function createAddressingPipelineBuilders(ctx: AddressingPipelineContext)
       const baseResolved = ctx.resolveEa(ea.base, span);
       const baseType = ctx.resolveEaTypeExpr(ea.base);
       if (!baseResolved || !baseType || baseType.kind !== 'ArrayType') return null;
+      if (baseResolved.kind === 'indirect') return null;
       const elemSize = ctx.sizeOfTypeExpr(baseType.element);
       if (elemSize !== 2) return null;
 

--- a/src/lowering/eaMaterialization.ts
+++ b/src/lowering/eaMaterialization.ts
@@ -21,28 +21,8 @@ export function createEaMaterializationHelpers(ctx: EaMaterializationContext) {
       ctx.emitAbs16Fixup(0x21, resolved.baseLower, resolved.addend, span);
       return true;
     }
-
-    const disp = resolved.ixDisp & 0xffff;
-    if (!ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'DE' }], span)) return false;
-    if (!ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'IX' }], span)) return false;
-    if (!ctx.emitInstr('pop', [{ kind: 'Reg', span, name: 'HL' }], span)) return false;
-    if (disp !== 0) {
-      if (!ctx.loadImm16ToDE(disp, span)) return false;
-      if (
-        !ctx.emitInstr(
-          'add',
-          [
-            { kind: 'Reg', span, name: 'HL' },
-            { kind: 'Reg', span, name: 'DE' },
-          ],
-          span,
-        )
-      ) {
-        return false;
-      }
-    }
-    if (!ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'HL' }], span)) return false;
-    return ctx.emitInstr('pop', [{ kind: 'Reg', span, name: 'DE' }], span);
+    if (!ctx.pushEaAddress(ea, span)) return false;
+    return ctx.emitInstr('pop', [{ kind: 'Reg', span, name: 'HL' }], span);
   };
 
   return {

--- a/src/lowering/valueMaterialization.ts
+++ b/src/lowering/valueMaterialization.ts
@@ -41,6 +41,22 @@ type Context = {
 };
 
 export function createValueMaterializationHelpers(ctx: Context) {
+  const ixDispMemExpr = (disp: number, span: SourceSpan): EaExprNode =>
+    disp === 0
+      ? { kind: 'EaName', span, name: 'IX' }
+      : {
+          kind: disp >= 0 ? 'EaAdd' : 'EaSub',
+          span,
+          base: { kind: 'EaName', span, name: 'IX' },
+          offset: { kind: 'ImmLiteral', span, value: Math.abs(disp) },
+        };
+
+  const ixDispMemOperand = (disp: number, span: SourceSpan): AsmOperandNode => ({
+    kind: 'Mem',
+    span,
+    expr: ixDispMemExpr(disp, span),
+  });
+
   const emitLoadWordFromHlAddress = (target: 'HL' | 'DE' | 'BC', span: SourceSpan): boolean => {
     if (target === 'DE') {
       return ctx.emitStepPipeline(ctx.LOAD_RP_EA('DE'), span);
@@ -54,6 +70,47 @@ export function createValueMaterializationHelpers(ctx: Context) {
     ctx.emitStepPipeline(ctx.STORE_RP_EA(source), span);
 
   let pushEaAddress: (ea: EaExprNode, span: SourceSpan) => boolean;
+
+  const materializeResolvedAddressToHL = (resolved: EaResolution, span: SourceSpan): boolean => {
+    if (resolved.kind === 'abs') {
+      ctx.emitAbs16Fixup(0x21, resolved.baseLower, resolved.addend, span);
+      return true;
+    }
+
+    if (resolved.kind === 'stack') {
+      if (!ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'IX' }], span)) return false;
+      if (!ctx.emitInstr('pop', [{ kind: 'Reg', span, name: 'HL' }], span)) return false;
+      if (resolved.ixDisp !== 0) {
+        if (!ctx.loadImm16ToDE(resolved.ixDisp & 0xffff, span)) return false;
+        if (!ctx.emitInstr('add', [{ kind: 'Reg', span, name: 'HL' }, { kind: 'Reg', span, name: 'DE' }], span))
+          return false;
+      }
+      return true;
+    }
+
+    if (
+      !ctx.emitInstr('ld', [{ kind: 'Reg', span, name: 'E' }, ixDispMemOperand(resolved.ixDisp, span)], span)
+    ) {
+      return false;
+    }
+    if (
+      !ctx.emitInstr(
+        'ld',
+        [{ kind: 'Reg', span, name: 'D' }, ixDispMemOperand(resolved.ixDisp + 1, span)],
+        span,
+      )
+    ) {
+      return false;
+    }
+    if (!ctx.emitInstr('ex', [{ kind: 'Reg', span, name: 'DE' }, { kind: 'Reg', span, name: 'HL' }], span))
+      return false;
+    if (resolved.addend !== 0) {
+      if (!ctx.loadImm16ToDE(resolved.addend & 0xffff, span)) return false;
+      if (!ctx.emitInstr('add', [{ kind: 'Reg', span, name: 'HL' }, { kind: 'Reg', span, name: 'DE' }], span))
+        return false;
+    }
+    return true;
+  };
 
   const emitStoreSavedHlToEa = (ea: EaExprNode, span: SourceSpan): boolean => {
     if (!ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'DE' }], span)) return false;
@@ -106,9 +163,23 @@ export function createValueMaterializationHelpers(ctx: Context) {
     }
 
     const eaPipe = ctx.buildEaBytePipeline(ea, span);
-    if (!eaPipe) return false;
-    const templated = ctx.TEMPLATE_L_ABC('A', eaPipe);
-    return ctx.emitStepPipeline(templated, span) && ctx.pushZeroExtendedReg8('A', span);
+    if (eaPipe) {
+      const templated = ctx.TEMPLATE_L_ABC('A', eaPipe);
+      return ctx.emitStepPipeline(templated, span) && ctx.pushZeroExtendedReg8('A', span);
+    }
+
+    if (!pushEaAddress(ea, span)) return false;
+    if (!ctx.emitInstr('pop', [{ kind: 'Reg', span, name: 'HL' }], span)) return false;
+    if (
+      !ctx.emitInstr(
+        'ld',
+        [{ kind: 'Reg', span, name: 'A' }, { kind: 'Mem', span, expr: { kind: 'EaName', span, name: 'HL' } }],
+        span,
+      )
+    ) {
+      return false;
+    }
+    return ctx.pushZeroExtendedReg8('A', span);
   };
 
   pushEaAddress = (ea: EaExprNode, span: SourceSpan): boolean => {
@@ -466,18 +537,8 @@ export function createValueMaterializationHelpers(ctx: Context) {
       if (!ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'HL' }], span)) return false;
 
       const baseResolved = ctx.resolveEa(ea.base, span);
-      if (baseResolved?.kind === 'abs') {
-        ctx.emitAbs16Fixup(0x21, baseResolved.baseLower, baseResolved.addend, span);
-      } else if (baseResolved?.kind === 'stack') {
-        if (!ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'DE' }], span)) return false;
-        if (!ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'IX' }], span)) return false;
-        if (!ctx.emitInstr('pop', [{ kind: 'Reg', span, name: 'HL' }], span)) return false;
-        if (baseResolved.ixDisp !== 0) {
-          if (!ctx.loadImm16ToDE(baseResolved.ixDisp & 0xffff, span)) return false;
-          if (!ctx.emitInstr('add', [{ kind: 'Reg', span, name: 'HL' }, { kind: 'Reg', span, name: 'DE' }], span))
-            return false;
-        }
-        if (!ctx.emitInstr('pop', [{ kind: 'Reg', span, name: 'DE' }], span)) return false;
+      if (baseResolved) {
+        if (!materializeResolvedAddressToHL(baseResolved, span)) return false;
       } else {
         if (!pushEaAddress(ea.base, span)) return false;
         if (!ctx.emitInstr('pop', [{ kind: 'Reg', span, name: 'HL' }], span)) return false;
@@ -489,20 +550,8 @@ export function createValueMaterializationHelpers(ctx: Context) {
       return ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'HL' }], span);
     }
 
-    if (r.kind === 'abs') {
-      ctx.emitAbs16Fixup(0x21, r.baseLower, r.addend, span);
-      return ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'HL' }], span);
-    }
-    if (!ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'DE' }], span)) return false;
-    if (!ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'IX' }], span)) return false;
-    if (!ctx.emitInstr('pop', [{ kind: 'Reg', span, name: 'HL' }], span)) return false;
-    if (r.ixDisp !== 0) {
-      if (!ctx.loadImm16ToDE(r.ixDisp & 0xffff, span)) return false;
-      if (!ctx.emitInstr('add', [{ kind: 'Reg', span, name: 'HL' }, { kind: 'Reg', span, name: 'DE' }], span))
-        return false;
-    }
-    if (!ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'HL' }], span)) return false;
-    return ctx.emitInstr('pop', [{ kind: 'Reg', span, name: 'DE' }], span);
+    if (!materializeResolvedAddressToHL(r, span)) return false;
+    return ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'HL' }], span);
   };
 
   return {

--- a/test/pr509_ea_materialization_helpers.test.ts
+++ b/test/pr509_ea_materialization_helpers.test.ts
@@ -13,12 +13,13 @@ const span: SourceSpan = {
 const eaName = (name: string): EaExprNode => ({ kind: 'EaName', span, name });
 
 describe('#509 ea materialization helpers', () => {
-  it('keeps absolute and frame-slot materialization shapes stable', () => {
+  it('keeps absolute materialization and non-abs delegation stable', () => {
     const emitted: string[] = [];
     const fixups: string[] = [];
     const resolutions = new Map<string, EaResolution>([
       ['globw', { kind: 'abs', baseLower: 'globw', addend: 2 }],
       ['slotw', { kind: 'stack', ixDisp: -4 }],
+      ['indw', { kind: 'indirect', ixDisp: -6, addend: 4 }],
     ]);
 
     const emitInstr = (head: string, operands: AsmOperandNode[]): boolean => {
@@ -50,16 +51,9 @@ describe('#509 ea materialization helpers', () => {
 
     expect(helpers.materializeEaAddressToHL(eaName('globw'), span)).toBe(true);
     expect(helpers.materializeEaAddressToHL(eaName('slotw'), span)).toBe(true);
+    expect(helpers.materializeEaAddressToHL(eaName('indw'), span)).toBe(true);
 
     expect(fixups).toEqual(['globw+2']);
-    expect(emitted).toEqual([
-      'push DE',
-      'push IX',
-      'pop HL',
-      'loadImm16ToDE 65532',
-      'add HL, DE',
-      'push HL',
-      'pop DE',
-    ]);
+    expect(emitted).toEqual(['pushEaAddress', 'pop HL', 'pushEaAddress', 'pop HL']);
   });
 });

--- a/test/pr710_indirect_ea_consumers.test.ts
+++ b/test/pr710_indirect_ea_consumers.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+
+import { DiagnosticIds, type Diagnostic } from '../src/diagnostics/types.js';
+import type { AsmOperandNode, EaExprNode, SourceSpan, TypeExprNode } from '../src/frontend/ast.js';
+import { createAddressingPipelineBuilders } from '../src/lowering/addressingPipelines.js';
+import { createValueMaterializationHelpers } from '../src/lowering/valueMaterialization.js';
+import type { EaResolution } from '../src/lowering/eaResolution.js';
+
+const span: SourceSpan = {
+  file: 'pr710.zax',
+  start: { line: 1, column: 1, offset: 0 },
+  end: { line: 1, column: 1, offset: 0 },
+};
+
+const typeName = (name: string): TypeExprNode => ({ kind: 'TypeName', span, name });
+const byteArray = (): TypeExprNode => ({ kind: 'ArrayType', span, element: typeName('byte'), length: 4 });
+const wordArray = (): TypeExprNode => ({ kind: 'ArrayType', span, element: typeName('word'), length: 4 });
+
+function renderOperand(operand: AsmOperandNode): string {
+  if (operand.kind === 'Reg') return operand.name;
+  if (operand.kind !== 'Mem') return operand.kind;
+  const expr = operand.expr;
+  if (expr.kind === 'EaName') return `(${expr.name})`;
+  if ((expr.kind === 'EaAdd' || expr.kind === 'EaSub') && expr.base.kind === 'EaName' && expr.offset.kind === 'ImmLiteral') {
+    const sign = expr.kind === 'EaAdd' ? '+' : '-';
+    return `(${expr.base.name}${sign}${expr.offset.value})`;
+  }
+  return operand.kind;
+}
+
+describe('#710 indirect ea consumers', () => {
+  it('materializes indirect addresses and byte loads through the pointer slot', () => {
+    const emitted: string[] = [];
+    const helpers = createValueMaterializationHelpers({
+      diagnostics: [],
+      diagAt: () => {},
+      reg8: new Set(['A', 'B', 'C', 'D', 'E', 'H', 'L']),
+      resolveEa: (ea: EaExprNode): EaResolution | undefined => {
+        if (ea.kind === 'EaName' && ea.name === 'slotArr') {
+          return { kind: 'indirect', ixDisp: 4, addend: 3, typeExpr: byteArray() };
+        }
+        return undefined;
+      },
+      resolveEaTypeExpr: () => undefined,
+      resolveScalarBinding: () => undefined,
+      resolveScalarKind: (typeExpr) =>
+        typeExpr.kind === 'TypeName' && (typeExpr.name === 'byte' || typeExpr.name === 'word' || typeExpr.name === 'addr')
+          ? typeExpr.name
+          : undefined,
+      sizeOfTypeExpr: () => undefined,
+      evalImmExpr: () => undefined,
+      evalImmNoDiag: () => undefined,
+      emitInstr: (head, operands) => {
+        emitted.push(`${head} ${operands.map(renderOperand).join(', ')}`.trim());
+        return true;
+      },
+      emitRawCodeBytes: () => {},
+      emitAbs16Fixup: () => {
+        throw new Error('unexpected abs fixup');
+      },
+      loadImm16ToDE: (value) => {
+        emitted.push(`loadImm16ToDE ${value}`);
+        return true;
+      },
+      loadImm16ToHL: () => true,
+      negateHL: () => true,
+      pushZeroExtendedReg8: (reg) => {
+        emitted.push(`pushZero:${reg}`);
+        return true;
+      },
+      emitStepPipeline: () => true,
+      buildEaBytePipeline: () => null,
+      buildEaWordPipeline: () => null,
+      emitScalarWordLoad: () => false,
+      formatIxDisp: (disp) => (disp >= 0 ? `+$${disp.toString(16).padStart(2, '0').toUpperCase()}` : `-$${Math.abs(disp).toString(16).padStart(2, '0').toUpperCase()}`),
+      TEMPLATE_L_ABC: () => [],
+      TEMPLATE_LW_DE: () => [],
+      LOAD_RP_EA: () => [],
+      STORE_RP_EA: () => [],
+    });
+
+    expect(helpers.pushEaAddress({ kind: 'EaName', span, name: 'slotArr' }, span)).toBe(true);
+    expect(helpers.pushMemValue({ kind: 'EaName', span, name: 'slotArr' }, 'byte', span)).toBe(true);
+
+    expect(emitted).toEqual([
+      'ld E, (IX+4)',
+      'ld D, (IX+5)',
+      'ex DE, HL',
+      'loadImm16ToDE 3',
+      'add HL, DE',
+      'push HL',
+      'ld E, (IX+4)',
+      'ld D, (IX+5)',
+      'ex DE, HL',
+      'loadImm16ToDE 3',
+      'add HL, DE',
+      'push HL',
+      'pop HL',
+      'ld A, (HL)',
+      'pushZero:A',
+    ]);
+  });
+
+  it('gates structured byte and word pipelines off for indirect bases', () => {
+    const diagnostics: Diagnostic[] = [];
+    const resolutions = new Map<string, EaResolution>([
+      ['byte_arr', { kind: 'indirect', ixDisp: 4, addend: 0, typeExpr: byteArray() }],
+      ['word_arr', { kind: 'indirect', ixDisp: 6, addend: 0, typeExpr: wordArray() }],
+    ]);
+
+    const helpers = createAddressingPipelineBuilders({
+      diagnostics,
+      diagAt: (_diagnostics, _span, message) => {
+        diagnostics.push({ id: DiagnosticIds.EmitError, severity: 'error', file: span.file, message });
+      },
+      reg8: new Set(['A', 'B', 'C', 'D', 'E', 'H', 'L']),
+      resolveEa: (ea) => (ea.kind === 'EaName' ? resolutions.get(ea.name.toLowerCase()) : undefined),
+      resolveEaTypeExpr: (ea) => (ea.kind === 'EaName' ? resolutions.get(ea.name.toLowerCase())?.typeExpr : undefined),
+      resolveScalarBinding: () => undefined,
+      resolveScalarKind: (typeExpr) =>
+        typeExpr.kind === 'TypeName' && (typeExpr.name === 'word' || typeExpr.name === 'addr')
+          ? typeExpr.name
+          : undefined,
+      sizeOfTypeExpr: (typeExpr) => {
+        if (typeExpr.kind !== 'TypeName') return undefined;
+        if (typeExpr.name === 'byte') return 1;
+        if (typeExpr.name === 'word' || typeExpr.name === 'addr') return 2;
+        return undefined;
+      },
+      evalImmExpr: () => undefined,
+    });
+
+    expect(
+      helpers.buildEaBytePipeline(
+        { kind: 'EaIndex', span, base: { kind: 'EaName', span, name: 'byte_arr' }, index: { kind: 'IndexReg8', span, reg: 'C' } },
+        span,
+      ),
+    ).toBeNull();
+
+    expect(
+      helpers.buildEaWordPipeline(
+        { kind: 'EaIndex', span, base: { kind: 'EaName', span, name: 'word_arr' }, index: { kind: 'IndexReg16', span, reg: 'HL' } },
+        span,
+      ),
+    ).toBeNull();
+
+    expect(diagnostics).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #710

What changed
- update indirect EA handling in value and address materialization helpers
- gate structured byte and word pipelines off for indirect bases
- remove old stack-materialization helper expectations that locked the buggy path
- refresh affected language-tour asm and d8dbg fixtures for corrected indirect lowering

Verification
- npm run typecheck
- npm test -- --run test/pr710_indirect_ea_consumers.test.ts test/pr509_ea_materialization_helpers.test.ts test/pr531_value_materialization_helpers.test.ts test/pr509_addressing_pipeline_builders.test.ts test/pr374_addressing_modes_mini_suite.test.ts test/pr509_lower_ld_integration.test.ts test/pr405_byte_scalar_fast_paths.test.ts test/pr406_word_scalar_accessors.test.ts test/pr468_typed_step_integration.test.ts test/smoke_language_tour_compile.test.ts