### PR TITLE
docs: consolidate addr-first spec references (#735)

### DIFF
--- a/docs/reference/ZAX-quick-guide.md
+++ b/docs/reference/ZAX-quick-guide.md
@@ -269,11 +269,20 @@ Use `sizeof` and `offsetof` everywhere instead of hand-computed constants. They 
 
 ## Chapter 3 — Addressing and Indexing
 
+The current surface is `addr`-first: `addr hl, ea_expr` is the primary explicit typed-addressing form. Direct typed-EA use inside `ld` still works as transitional compatibility, but it should be understood as shorthand over `addr`, not as the center of the model.
+
 ### 3.1 Place Expressions
 
 In ZAX, `rec.field` and `arr[i]` are **place expressions** — typed storage paths that the compiler can lower to a concrete location when needed.
 
-In ordinary **value/store contexts** (such as `LD A, rec.field` or `LD rec.field, A`), scalar places use value semantics and the compiler inserts the required load or store automatically. In **storage-location contexts** (such as an `ea`-typed `op` parameter), the same place expression is passed as a storage location for the op body to use.
+The primary explicit way to consume a place expression is:
+
+```zax
+addr hl, player.x
+ld a, (hl)
+```
+
+In ordinary **value/store contexts** (such as `LD A, rec.field` or `LD rec.field, A`), scalar places still use value semantics and the compiler inserts the required load or store automatically. Those direct `ld` forms are transitional compatibility over the `addr` model. In **storage-location contexts** (such as an `ea`-typed `op` parameter), the same place expression is passed as a storage location for the op body to use.
 
 Examples:
 
@@ -310,7 +319,7 @@ arr[(HL)]   ; the index is the byte READ FROM memory at address HL (indirect)
 
 If your code intends to use the byte at the address in `HL` as an index, write `arr[(HL)]`. If `HL` itself is the index, write `arr[HL]`.
 
-### 3.4 Value Semantics in `LD`
+### 3.4 Value Semantics in `LD` (Transitional Compatibility)
 
 Scalar typed storage — module symbols from named `data` sections, function-local `var` slots, and scalar record fields — uses **value semantics** in `LD` operands in v0.2. You do not need parentheses to read or write scalar module symbols:
 
@@ -333,9 +342,26 @@ end
 
 Explicit parentheses on scalar symbols are still accepted but are redundant. Parentheses continue to mean memory dereference for non-scalar expressions and for explicit indirection where the context demands it.
 
+This remains convenient source syntax, but the preferred explicit addressing model is still `addr hl, ea_expr` followed by the raw access you want.
+
 ### 3.5 Field and Element Access
 
-`rec.field` and `arr[idx]` are place expressions. In scalar `LD` contexts, the compiler lowers them to the required address calculation and load/store sequence:
+`rec.field` and `arr[idx]` are place expressions. The preferred explicit form is `addr hl, ...` plus raw access, while scalar `LD` contexts remain supported as transitional shorthand for the same lowering:
+
+```zax
+section data vars at $8000
+  player: Sprite
+end
+
+func update_explicit(): void
+  addr hl, player.x
+  ld a, (hl)
+  inc a
+  ld (hl), a
+end
+```
+
+The transitional shorthand still works:
 
 ```zax
 section data vars at $8000

--- a/docs/reference/arrays.md
+++ b/docs/reference/arrays.md
@@ -1,11 +1,11 @@
 # ZAX Array Indexing and Address Lowering — Design Document
 
-Status: design exploration for the lowering appendix. Updated with v0.2 calling/ea semantics and guidance on keeping array addressing simple and fast.
+Status: design exploration for the lowering appendix. Updated with the addr-first transition and guidance on keeping array addressing simple and fast.
 Date: 2026-02-21.
 
 This document works through the concrete lowering strategies for effective-address computation in ZAX, given the decision to use IX as a permanent frame pointer. It covers every combination of base and offset provenance (register, local/arg variable, global symbol), for both 8-bit and 16-bit offsets, with approximate T-state costs and practical guidance for the compiler and the programmer.
 
-The focus is array indexing (`arr[i]`) and field access on records, but the same machinery applies to any `ea + offset` computation used internally by lowering. Examples use the v0.2 value-semantics model: `arr[i]` / `rec.field` are source-level storage accesses, while lowered Z80 examples may still show `(addr)` forms to make the emitted code explicit.
+The focus is array indexing (`arr[i]`) and field access on records, but the same machinery applies to any `ea + offset` computation used internally by lowering. The primary source-level model is `addr hl, ea_expr` followed by explicit access. Direct typed-EA use inside `ld` remains transitional compatibility, so some examples still show that shorthand when discussing lowering shape.
 
 ---
 
@@ -32,7 +32,7 @@ Lowering convention (v0.2):
 
 ## 2. The Lowering Problem
 
-When the programmer writes `ld a, arr[i]` or `ld hl, sprites[C].x`, the compiler must produce an instruction sequence that computes the effective address and performs the memory access. The effective address is always `base + offset`, where:
+When the programmer writes `addr hl, arr[i]`, or uses transitional shorthand such as `ld a, arr[i]`, the compiler must produce an instruction sequence that computes the effective address and then performs the intended memory access. The effective address is always `base + offset`, where:
 
 The **base** is the starting address of the storage (an array, a record, a variable). It might be a compile-time constant (a global symbol), a value in a register, or a value stored in a local/arg slot.
 

--- a/docs/reference/source-overview.md
+++ b/docs/reference/source-overview.md
@@ -57,7 +57,7 @@ src/
     parseGlobals.ts       Legacy module-scope storage-block parser
     parseImm.ts           Immediate expression parser (literals, names, sizeof, binary)
     parseOp.ts            Op declaration parser (header + asm body)
-    parseOperands.ts      Operand parser (Reg, Imm, Ea, Mem, PortC, PortImm8)
+    parseOperands.ts      Operand parser (Reg, Imm, Ea, Mem, PortC, PortImm8, addr)
     parseParams.ts        Parameter list parser (typed params and op matcher params)
     parseTopLevelSimple.ts Simple single-line parsers: import, const, section, align, bin, hex
     parseTypes.ts         Type and union declaration parsers (multi-line blocks)
@@ -268,9 +268,18 @@ Field access (`.field`) and constant index (`[n]`) are folded into the addend/ix
 resolution time. Runtime-indexed access (reg8/reg16 index) falls back to address materialization
 into HL.
 
-### 4.6 Lowering: LD Instruction
+### 4.6 Lowering: `addr` and `LD`
 
-`ldLowering.ts` handles the core complexity of the `ld` instruction, which must cover:
+The addr-first transition makes:
+
+- `addr hl, ea_expr` the primary explicit typed-addressing surface
+- direct typed-EA use inside `ld` transitional compatibility only
+
+`ldLowering.ts` still handles the core complexity of transitional typed-EA `ld` forms and raw `ld`
+encoding, but those typed-EA cases are expected to route through the same HL materialization model
+used by `addr`.
+
+Current transitional typed-EA coverage includes:
 
 - `ld r8, (ea)` — load byte from EA into reg8
 - `ld r16, (ea)` — load word from EA into reg16 pair
@@ -279,7 +288,7 @@ into HL.
 - `ld (ea), (ea)` — memory-to-memory copy (byte or word)
 - `ld (ea), imm` — store immediate to EA
 
-Each case tries multiple paths in priority order:
+These cases try multiple paths in priority order:
 
 1. Direct IX+d form (for stack slots within ±128 byte range)
 2. Step-pipeline template (for EAs that can be resolved to a step sequence)

--- a/docs/spec/zax-grammar.ebnf.md
+++ b/docs/spec/zax-grammar.ebnf.md
@@ -130,7 +130,8 @@ matcher_type    = "reg8" | "reg16"
 ```ebnf
 instr_stream    = { instr_line } ;
 
-instr_line      = z80_instruction
+instr_line      = addr_stmt
+                | z80_instruction
                 | op_invoke
                 | func_call
                 | if_stmt
@@ -139,6 +140,8 @@ instr_line      = z80_instruction
                 | select_stmt
                 | local_label
                 | local_jump ;
+
+addr_stmt       = "addr" , "HL" , "," , ea_expr ;
 
 if_stmt         = "if" , cc_expr , newline , instr_stream ,
                   [ "else" , newline , instr_stream ] , "end" ;
@@ -193,12 +196,15 @@ init_item       = imm_expr | aggregate_init ;
 
 These are semantic constraints enforced beyond pure grammar:
 
+- `addr` is the primary explicit typed-addressing form and currently requires destination `HL`:
+  - `addr hl, ea_expr`
 - Typed alias form is invalid in function-local `var`:
   - `name: Type = rhsAlias`
 - `import` remains module-scope only. It is not valid inside a named section.
 - Variable declarations inside a `code` named section are a compile error.
 - Local non-scalar value-init declarations are invalid.
 - Local non-scalar declarations are alias-only (`name = rhs`).
+- Direct typed-EA use inside `ld` remains transitional compatibility over `addr`; it is not the primary addressing model.
 - `@place` explicit address-of syntax is not part of the normative v0.2 surface.
 
 ## 9. Maintenance Rule

--- a/docs/spec/zax-spec.md
+++ b/docs/spec/zax-spec.md
@@ -178,7 +178,7 @@ Escapes in string/char literals:
 
 ZAX treats the following as **reserved** (case-insensitive):
 
-- Z80 mnemonics and assembler keywords used inside instruction streams (e.g., `ld`, `add`, `ret`, `jp`, ...).
+- Z80 mnemonics and assembler keywords used inside instruction streams (e.g., `ld`, `add`, `ret`, `jp`, ...) plus the ZAX instruction keyword `addr`.
 - Register names: `A F AF B C D E H L HL DE BC SP IX IY I R`.
 - Condition codes used by structured control flow: `Z NZ C NC PO PE M P`.
 - Structured-control keywords: `if`, `else`, `while`, `repeat`, `until`, `select`, `case`, `end`.
@@ -457,14 +457,15 @@ Field access:
 - If the field type is scalar, bare use has value semantics in `LD` and call arguments.
 - If the field type is aggregate, the result is the nested storage object and may be indexed or field-selected further.
 
-Example: arrays of records lower through storage-path access (informative):
+Example: arrays of records can be accessed explicitly through `addr` (informative):
 
 ```
 
-; `sprites[C].x` is a scalar field access. The compiler performs the
-; required address calculation internally, then loads/stores the value:
-ld hl, sprites[C].x   ; load word at sprites[C].x
-ld sprites[C].x, hl   ; store word to sprites[C].x
+; `sprites[C].x` is a scalar field access. `addr` makes the address step
+; explicit, then ordinary raw access uses `(hl)`:
+addr hl, sprites[C].x
+ld a, (hl)
+ld (hl), a
 
 ```
 
@@ -527,6 +528,8 @@ Module storage is declared inside named `data` sections.
 - Function-local `var`, parameters, and named-section `data` declarations are typed storage.
 - Scalar storage uses **value semantics** in `LD` and call arguments: a bare name means the stored value.
 - Composite storage (arrays, records, unions) is still referred to by name in source, but the compiler transparently passes or lowers it as a storage base when an aggregate operation needs one.
+- `addr hl, ea_expr` is the primary explicit typed-addressing form in the current language surface.
+- Direct typed-EA use inside `ld` remains supported only as transitional compatibility shorthand over the `addr` model.
 - `bin` and `hex` names denote storage regions/blobs and are primarily used as storage bases rather than scalar values.
 - Parentheses are an explicit low-level dereference form: `(ea)` denotes memory at the computed location `ea`. For normal scalar variables, bare forms are the normative source syntax.
 - Dereference width is implied by the instruction operand size:
@@ -544,7 +547,7 @@ Notes (v0.1):
   - These port forms refer to the Z80 I/O space (not memory) and are only valid where a raw Z80 mnemonic expects a port operand. They are not `ea` expressions.
 - Grouping parentheses apply only inside `imm` expressions (e.g., `const X = (1+2)*3`, or `ea + (1+2)`).
 
-### 6.1.1 Lowering of Non-Encodable Operands
+### 6.1.1 `addr` and Lowering of Non-Encodable Operands
 
 Many `ea` forms (locals/args, `rec.field`, `arr[i]`, and address arithmetic) are not directly encodable in a single Z80 instruction. In these cases, the compiler lowers the instruction to an equivalent instruction sequence.
 
@@ -559,15 +562,29 @@ Lowering limitations (v0.1):
 
 - Some source forms may be rejected if no correct lowering exists under the constraints above (e.g., operations whose operand ordering cannot be preserved without clobbering).
 
-Lowering guarantees and rejected patterns (v0.1):
+Primary and transitional forms (current surface):
 
-- The compiler guarantees lowering for loads/stores whose memory operand is an `ea` expression of the following forms:
-  - `LD r8, (ea)` and `LD (ea), r8`
-  - `LD r16, (ea)` and `LD (ea), r16`
-    where `ea` is a local/arg slot, a module-scope storage address (`data`/`bin`), `rec.field`, `arr[i]`, or `ea +/- imm`.
+- The primary explicit addressing form is:
+
+```zax
+addr hl, ea_expr
+```
+
+  It computes the effective address of `ea_expr` into `HL` and preserves all other registers and flags.
+- Direct typed-EA uses inside `ld` remain supported only as transitional compatibility.
+  - Examples: `ld a, rec.field`, `ld rec.field, a`, `ld hl, table[idx]`
+  - These forms are defined in terms of `addr hl, ea_expr` plus the explicit byte/word access sequence required by the raw Z80 instruction.
+  - They are not the primary source model and should not gain bespoke lowering semantics separate from `addr`.
+- Supported `ea_expr` shapes for `addr` and transitional typed-EA lowering are:
+  - local/arg slots
+  - module-scope storage addresses (`data` / `bin`)
+  - field access (`rec.field`)
+  - indexing (`arr[i]`)
+  - address arithmetic (`ea +/- imm`)
 - The compiler rejects source forms that are not meaningful on Z80 and do not have a well-defined lowering under the preservation constraints, including:
   - memory-to-memory forms (e.g., `LD (ea1), (ea2)`).
   - instructions where both operands require lowering and a correct sequence cannot be produced without clobbering non-destination registers or flags that must be preserved.
+  - transitional typed-EA word stores from `HL` (for example `ld rec.field, hl`), which must use `addr hl, ea` followed by an explicit store sequence or a dedicated op.
 
 Non-guarantees (v0.1):
 
@@ -778,7 +795,9 @@ Conceptually, an `ea` is a base storage location plus a sequence of path segment
 Value semantics note (v0.2):
 
 - Bare scalar variables use value semantics in ordinary instruction and call contexts.
+- `addr hl, ea_expr` is the primary explicit consumer of `ea` expressions.
 - `rec.field` and `arr[idx]` are storage-path expressions. In scalar value/store contexts (for example `LD A, rec.field`, `LD rec.field, A`), the compiler inserts the required load/store lowering.
+- Those direct `ld` forms are transitional compatibility over the `addr` model, not a separate primary addressing surface.
 - In aggregate contexts (for example passing an array/record parameter), the compiler passes the storage reference transparently.
 - Older address-of style wording (including `@place`) is retired from the normative v0.2 source model.
 
@@ -818,7 +837,7 @@ Rules:
   - at most one optional `var` block
   - instruction stream starts after the optional `var` block (or immediately if no `var` block)
   - `end` terminates the function body
-- Function instruction streams may contain Z80 mnemonics, `op` invocations, and structured control flow (Section 10).
+- Function instruction streams may contain Z80 mnemonics, `addr` instructions, `op` invocations, and structured control flow (Section 10).
 
 Function-local `var` declaration forms (v0.2):
 
@@ -855,6 +874,23 @@ Function-body block termination (v0.1):
 - Legacy explicit `asm` body markers are rejected with diagnostics (`Unexpected "asm" in function body ...`).
 - Function instruction streams may be empty (no instructions).
 - If control reaches the end of the function instruction stream (falls off the end), the compiler behaves as if a `ret` instruction were present at that point (i.e., it returns via the normal return/trampoline mechanism described in 8.4).
+
+### 8.1.1 `addr` Instruction
+
+Syntax:
+
+```zax
+addr hl, ea_expr
+```
+
+Rules:
+
+- `addr` is the primary explicit typed-addressing instruction in the current language surface.
+- The destination register is currently fixed to `HL`.
+- The source must be an `ea` expression as defined in Section 7.2.
+- The instruction computes the effective address of `ea_expr` into `HL`.
+- The instruction preserves all registers other than `HL`, preserves flags, and has net stack delta 0.
+- Direct typed-EA use inside `ld` remains transitional compatibility only and is defined in terms of this instruction plus explicit byte/word access.
 
 ### 8.2 Calling Convention
 


### PR DESCRIPTION
## Summary
- align the current spec and grammar with the addr-first transition
- make `addr hl, ea_expr` explicit in the normative surface
- remove stale wording that treated typed EA inside `ld` as the primary model
- update supporting references to describe direct typed-EA `ld` forms as transitional compatibility only

## Changed files
- docs/spec/zax-spec.md
- docs/spec/zax-grammar.ebnf.md
- docs/reference/ZAX-quick-guide.md
- docs/reference/arrays.md
- docs/reference/source-overview.md

## Verification
- git diff --check
