### PR TITLE
DOC: refresh active design docs and add LANG-02 anchor

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Active design work and review-target design records.
 Current active design docs:
 - `docs/design/grammar-parser-convergence-plan.md`
 - `docs/design/type-system-reform-plan.md`
+- `docs/design/typed-reinterpretation-cast.md`
 
 These documents are not normative language authority. They describe current direction, decisions, and unresolved design work.
 

--- a/docs/design/type-system-reform-plan.md
+++ b/docs/design/type-system-reform-plan.md
@@ -1,10 +1,27 @@
 # Type System Reform Plan
 
 **Date:** 2026-03-07
-**Status:** Proposal — awaiting review
-**Validated against:** `main` at `a6b731b` (post-encoder-registry merge)
+**Status:** Partial historical record; refresh on 2026-03-12
+**Validated against:** `main` at `4d626c2`
 
-This document covers four phases of work to fix the ZAX type system, layout engine, and addressing pipeline. They are ordered by severity: the first two phases fix live wrong-code bugs; the latter two generalise and clean up. All four are needed before the module/section system can rely on stable layout semantics.
+This document originally proposed four phases of work to fix the ZAX type
+system, layout engine, and addressing pipeline.
+
+On current `main`, the situation has changed:
+
+- Phase A is implemented.
+- Phase B is implemented.
+- Phase C is implemented.
+- Phase D remains the main unfinished item in this document.
+
+This file is therefore no longer a pure forward plan. It is now a mixed design
+record:
+
+- Phases A-C explain why those changes were needed and what landed.
+- Phase D remains active design/work.
+
+Do not create new implementation tickets from this document without first
+checking current `main`.
 
 ---
 
@@ -24,15 +41,28 @@ Specifically:
 
 The current implementation applies `nextPow2` universally through `src/semantics/layout.ts`. This is safe (it never generates wrong code for single objects) but wastes memory and produces misleading field offset arithmetic. Phase D separates `preRoundSize` (the real packed size) from `storageSize` (the pow2-rounded stride used only when computing array element offsets).
 
-### What is currently broken
+### Original broken areas
 
-**1. Byte pipeline missing `IndexImm` — live wrong code today.** When a byte-array function parameter is indexed with a named word variable (e.g. `arr[idx_word]`), `buildEaBytePipeline` in `src/lowering/addressingPipelines.ts` returns null because it has no `IndexImm` case. The fallback path computes `IX+ixDisp+index` (the address of the pointer slot plus the index) instead of `*(IX+ixDisp)+index` (the actual array element). Three language-tour golden files (38, 41, 42) encode this wrong output.
+The following problems motivated the original plan. On current `main`, items
+1-3 are fixed; item 4 remains the live design/work item.
 
-**2. EA resolution for non-scalar function parameters — silently wrong code.** When a function declares a non-scalar parameter (e.g. `func render(s: Sprite[8]): void`), the caller correctly pushes the address of the sprite array. The callee receives a 2-byte pointer at IX+4. But `eaResolution.ts` then treats IX+4 as if the array data lived there directly — it resolves `s[2].flags` as `(IX + 4 + 2*elemStride + fieldOffset)`, which is a random stack location, not the actual flags byte.
+**1. Byte pipeline missing `IndexImm` — fixed on current `main`.** When this
+document was written, byte-array indexing with named word variables could fall
+through to the wrong fallback path. That gap has since been fixed and covered
+by targeted regression tests.
 
-**3. Wide array element pipelines stop at elemSize 2.** The structured addressing pipeline (`addressingPipelines.ts`) only handles element sizes 1 and 2. Any other power-of-two size falls through to an unstructured fallback in `valueMaterialization.ts` that is both slower (extra stack round-trips) and wrong for pointer-slot bases.
+**2. EA resolution for non-scalar function parameters — fixed on current
+`main`.** The original wrong-code path has been replaced by explicit indirect EA
+resolution and consumer handling.
 
-**4. Record field packing wastes memory.** `layout.ts` applies `nextPow2` to every composite type's total size. When a record is used as a field inside another record, its `storageSize` (pow2) is used for the field-to-field offset. A 3-byte record contributes 4 bytes to any outer record.
+**3. Wide array element pipelines stop at elemSize 2 — fixed on current
+`main`.** Wide `EAW_*` routing now handles broader power-of-two element sizes.
+
+**4. Record field packing wastes memory — still active.** `layout.ts` still
+applies `nextPow2` to every composite type's total size. When a record is used
+as a field inside another record, its `storageSize` (pow2) is used for the
+field-to-field offset. A 3-byte record contributes 4 bytes to any outer
+record.
 
 ### `push IX; pop HL` — full inventory
 
@@ -46,7 +76,7 @@ A codebase sweep confirmed that the `push IX; pop HL` idiom appears in exactly f
 | 4 | `src/lowering/eaMaterialization.ts` | 27–28 | `materializeEaAddressToHL`, `resolved.kind === 'stack'` | ⚠️ stack imbalance: `push DE` at line 26 never restored; locked in by `test/pr509_ea_materialization_helpers.test.ts` lines 51–63 | Phase B eliminates non-scalar case; scalar case needs audit |
 | — | `src/lowering/functionLowering.ts` | 341 | Function prologue | ✅ correct (saves IX for frame setup) | N/A |
 
-### Known wrong golden files
+### Historical wrong golden files
 
 These language-tour examples encode wrong assembly. Tests currently pass against the wrong output.
 
@@ -60,7 +90,9 @@ For comparison: `39_byte_fvar_reg16.asm` (`arr[hl]` — explicit HL register) is
 
 ---
 
-## Phase A — Byte pipeline `IndexImm` gap (immediate correctness fix)
+## Phase A — Byte pipeline `IndexImm` gap
+
+**Current status:** implemented on `main`
 
 ### Root cause
 
@@ -122,6 +154,8 @@ Low. This is a narrow, targeted fix. The byte EA_* pipeline families already exi
 ---
 
 ## Phase B — Indirect EA resolution (correct reference semantics for non-scalar parameters)
+
+**Current status:** implemented on `main`
 
 ### Current behaviour and bug
 
@@ -307,6 +341,8 @@ Moderate. The `indirect` kind must be handled in every consumer. TypeScript's ex
 
 ## Phase C — Wide EAW pipeline (any pow2 element size up to $8000)
 
+**Current status:** implemented on `main`
+
 ### Current behaviour
 
 The structured addressing pipeline only handles element sizes 1 (byte, `EA_*` family) and 2 (word, `EAW_*` family). The guards are:
@@ -470,6 +506,8 @@ Low–moderate. The ten `EAW_*` export names are preserved. `buildEaWordPipeline
 
 ## Phase D — Layout: separate packed size from array element stride
 
+**Current status:** still active design/work
+
 ### Current behaviour
 
 `src/semantics/layout.ts` applies `nextPow2` to every composite type's total size via `storageSize`. When a record is used as a field inside another record, its `storageSize` (pow2) is used for both the field's size contribution and the field-to-field offset.
@@ -527,14 +565,14 @@ Low–moderate. Only affects composite types used as record fields. Scalar types
 
 Phases are ordered by severity — correctness bugs first, then generalisation and cleanup.
 
-| Phase | What | Key files | Prerequisite |
+| Phase | What | Current state | Key files |
 |---|---|---|---|
-| A | Byte pipeline `IndexImm` gap | `src/lowering/addressingPipelines.ts` | None |
-| B | Indirect EA resolution | `src/lowering/eaResolution.ts`, `src/lowering/ldEncoding.ts`, `src/lowering/valueMaterialization.ts`, `src/lowering/eaMaterialization.ts` | None (independent of A) |
-| C | Wide EAW pipeline (2–$8000) | `src/addressing/steps.ts`, `src/lowering/addressingPipelines.ts`, `src/lowering/valueMaterialization.ts` | None (independent of A and B, but cleaner after B) |
-| D | Packed layout for record fields | `src/semantics/layout.ts`, `src/lowering/eaResolution.ts` | Phase B should land first (EaField uses field offsets) |
+| A | Byte pipeline `IndexImm` gap | Done on `main` | `src/lowering/addressingPipelines.ts` |
+| B | Indirect EA resolution | Done on `main` | `src/lowering/eaResolution.ts`, lowering consumers |
+| C | Wide EAW pipeline (2–$8000) | Done on `main` | `src/addressing/steps.ts`, `src/lowering/addressingPipelines.ts` |
+| D | Packed layout for record fields | Still pending | `src/semantics/layout.ts`, `src/lowering/eaResolution.ts` |
 
-Phases A and B can be done in parallel. Phase C is independent but benefits from B landing first (Instances 1 and 2 become unreachable after B). Phase D should wait for B (the `EaField` offset calculation changes overlap).
+Only Phase D should be treated as live unfinished work from this document.
 
 ---
 

--- a/docs/design/typed-reinterpretation-cast.md
+++ b/docs/design/typed-reinterpretation-cast.md
@@ -1,0 +1,309 @@
+# Typed Reinterpretation Cast (`LANG-02`)
+
+**Date:** 2026-03-12
+**Status:** Active design proposal
+**Source:** GitHub issue `#736 (LANG-02)`
+
+This document defines the intended source-language shape for typed
+reinterpretation using angle-bracket cast syntax:
+
+```zax
+<Type>base.tail
+```
+
+It replaces the scattered historical cast notes in archived addressing
+documents and serves as the single active design anchor for `LANG-02`.
+
+---
+
+## Purpose
+
+ZAX already has strong typed storage-path syntax:
+
+- `rec.field`
+- `arr[index]`
+- nested paths such as `sprites[C].flags`
+
+What it lacks is a way to apply those typed path rules to an address value that
+already exists at runtime.
+
+That gap appears in common low-level cases:
+
+- a pointer-like value already lives in `HL`, `DE`, `BC`, `IX`, or `IY`
+- a scalar `word`/`addr` variable contains a runtime address
+- a function parameter is an address that should be viewed as a specific record
+  or array type at the access site
+
+The goal of `LANG-02` is to make that explicit and local without changing the
+rest of the language model.
+
+---
+
+## Core rule
+
+`<Type>base` means:
+
+> treat `base` as the address of a value of type `Type`
+
+The result is a typed storage base. Normal typed path rules then continue from
+that base:
+
+- `.field` selects a record or union field
+- `[index]` selects an array element
+- existing scalar-versus-aggregate access rules remain unchanged
+
+Examples:
+
+```zax
+ld a, <Sprite>hl.flags
+ld hl, <Sprite>ptr.position
+ld a, <TileMap>map_base[row][col]
+ld (<Header>ix.checksum), a
+```
+
+The cast is local. It does not permanently type the register or variable used
+as the base.
+
+---
+
+## Design goals
+
+- Add typed reinterpretation without changing the existing direct typed-`ld`
+  surface.
+- Keep source intent explicit at the access site.
+- Avoid introducing generic pointer types or persistent typed-register state.
+- Reuse the existing field/indexing model instead of creating a second access
+  language.
+- Keep the grammar simple enough to fit the grammar-driven parser strategy.
+
+---
+
+## Accepted v1 shape
+
+### Syntax
+
+The intended surface syntax is:
+
+```ebnf
+typed_reinterpret_expr = "<" , type_expr , ">" , reinterpret_base , reinterpret_tail ;
+reinterpret_tail       = ( "." , identifier | "[" , ea_index , "]" ) ,
+                         { "." , identifier | "[" , ea_index , "]" } ;
+```
+
+This is intentionally a typed-path form, not a general expression cast.
+
+### Required tail
+
+In v1, the cast must be followed by at least one path segment:
+
+- valid: `<Sprite>hl.flags`
+- valid: `<Sprite[8]>ptr[2]`
+- invalid in v1: `<Sprite>hl`
+
+Rationale:
+
+- the language value comes from typed field/index access
+- requiring a tail keeps the feature visually tied to storage navigation
+- it avoids introducing a new “bare typed pointer value” category before the
+  language has a broader address-value design
+
+---
+
+## Valid base forms in v1
+
+`reinterpret_base` should accept values that are already plausible address
+holders in current ZAX.
+
+### Allowed base forms
+
+1. Address-capable 16-bit registers:
+   - `HL`
+   - `DE`
+   - `BC`
+   - `IX`
+   - `IY`
+
+2. Scalar names whose type is `word` or `addr`:
+   - globals
+   - locals
+   - function parameters
+   - constants are not included here because the cast is for runtime address
+     values, not compile-time storage naming
+
+3. Parenthesized address-value forms built from an allowed base plus `+ imm` or
+   `- imm`:
+
+```zax
+<Sprite>(hl + 4).flags
+<Header>(ptr - 2).checksum
+```
+
+### Explicitly not valid in v1
+
+- bare aggregates such as `<Sprite>sprites`
+- general `imm` expressions
+- `AF`
+- `SP`
+- arbitrary nested casts as bases
+
+Reasons:
+
+- bare aggregates already have native typed storage semantics and do not need
+  reinterpretation
+- `imm` expressions are not the current source model for runtime addresses
+- `AF` is not an address base
+- `SP` introduces stack-model questions that are better handled separately
+- nested casts complicate the grammar and are not needed for the first useful
+  slice
+
+---
+
+## Semantics
+
+### Storage-path semantics
+
+`<Type>base.tail` creates a typed storage path exactly as though there were an
+anonymous storage object of type `Type` rooted at address `base`.
+
+That means:
+
+- field offsets come from `Type`
+- array element stride comes from the selected array element type
+- further `.field` / `[index]` traversal behaves the same way as ordinary typed
+  storage access
+
+### Scalar and aggregate use
+
+Existing value semantics remain in force:
+
+- if the final selected thing is scalar, bare use in ordinary instruction and
+  call contexts has scalar value semantics
+- if the final selected thing is aggregate, the result remains a storage base
+  for further navigation or aggregate use
+
+Examples:
+
+```zax
+ld a, <Sprite>hl.flags      ; scalar byte load
+ld hl, <Sprite>hl.position  ; scalar word load
+ld a, <RowTable>de[row].x   ; scalar via array + field path
+ld hl, <Sprite>hl           ; invalid in v1, no tail
+```
+
+### No persistent typing
+
+After:
+
+```zax
+ld a, <Sprite>hl.flags
+```
+
+`HL` is still just `HL`. The cast does not mutate register identity or attach a
+lasting type to the register.
+
+---
+
+## Interaction with existing `ea` rules
+
+Typed reinterpretation is additive. It does not replace ordinary `ea` forms.
+
+Current ZAX already supports typed storage access when the compiler knows the
+type of the storage base:
+
+- `player.flags`
+- `sprites[C].x`
+
+`LANG-02` extends that same access model to explicit runtime address values.
+
+Conceptually:
+
+- ordinary typed storage path: typed base is known from the declaration
+- reinterpretation path: typed base is supplied explicitly at the access site
+
+This keeps one storage-path language instead of splitting the language into two
+unrelated addressing models.
+
+---
+
+## Lowering intent
+
+This document does not prescribe implementation details, but the intended
+lowering model is straightforward:
+
+1. Evaluate the base as a runtime address value.
+2. Reuse the same field/index offset logic already used for typed storage-path
+   lowering.
+3. Materialize the effective address when the target Z80 form needs one.
+4. Preserve existing scalar load/store semantics and diagnostics.
+
+Important consequence:
+
+- `LANG-02` is not a reason to reintroduce `addr` as a source-language feature
+- it should fit the current direct typed-`ld` world, not replace it
+
+---
+
+## Diagnostics
+
+V1 should diagnose the following clearly:
+
+- unknown cast type
+- invalid base form for reinterpretation
+- missing tail after `<Type>base`
+- field selection on a non-record/non-union cast type
+- indexing on a non-array cast type
+- invalid index form under the existing `ea` rules
+
+Representative invalid forms:
+
+```zax
+ld a, <Sprite>hl            ; error: reinterpret cast requires a field/index tail
+ld a, <Sprite>af.flags      ; error: AF is not a valid reinterpret base
+ld a, <word>hl.low          ; error: scalar cast type cannot be field-selected
+ld a, <Sprite>sprites.flags ; error: aggregate storage name is not a reinterpret base
+```
+
+---
+
+## Grammar impact
+
+The parser should treat the cast as a privileged storage-path head, not as a
+general-purpose expression cast.
+
+That means the grammar update should live near the `ea` / storage-path area in
+`docs/spec/zax-grammar.ebnf.md`, not in the arithmetic `imm_expr` section.
+
+The intended shape is:
+
+- a new typed reinterpretation head
+- followed by ordinary path segments
+- with no change to arithmetic expression casting rules, because there are none
+
+This keeps the feature aligned with the grammar-driven parser strategy: one
+small new head form feeding the existing path machinery.
+
+---
+
+## Out of scope for v1
+
+- bare `<Type>base` with no field/index tail
+- general expression-cast semantics
+- nested casts
+- `SP` as a cast base
+- implicit typed registers
+- pointer arithmetic beyond `base +/- imm`
+- generic pointer or reference types
+- any revival of `addr` as a source-language prerequisite
+
+---
+
+## Recommended next docs steps
+
+If this design direction is accepted:
+
+1. Update GitHub issue `#736 (LANG-02)` so it points to this document as the
+   canonical design anchor.
+2. Add the accepted grammar form to `docs/spec/zax-grammar.ebnf.md`.
+3. Add the accepted semantics to `docs/spec/zax-spec.md`.
+4. Add a short example to `docs/reference/ZAX-quick-guide.md`.
+5. Only then create parser / lowering implementation tickets.

--- a/docs/work/current-stream.md
+++ b/docs/work/current-stream.md
@@ -8,10 +8,9 @@ direction.
 ### Current implementation state
 
 - Direct typed `ld` forms remain the active language surface.
-- Grouped `select case` values are implemented; ranged `case` values remain deferred.
+- Grouped and ranged `select case` values are implemented.
 - Parser/grammar convergence work is active again.
-- The next additive language design topic is typed reinterpretation syntax
-  `<Type>base.tail`.
+- Typed reinterpretation syntax `<Type>base.tail` is now active design work.
 
 ### Immediate priority
 
@@ -19,7 +18,8 @@ direction.
    implemented language.
 2. Continue parser/grammar convergence work.
 3. Define typed reinterpretation syntax as an additive feature on top of the
-   current direct typed-`ld` model.
+   current direct typed-`ld` model using
+   `docs/design/typed-reinterpretation-cast.md` as the design anchor.
 
 ### Deferred until re-planned
 

--- a/docs/work/deferred-work.md
+++ b/docs/work/deferred-work.md
@@ -26,14 +26,14 @@ For each item record:
   - this is separate from current parser/spec cleanup work
 
 ### Typed cast surface `<Type>base.tail`
-- Status: deferred
-- Why deferred: the feature needs a dedicated grammar and semantics design pass
-  before implementation
+- Status: implementation deferred; design active
+- Why deferred: implementation should wait until the active design doc is
+  accepted and the grammar/spec deltas are written
 - Preconditions:
-  - a dedicated active design doc for typed reinterpretation
-  - valid base forms for v1 decided
-  - spec and quick guide stabilized around the current direct typed-`ld`
-    surface
+  - `docs/design/typed-reinterpretation-cast.md` accepted as the active design
+    basis
+  - grammar form added to `docs/spec/zax-grammar.ebnf.md`
+  - semantic rules added to `docs/spec/zax-spec.md`
 - Source:
   - GitHub issue `#736 (LANG-02)`
 - Notes:


### PR DESCRIPTION
## Summary
- add a single active design doc for GitHub issue #736 (LANG-02)
- move typed reinterpretation out of the purely deferred bucket and into active design
- refresh the type-system reform plan so already-landed work is marked as completed on main
- align current-stream and docs index with the active design set

## Scope
- docs only
- no compiler, parser, lowering, or test changes

## Key files
- docs/design/typed-reinterpretation-cast.md
- docs/design/type-system-reform-plan.md
- docs/work/current-stream.md
- docs/work/deferred-work.md
- docs/README.md

## Notes
- GitHub issues #763 (TYPE-02) and #764 (TYPE-03) were already closed separately as stale implementation tickets because current main already contains those changes.
- This PR is intended to finish the docs/design phase before any new implementation work is assigned.
