### PR TITLE
PARSER-02: split asm structured-control parser

### DIFF
--- a/src/frontend/grammarData.ts
+++ b/src/frontend/grammarData.ts
@@ -35,6 +35,18 @@ export const RETURN_REGISTERS = new Set<string>(['HL', 'DE', 'BC', 'AF']);
 export const CONDITION_CODE_LIST = ['z', 'nz', 'c', 'nc', 'pe', 'po', 'm', 'p'] as const;
 export const CONDITION_CODES = new Set<string>(CONDITION_CODE_LIST);
 
+export const ASM_CONTROL_KEYWORD_LIST = [
+  'if',
+  'else',
+  'end',
+  'while',
+  'repeat',
+  'until',
+  'select',
+  'case',
+] as const;
+export const ASM_CONTROL_KEYWORDS = new Set<string>(ASM_CONTROL_KEYWORD_LIST);
+
 export const SCALAR_TYPE_LIST = ['byte', 'word', 'addr', 'ptr'] as const;
 export const SCALAR_TYPES = new Set<string>(SCALAR_TYPE_LIST);
 

--- a/src/frontend/parseAsmStatements.ts
+++ b/src/frontend/parseAsmStatements.ts
@@ -3,7 +3,11 @@ import type { Diagnostic } from '../diagnostics/types.js';
 import { parseDiag as diag } from './parseDiagnostics.js';
 import { immLiteral, parseImmExprFromText } from './parseImm.js';
 import { parseAsmInstruction, parseAsmOperand } from './parseOperands.js';
-import { CONDITION_CODES, CONDITION_CODE_LIST } from './grammarData.js';
+import {
+  ASM_CONTROL_KEYWORDS,
+  CONDITION_CODES,
+  CONDITION_CODE_LIST,
+} from './grammarData.js';
 
 export type AsmControlFrame =
   | { kind: 'If'; elseSeen: boolean; openSpan: SourceSpan; recoverOnly?: boolean }
@@ -27,6 +31,14 @@ export function isRecoverOnlyControlFrame(frame: AsmControlFrame): boolean {
 export type ParsedAsmStatement = AsmItemNode | AsmItemNode[] | undefined;
 export type ParseAsmStatementOptions = {
   allowedConditionIdentifiers?: ReadonlySet<string>;
+};
+
+type ParseAsmStatementContext = {
+  filePath: string;
+  stmtSpan: SourceSpan;
+  diagnostics: Diagnostic[];
+  controlStack: AsmControlFrame[];
+  options?: ParseAsmStatementOptions;
 };
 
 export function appendParsedAsmStatement(out: AsmItemNode[], parsed: ParsedAsmStatement): void {
@@ -59,6 +71,13 @@ function parseConditionCode(
     },
   );
   return '__missing__';
+}
+
+function firstAsmControlKeyword(text: string): string | undefined {
+  const head = text.match(/^[A-Za-z]+/)?.[0]?.toLowerCase();
+  if (!head || !ASM_CONTROL_KEYWORDS.has(head)) return undefined;
+  const next = text[head.length];
+  return next === undefined || !/[A-Za-z0-9_]/.test(next) ? head : undefined;
 }
 
 type ParsedCaseItem = { value: ImmExprNode; end?: ImmExprNode };
@@ -223,64 +242,22 @@ function parseCaseValuesFromText(
   return values.length > 0 ? values : undefined;
 }
 
-export function parseAsmStatement(
-  filePath: string,
-  text: string,
-  stmtSpan: SourceSpan,
-  diagnostics: Diagnostic[],
-  controlStack: AsmControlFrame[],
-  options?: ParseAsmStatementOptions,
-): ParsedAsmStatement {
-  const trimmed = text.trim();
-  const lower = trimmed.toLowerCase();
-  const hasKeyword = (kw: string): boolean => new RegExp(`^${kw}\\b`, 'i').test(trimmed);
-
-  const missingCc = '__missing__';
-
-  if (lower === 'repeat') {
+function parseRepeatStatement(trimmed: string, ctx: ParseAsmStatementContext): ParsedAsmStatement {
+  const { filePath, stmtSpan, diagnostics, controlStack } = ctx;
+  if (trimmed.toLowerCase() === 'repeat') {
     controlStack.push({ kind: 'Repeat', openSpan: stmtSpan });
     return { kind: 'Repeat', span: stmtSpan };
   }
-  if (hasKeyword('repeat')) {
-    diag(diagnostics, filePath, `"repeat" does not take operands`, {
-      line: stmtSpan.start.line,
-      column: stmtSpan.start.column,
-    });
-    return undefined;
-  }
+  diag(diagnostics, filePath, `"repeat" does not take operands`, {
+    line: stmtSpan.start.line,
+    column: stmtSpan.start.column,
+  });
+  return undefined;
+}
 
-  if (lower === 'else') {
-    const top = controlStack[controlStack.length - 1];
-    if (top?.kind === 'Select') {
-      if (top.elseSeen) {
-        diag(diagnostics, filePath, `"else" duplicated in select`, {
-          line: stmtSpan.start.line,
-          column: stmtSpan.start.column,
-        });
-        return undefined;
-      }
-      top.elseSeen = true;
-      top.armSeen = true;
-      return { kind: 'SelectElse', span: stmtSpan };
-    }
-    if (top?.kind !== 'If') {
-      diag(diagnostics, filePath, `"else" without matching "if" or "select"`, {
-        line: stmtSpan.start.line,
-        column: stmtSpan.start.column,
-      });
-      return undefined;
-    }
-    if (top.elseSeen) {
-      diag(diagnostics, filePath, `"else" duplicated in if`, {
-        line: stmtSpan.start.line,
-        column: stmtSpan.start.column,
-      });
-      return undefined;
-    }
-    top.elseSeen = true;
-    return { kind: 'Else', span: stmtSpan };
-  }
-  if (hasKeyword('else')) {
+function parseElseStatement(trimmed: string, ctx: ParseAsmStatementContext): ParsedAsmStatement {
+  const { filePath, stmtSpan, diagnostics, controlStack } = ctx;
+  if (trimmed.toLowerCase() !== 'else') {
     diag(diagnostics, filePath, `"else" does not take operands`, {
       line: stmtSpan.start.line,
       column: stmtSpan.start.column,
@@ -288,32 +265,40 @@ export function parseAsmStatement(
     return undefined;
   }
 
-  if (lower === 'end') {
-    const top = controlStack.pop();
-    if (!top) {
-      diag(diagnostics, filePath, `Unexpected "end" in asm block`, {
+  const top = controlStack[controlStack.length - 1];
+  if (top?.kind === 'Select') {
+    if (top.elseSeen) {
+      diag(diagnostics, filePath, `"else" duplicated in select`, {
         line: stmtSpan.start.line,
         column: stmtSpan.start.column,
       });
       return undefined;
     }
-    if (top.kind === 'Repeat') {
-      diag(diagnostics, filePath, `"repeat" blocks must close with "until <cc>"`, {
-        line: stmtSpan.start.line,
-        column: stmtSpan.start.column,
-      });
-      return undefined;
-    }
-    if (top.kind === 'Select' && !top.armSeen && !top.recoverOnly) {
-      diag(diagnostics, filePath, `"select" must contain at least one arm ("case" or "else")`, {
-        line: stmtSpan.start.line,
-        column: stmtSpan.start.column,
-      });
-      return undefined;
-    }
-    return { kind: 'End', span: stmtSpan };
+    top.elseSeen = true;
+    top.armSeen = true;
+    return { kind: 'SelectElse', span: stmtSpan };
   }
-  if (hasKeyword('end')) {
+  if (top?.kind !== 'If') {
+    diag(diagnostics, filePath, `"else" without matching "if" or "select"`, {
+      line: stmtSpan.start.line,
+      column: stmtSpan.start.column,
+    });
+    return undefined;
+  }
+  if (top.elseSeen) {
+    diag(diagnostics, filePath, `"else" duplicated in if`, {
+      line: stmtSpan.start.line,
+      column: stmtSpan.start.column,
+    });
+    return undefined;
+  }
+  top.elseSeen = true;
+  return { kind: 'Else', span: stmtSpan };
+}
+
+function parseEndStatement(trimmed: string, ctx: ParseAsmStatementContext): ParsedAsmStatement {
+  const { filePath, stmtSpan, diagnostics, controlStack } = ctx;
+  if (trimmed.toLowerCase() !== 'end') {
     diag(diagnostics, filePath, `"end" does not take operands`, {
       line: stmtSpan.start.line,
       column: stmtSpan.start.column,
@@ -321,13 +306,41 @@ export function parseAsmStatement(
     return undefined;
   }
 
+  const top = controlStack.pop();
+  if (!top) {
+    diag(diagnostics, filePath, `Unexpected "end" in asm block`, {
+      line: stmtSpan.start.line,
+      column: stmtSpan.start.column,
+    });
+    return undefined;
+  }
+  if (top.kind === 'Repeat') {
+    diag(diagnostics, filePath, `"repeat" blocks must close with "until <cc>"`, {
+      line: stmtSpan.start.line,
+      column: stmtSpan.start.column,
+    });
+    return undefined;
+  }
+  if (top.kind === 'Select' && !top.armSeen && !top.recoverOnly) {
+    diag(diagnostics, filePath, `"select" must contain at least one arm ("case" or "else")`, {
+      line: stmtSpan.start.line,
+      column: stmtSpan.start.column,
+    });
+    return undefined;
+  }
+  return { kind: 'End', span: stmtSpan };
+}
+
+function parseIfStatement(trimmed: string, ctx: ParseAsmStatementContext): ParsedAsmStatement {
+  const { filePath, stmtSpan, diagnostics, controlStack, options } = ctx;
+  const missingCc = '__missing__';
   const ifMatch = /^if\s+([A-Za-z][A-Za-z0-9]*)$/i.exec(trimmed);
   if (ifMatch) {
     const cc = parseConditionCode(filePath, 'if', ifMatch[1]!, stmtSpan, diagnostics, options);
     controlStack.push({ kind: 'If', elseSeen: false, openSpan: stmtSpan });
     return { kind: 'If', span: stmtSpan, cc };
   }
-  if (lower === 'if') {
+  if (trimmed.toLowerCase() === 'if') {
     diag(diagnostics, filePath, `"if" expects a condition code`, {
       line: stmtSpan.start.line,
       column: stmtSpan.start.column,
@@ -335,22 +348,24 @@ export function parseAsmStatement(
     controlStack.push({ kind: 'If', elseSeen: false, openSpan: stmtSpan });
     return { kind: 'If', span: stmtSpan, cc: missingCc };
   }
-  if (hasKeyword('if')) {
-    diag(diagnostics, filePath, `"if" expects a condition code`, {
-      line: stmtSpan.start.line,
-      column: stmtSpan.start.column,
-    });
-    controlStack.push({ kind: 'If', elseSeen: false, openSpan: stmtSpan, recoverOnly: true });
-    return { kind: 'If', span: stmtSpan, cc: missingCc };
-  }
+  diag(diagnostics, filePath, `"if" expects a condition code`, {
+    line: stmtSpan.start.line,
+    column: stmtSpan.start.column,
+  });
+  controlStack.push({ kind: 'If', elseSeen: false, openSpan: stmtSpan, recoverOnly: true });
+  return { kind: 'If', span: stmtSpan, cc: missingCc };
+}
 
+function parseWhileStatement(trimmed: string, ctx: ParseAsmStatementContext): ParsedAsmStatement {
+  const { filePath, stmtSpan, diagnostics, controlStack, options } = ctx;
+  const missingCc = '__missing__';
   const whileMatch = /^while\s+([A-Za-z][A-Za-z0-9]*)$/i.exec(trimmed);
   if (whileMatch) {
     const cc = parseConditionCode(filePath, 'while', whileMatch[1]!, stmtSpan, diagnostics, options);
     controlStack.push({ kind: 'While', openSpan: stmtSpan });
     return { kind: 'While', span: stmtSpan, cc };
   }
-  if (lower === 'while') {
+  if (trimmed.toLowerCase() === 'while') {
     diag(diagnostics, filePath, `"while" expects a condition code`, {
       line: stmtSpan.start.line,
       column: stmtSpan.start.column,
@@ -358,24 +373,27 @@ export function parseAsmStatement(
     controlStack.push({ kind: 'While', openSpan: stmtSpan });
     return { kind: 'While', span: stmtSpan, cc: missingCc };
   }
-  if (hasKeyword('while')) {
-    diag(diagnostics, filePath, `"while" expects a condition code`, {
+  diag(diagnostics, filePath, `"while" expects a condition code`, {
+    line: stmtSpan.start.line,
+    column: stmtSpan.start.column,
+  });
+  controlStack.push({ kind: 'While', openSpan: stmtSpan, recoverOnly: true });
+  return { kind: 'While', span: stmtSpan, cc: missingCc };
+}
+
+function parseUntilStatement(trimmed: string, ctx: ParseAsmStatementContext): ParsedAsmStatement {
+  const { filePath, stmtSpan, diagnostics, controlStack, options } = ctx;
+  const missingCc = '__missing__';
+  const top = controlStack[controlStack.length - 1];
+  if (top?.kind !== 'Repeat') {
+    diag(diagnostics, filePath, `"until" without matching "repeat"`, {
       line: stmtSpan.start.line,
       column: stmtSpan.start.column,
     });
-    controlStack.push({ kind: 'While', openSpan: stmtSpan, recoverOnly: true });
-    return { kind: 'While', span: stmtSpan, cc: missingCc };
+    return undefined;
   }
 
-  if (lower === 'until') {
-    const top = controlStack[controlStack.length - 1];
-    if (top?.kind !== 'Repeat') {
-      diag(diagnostics, filePath, `"until" without matching "repeat"`, {
-        line: stmtSpan.start.line,
-        column: stmtSpan.start.column,
-      });
-      return undefined;
-    }
+  if (trimmed.toLowerCase() === 'until') {
     diag(diagnostics, filePath, `"until" expects a condition code`, {
       line: stmtSpan.start.line,
       column: stmtSpan.start.column,
@@ -383,16 +401,9 @@ export function parseAsmStatement(
     controlStack.pop();
     return { kind: 'Until', span: stmtSpan, cc: missingCc };
   }
+
   const untilMatch = /^until\s+([A-Za-z][A-Za-z0-9]*)$/i.exec(trimmed);
   if (untilMatch) {
-    const top = controlStack[controlStack.length - 1];
-    if (top?.kind !== 'Repeat') {
-      diag(diagnostics, filePath, `"until" without matching "repeat"`, {
-        line: stmtSpan.start.line,
-        column: stmtSpan.start.column,
-      });
-      return undefined;
-    }
     const cc = parseConditionCode(
       filePath,
       'until',
@@ -404,35 +415,32 @@ export function parseAsmStatement(
     controlStack.pop();
     return { kind: 'Until', span: stmtSpan, cc };
   }
-  if (hasKeyword('until')) {
-    const top = controlStack[controlStack.length - 1];
-    if (top?.kind !== 'Repeat') {
-      diag(diagnostics, filePath, `"until" without matching "repeat"`, {
-        line: stmtSpan.start.line,
-        column: stmtSpan.start.column,
-      });
-      return undefined;
-    }
-    diag(diagnostics, filePath, `"until" expects a condition code`, {
-      line: stmtSpan.start.line,
-      column: stmtSpan.start.column,
-    });
-    controlStack.pop();
-    return { kind: 'Until', span: stmtSpan, cc: missingCc };
-  }
 
-  if (lower === 'select') {
+  diag(diagnostics, filePath, `"until" expects a condition code`, {
+    line: stmtSpan.start.line,
+    column: stmtSpan.start.column,
+  });
+  controlStack.pop();
+  return { kind: 'Until', span: stmtSpan, cc: missingCc };
+}
+
+function parseSelectStatement(trimmed: string, ctx: ParseAsmStatementContext): ParsedAsmStatement {
+  const { filePath, stmtSpan, diagnostics, controlStack } = ctx;
+  const fallbackNode = {
+    kind: 'Select' as const,
+    span: stmtSpan,
+    selector: { kind: 'Imm' as const, span: stmtSpan, expr: immLiteral(filePath, stmtSpan, 0) },
+  };
+
+  if (trimmed.toLowerCase() === 'select') {
     diag(diagnostics, filePath, `"select" expects a selector`, {
       line: stmtSpan.start.line,
       column: stmtSpan.start.column,
     });
     controlStack.push({ kind: 'Select', elseSeen: false, armSeen: false, openSpan: stmtSpan });
-    return {
-      kind: 'Select',
-      span: stmtSpan,
-      selector: { kind: 'Imm', span: stmtSpan, expr: immLiteral(filePath, stmtSpan, 0) },
-    };
+    return fallbackNode;
   }
+
   const selectMatch = /^select\s+(.+)$/i.exec(trimmed);
   if (selectMatch) {
     const selectorText = selectMatch[1]!.trim();
@@ -449,52 +457,55 @@ export function parseAsmStatement(
         openSpan: stmtSpan,
         recoverOnly: true,
       });
-      return {
-        kind: 'Select',
-        span: stmtSpan,
-        selector: { kind: 'Imm', span: stmtSpan, expr: immLiteral(filePath, stmtSpan, 0) },
-      };
+      return fallbackNode;
     }
     controlStack.push({ kind: 'Select', elseSeen: false, armSeen: false, openSpan: stmtSpan });
     return { kind: 'Select', span: stmtSpan, selector };
   }
-  if (hasKeyword('select')) {
-    diag(diagnostics, filePath, `Invalid select selector`, {
+
+  diag(diagnostics, filePath, `Invalid select selector`, {
+    line: stmtSpan.start.line,
+    column: stmtSpan.start.column,
+  });
+  controlStack.push({
+    kind: 'Select',
+    elseSeen: false,
+    armSeen: false,
+    openSpan: stmtSpan,
+    recoverOnly: true,
+  });
+  return fallbackNode;
+}
+
+function parseCaseStatement(trimmed: string, ctx: ParseAsmStatementContext): ParsedAsmStatement {
+  const { filePath, stmtSpan, diagnostics, controlStack } = ctx;
+  const top = controlStack[controlStack.length - 1];
+  if (top?.kind !== 'Select') {
+    diag(diagnostics, filePath, `"case" without matching "select"`, {
       line: stmtSpan.start.line,
       column: stmtSpan.start.column,
     });
-    controlStack.push({
-      kind: 'Select',
-      elseSeen: false,
-      armSeen: false,
-      openSpan: stmtSpan,
-      recoverOnly: true,
+    return undefined;
+  }
+  if (top.elseSeen) {
+    diag(diagnostics, filePath, `"case" after "else" in select`, {
+      line: stmtSpan.start.line,
+      column: stmtSpan.start.column,
     });
-    return {
-      kind: 'Select',
-      span: stmtSpan,
-      selector: { kind: 'Imm', span: stmtSpan, expr: immLiteral(filePath, stmtSpan, 0) },
-    };
+    return undefined;
+  }
+  top.armSeen = true;
+
+  if (trimmed.toLowerCase() === 'case') {
+    diag(diagnostics, filePath, `"case" expects a value`, {
+      line: stmtSpan.start.line,
+      column: stmtSpan.start.column,
+    });
+    return undefined;
   }
 
   const caseMatch = /^case\s+(.+)$/i.exec(trimmed);
   if (caseMatch) {
-    const top = controlStack[controlStack.length - 1];
-    if (top?.kind !== 'Select') {
-      diag(diagnostics, filePath, `"case" without matching "select"`, {
-        line: stmtSpan.start.line,
-        column: stmtSpan.start.column,
-      });
-      return undefined;
-    }
-    if (top.elseSeen) {
-      diag(diagnostics, filePath, `"case" after "else" in select`, {
-        line: stmtSpan.start.line,
-        column: stmtSpan.start.column,
-      });
-      return undefined;
-    }
-    top.armSeen = true;
     const exprText = caseMatch[1]!.trim();
     const values = parseCaseValuesFromText(filePath, exprText, stmtSpan, diagnostics);
     if (!values) {
@@ -506,51 +517,47 @@ export function parseAsmStatement(
     }
     return values.map((value) => ({ kind: 'Case', span: stmtSpan, ...value }));
   }
-  if (lower === 'case') {
-    const top = controlStack[controlStack.length - 1];
-    if (top?.kind !== 'Select') {
-      diag(diagnostics, filePath, `"case" without matching "select"`, {
-        line: stmtSpan.start.line,
-        column: stmtSpan.start.column,
-      });
-      return undefined;
-    }
-    if (top.elseSeen) {
-      diag(diagnostics, filePath, `"case" after "else" in select`, {
-        line: stmtSpan.start.line,
-        column: stmtSpan.start.column,
-      });
-      return undefined;
-    }
-    top.armSeen = true;
-    diag(diagnostics, filePath, `"case" expects a value`, {
-      line: stmtSpan.start.line,
-      column: stmtSpan.start.column,
-    });
-    return undefined;
-  }
-  if (hasKeyword('case')) {
-    const top = controlStack[controlStack.length - 1];
-    if (top?.kind !== 'Select') {
-      diag(diagnostics, filePath, `"case" without matching "select"`, {
-        line: stmtSpan.start.line,
-        column: stmtSpan.start.column,
-      });
-      return undefined;
-    }
-    if (top.elseSeen) {
-      diag(diagnostics, filePath, `"case" after "else" in select`, {
-        line: stmtSpan.start.line,
-        column: stmtSpan.start.column,
-      });
-      return undefined;
-    }
-    top.armSeen = true;
-    diag(diagnostics, filePath, `Invalid case value`, {
-      line: stmtSpan.start.line,
-      column: stmtSpan.start.column,
-    });
-    return undefined;
+
+  diag(diagnostics, filePath, `Invalid case value`, {
+    line: stmtSpan.start.line,
+    column: stmtSpan.start.column,
+  });
+  return undefined;
+}
+
+export function parseAsmStatement(
+  filePath: string,
+  text: string,
+  stmtSpan: SourceSpan,
+  diagnostics: Diagnostic[],
+  controlStack: AsmControlFrame[],
+  options?: ParseAsmStatementOptions,
+): ParsedAsmStatement {
+  const trimmed = text.trim();
+  const ctx: ParseAsmStatementContext = {
+    filePath,
+    stmtSpan,
+    diagnostics,
+    controlStack,
+    ...(options ? { options } : {}),
+  };
+  switch (firstAsmControlKeyword(trimmed)) {
+    case 'repeat':
+      return parseRepeatStatement(trimmed, ctx);
+    case 'else':
+      return parseElseStatement(trimmed, ctx);
+    case 'end':
+      return parseEndStatement(trimmed, ctx);
+    case 'if':
+      return parseIfStatement(trimmed, ctx);
+    case 'while':
+      return parseWhileStatement(trimmed, ctx);
+    case 'until':
+      return parseUntilStatement(trimmed, ctx);
+    case 'select':
+      return parseSelectStatement(trimmed, ctx);
+    case 'case':
+      return parseCaseStatement(trimmed, ctx);
   }
 
   return parseAsmInstruction(filePath, trimmed, stmtSpan, diagnostics);


### PR DESCRIPTION
Implements GitHub issue #751 (PARSER-02).

This refactor splits asm structured-control parsing into dedicated helpers and leaves `parseAsmStatement()` as a thin dispatcher/router. No language behavior is intended to change.

Verification run:
- npm run typecheck
- npx vitest run test/pr476_parse_asm_statements_helpers.test.ts
- npx vitest run test/pr253_parser_control_cc_canonicalization.test.ts test/pr97_parser_span_structured_control.test.ts test/pr170_block_termination_recovery_matrix.test.ts
- npx vitest run test/pr738_select_case_ranges.test.ts