### PR TITLE
feat: support select case ranges and groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ select A
 end
 ```
 
-Each `case` compares the selected register against a compile-time constant and jumps to the matching arm. The `else` arm handles anything that falls through. The `select` dispatch may use `A` internally — the programmer controls what is loaded before the construct and what registers the arms use.
+Each `case` compares the selected register against compile-time values or inclusive ranges and jumps to the matching arm. A `case` line may also group multiple items with commas, such as `case 'A'..'Z', '_'`. The `else` arm handles anything that falls through. The `select` dispatch may use `A` internally — the programmer controls what is loaded before the construct and what registers the arms use.
 
 ---
 

--- a/docs/design/addr-prereq-decisions.md
+++ b/docs/design/addr-prereq-decisions.md
@@ -189,7 +189,7 @@ Deferred op contracts are about **user-written op bodies**, where the compiler l
 | `<Type>base.tail` grammar production | Open | Before cast syntax implementation begins |
 | Valid `base` for cast in v1 | Open | Before cast syntax implementation begins |
 | `@dead` pragma surface and scope rules | Deferred | After `addr` lowering is stable |
-| `select case` range/group overlap lowering | Open | Before `select` range implementation begins |
+| `select case` range/group overlap lowering | Resolved | Overlapping reachable values are compile errors; out-of-range `reg8` portions warn and are omitted/clipped |
 
 ---
 
@@ -206,5 +206,5 @@ Not part of this first slice:
 
 - `@dead` pragma syntax or propagation
 - typed cast syntax
-- grouped/ranged `select case`
+- grouped/ranged `select case` (implemented later)
 - user-authored op contract metadata

--- a/docs/reference/ZAX-quick-guide.md
+++ b/docs/reference/ZAX-quick-guide.md
@@ -670,12 +670,14 @@ The compiler-generated dispatch may modify `A` and flags. All other registers ar
 - If the selector is `A`, `A` may be clobbered by dispatch. Do not rely on `A` still holding the selector value inside a `case` body.
 - If the selector is any other register, that register's value is preserved across dispatch.
 
-#### Multiple Values per `case`
+#### Multiple Values and Ranges per `case`
 
-A single `case` line may list comma-separated values; any of them will match:
+A single `case` line may list comma-separated values or inclusive ranges; any listed item may match:
 
 ```zax
 select A
+  case 'A'..'Z', '_'             ; range + singleton group
+    ld a, 0
   case Mode.Idle, Mode.Stopped   ; either value routes here
     ld a, 0
   case Mode.Run
@@ -699,14 +701,15 @@ end
 
 - `else` is optional. If no `case` matches and there is no `else`, control falls through to after `end`.
 - `else` must be the final arm. A `case` after `else` is a compile error.
-- Duplicate `case` values in the same `select` are a compile error.
+- Overlapping reachable `case` items in the same `select` are a compile error.
 - `select` must contain at least one arm; a `select` with no arms is a compile error.
 - Nested `select` is allowed.
-- A `case` value outside `0..255` for a `reg8` selector can never match; the compiler warns and omits those arms from dispatch.
+- A `case` value outside `0..255` for a `reg8` selector can never match; the compiler warns and omits that item from dispatch.
+- A `case` range that partly exceeds `0..255` for a `reg8` selector warns and dispatches only on the reachable clipped portion.
 
 #### Lowering
 
-The compiler may implement `select` as a compare-and-branch chain or as a jump table. The strategy is a quality-of-implementation decision — no threshold is defined. Compile-time `imm` selectors may be folded entirely at compile time. In all cases the observable behavior is identical: the selector is evaluated once, each `case` is compared against it, and the matching body executes.
+The compiler may implement `select` as a compare-and-branch chain or as a jump table. The strategy is a quality-of-implementation decision — no threshold is defined. Compile-time `imm` selectors may be folded entirely at compile time. In all cases the observable behavior is identical: the selector is evaluated once, each `case` item is tested against it, and the matching body executes.
 
 ### 5.8 Local Labels
 

--- a/docs/spec/zax-grammar.ebnf.md
+++ b/docs/spec/zax-grammar.ebnf.md
@@ -150,7 +150,8 @@ repeat_stmt     = "repeat" , newline , instr_stream , "until" , cc_expr ;
 select_stmt     = "select" , select_expr , newline ,
                   case_clause , { case_clause } , [ else_clause ] , "end" ;
 
-case_clause     = "case" , imm_expr , newline , instr_stream ;
+case_clause     = "case" , case_item , { "," , case_item } , newline , instr_stream ;
+case_item       = imm_expr | imm_expr , ".." , imm_expr ;
 else_clause     = "else" , newline , instr_stream ;
 
 local_label     = "." , identifier , ":" ;

--- a/docs/spec/zax-spec.md
+++ b/docs/spec/zax-spec.md
@@ -1235,8 +1235,8 @@ Syntax:
 
 ```
 select <selector>
-  case <imm>[, <imm> ...]
-  case <imm>[, <imm> ...]
+  case <imm-or-range>[, <imm-or-range> ...]
+  case <imm-or-range>[, <imm-or-range> ...]
   else ...
 end
 ```
@@ -1246,15 +1246,17 @@ Rules:
 - `<selector>` is evaluated once at `select` and treated as a 16-bit value.
   - Allowed selector forms: `reg16`, `reg8` (zero-extended), `imm` expression, `ea` (storage reference value), `(ea)` (loaded value).
   - `(ea)` selectors read a 16-bit word from memory.
-- Each `case` value must be a compile-time immediate (`imm`) and is compared against the selector.
-  - Comparisons are by 16-bit equality.
-  - For `reg8` selectors, the selector value is in the range `0..255` (zero-extended). `case` values outside `0..255` can never match; the compiler may warn.
+- Each `case` item must be either a compile-time immediate (`imm`) or an inclusive compile-time range (`imm .. imm`).
+  - Single values compare by 16-bit equality.
+  - Ranges match when the selector lies within the inclusive 16-bit interval.
+  - For `reg8` selectors, the selector value is in the range `0..255` (zero-extended). `case` items outside `0..255` can never match; the compiler may warn.
+  - For `reg8` selectors, a partially out-of-range `case` range may be clipped to its reachable `0..255` portion with a warning.
 - `else` is optional and is taken if no `case` matches. If no `else` is present and no `case` matches, control transfers to after the enclosing `end`.
 - If present, `else` must be the final arm in the `select`. A `case` after `else` is a compile error.
 - There is no fallthrough: after a `case` body finishes, control transfers to after the enclosing `end` (unless the case body terminates, e.g., `ret`).
-- Duplicate `case` values within the same `select` are a compile error.
+- Overlapping reachable `case` items within the same `select` are a compile error.
 - Nested `select` is allowed.
-- A `case` line may list one or more values separated by commas (for example, `case 0, 1`).
+- A `case` line may list one or more values or ranges separated by commas (for example, `case 0, 1..3`).
 - Consecutive `case` lines before statements share one clause body (stacked-case syntax), e.g.:
   - `case 0`
   - `case 1`
@@ -1272,8 +1274,9 @@ Notes:
 
 - `select <ea>` dispatches on the storage reference value carried by `<ea>`. To dispatch on the stored value, use `select (ea)`.
 - If you want to dispatch on a byte-sized value in memory, prefer loading into a `reg8` and using `select <reg8>` rather than `select (ea)` (which reads a 16-bit word).
-- The current compiler implementation emits a warning when a `reg8` selector has a `case` value outside `0..255`, because that arm can never match.
-  - Those unreachable `reg8` case values are omitted from runtime dispatch comparisons.
+- The current compiler implementation emits a warning when a `reg8` selector has a `case` item outside `0..255`, because that item can never match.
+  - Those unreachable `reg8` case items are omitted from runtime dispatch comparisons.
+  - Partially reachable `reg8` ranges are clipped to the reachable portion for runtime dispatch.
 
 Lowering (informative):
 
@@ -1281,7 +1284,7 @@ Lowering (informative):
   - For `reg8` selectors, lowering naturally uses 8-bit compares (e.g., `ld a, <reg8>` then `cp imm8`) because the selector’s high byte is always zero.
     - The current compiler implementation loads the selector byte once and reuses it across the compare chain.
   - For `reg16` selectors, lowering may require multi-instruction comparison sequences.
-  - Runtime compare-chain lowering evaluates the selector once, then compares case values against that stable selector value.
+  - Runtime compare-chain lowering evaluates the selector once, then compares case items against that stable selector value.
   - The compiler may test `case` values in any order.
     - Do not rely on any particular case-test order or intermediate dispatch effects.
   - If the selector is a compile-time `imm` expression, the compiler may resolve the match at compile time and emit only the matching arm (or nothing).

--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -392,7 +392,7 @@ export type AsmControlNode =
   | { kind: 'Repeat'; span: SourceSpan }
   | { kind: 'Until'; span: SourceSpan; cc: string }
   | { kind: 'Select'; span: SourceSpan; selector: AsmOperandNode }
-  | { kind: 'Case'; span: SourceSpan; value: ImmExprNode }
+  | { kind: 'Case'; span: SourceSpan; value: ImmExprNode; end?: ImmExprNode }
   | { kind: 'SelectElse'; span: SourceSpan };
 
 /**

--- a/src/frontend/parseAsmStatements.ts
+++ b/src/frontend/parseAsmStatements.ts
@@ -38,12 +38,9 @@ export function appendParsedAsmStatement(out: AsmItemNode[], parsed: ParsedAsmSt
   out.push(parsed);
 }
 
-function parseCaseValuesFromText(
-  filePath: string,
-  caseText: string,
-  stmtSpan: SourceSpan,
-  diagnostics: Diagnostic[],
-): ImmExprNode[] | undefined {
+type ParsedCaseItem = { value: ImmExprNode; end?: ImmExprNode };
+
+function splitTopLevelCaseText(caseText: string): string[] {
   const parts: string[] = [];
   let start = 0;
   let parenDepth = 0;
@@ -98,12 +95,105 @@ function parseCaseValuesFromText(
     }
   }
   parts.push(caseText.slice(start));
+  return parts;
+}
 
-  const values: ImmExprNode[] = [];
-  for (const rawPart of parts) {
+function findTopLevelRangeSeparator(caseText: string): number | undefined {
+  let rangeStart: number | undefined;
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  let inChar = false;
+  let escaped = false;
+
+  for (let i = 0; i < caseText.length; i++) {
+    const ch = caseText[i]!;
+    if (inChar) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === '\\') {
+        escaped = true;
+      } else if (ch === "'") {
+        inChar = false;
+      }
+      continue;
+    }
+    if (ch === "'") {
+      inChar = true;
+      continue;
+    }
+    if (ch === '(') {
+      parenDepth++;
+      continue;
+    }
+    if (ch === ')') {
+      if (parenDepth > 0) parenDepth--;
+      continue;
+    }
+    if (ch === '[') {
+      bracketDepth++;
+      continue;
+    }
+    if (ch === ']') {
+      if (bracketDepth > 0) bracketDepth--;
+      continue;
+    }
+    if (ch === '{') {
+      braceDepth++;
+      continue;
+    }
+    if (ch === '}') {
+      if (braceDepth > 0) braceDepth--;
+      continue;
+    }
+    if (
+      ch === '.' &&
+      caseText[i + 1] === '.' &&
+      parenDepth === 0 &&
+      bracketDepth === 0 &&
+      braceDepth === 0
+    ) {
+      if (rangeStart !== undefined) return undefined;
+      rangeStart = i;
+      i++;
+    }
+  }
+
+  return rangeStart;
+}
+
+function parseCaseItemFromText(
+  filePath: string,
+  caseText: string,
+  stmtSpan: SourceSpan,
+  diagnostics: Diagnostic[],
+): ParsedCaseItem | undefined {
+  const rangeStart = findTopLevelRangeSeparator(caseText);
+  if (rangeStart === undefined) {
+    const value = parseImmExprFromText(filePath, caseText, stmtSpan, diagnostics, false);
+    return value ? { value } : undefined;
+  }
+
+  const startText = caseText.slice(0, rangeStart).trim();
+  const endText = caseText.slice(rangeStart + 2).trim();
+  if (startText.length === 0 || endText.length === 0) return undefined;
+  const value = parseImmExprFromText(filePath, startText, stmtSpan, diagnostics, false);
+  const end = parseImmExprFromText(filePath, endText, stmtSpan, diagnostics, false);
+  if (!value || !end) return undefined;
+  return { value, end };
+}
+
+function parseCaseValuesFromText(
+  filePath: string,
+  caseText: string,
+  stmtSpan: SourceSpan,
+  diagnostics: Diagnostic[],
+): ParsedCaseItem[] | undefined {
+  const values: ParsedCaseItem[] = [];
+  for (const rawPart of splitTopLevelCaseText(caseText)) {
     const part = rawPart.trim();
     if (part.length === 0) return undefined;
-    const value = parseImmExprFromText(filePath, part, stmtSpan, diagnostics, false);
+    const value = parseCaseItemFromText(filePath, part, stmtSpan, diagnostics);
     if (!value) return undefined;
     values.push(value);
   }
@@ -383,7 +473,7 @@ export function parseAsmStatement(
       });
       return undefined;
     }
-    return values.map((value) => ({ kind: 'Case', span: stmtSpan, value }));
+    return values.map((value) => ({ kind: 'Case', span: stmtSpan, ...value }));
   }
   if (lower === 'case') {
     const top = controlStack[controlStack.length - 1];

--- a/src/lowering/asmRangeLowering.ts
+++ b/src/lowering/asmRangeLowering.ts
@@ -30,8 +30,28 @@ type Context<TCodeSegmentTag> = {
   emitRawCodeBytes: (bytes: Uint8Array, file: string, trace: string) => void;
   emitSelectCompareReg8ToImm8: (value: number, missLabel: string, span: SourceSpan) => void;
   emitSelectCompareToImm16: (value: number, missLabel: string, span: SourceSpan) => void;
+  emitSelectCompareReg8Range: (
+    start: number,
+    end: number,
+    missLabel: string,
+    span: SourceSpan,
+  ) => void;
+  emitSelectCompareImm16Range: (
+    start: number,
+    end: number,
+    missLabel: string,
+    span: SourceSpan,
+  ) => void;
   emitInstr: (name: string, operands: AsmOperandNode[], span: SourceSpan) => boolean;
 };
+
+type SelectCaseArm =
+  | { kind: 'value'; value: number; bodyLabel: string; span: SourceSpan }
+  | { kind: 'range'; start: number; end: number; bodyLabel: string; span: SourceSpan };
+
+function formatCaseInterval(start: number, end: number): string {
+  return start === end ? `${start}` : `${start}..${end}`;
+}
 
 export function createAsmRangeLoweringHelpers<TCodeSegmentTag>(ctx: Context<TCodeSegmentTag>) {
   const lowerAsmRange = (
@@ -222,8 +242,8 @@ export function createAsmRangeLoweringHelpers<TCodeSegmentTag>(ctx: Context<TCod
           const endLabel = ctx.newHiddenLabel('__zax_select_end');
           const selectorIsReg8 =
             it.selector.kind === 'Reg' && ctx.reg8.has(it.selector.name.toUpperCase());
-          const caseValues = new Set<number>();
-          const caseArms: { value: number; bodyLabel: string; span: SourceSpan }[] = [];
+          const seenCaseIntervals: Array<{ start: number; end: number; desc: string }> = [];
+          const caseArms: SelectCaseArm[] = [];
           let elseLabel: string | undefined;
           let sawArm = false;
           const armExits: FlowState[] = [];
@@ -245,20 +265,71 @@ export function createAsmRangeLoweringHelpers<TCodeSegmentTag>(ctx: Context<TCod
               while (k < asmItems.length) {
                 const caseItem = asmItems[k]!;
                 if (caseItem.kind !== 'Case') break;
-                const v = ctx.evalImmExpr(caseItem.value);
-                if (v === undefined) {
+                const startValue = ctx.evalImmExpr(caseItem.value);
+                const endValue = caseItem.end ? ctx.evalImmExpr(caseItem.end) : startValue;
+                if (startValue === undefined || endValue === undefined) {
                   ctx.diagAt(caseItem.span, 'Failed to evaluate case value.');
                 } else {
-                  const key = v & 0xffff;
-                  const canMatchSelector = !selectorIsReg8 || key <= 0xff;
-                  if (selectorIsReg8 && key > 0xff) {
-                    ctx.warnAt(caseItem.span, `Case value ${key} can never match reg8 selector.`);
+                  const rawStart = startValue & 0xffff;
+                  const rawEnd = endValue & 0xffff;
+                  if (rawStart > rawEnd) {
+                    ctx.diagAt(
+                      caseItem.span,
+                      `Case range ${formatCaseInterval(rawStart, rawEnd)} is descending.`,
+                    );
+                    k++;
+                    continue;
                   }
-                  if (caseValues.has(key)) {
-                    ctx.diagAt(caseItem.span, `Duplicate case value ${key}.`);
+
+                  let start = rawStart;
+                  let end = rawEnd;
+                  if (selectorIsReg8 && start > 0xff) {
+                    const intervalText = formatCaseInterval(rawStart, rawEnd);
+                    ctx.warnAt(caseItem.span, `Case ${intervalText} can never match reg8 selector.`);
+                    k++;
+                    continue;
+                  }
+                  if (selectorIsReg8 && end > 0xff) {
+                    const original = formatCaseInterval(rawStart, rawEnd);
+                    ctx.warnAt(
+                      caseItem.span,
+                      `Case range ${original} exceeds reg8 selector range; reachable portion ${formatCaseInterval(
+                        start,
+                        0xff,
+                      )} is used.`,
+                    );
+                    end = 0xff;
+                  }
+
+                  const overlap = seenCaseIntervals.find(
+                    (interval) => !(end < interval.start || start > interval.end),
+                  );
+                  if (overlap) {
+                    const overlapStart = Math.max(start, overlap.start);
+                    const overlapEnd = Math.min(end, overlap.end);
+                    if (overlapStart === overlapEnd) {
+                      ctx.diagAt(caseItem.span, `Duplicate case value ${overlapStart}.`);
+                    } else {
+                      ctx.diagAt(
+                        caseItem.span,
+                        `Case range ${formatCaseInterval(start, end)} overlaps existing case ${
+                          overlap.desc
+                        } on ${formatCaseInterval(overlapStart, overlapEnd)}.`,
+                      );
+                    }
+                    k++;
+                    continue;
+                  }
+
+                  seenCaseIntervals.push({
+                    start,
+                    end,
+                    desc: formatCaseInterval(start, end),
+                  });
+                  if (start === end) {
+                    caseArms.push({ kind: 'value', value: start, bodyLabel, span: caseItem.span });
                   } else {
-                    caseValues.add(key);
-                    if (canMatchSelector) caseArms.push({ value: key, bodyLabel, span: caseItem.span });
+                    caseArms.push({ kind: 'range', start, end, bodyLabel, span: caseItem.span });
                   }
                 }
                 k++;
@@ -301,7 +372,11 @@ export function createAsmRangeLoweringHelpers<TCodeSegmentTag>(ctx: Context<TCod
             if (v !== undefined) selectorConst = v & 0xffff;
           }
           if (selectorConst !== undefined) {
-            const matched = caseArms.find((arm) => arm.value === selectorConst);
+            const matched = caseArms.find((arm) =>
+              arm.kind === 'value'
+                ? arm.value === selectorConst
+                : selectorConst >= arm.start && selectorConst <= arm.end,
+            );
             ctx.emitJumpTo(matched?.bodyLabel ?? elseLabel ?? endLabel, asmItems[j]!.span);
           } else if (caseArms.length === 0) {
             ctx.emitJumpTo(elseLabel ?? endLabel, asmItems[j]!.span);
@@ -317,10 +392,14 @@ export function createAsmRangeLoweringHelpers<TCodeSegmentTag>(ctx: Context<TCod
             }
             for (const arm of caseArms) {
               const miss = ctx.newHiddenLabel('__zax_select_next');
-              if (selectorIsReg8) {
+              if (arm.kind === 'value' && selectorIsReg8) {
                 ctx.emitSelectCompareReg8ToImm8(arm.value, miss, arm.span);
-              } else {
+              } else if (arm.kind === 'value') {
                 ctx.emitSelectCompareToImm16(arm.value, miss, arm.span);
+              } else if (selectorIsReg8) {
+                ctx.emitSelectCompareReg8Range(arm.start, arm.end, miss, arm.span);
+              } else {
+                ctx.emitSelectCompareImm16Range(arm.start, arm.end, miss, arm.span);
               }
               ctx.emitInstr('pop', [{ kind: 'Reg', span: arm.span, name: 'HL' }], arm.span);
               ctx.emitJumpTo(arm.bodyLabel, arm.span);

--- a/src/lowering/functionBodySetup.ts
+++ b/src/lowering/functionBodySetup.ts
@@ -309,6 +309,50 @@ export function createFunctionBodySetupHelpers({
     emitJumpCondTo(0xc2, mismatchLabel, span);
   };
 
+  const emitSelectCompareReg8Range = (
+    start: number,
+    end: number,
+    mismatchLabel: string,
+    span: SourceSpan,
+  ): void => {
+    emitRawCodeBytes(Uint8Array.of(0xfe, start & 0xff), span.file, 'cp imm8');
+    emitJumpCondTo(0xda, mismatchLabel, span);
+    if (end < 0xff) {
+      emitRawCodeBytes(Uint8Array.of(0xfe, (end + 1) & 0xff), span.file, 'cp imm8');
+      emitJumpCondTo(0xd2, mismatchLabel, span);
+    }
+  };
+
+  const emitSelectCompareImm16Range = (
+    start: number,
+    end: number,
+    mismatchLabel: string,
+    span: SourceSpan,
+  ): void => {
+    const lowerOk = newHiddenLabel('__zax_select_range_lower_ok');
+    const upperOk = newHiddenLabel('__zax_select_range_upper_ok');
+
+    emitRawCodeBytes(Uint8Array.of(0x7c), span.file, 'ld a, h');
+    emitRawCodeBytes(Uint8Array.of(0xfe, (start >> 8) & 0xff), span.file, 'cp imm8');
+    emitJumpCondTo(0xda, mismatchLabel, span);
+    emitJumpCondTo(0xc2, lowerOk, span);
+    emitRawCodeBytes(Uint8Array.of(0x7d), span.file, 'ld a, l');
+    emitRawCodeBytes(Uint8Array.of(0xfe, start & 0xff), span.file, 'cp imm8');
+    emitJumpCondTo(0xda, mismatchLabel, span);
+    defineCodeLabel(lowerOk, span, 'local');
+
+    emitRawCodeBytes(Uint8Array.of(0x7c), span.file, 'ld a, h');
+    emitRawCodeBytes(Uint8Array.of(0xfe, (end >> 8) & 0xff), span.file, 'cp imm8');
+    emitJumpCondTo(0xda, upperOk, span);
+    emitJumpCondTo(0xc2, mismatchLabel, span);
+    emitRawCodeBytes(Uint8Array.of(0x7d), span.file, 'ld a, l');
+    emitRawCodeBytes(Uint8Array.of(0xfe, end & 0xff), span.file, 'cp imm8');
+    emitJumpCondTo(0xda, upperOk, span);
+    emitJumpCondTo(0xca, upperOk, span);
+    emitJumpTo(mismatchLabel, span);
+    defineCodeLabel(upperOk, span, 'local');
+  };
+
   const loadSelectorIntoHL = (selector: AsmOperandNode, span: SourceSpan): boolean => {
     if (selector.kind === 'Reg') {
       const r = selector.name.toUpperCase();
@@ -368,6 +412,8 @@ export function createFunctionBodySetupHelpers({
     joinFlows,
     emitSelectCompareToImm16,
     emitSelectCompareReg8ToImm8,
+    emitSelectCompareReg8Range,
+    emitSelectCompareImm16Range,
     loadSelectorIntoHL,
   };
 }

--- a/src/lowering/functionCallLowering.ts
+++ b/src/lowering/functionCallLowering.ts
@@ -114,6 +114,18 @@ type Context = {
   emitRawCodeBytes: (bytes: Uint8Array, file: string, trace: string) => void;
   emitSelectCompareReg8ToImm8: (value: number, missLabel: string, span: SourceSpan) => void;
   emitSelectCompareToImm16: (value: number, missLabel: string, span: SourceSpan) => void;
+  emitSelectCompareReg8Range: (
+    start: number,
+    end: number,
+    missLabel: string,
+    span: SourceSpan,
+  ) => void;
+  emitSelectCompareImm16Range: (
+    start: number,
+    end: number,
+    missLabel: string,
+    span: SourceSpan,
+  ) => void;
 };
 
 export function createFunctionCallLoweringHelpers(ctx: Context) {
@@ -446,6 +458,8 @@ export function createFunctionCallLoweringHelpers(ctx: Context) {
     emitRawCodeBytes: ctx.emitRawCodeBytes,
     emitSelectCompareReg8ToImm8: ctx.emitSelectCompareReg8ToImm8,
     emitSelectCompareToImm16: ctx.emitSelectCompareToImm16,
+    emitSelectCompareReg8Range: ctx.emitSelectCompareReg8Range,
+    emitSelectCompareImm16Range: ctx.emitSelectCompareImm16Range,
     emitInstr: ctx.emitInstr,
   });
 

--- a/src/lowering/functionLowering.ts
+++ b/src/lowering/functionLowering.ts
@@ -518,6 +518,8 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
     joinFlows,
     emitSelectCompareToImm16,
     emitSelectCompareReg8ToImm8,
+    emitSelectCompareReg8Range,
+    emitSelectCompareImm16Range,
     loadSelectorIntoHL,
   } = createFunctionBodySetupHelpers({
     diagnostics,
@@ -736,6 +738,8 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
     emitRawCodeBytes,
     emitSelectCompareReg8ToImm8,
     emitSelectCompareToImm16,
+    emitSelectCompareReg8Range,
+    emitSelectCompareImm16Range,
   });
 
   const { lowerAndFinalizeFunctionBody } = createAsmBodyOrchestrationHelpers({

--- a/src/lowering/opExpansionExecution.ts
+++ b/src/lowering/opExpansionExecution.ts
@@ -72,6 +72,7 @@ export function createOpExpansionExecutionHelpers(ctx: OpExpansionExecutionConte
           kind: 'Case',
           span: bodyItem.span,
           value: substituteImmWithOpLabels(bodyItem.value, localLabelMap),
+          ...(bodyItem.end ? { end: substituteImmWithOpLabels(bodyItem.end, localLabelMap) } : {}),
         };
       }
       if (bodyItem.kind === 'If' || bodyItem.kind === 'While' || bodyItem.kind === 'Until') {

--- a/test/fixtures/pr738_select_case_range_group_reg8.zax
+++ b/test/fixtures/pr738_select_case_range_group_reg8.zax
@@ -1,0 +1,12 @@
+export func main()
+  ld a, '_'
+  select A
+    case 'A'..'Z', '_'
+      ld b, 1
+    case '0'..'9'
+      ld c, 2
+    else
+      ld d, 3
+  end
+  ret
+end

--- a/test/fixtures/pr738_select_case_range_overlap.zax
+++ b/test/fixtures/pr738_select_case_range_overlap.zax
@@ -1,0 +1,10 @@
+export func main()
+  ld a, 3
+  select A
+    case 1..3
+      ld b, 1
+    case 3..5
+      ld c, 2
+  end
+  ret
+end

--- a/test/fixtures/pr738_select_const_range_folded.zax
+++ b/test/fixtures/pr738_select_const_range_folded.zax
@@ -1,0 +1,9 @@
+export func main()
+  select 5
+    case 1..10, 20
+      ld b, 1
+    else
+      ld c, 2
+  end
+  ret
+end

--- a/test/fixtures/pr738_select_reg16_range_dispatch.zax
+++ b/test/fixtures/pr738_select_reg16_range_dispatch.zax
@@ -1,0 +1,10 @@
+export func main()
+  ld hl, $1080
+  select HL
+    case $1000..$10FF
+      ld b, 1
+    else
+      ld c, 2
+  end
+  ret
+end

--- a/test/fixtures/pr738_select_reg8_range_clip_warning.zax
+++ b/test/fixtures/pr738_select_reg8_range_clip_warning.zax
@@ -1,0 +1,10 @@
+export func main()
+  ld a, 252
+  select A
+    case 250..260
+      ld b, 1
+    else
+      ld c, 2
+  end
+  ret
+end

--- a/test/pr476_parse_asm_statements_helpers.test.ts
+++ b/test/pr476_parse_asm_statements_helpers.test.ts
@@ -36,6 +36,26 @@ describe('PR476 asm statement parsing extraction', () => {
     expect(diagnostics).toEqual([]);
   });
 
+  it('parses grouped range case items without flattening the ranges away', () => {
+    const diagnostics: Diagnostic[] = [];
+    const controlStack: AsmControlFrame[] = [{ kind: 'Select', elseSeen: false, armSeen: false, openSpan: zeroSpan }];
+
+    const parsed = parseAsmStatement(file.path, "case 'A'..'Z', '_'", zeroSpan, diagnostics, controlStack);
+    const out: any[] = [];
+    appendParsedAsmStatement(out, parsed);
+
+    expect(out).toEqual([
+      {
+        kind: 'Case',
+        span: zeroSpan,
+        value: { kind: 'ImmLiteral', span: zeroSpan, value: 65 },
+        end: { kind: 'ImmLiteral', span: zeroSpan, value: 90 },
+      },
+      { kind: 'Case', span: zeroSpan, value: { kind: 'ImmLiteral', span: zeroSpan, value: 95 } },
+    ]);
+    expect(diagnostics).toEqual([]);
+  });
+
   it('keeps recovery markers intact', () => {
     const diagnostics: Diagnostic[] = [];
     const controlStack: AsmControlFrame[] = [];

--- a/test/pr738_select_case_ranges.test.ts
+++ b/test/pr738_select_case_ranges.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('#738 select case ranges/groups', () => {
+  it('supports grouped case ranges for reg8 selector dispatch', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr738_select_case_range_group_reg8.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+
+    const bytes = [...bin!.bytes];
+    const cpImmCount = bytes.filter((byte) => byte === 0xfe).length;
+    expect(cpImmCount).toBe(5);
+    expect(bin!.bytes[bin!.bytes.length - 1]).toBe(0xc9);
+  });
+
+  it('folds grouped range dispatch when selector is compile-time immediate', async () => {
+    const constEntry = join(__dirname, 'fixtures', 'pr738_select_const_range_folded.zax');
+    const runtimeEntry = join(__dirname, 'fixtures', 'pr738_select_case_range_group_reg8.zax');
+    const constRes = await compile(constEntry, {}, { formats: defaultFormatWriters });
+    const runtimeRes = await compile(runtimeEntry, {}, { formats: defaultFormatWriters });
+    expect(constRes.diagnostics).toEqual([]);
+    expect(runtimeRes.diagnostics).toEqual([]);
+
+    const constBin = constRes.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    const runtimeBin = runtimeRes.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(constBin).toBeDefined();
+    expect(runtimeBin).toBeDefined();
+
+    expect([...constBin!.bytes].filter((byte) => byte === 0xfe)).toHaveLength(0);
+    expect(constBin!.bytes.length).toBeLessThan(runtimeBin!.bytes.length);
+    expect(constBin!.bytes[constBin!.bytes.length - 1]).toBe(0xc9);
+  });
+
+  it('diagnoses overlapping case ranges in select', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr738_select_case_range_overlap.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.artifacts).toEqual([]);
+    expect(res.diagnostics.some((d) => d.message.includes('Duplicate case value 3.'))).toBe(true);
+  });
+
+  it('warns and clips partially unreachable reg8 case ranges', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr738_select_reg8_range_clip_warning.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const warnings = res.diagnostics.filter(
+      (d) =>
+        d.severity === 'warning' &&
+        d.message.includes('reachable portion 250..255 is used'),
+    );
+    expect(warnings).toHaveLength(1);
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    const cpImmCount = [...bin!.bytes].filter((byte) => byte === 0xfe).length;
+    expect(cpImmCount).toBe(1);
+    expect(bin!.bytes[bin!.bytes.length - 1]).toBe(0xc9);
+  });
+
+  it('supports 16-bit selector range dispatch', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr738_select_reg16_range_dispatch.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+
+    const cpImmCount = [...bin!.bytes].filter((byte) => byte === 0xfe).length;
+    expect(cpImmCount).toBe(4);
+    expect(bin!.bytes[bin!.bytes.length - 1]).toBe(0xc9);
+  });
+});


### PR DESCRIPTION
## Summary
- add grouped and ranged `select case` syntax, including `case a..b, c`
- lower grouped/ranged case items for reg8 and reg16 selectors, with constant-folded dispatch when possible
- document overlap/clipping semantics and add focused parser/lowering coverage for #738

## Verification
- npm exec tsc -- --noEmit
- npm exec vitest run test/pr476_parse_asm_statements_helpers.test.ts test/pr738_select_case_ranges.test.ts

Refs #738
