### PR TITLE
DOC: normalize current language version framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ All module-scope names share a single global namespace. Name collisions across m
 
 ## Project Status
 
-ZAX is under active development. The compiler exists as a Node.js CLI tool and handles a meaningful subset of the active v0.2 draft specification. The end-to-end pipeline (lex → parse → lower → encode → emit) is functional and produces `.bin`, `.hex`, `.d8dbg.json` (Debug80-compatible debug maps), and `.lst` output.
+ZAX is under active development. The compiler exists as a Node.js CLI tool and handles a meaningful subset of the current language specification. The end-to-end pipeline (lex → parse → lower → encode → emit) is functional and produces `.bin`, `.hex`, `.d8dbg.json` (Debug80-compatible debug maps), and `.lst` output.
 
 What works today: single and multi-module compilation, functions with locals and calling conventions, structured control flow, the op system, records/unions/arrays, named `section code`/`section data` blocks with direct declarations (`const`/`enum`/typed storage/`bin`/`hex`/`extern`), forward references and fixups, and a growing slice of the Z80 instruction set.
 

--- a/docs/spec/zax-spec.md
+++ b/docs/spec/zax-spec.md
@@ -15,6 +15,10 @@ ZAX aims to make assembly code easier to read and refactor by providing:
 Normative status for the current language surface: this document is the sole
 normative language source.
 
+Historical `v0.1` / `v0.2` labels are retained where they mark migrations,
+feature-era rules, or compatibility notes. They do not imply a separate
+competing versioned spec for the current language surface.
+
 Grammar companion: `docs/spec/zax-grammar.ebnf.md` provides a single-file syntax reference. If any grammar text diverges from this specification, this specification wins.
 
 Anything not defined here is undefined behavior or a compile error.
@@ -1705,7 +1709,8 @@ The document addresses both by stating normative rules precisely while also expl
 - Implementation notes marked "(impl)" are recommendations for compiler authors; any compliant implementation that produces the same observable behavior is acceptable.
 - Algorithm descriptions use pseudocode for clarity; actual implementation may differ in structure as long as behavior matches.
 
-**Version:** This specification corresponds to ZAX v0.2 on `main`.
+**Version position:** This specification describes the current ZAX language
+surface on `main`.
 Normative precedence: `docs/spec/zax-spec.md` governs language behavior; this document expands op-specific details and must not introduce conflicting normative rules.
 Authority constraint: if behavior is required by this document but not required by `docs/spec/zax-spec.md`, treat it as implementation guidance until promoted into `docs/spec/zax-spec.md`.
 


### PR DESCRIPTION
## Summary

This is a docs-only PR that normalizes the version framing in the reviewer-facing core docs.

It does not try to assign a new release number. Instead, it removes the last contradictory top-level claims and makes the docs describe the language as the current surface on `main`.

## Changes

- `README.md`
  - changes "active v0.2 draft specification" to "current language specification"
- `docs/spec/zax-spec.md`
  - adds a short note near the top clarifying that retained `v0.1` / `v0.2` labels inside the spec are historical migration/feature-era markers, not competing top-level version claims
  - changes the remaining "Version: corresponds to ZAX v0.2 on main" line to "Version position: describes the current ZAX language surface on main"

## Why

Right now the repo still exposes mixed version signals:

- package/tool version: `0.0.0`
- quick guide: current language surface
- scattered spec/history text: retained `v0.1` / `v0.2` markers

This PR makes the top-level story honest and reviewable without forcing an inaccurate single numeric label onto the whole current language surface.

## Scope

- docs only
- no code, parser, lowering, or tests changed
- no semantic language changes

## Verification

- inspected diff for `README.md` and `docs/spec/zax-spec.md`
- confirmed branch remains docs-only
