### PR TITLE
#734 Lock addr-first behavior in tests and corpus artifacts

### DIFF
--- a/test/pr734_addr_first_artifacts.test.ts
+++ b/test/pr734_addr_first_artifacts.test.ts
@@ -1,0 +1,87 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { AsmArtifact, D8mArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const addrFirstExamples = [
+  '00_call_with_arg_and_local_baseline',
+  '01_args_locals_basics',
+  '02_fibonacci_args_locals',
+  '14_ops_and_calls',
+] as const;
+
+function canonicalProgramAsm(text: string): string {
+  const out: string[] = [];
+  const canonicalizeIxIyDisp = (input: string): string =>
+    input.replace(
+      /\(\s*(IX|IY)\s*([+-])\s*\$([0-9A-F]{1,4})\s*\)/gi,
+      (_m, base: string, sign: string, hex: string) => {
+        const value = Number.parseInt(hex, 16) & 0xff;
+        return `(${base.toUpperCase()}${sign}$${value.toString(16).toUpperCase().padStart(2, '0')})`;
+      },
+    );
+
+  for (const rawLine of text.replace(/\r\n/g, '\n').split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (line.startsWith(';')) continue;
+    if (line.toLowerCase() === '; symbols:') continue;
+    if (/^; (label|var|data|constant)\b/i.test(line)) continue;
+    if (line.endsWith(':')) {
+      out.push(line.toUpperCase());
+      continue;
+    }
+    const noTraceComment = line.replace(/\s*;\s*[0-9A-F]{4}:\s+[0-9A-F ]+\s*$/i, '');
+    const noInlineComment = noTraceComment.replace(/\s*;.*/, '');
+    const normalized = canonicalizeIxIyDisp(noInlineComment.replace(/\s+/g, ' ').trim());
+    if (!normalized) continue;
+    out.push(normalized.toUpperCase());
+  }
+
+  return out.join('\n');
+}
+
+describe('PR734: addr-first language-tour artifacts stay locked', () => {
+  for (const stem of addrFirstExamples) {
+    it(`${stem} matches checked-in asm and d8dbg after the addr-first migration`, async () => {
+      const entry = join(__dirname, '..', 'examples', 'language-tour', `${stem}.zax`);
+      const asmPath = join(__dirname, '..', 'examples', 'language-tour', `${stem}.asm`);
+      const d8Path = join(__dirname, '..', 'examples', 'language-tour', `${stem}.d8dbg.json`);
+
+      const [expectedAsm, expectedD8Text] = await Promise.all([
+        readFile(asmPath, 'utf8'),
+        readFile(d8Path, 'utf8'),
+      ]);
+
+      const result = await compile(
+        entry,
+        {
+          emitBin: false,
+          emitHex: false,
+          emitD8m: true,
+          emitListing: false,
+          emitAsm: true,
+          defaultCodeBase: 0x0100,
+        },
+        { formats: defaultFormatWriters },
+      );
+
+      expect(result.diagnostics).toEqual([]);
+
+      const asm = result.artifacts.find((a): a is AsmArtifact => a.kind === 'asm');
+      const d8m = result.artifacts.find((a): a is D8mArtifact => a.kind === 'd8m');
+
+      expect(asm).toBeDefined();
+      expect(d8m).toBeDefined();
+      expect(canonicalProgramAsm(asm!.text)).toBe(canonicalProgramAsm(expectedAsm));
+      expect(d8m!.json).toEqual(JSON.parse(expectedD8Text));
+    });
+  }
+});

--- a/test/pr734_addr_first_guardrail.test.ts
+++ b/test/pr734_addr_first_guardrail.test.ts
@@ -1,0 +1,40 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const addrFirstSources = [
+  join(__dirname, '..', 'examples', 'language-tour', '00_call_with_arg_and_local_baseline.zax'),
+  join(__dirname, '..', 'examples', 'language-tour', '01_args_locals_basics.zax'),
+  join(__dirname, '..', 'examples', 'language-tour', '02_fibonacci_args_locals.zax'),
+  join(__dirname, '..', 'examples', 'language-tour', '14_ops_and_calls.zax'),
+  join(__dirname, '..', 'examples', 'language-tour', '32_scalar_word_glob.zax'),
+  join(__dirname, '..', 'examples', 'language-tour', '60_word_glob_const.zax'),
+  join(__dirname, '..', 'examples', 'language-tour', '61_word_glob_reg8.zax'),
+  join(__dirname, '..', 'examples', 'language-tour', '63_word_fvar_const.zax'),
+  join(__dirname, '..', 'examples', 'language-tour', '66_word_glob_fvar.zax'),
+  join(__dirname, '..', 'examples', 'language-tour', '68_word_fvar_glob.zax'),
+  join(__dirname, '..', 'examples', 'language-tour', '69_word_glob_glob.zax'),
+  join(__dirname, '..', 'examples', 'codegen-corpus', '32_scalar_word_glob.zax'),
+  join(__dirname, '..', 'examples', 'codegen-corpus', 'advanced_typed_calls.zax'),
+  join(__dirname, '..', 'examples', 'codegen-corpus', 'pr276_typed_call_preservation_matrix.zax'),
+  join(__dirname, 'fixtures', 'pr256_value_semantics_scalar_ld.zax'),
+  join(__dirname, 'fixtures', 'pr276_typed_call_preservation_matrix.zax'),
+  join(__dirname, 'fixtures', 'pr278_nested_runtime_store_matrix.zax'),
+  join(__dirname, 'fixtures', 'pr364_call_with_arg_and_local.zax'),
+  join(__dirname, 'fixtures', 'pr365_args_locals_basics.zax'),
+] as const;
+
+const unsupportedTypedEaStoreFromHl = /^\s*ld\s+(?!\()(?!bc\b)(?!de\b)(?!sp\b)([^,]+),\s*hl\b/im;
+
+describe('PR734: addr-first source guardrail', () => {
+  it('keeps unsupported transitional `ld ea, hl` out of positive examples and fixtures', async () => {
+    for (const path of addrFirstSources) {
+      const text = await readFile(path, 'utf8');
+      expect(text, path).not.toMatch(unsupportedTypedEaStoreFromHl);
+    }
+  });
+});


### PR DESCRIPTION
Implements #734.

Scope:
- focused addr-first artifact locks for migrated language-tour examples
- source guardrail against unsupported transitional `ld ea, hl` in positive examples/fixtures
- no lowering or parser changes

Verification:
- `npm run typecheck`
- `npm test -- --run test/pr734_addr_first_artifacts.test.ts test/pr734_addr_first_guardrail.test.ts test/pr374_addressing_modes_mini_suite.test.ts test/pr680_asm_golden_contract.test.ts test/pr307_baseline_expected_trace_harness.test.ts test/pr364_call_with_arg_and_local_regression.test.ts test/pr365_args_locals_basics_regression.test.ts test/pr733_typed_ea_transition_diagnostics.test.ts test/smoke_language_tour_compile.test.ts`