### PR TITLE
#711 Generalize EAW to wide pow2 element sizes

### DIFF
--- a/src/addressing/steps.ts
+++ b/src/addressing/steps.ts
@@ -166,6 +166,21 @@ export const CALC_EA = (): StepPipeline => [step({ kind: 'addHlDe' })];
 
 export const CALC_EA_2 = (): StepPipeline => [step({ kind: 'addHlHl' }), step({ kind: 'addHlDe' })];
 
+const calcEaShift = (shiftCount: number): StepPipeline => [
+  ...Array.from({ length: shiftCount }, () => step({ kind: 'addHlHl' })),
+  step({ kind: 'addHlDe' }),
+];
+
+export const CALC_EA_WIDE = (elemSize: number): StepPipeline => {
+  let n = elemSize;
+  let shiftCount = 0;
+  while (n > 1 && (n & 1) === 0) {
+    n >>= 1;
+    shiftCount++;
+  }
+  return n === 1 ? calcEaShift(shiftCount) : CALC_EA_2();
+};
+
 // ---------------------------------------------------------------------------
 // Accessors (byte)
 // ---------------------------------------------------------------------------
@@ -368,63 +383,63 @@ export const EA_GLOB_GLOB = (globBase: string, globIdx: string): StepPipeline =>
 // ---------------------------------------------------------------------------
 // EA builders (word size, HL=EA, scaled by 2)
 // ---------------------------------------------------------------------------
-export const EAW_GLOB_CONST = (glob: string, idxConst: number): StepPipeline => [
+export const EAW_GLOB_CONST = (glob: string, idxConst: number, elemSize = 2): StepPipeline => [
   ...LOAD_BASE_GLOB(glob),
   ...LOAD_IDX_CONST(idxConst),
-  ...CALC_EA_2(),
+  ...CALC_EA_WIDE(elemSize),
 ];
 
-export const EAW_GLOB_REG = (glob: string, reg8: string): StepPipeline => [
+export const EAW_GLOB_REG = (glob: string, reg8: string, elemSize = 2): StepPipeline => [
   ...LOAD_BASE_GLOB(glob),
   ...LOAD_IDX_REG(reg8),
-  ...CALC_EA_2(),
+  ...CALC_EA_WIDE(elemSize),
 ];
 
-export const EAW_GLOB_RP = (glob: string, rp: string): StepPipeline => [
+export const EAW_GLOB_RP = (glob: string, rp: string, elemSize = 2): StepPipeline => [
   ...LOAD_BASE_GLOB(glob),
   ...LOAD_IDX_RP(rp),
-  ...CALC_EA_2(),
+  ...CALC_EA_WIDE(elemSize),
 ];
 
-export const EAW_FVAR_CONST = (fvar: number, idxConst: number): StepPipeline => {
-  const folded = foldFvar(fvar, idxConst * 2);
-  return [...LOAD_BASE_FVAR(folded.base), ...LOAD_IDX_CONST(folded.idx), ...CALC_EA_2()];
+export const EAW_FVAR_CONST = (fvar: number, idxConst: number, elemSize = 2): StepPipeline => {
+  const folded = foldFvar(fvar, idxConst * elemSize);
+  return [...LOAD_BASE_FVAR(folded.base), ...LOAD_IDX_CONST(folded.idx), ...CALC_EA_WIDE(elemSize)];
 };
 
-export const EAW_FVAR_REG = (fvar: number, reg8: string): StepPipeline => [
+export const EAW_FVAR_REG = (fvar: number, reg8: string, elemSize = 2): StepPipeline => [
   ...LOAD_BASE_FVAR(fvar),
   ...LOAD_IDX_REG(reg8),
-  ...CALC_EA_2(),
+  ...CALC_EA_WIDE(elemSize),
 ];
 
-export const EAW_FVAR_RP = (fvar: number, rp: string): StepPipeline => [
+export const EAW_FVAR_RP = (fvar: number, rp: string, elemSize = 2): StepPipeline => [
   ...LOAD_BASE_FVAR(fvar),
   ...LOAD_IDX_RP(rp),
-  ...CALC_EA_2(),
+  ...CALC_EA_WIDE(elemSize),
 ];
 
-export const EAW_GLOB_FVAR = (glob: string, fvar: number): StepPipeline => [
+export const EAW_GLOB_FVAR = (glob: string, fvar: number, elemSize = 2): StepPipeline => [
   ...LOAD_BASE_GLOB(glob),
   ...LOAD_IDX_FVAR(fvar),
-  ...CALC_EA_2(),
+  ...CALC_EA_WIDE(elemSize),
 ];
 
-export const EAW_FVAR_FVAR = (fvarBase: number, fvarIdx: number): StepPipeline => [
+export const EAW_FVAR_FVAR = (fvarBase: number, fvarIdx: number, elemSize = 2): StepPipeline => [
   ...LOAD_BASE_FVAR(fvarBase),
   ...LOAD_IDX_FVAR(fvarIdx),
-  ...CALC_EA_2(),
+  ...CALC_EA_WIDE(elemSize),
 ];
 
-export const EAW_FVAR_GLOB = (fvar: number, glob: string): StepPipeline => [
+export const EAW_FVAR_GLOB = (fvar: number, glob: string, elemSize = 2): StepPipeline => [
   ...LOAD_BASE_FVAR(fvar),
   ...LOAD_IDX_GLOB(glob),
-  ...CALC_EA_2(),
+  ...CALC_EA_WIDE(elemSize),
 ];
 
-export const EAW_GLOB_GLOB = (globBase: string, globIdx: string): StepPipeline => [
+export const EAW_GLOB_GLOB = (globBase: string, globIdx: string, elemSize = 2): StepPipeline => [
   ...LOAD_BASE_GLOB(globBase),
   ...LOAD_IDX_GLOB(globIdx),
-  ...CALC_EA_2(),
+  ...CALC_EA_WIDE(elemSize),
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/lowering/addressingPipelines.ts
+++ b/src/lowering/addressingPipelines.ts
@@ -1,6 +1,6 @@
 import {
   CALC_EA,
-  CALC_EA_2,
+  CALC_EA_WIDE,
   EA_FVAR_CONST,
   EA_FVAR_FVAR,
   EA_FVAR_GLOB,
@@ -54,6 +54,18 @@ export function createAddressingPipelineBuilders(ctx: AddressingPipelineContext)
       default:
         return false;
     }
+  };
+
+  const getPow2ShiftCount = (elemSize: number | undefined): number | undefined => {
+    if (elemSize === undefined) return undefined;
+    let n = elemSize;
+    let shiftCount = 0;
+    while (n > 1 && (n & 1) === 0) {
+      n >>= 1;
+      shiftCount++;
+    }
+    if (n !== 1 || shiftCount < 1 || shiftCount > 15) return undefined;
+    return shiftCount;
   };
 
   const buildEaBytePipeline = (ea: EaExprNode, span: SourceSpan): StepPipeline | null => {
@@ -151,14 +163,15 @@ export function createAddressingPipelineBuilders(ctx: AddressingPipelineContext)
       if (!baseResolved || !baseType || baseType.kind !== 'ArrayType') return null;
       if (baseResolved.kind === 'indirect') return null;
       const elemSize = ctx.sizeOfTypeExpr(baseType.element);
-      if (elemSize !== 2) return null;
+      if (getPow2ShiftCount(elemSize) === undefined || elemSize === undefined) return null;
+      const wideElemSize = elemSize;
 
       if (ea.index.kind === 'IndexImm') {
         const imm = ctx.evalImmExpr(ea.index.value);
         if (imm !== undefined) {
           return baseResolved.kind === 'abs'
-            ? EAW_GLOB_CONST(baseResolved.baseLower, imm)
-            : EAW_FVAR_CONST(baseResolved.ixDisp, imm);
+            ? EAW_GLOB_CONST(baseResolved.baseLower, imm, wideElemSize)
+            : EAW_FVAR_CONST(baseResolved.ixDisp, imm, wideElemSize);
         }
 
         if (ea.index.value.kind === 'ImmName') {
@@ -169,13 +182,13 @@ export function createAddressingPipelineBuilders(ctx: AddressingPipelineContext)
           if (!idxResolved) return null;
           if (idxResolved.kind === 'abs') {
             return baseResolved.kind === 'abs'
-              ? EAW_GLOB_GLOB(baseResolved.baseLower, idxResolved.baseLower)
-              : EAW_FVAR_GLOB(baseResolved.ixDisp, idxResolved.baseLower);
+              ? EAW_GLOB_GLOB(baseResolved.baseLower, idxResolved.baseLower, wideElemSize)
+              : EAW_FVAR_GLOB(baseResolved.ixDisp, idxResolved.baseLower, wideElemSize);
           }
           if (idxResolved.kind === 'stack') {
             return baseResolved.kind === 'abs'
-              ? EAW_GLOB_FVAR(baseResolved.baseLower, idxResolved.ixDisp)
-              : EAW_FVAR_FVAR(baseResolved.ixDisp, idxResolved.ixDisp);
+              ? EAW_GLOB_FVAR(baseResolved.baseLower, idxResolved.ixDisp, wideElemSize)
+              : EAW_FVAR_FVAR(baseResolved.ixDisp, idxResolved.ixDisp, wideElemSize);
           }
         }
         return null;
@@ -187,17 +200,21 @@ export function createAddressingPipelineBuilders(ctx: AddressingPipelineContext)
 
         if (baseResolved.kind === 'abs') {
           if (ea.index.kind === 'IndexReg8') {
-            return EAW_GLOB_REG(baseResolved.baseLower, idxReg.toLowerCase());
+            return EAW_GLOB_REG(baseResolved.baseLower, idxReg.toLowerCase(), wideElemSize);
           }
-          if (idxUpper === 'HL') return [...LOAD_BASE_GLOB(baseResolved.baseLower), ...CALC_EA_2()];
-          return EAW_GLOB_RP(baseResolved.baseLower, idxUpper);
+          if (idxUpper === 'HL') {
+            return [...LOAD_BASE_GLOB(baseResolved.baseLower), ...CALC_EA_WIDE(wideElemSize)];
+          }
+          return EAW_GLOB_RP(baseResolved.baseLower, idxUpper, wideElemSize);
         }
         if (baseResolved.kind === 'stack') {
           if (ea.index.kind === 'IndexReg8') {
-            return EAW_FVAR_REG(baseResolved.ixDisp, idxReg.toLowerCase());
+            return EAW_FVAR_REG(baseResolved.ixDisp, idxReg.toLowerCase(), wideElemSize);
           }
-          if (idxUpper === 'HL') return [...LOAD_BASE_FVAR(baseResolved.ixDisp), ...CALC_EA_2()];
-          return EAW_FVAR_RP(baseResolved.ixDisp, idxUpper);
+          if (idxUpper === 'HL') {
+            return [...LOAD_BASE_FVAR(baseResolved.ixDisp), ...CALC_EA_WIDE(wideElemSize)];
+          }
+          return EAW_FVAR_RP(baseResolved.ixDisp, idxUpper, wideElemSize);
         }
         return null;
       }
@@ -207,13 +224,13 @@ export function createAddressingPipelineBuilders(ctx: AddressingPipelineContext)
         if (!idxResolved) return null;
         if (idxResolved.kind === 'abs') {
           return baseResolved.kind === 'abs'
-            ? EAW_GLOB_GLOB(baseResolved.baseLower, idxResolved.baseLower)
-            : EAW_FVAR_GLOB(baseResolved.ixDisp, idxResolved.baseLower);
+            ? EAW_GLOB_GLOB(baseResolved.baseLower, idxResolved.baseLower, wideElemSize)
+            : EAW_FVAR_GLOB(baseResolved.ixDisp, idxResolved.baseLower, wideElemSize);
         }
         if (idxResolved.kind === 'stack') {
           return baseResolved.kind === 'abs'
-            ? EAW_GLOB_FVAR(baseResolved.baseLower, idxResolved.ixDisp)
-            : EAW_FVAR_FVAR(baseResolved.ixDisp, idxResolved.ixDisp);
+            ? EAW_GLOB_FVAR(baseResolved.baseLower, idxResolved.ixDisp, wideElemSize)
+            : EAW_FVAR_FVAR(baseResolved.ixDisp, idxResolved.ixDisp, wideElemSize);
         }
         return null;
       }
@@ -224,9 +241,9 @@ export function createAddressingPipelineBuilders(ctx: AddressingPipelineContext)
     const scalarKind = resolved.typeExpr ? ctx.resolveScalarKind(resolved.typeExpr) : undefined;
     const elemSize: number | undefined = (resolved as { elemSize?: number }).elemSize ?? 2;
     if (scalarKind !== 'word' && scalarKind !== 'addr') return null;
-    if (elemSize !== 2) return null;
-    if (resolved.kind === 'abs') return EAW_GLOB_CONST(resolved.baseLower, resolved.addend);
-    if (resolved.kind === 'stack') return EAW_FVAR_CONST(resolved.ixDisp, 0);
+    if (getPow2ShiftCount(elemSize) === undefined) return null;
+    if (resolved.kind === 'abs') return EAW_GLOB_CONST(resolved.baseLower, resolved.addend, elemSize);
+    if (resolved.kind === 'stack') return EAW_FVAR_CONST(resolved.ixDisp, 0, elemSize);
     return null;
   };
 

--- a/src/lowering/valueMaterialization.ts
+++ b/src/lowering/valueMaterialization.ts
@@ -57,6 +57,18 @@ export function createValueMaterializationHelpers(ctx: Context) {
     expr: ixDispMemExpr(disp, span),
   });
 
+  const getPow2ShiftCount = (elemSize: number | undefined): number | undefined => {
+    if (elemSize === undefined) return undefined;
+    let n = elemSize;
+    let shiftCount = 0;
+    while (n > 1 && (n & 1) === 0) {
+      n >>= 1;
+      shiftCount++;
+    }
+    if (n !== 1 || shiftCount > 15) return undefined;
+    return shiftCount;
+  };
+
   const emitLoadWordFromHlAddress = (target: 'HL' | 'DE' | 'BC', span: SourceSpan): boolean => {
     if (target === 'DE') {
       return ctx.emitStepPipeline(ctx.LOAD_RP_EA('DE'), span);
@@ -189,17 +201,8 @@ export function createValueMaterializationHelpers(ctx: Context) {
       const baseType = ctx.resolveEaTypeExpr(ea.base);
       if (!baseResolved || !baseType || baseType.kind !== 'ArrayType') return false;
       const elemSize = ctx.sizeOfTypeExpr(baseType.element);
-      const shiftCount = (() => {
-        if (elemSize === undefined) return -1;
-        let n = elemSize;
-        let s = 0;
-        while (n > 1 && (n & 1) === 0) {
-          n >>= 1;
-          s++;
-        }
-        return n === 1 ? s : -1;
-      })();
-      if (shiftCount < 0 || shiftCount > 4) return false;
+      const shiftCount = getPow2ShiftCount(elemSize);
+      if (shiftCount === undefined) return false;
 
       const loadIndexToHL = (): boolean => {
         const index = ea.index;
@@ -440,21 +443,12 @@ export function createValueMaterializationHelpers(ctx: Context) {
         return false;
       }
       const elemSize = ctx.sizeOfTypeExpr(baseType.element);
-      const shiftCount = (() => {
-        if (elemSize === undefined) return -1;
-        let n = elemSize;
-        let s = 0;
-        while (n > 1 && (n & 1) === 0) {
-          n >>= 1;
-          s++;
-        }
-        return n === 1 ? s : -1;
-      })();
-      if (shiftCount < 0 || shiftCount > 4) {
+      const shiftCount = getPow2ShiftCount(elemSize);
+      if (shiftCount === undefined) {
         ctx.diagAt(
           ctx.diagnostics,
           span,
-          `Runtime indexing currently supports element sizes that are powers of two up to 16 bytes (got ${elemSize}).`,
+          `Runtime indexing currently supports element sizes that are powers of two up to $8000 (got ${elemSize}).`,
         );
         return false;
       }

--- a/test/pr711_wide_eaw.test.ts
+++ b/test/pr711_wide_eaw.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+
+import { EAW_FVAR_CONST, EAW_GLOB_CONST, renderStepPipeline } from '../src/addressing/steps.js';
+import { DiagnosticIds, type Diagnostic } from '../src/diagnostics/types.js';
+import type { AsmOperandNode, EaExprNode, SourceSpan, TypeExprNode } from '../src/frontend/ast.js';
+import { createAddressingPipelineBuilders } from '../src/lowering/addressingPipelines.js';
+import { createValueMaterializationHelpers } from '../src/lowering/valueMaterialization.js';
+import type { EaResolution } from '../src/lowering/eaResolution.js';
+
+const span: SourceSpan = {
+  file: 'fixture.zax',
+  start: { line: 1, column: 1, offset: 0 },
+  end: { line: 1, column: 1, offset: 0 },
+};
+
+const typeName = (name: string): TypeExprNode => ({ kind: 'TypeName', span, name });
+const arrayType = (element: TypeExprNode): TypeExprNode => ({ kind: 'ArrayType', span, element, length: 4 });
+const eaName = (name: string): EaExprNode => ({ kind: 'EaName', span, name });
+
+describe('#711 wide EAW scaling', () => {
+  it('scales step builders by arbitrary pow2 element sizes', () => {
+    expect(renderStepPipeline(EAW_GLOB_CONST('glob_wide', 1, 8))).toEqual([
+      'ld de, glob_wide',
+      'ld hl, $0001',
+      'add hl, hl',
+      'add hl, hl',
+      'add hl, hl',
+      'add hl, de',
+    ]);
+
+    expect(renderStepPipeline(EAW_FVAR_CONST(-20, 1, 8))).toEqual([
+      'ld e, (ix-$0c)',
+      'ld d, (ix-$0b)',
+      'ld hl, $0000',
+      'add hl, hl',
+      'add hl, hl',
+      'add hl, hl',
+      'add hl, de',
+    ]);
+  });
+
+  it('keeps word pipeline lowering on the structural path for wide pow2 elements', () => {
+    const diagnostics: Diagnostic[] = [];
+    const reg8 = new Set(['A', 'B', 'C', 'D', 'E', 'H', 'L']);
+    const wideArray = arrayType(typeName('wide8'));
+
+    const resolutions = new Map<string, EaResolution>([
+      ['globwide', { kind: 'abs', baseLower: 'globwide', addend: 0, typeExpr: wideArray }],
+      ['framewide', { kind: 'stack', ixDisp: -16, typeExpr: wideArray }],
+      ['idxw', { kind: 'abs', baseLower: 'idxw', addend: 0, typeExpr: typeName('word') }],
+    ]);
+
+    const helpers = createAddressingPipelineBuilders({
+      diagnostics,
+      diagAt: (_diagnostics, _span, message) => {
+        diagnostics.push({
+          id: DiagnosticIds.EmitError,
+          severity: 'error',
+          file: span.file,
+          message,
+        });
+      },
+      reg8,
+      resolveEa: (ea) => (ea.kind === 'EaName' ? resolutions.get(ea.name.toLowerCase()) : undefined),
+      resolveEaTypeExpr: (ea) => (ea.kind === 'EaName' ? resolutions.get(ea.name.toLowerCase())?.typeExpr : undefined),
+      resolveScalarBinding: (name) => (name.toLowerCase() === 'idxw' ? 'word' : undefined),
+      resolveScalarKind: (typeExpr) =>
+        typeExpr.kind === 'TypeName' && (typeExpr.name === 'word' || typeExpr.name === 'addr')
+          ? typeExpr.name
+          : undefined,
+      sizeOfTypeExpr: (typeExpr) => {
+        if (typeExpr.kind !== 'TypeName') return undefined;
+        if (typeExpr.name === 'wide8') return 8;
+        if (typeExpr.name === 'word' || typeExpr.name === 'addr') return 2;
+        return undefined;
+      },
+      evalImmExpr: () => undefined,
+    });
+
+    const globPipe = helpers.buildEaWordPipeline(
+      { kind: 'EaIndex', span, base: eaName('globwide'), index: { kind: 'IndexReg16', span, reg: 'HL' } },
+      span,
+    );
+    const framePipe = helpers.buildEaWordPipeline(
+      {
+        kind: 'EaIndex',
+        span,
+        base: eaName('framewide'),
+        index: { kind: 'IndexImm', span, value: { kind: 'ImmName', span, name: 'idxw' } },
+      },
+      span,
+    );
+
+    expect(renderStepPipeline(globPipe ?? [])).toEqual([
+      'ld de, globwide',
+      'add hl, hl',
+      'add hl, hl',
+      'add hl, hl',
+      'add hl, de',
+    ]);
+    expect(renderStepPipeline(framePipe ?? [])).toEqual([
+      'ld e, (ix-$10)',
+      'ld d, (ix-$0f)',
+      'ld hl, (idxw)',
+      'add hl, hl',
+      'add hl, hl',
+      'add hl, hl',
+      'add hl, de',
+    ]);
+    expect(diagnostics).toEqual([]);
+  });
+
+  it('keeps runtime address materialization valid up to $8000-sized elements', () => {
+    const diagnostics: Diagnostic[] = [];
+    const emittedInstrs: string[] = [];
+    const absFixups: Array<{ opcode: number; baseLower: string; addend: number }> = [];
+    const hugeArray = arrayType(typeName('wide32768'));
+
+    const helpers = createValueMaterializationHelpers({
+      diagnostics,
+      diagAt: (_diagnostics, _span, message) => {
+        diagnostics.push({
+          id: DiagnosticIds.EmitError,
+          severity: 'error',
+          file: span.file,
+          message,
+        });
+      },
+      reg8: new Set(['A', 'B', 'C', 'D', 'E', 'H', 'L']),
+      resolveEa: (ea) => {
+        if (ea.kind === 'EaName' && ea.name === 'globHuge') {
+          return { kind: 'abs', baseLower: 'globhuge', addend: 0, typeExpr: hugeArray } as const;
+        }
+        return undefined;
+      },
+      resolveEaTypeExpr: (ea) => {
+        if (ea.kind === 'EaName' && ea.name === 'globHuge') return hugeArray;
+        return undefined;
+      },
+      resolveScalarBinding: () => undefined,
+      resolveScalarKind: () => undefined,
+      sizeOfTypeExpr: (typeExpr) => {
+        if (typeExpr.kind === 'TypeName' && typeExpr.name === 'wide32768') return 0x8000;
+        return undefined;
+      },
+      evalImmExpr: () => undefined,
+      evalImmNoDiag: () => undefined,
+      emitInstr: (head: string, operands: AsmOperandNode[]) => {
+        emittedInstrs.push(`${head} ${operands.map((operand) => operand.kind).join(',')}`);
+        return true;
+      },
+      emitRawCodeBytes: () => {},
+      emitAbs16Fixup: (opcode: number, baseLower: string, addend: number) => {
+        absFixups.push({ opcode, baseLower, addend });
+      },
+      loadImm16ToDE: () => true,
+      loadImm16ToHL: () => true,
+      negateHL: () => true,
+      pushZeroExtendedReg8: () => true,
+      emitStepPipeline: () => true,
+      buildEaBytePipeline: () => null,
+      buildEaWordPipeline: () => null,
+      emitScalarWordLoad: () => false,
+      formatIxDisp: (disp: number) => `${disp >= 0 ? '+' : ''}${disp}`,
+      TEMPLATE_L_ABC: () => [],
+      TEMPLATE_LW_DE: () => [],
+      LOAD_RP_EA: () => [],
+      STORE_RP_EA: () => [],
+    });
+
+    const result = helpers.pushEaAddress(
+      { kind: 'EaIndex', span, base: eaName('globHuge'), index: { kind: 'IndexReg8', span, reg: 'C' } },
+      span,
+    );
+
+    expect(result).toBe(true);
+    expect(absFixups).toEqual([{ opcode: 0x11, baseLower: 'globhuge', addend: 0 }]);
+    expect(emittedInstrs.filter((instr) => instr === 'add Reg,Reg')).toHaveLength(16);
+    expect(diagnostics).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary\n- generalize EAW step builders to scale by arbitrary power-of-two element sizes up to ``\n- keep addressing pipeline selection on the structural wide-element path instead of bailing out above 2-byte elements\n- lift runtime EA materialization from the old 16-byte ceiling and add focused wide-element coverage\n\n## Verification\n- npm run typecheck\n- npm test -- --run test/pr711_wide_eaw.test.ts test/addressing_model_steps.test.ts test/pr407_step_matrix.test.ts test/pr509_addressing_pipeline_builders.test.ts test/pr531_value_materialization_helpers.test.ts test/pr374_addressing_modes_mini_suite.test.ts test/smoke_language_tour_compile.test.ts