### PR TITLE
docs: solidify addr-first language direction

### DIFF
--- a/docs/design/ops-first-addressing-decisions.md
+++ b/docs/design/ops-first-addressing-decisions.md
@@ -141,30 +141,49 @@ Rationale:
 
 ---
 
-### D5. Compiler-owned preservation machinery lands first; `@dead` comes later
+### D5. Dead-register pragmas trim only explicit preservation regions
 
-ZAX should give `addr` a fixed, compiler-guaranteed public contract:
+ZAX should support dead-register metadata scoped to:
 
-> `addr hl, ea_expr` places the effective address in `HL` and preserves everything else.
+- functions
+- blocks
 
-That requires compiler-owned preservation machinery from the first implementation slice.
+Examples:
+
+```zax
+func render(): HL
+  @dead DE
+  ...
+end
+```
+
+```zax
+repeat
+  @dead DE
+  addr hl, arr[C]
+  ld a, (hl)
+until Z
+```
+
+Semantics:
+
+- pragmas do not change program meaning
+- they only permit the compiler to skip unnecessary preservation work
+- the compiler may ignore them
+- they apply only to compiler-owned preservation regions, not arbitrary stack traffic in the body
 
 Required internal model:
 
-- each compiler-owned lowering slab such as `addr` lowering or transitional sugary EA access must explicitly know which registers it uses transiently
-- the compiler emits preservation wrappers from that internal metadata
-- preservation scaffolding remains distinct from semantic body operations
-
-Future direction:
-
-- a later `@dead` surface may trim only compiler-owned preservation regions
-- it must not rewrite arbitrary stack juggling inside the body
+- compiler-owned slabs such as `addr` lowering or transitional sugary EA access must carry a clobber/result set
+- the compiler derives the preserve set as the complement of that clobber set
+- `@dead` trims only that derived preserve set before concrete `push`/`pop` emission
+- semantic stack juggling inside the body remains untouched
 
 Rationale:
 
-- keeps the programmer-facing contract simple and ZAX-like
-- avoids exposing internal lowering details to the programmer
-- builds the right machinery first, before adding optimization controls on top
+- correct use of pragmas is advisory, not semantic
+- this keeps dead-register optimization targeted at preservation scaffolding only
+- it avoids unsafe deletion of stack operations that are actually part of the algorithm
 
 ---
 
@@ -248,31 +267,23 @@ But this direction does not commit to keeping them once `addr` is established.
 
 ### N6. No mandatory liveness analysis
 
-Any future dead-register optimization remains advisory.
+Dead-register pragmas are advisory.
 The compiler is not required to prove or infer full liveness in order to use this model.
-
-### N7. No `@dead` surface in the first slice
-
-The first slice must land compiler-owned preservation machinery for `addr`.
-The pragma surface itself can come later once that machinery is stable.
 
 ---
 
-## 4. Follow-up Spec Questions
+## 4. Required Spec Questions Before Implementation
 
-Resolved by `docs/design/addr-prereq-decisions.md`:
-
-1. Transitional status of typed EA inside `ld`
-2. Semantic mapping of transitional direct EA forms onto `addr`
-3. Op contracts deferred for v1
-4. `addr` preservation contract and compiler-owned preservation machinery
-
-Still open:
+These questions need explicit answers before any implementation backlog is created:
 
 1. What is the exact grammar production for `<Type>base.tail`?
 2. What counts as a valid `base` for casted EA interpretation in v1?
-3. Should `@dead` remain deferred until after `addr` stabilizes, or follow immediately after?
-4. How do range/grouped `case` values lower in the presence of overlapping clauses?
+3. Is direct typed EA inside `ld` specified only as transitional compatibility, or removed once `addr` lands well?
+4. What exact semantic definition maps any transitional direct EA load/store forms onto `addr`?
+5. Does v1 expose any op metadata at all, or are op contracts entirely deferred?
+6. What exact internal preservation-region model makes `@dead` safe?
+7. What pragma placement rules apply to `@dead`?
+8. How do range/grouped `case` values lower in the presence of overlapping clauses?
 
 ---
 
@@ -281,12 +292,12 @@ Still open:
 If this direction is accepted, the safest first implementation boundary is:
 
 1. add `addr hl, ea`
-2. give `addr` a compiler-guaranteed preservation contract using compiler-owned preservation machinery
-3. route existing `ld`-embedded typed EA forms through `addr` as transitional compatibility only
-4. leave existing op semantics unchanged
-5. add cast syntax only once the `addr` boundary is stable
-6. decide whether to retire direct typed EA from `ld`
-7. add any `@dead` pragma surface only after generated `addr` code is stable
+2. leave existing `ld`-embedded typed EA forms untouched or transitional only
+3. leave existing op semantics unchanged
+4. introduce explicit compiler-owned preservation regions derived from clobber/result sets
+5. add dead-register pragmas on top of those preservation regions
+6. add cast syntax only once the `addr` boundary is stable
+7. decide whether to retire direct typed EA from `ld`
 8. revisit op metadata only after there is a real effect-analysis mechanism
 
 This keeps the first implementation step focused and prevents the whole idea from becoming an entangled “big bang” redesign.

--- a/docs/design/ops-first-addressing-direction.md
+++ b/docs/design/ops-first-addressing-direction.md
@@ -400,7 +400,7 @@ The compiler should either prove the contract or refuse it.
 
 ---
 
-## 9. Dead-register pragmas are a good fit later
+## 9. Dead-register pragmas are a good fit
 
 This is exactly the kind of thing pragmas *should* do.
 
@@ -415,7 +415,7 @@ Dead-register information is:
 
 That makes it a good pragma candidate.
 
-### 9.2 Proposed later scope
+### 9.2 Proposed scope
 
 Support:
 
@@ -440,7 +440,6 @@ until Z
 ```
 
 This is enough to be useful without becoming a full liveness language.
-But it should land only after `addr` and its preservation machinery are stable in real code.
 
 ### 9.3 What `@dead` must and must not touch
 
@@ -477,7 +476,7 @@ Example shape:
 - clobber/result set: `HL, AF`
 - derived preserve set: `BC, DE`
 
-If a future scope contains:
+If the current scope contains:
 
 ```zax
 @dead DE
@@ -485,7 +484,7 @@ If a future scope contains:
 
 then the compiler trims only the derived preserve set and emits preservation for `BC` but not `DE`.
 
-This means any future dead-register optimization should operate on compiler-owned preservation metadata, not on raw emitted opcodes.
+This means dead-register optimization should operate on compiler-owned preservation metadata, not on raw emitted opcodes.
 
 ### 9.5 Why this pairs well with ops-first addressing
 
@@ -495,7 +494,7 @@ This fits the broader direction cleanly:
 - future standard-library ops can conceptually follow the same shape
 - semantic stack shuffling inside a body remains explicit and untouched
 
-So once `addr` is stable, dead-register metadata can reduce preservation cost without becoming unsafe.
+So even during any transition period, dead-register metadata can reduce preservation cost without becoming unsafe.
 
 ---
 


### PR DESCRIPTION
## Summary
- restore the addr-first docs stance on dead-register pragmas and preservation regions
- keep the change limited to the two addr-first design docs
- leave licensing metadata unchanged as GPL-3.0-only

## Verification
- README license footer remains GPL-3.0-only
- package metadata remains GPL-3.0-only