### PR TITLE
#731 Lower addr hl with preservation contract

### DIFF
--- a/src/lowering/addrLowering.ts
+++ b/src/lowering/addrLowering.ts
@@ -1,0 +1,29 @@
+import type { AsmAddrNode, AsmOperandNode, EaExprNode, SourceSpan } from '../frontend/ast.js';
+
+type Context = {
+  emitInstr: (head: string, operands: AsmOperandNode[], span: SourceSpan) => boolean;
+  materializeEaAddressToHL: (ea: EaExprNode, span: SourceSpan) => boolean;
+};
+
+export function createAddrLoweringHelpers(ctx: Context) {
+  const preservedRegs: Array<'AF' | 'BC' | 'DE'> = ['AF', 'BC', 'DE'];
+
+  const lowerAsmAddr = (item: AsmAddrNode): boolean => {
+    for (const reg of preservedRegs) {
+      if (!ctx.emitInstr('push', [{ kind: 'Reg', span: item.span, name: reg }], item.span)) return false;
+    }
+
+    if (!ctx.materializeEaAddressToHL(item.expr, item.span)) return false;
+
+    for (let i = preservedRegs.length - 1; i >= 0; i--) {
+      const reg = preservedRegs[i]!;
+      if (!ctx.emitInstr('pop', [{ kind: 'Reg', span: item.span, name: reg }], item.span)) return false;
+    }
+
+    return true;
+  };
+
+  return {
+    lowerAsmAddr,
+  };
+}

--- a/src/lowering/asmRangeLowering.ts
+++ b/src/lowering/asmRangeLowering.ts
@@ -1,4 +1,4 @@
-import type { AsmInstructionNode, AsmItemNode, AsmOperandNode, ImmExprNode, SourceSpan } from '../frontend/ast.js';
+import type { AsmAddrNode, AsmInstructionNode, AsmItemNode, AsmOperandNode, ImmExprNode, SourceSpan } from '../frontend/ast.js';
 
 type FlowState = {
   reachable: boolean;
@@ -13,6 +13,7 @@ type Context<TCodeSegmentTag> = {
   setCurrentCodeSegmentTag: (tag: TCodeSegmentTag | undefined) => void;
   defineCodeLabel: (name: string, span: SourceSpan, scope: 'global' | 'local') => void;
   emitAsmInstruction: (item: AsmInstructionNode) => void;
+  emitAsmAddr: (item: AsmAddrNode) => void;
   flowRef: { readonly current: FlowState };
   syncFromFlow: () => void;
   snapshotFlow: () => FlowState;
@@ -60,6 +61,11 @@ export function createAsmRangeLoweringHelpers<TCodeSegmentTag>(ctx: Context<TCod
         }
         if (it.kind === 'AsmInstruction') {
           ctx.emitAsmInstruction(it);
+          i++;
+          continue;
+        }
+        if (it.kind === 'AsmAddr') {
+          ctx.emitAsmAddr(it);
           i++;
           continue;
         }

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -824,6 +824,7 @@ export function emitProgram(
     pushImm16,
     pushZeroExtendedReg8,
     loadImm16ToHL,
+    materializeEaAddressToHL,
     emitStepPipeline,
     lowerLdWithEa,
   };

--- a/src/lowering/functionCallLowering.ts
+++ b/src/lowering/functionCallLowering.ts
@@ -2,6 +2,7 @@ import { TEMPLATE_SW_DEBC } from '../addressing/steps.js';
 import { DiagnosticIds } from '../diagnostics/types.js';
 import type { Diagnostic } from '../diagnostics/types.js';
 import type {
+  AsmAddrNode,
   AsmInstructionNode,
   AsmOperandNode,
   EaExprNode,
@@ -101,6 +102,7 @@ type Context = {
   inverseConditionName: (name: string) => string | undefined;
   newHiddenLabel: (prefix: string) => string;
   lowerAsmInstructionDispatcher: (asmItem: AsmInstructionNode) => void;
+  lowerAsmAddr: (asmItem: AsmAddrNode) => boolean;
   defineCodeLabel: (name: string, span: SourceSpan, scope: 'global' | 'local') => void;
   flowRef: { readonly current: FlowState };
   syncFromFlow: () => void;
@@ -117,6 +119,17 @@ type Context = {
 };
 
 export function createFunctionCallLoweringHelpers(ctx: Context) {
+  const emitAsmAddr = (asmItem: AsmAddrNode): void => {
+    const prevTag = ctx.getCurrentCodeSegmentTag();
+    ctx.setCurrentCodeSegmentTag(ctx.asmItemSpanSourceTag(asmItem.span));
+    try {
+      ctx.lowerAsmAddr(asmItem);
+      ctx.syncToFlow();
+    } finally {
+      ctx.setCurrentCodeSegmentTag(prevTag);
+    }
+  };
+
   const emitAsmInstruction = (asmItem: AsmInstructionNode): void => {
     const prevTag = ctx.getCurrentCodeSegmentTag();
     const diagnosticsStart = ctx.diagnostics.length;
@@ -429,6 +442,7 @@ export function createFunctionCallLoweringHelpers(ctx: Context) {
     setCurrentCodeSegmentTag: ctx.setCurrentCodeSegmentTag,
     defineCodeLabel: ctx.defineCodeLabel,
     emitAsmInstruction,
+    emitAsmAddr,
     flowRef: ctx.flowRef,
     syncFromFlow: ctx.syncFromFlow,
     snapshotFlow: ctx.snapshotFlow,
@@ -450,6 +464,7 @@ export function createFunctionCallLoweringHelpers(ctx: Context) {
   });
 
   return {
+    emitAsmAddr,
     emitAsmInstruction,
     lowerAsmRange,
   };

--- a/src/lowering/functionLowering.ts
+++ b/src/lowering/functionLowering.ts
@@ -3,6 +3,7 @@ import type { StepPipeline } from '../addressing/steps.js';
 import { DiagnosticIds } from '../diagnostics/types.js';
 import type { Diagnostic, DiagnosticId } from '../diagnostics/types.js';
 import type {
+  AsmAddrNode,
   AsmInstructionNode,
   AsmOperandNode,
   EaExprNode,
@@ -24,6 +25,7 @@ import type { OpOverloadSelection } from './opMatching.js';
 import type { OpStackSummary } from './opStackAnalysis.js';
 import type { ScalarKind } from './typeResolution.js';
 import { createAsmInstructionLoweringHelpers } from './asmInstructionLowering.js';
+import { createAddrLoweringHelpers } from './addrLowering.js';
 import { createAsmBodyOrchestrationHelpers } from './asmBodyOrchestration.js';
 import {
   createFunctionBodySetupHelpers,
@@ -145,6 +147,7 @@ export type FunctionLoweringMaterializationContext = {
   pushImm16: (value: number, span: SourceSpan) => boolean;
   pushZeroExtendedReg8: (regName: string, span: SourceSpan) => boolean;
   loadImm16ToHL: (value: number, span: SourceSpan) => boolean;
+  materializeEaAddressToHL: (ea: EaExprNode, span: SourceSpan) => boolean;
   emitStepPipeline: (pipe: StepPipeline, span: SourceSpan) => boolean;
   lowerLdWithEa: (asmItem: AsmInstructionNode) => boolean;
 };
@@ -220,7 +223,7 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
   const { evalImmExpr, env, resolveScalarBinding, resolveScalarKind, resolveEaTypeExpr } = ctx;
   const { resolveScalarTypeForEa, resolveArrayType, buildEaWordPipeline } = ctx;
   const { enforceEaRuntimeAtomBudget, enforceDirectCallSiteEaBudget } = ctx;
-  const { pushEaAddress, pushMemValue, pushImm16, pushZeroExtendedReg8, loadImm16ToHL } = ctx;
+  const { pushEaAddress, pushMemValue, pushImm16, pushZeroExtendedReg8, loadImm16ToHL, materializeEaAddressToHL } = ctx;
   const { stackSlotOffsets, stackSlotTypes, localAliasTargets, storageTypes } = ctx;
   const { rawTypedCallWarningsEnabled, resolveCallable, resolveOpCandidates, opStackPolicyMode } = ctx;
   const { formatAsmOperandForOpDiag, selectOpOverload, summarizeOpStackEffect } = ctx;
@@ -659,6 +662,11 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
     flowRef,
   });
 
+  const { lowerAsmAddr } = createAddrLoweringHelpers({
+    emitInstr,
+    materializeEaAddressToHL,
+  });
+
   const { emitAsmInstruction, lowerAsmRange } = createFunctionCallLoweringHelpers({
     diagnostics,
     asmItemSpanSourceTag: (span) => sourceTagForSpan(span, opExpansionStack),
@@ -722,6 +730,7 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
     inverseConditionName,
     newHiddenLabel,
     lowerAsmInstructionDispatcher,
+    lowerAsmAddr: (asmItem: AsmAddrNode) => lowerAsmAddr(asmItem),
     defineCodeLabel,
     flowRef,
     syncFromFlow,

--- a/test/fixtures/pr731_addr_preservation.zax
+++ b/test/fixtures/pr731_addr_preservation.zax
@@ -1,0 +1,11 @@
+section data vars at $4000
+  words: word[4] = { $1111, $2222, $3333, $4444 }
+end
+
+func main()
+  ld a, $12
+  ld bc, $3456
+  ld de, $789A
+  addr hl, words[C]
+  ret
+end

--- a/test/pr731_addr_lowering_helpers.test.ts
+++ b/test/pr731_addr_lowering_helpers.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AsmAddrNode, AsmOperandNode, SourceSpan } from '../src/frontend/ast.js';
+import { createAddrLoweringHelpers } from '../src/lowering/addrLowering.js';
+
+const span: SourceSpan = {
+  file: 'pr731_addr_lowering_helpers.zax',
+  start: { line: 1, column: 1, offset: 0 },
+  end: { line: 1, column: 1, offset: 0 },
+};
+
+describe('#731 addr lowering helpers', () => {
+  it('preserves AF, BC, and DE while materializing the address into HL', () => {
+    const emitted: string[] = [];
+    const item: AsmAddrNode = {
+      kind: 'AsmAddr',
+      span,
+      dst: 'HL',
+      expr: {
+        kind: 'EaAdd',
+        span,
+        base: {
+          kind: 'EaIndex',
+          span,
+          base: { kind: 'EaName', span, name: 'table' },
+          index: { kind: 'IndexImm', span, value: { kind: 'ImmLiteral', span, value: 1 } },
+        },
+        offset: { kind: 'ImmLiteral', span, value: 2 },
+      },
+    };
+
+    const emitInstr = (head: string, operands: AsmOperandNode[]) => {
+      const rendered = operands
+        .map((operand) => (operand.kind === 'Reg' ? operand.name : operand.kind))
+        .join(', ');
+      emitted.push(rendered ? `${head} ${rendered}` : head);
+      return true;
+    };
+
+    const helpers = createAddrLoweringHelpers({
+      emitInstr,
+      materializeEaAddressToHL: () => {
+        emitted.push('materialize -> ld E, (IX+4)');
+        emitted.push('materialize -> ld D, (IX+5)');
+        emitted.push('materialize -> ex DE, HL');
+        return true;
+      },
+    });
+
+    expect(helpers.lowerAsmAddr(item)).toBe(true);
+    expect(emitted).toEqual([
+      'push AF',
+      'push BC',
+      'push DE',
+      'materialize -> ld E, (IX+4)',
+      'materialize -> ld D, (IX+5)',
+      'materialize -> ex DE, HL',
+      'pop DE',
+      'pop BC',
+      'pop AF',
+    ]);
+  });
+});

--- a/test/pr731_addr_lowering_integration.test.ts
+++ b/test/pr731_addr_lowering_integration.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { AsmArtifact } from '../src/formats/types.js';
+
+describe('#731 addr lowering integration', () => {
+  it('lowers addr hl, ea_expr with HL result and preserved AF/BC/DE', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr731_addr_preservation.zax');
+    const res = await compile(
+      entry,
+      { emitAsm: true, emitBin: false, emitHex: false, emitListing: false, emitD8m: false },
+      { formats: defaultFormatWriters },
+    );
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+
+    const asm = res.artifacts.find((artifact): artifact is AsmArtifact => artifact.kind === 'asm');
+    expect(asm).toBeDefined();
+
+    expect(asm!.text).toContain('push AF');
+    expect(asm!.text).toContain('push BC');
+    expect(asm!.text).toContain('push DE');
+    expect(asm!.text).toContain('ld DE, words');
+    expect(asm!.text).toContain('ld H, $0000');
+    expect(asm!.text).toContain('ld L, C');
+    expect(asm!.text).toContain('add HL, HL');
+    expect(asm!.text).toContain('add HL, DE');
+    expect(asm!.text).toContain('pop DE');
+    expect(asm!.text).toContain('pop BC');
+    expect(asm!.text).toContain('pop AF');
+  });
+});


### PR DESCRIPTION
## Summary\n- lower `addr hl, ea_expr` through a dedicated lowering helper with an explicit AF/BC/DE preservation contract\n- thread the new asm item through asm-range and function-call lowering dispatch\n- add focused helper and integration coverage for preservation and end-to-end lowering\n\n## Verification\n- npm run typecheck\n- npm test -- --run test/pr731_addr_lowering_helpers.test.ts test/pr731_addr_lowering_integration.test.ts test/pr543_function_lowering_integration.test.ts\n- npm test -- --run test/smoke_language_tour_compile.test.ts