### PR TITLE
DOC: add LANG-02 grammar and spec delta

### DIFF
--- a/docs/reference/ZAX-quick-guide.md
+++ b/docs/reference/ZAX-quick-guide.md
@@ -355,6 +355,20 @@ end
 
 For non-scalar fields (arrays, nested records), the place expression remains an address and no automatic dereference is inserted.
 
+Typed reinterpretation extends that same place-expression model to runtime
+address values:
+
+```zax
+ld a, <Sprite>hl.flags
+ld hl, <Header>ptr.checksum
+```
+
+The cast does not permanently type `HL` or `ptr`. It only supplies a typed
+storage base for the following field/index path.
+
+Implementation note: this surface is now part of the accepted language docs,
+but compiler support may lag while implementation work catches up.
+
 ### 3.6 Combining Field Access and Indexing
 
 Indexed element access and field access compose:

--- a/docs/spec/zax-grammar.ebnf.md
+++ b/docs/spec/zax-grammar.ebnf.md
@@ -178,9 +178,18 @@ enum_ref        = identifier , "." , identifier ;
 field_path      = identifier , { "." , identifier | "[" , imm_expr , "]" } ;
 
 ea_expr         = ea_term , { ( "+" | "-" ) , imm_expr } ;
-ea_term         = ea_base , { ea_segment } ;
+ea_term         = ea_base , { ea_segment }
+                | typed_reinterpret_expr ;
 ea_base         = identifier | "(" , ea_expr , ")" ;
 ea_segment      = "." , identifier | "[" , ea_index , "]" ;
+typed_reinterpret_expr = "<" , type_expr , ">" , reinterpret_base , ea_segment , { ea_segment } ;
+reinterpret_base = reinterpret_reg
+                 | reinterpret_name
+                 | "(" , reinterpret_addr_expr , ")" ;
+reinterpret_addr_expr = reinterpret_atom , ( "+" | "-" ) , imm_expr ;
+reinterpret_atom = reinterpret_reg | reinterpret_name ;
+reinterpret_reg  = "HL" | "DE" | "BC" | "IX" | "IY" ;
+reinterpret_name = identifier ;
 ea_index        = imm_expr | reg8 | reg16 | "(" , reg16 , ")" ;
 
 value_init_expr = imm_expr | "0" ;
@@ -201,6 +210,9 @@ These are semantic constraints enforced beyond pure grammar:
 - Local non-scalar value-init declarations are invalid.
 - Local non-scalar declarations are alias-only (`name = rhs`).
 - `@place` explicit address-of syntax is not part of the normative v0.2 surface.
+- Typed reinterpretation requires at least one tail segment after the cast head.
+- `reinterpret_name` is limited semantically to scalar names of type `word` or `addr`.
+- Bare aggregate storage names are not valid reinterpret bases.
 
 ## 9. Maintenance Rule
 

--- a/docs/spec/zax-spec.md
+++ b/docs/spec/zax-spec.md
@@ -765,6 +765,7 @@ Integer semantics (v0.1):
 - function-scope symbols: argument names and local `var` names (as frame slots)
 - field access: `rec.field`
 - indexing: `arr[i]` and nested `arr[r][c]` (index forms as defined above)
+- typed reinterpretation: `<Type>base.tail`
 - address arithmetic: `ea + imm`, `ea - imm`
 
 Conceptually, an `ea` is a base storage location plus a sequence of path segments: `.field` selects a record field, and `[index]` selects an array element. Lowering turns that path into an effective address when a Z80 instruction sequence needs one.
@@ -773,6 +774,9 @@ Value semantics note (v0.2):
 
 - Bare scalar variables use value semantics in ordinary instruction and call contexts.
 - `rec.field` and `arr[idx]` are storage-path expressions. In scalar value/store contexts (for example `LD A, rec.field`, `LD rec.field, A`), the compiler inserts the required load/store lowering.
+- `<Type>base.tail` is also a storage-path expression. It supplies the base
+  type explicitly at the access site, then applies ordinary field/index
+  traversal.
 - In aggregate contexts (for example passing an array/record parameter), the compiler passes the storage reference transparently.
 - Older address-of style wording (including `@place`) is retired from the
   current source model.
@@ -785,6 +789,60 @@ Notes (v0.1):
 
 - `imm + ea` is not permitted; write `ea + imm`.
 - `ea` describes memory addresses. Z80 I/O port operands (e.g., `(C)` and `($imm8)` used by `in`/`out`) are not `ea` expressions.
+
+### 7.2.1 Typed Reinterpretation
+
+ZAX supports typed reinterpretation using angle-bracket cast syntax:
+
+```zax
+<Type>base.tail
+```
+
+Meaning:
+
+- `base` is treated as the address of a value of type `Type`
+- the result is a typed storage base
+- normal storage-path traversal then applies:
+  - `.field`
+  - `[index]`
+
+Examples:
+
+```zax
+ld a, <Sprite>hl.flags
+ld hl, <Header>ptr.checksum
+ld a, <TileMap>(map_base + 32)[row][col]
+```
+
+Rules:
+
+- v1 requires at least one tail segment after the cast head:
+  - valid: `<Sprite>hl.flags`
+  - valid: `<Sprite[8]>ptr[2]`
+  - invalid: `<Sprite>hl`
+- valid base forms in v1 are:
+  - `HL`, `DE`, `BC`, `IX`, `IY`
+  - scalar names of type `word` or `addr`
+  - parenthesized base-plus-constant or base-minus-constant forms built from
+    those bases
+- invalid base forms in v1 include:
+  - `AF`
+  - `SP`
+  - bare aggregate storage names
+  - general immediate expressions
+  - nested casts
+
+Semantics:
+
+- The cast is local to the expression. It does not permanently type a register
+  or scalar name.
+- If the final selected target is scalar, ordinary scalar value/store semantics
+  apply in instruction and call contexts.
+- If the final selected target is aggregate, the result remains a storage base
+  for further traversal or aggregate use.
+
+This feature extends the existing typed storage-path model. It does not replace
+direct typed `ld`, and it is not coupled to any source-language `addr` feature.
 
 ---
 
@@ -1902,7 +1960,7 @@ end
 
 ### 3.3 Location and Dereference Matchers
 
-**`ea`** matches a storage-location expression as defined in Section 7.2 of the spec: storage names (`data`/`bin` names), function-local names (as frame slots), field access (`rec.field`), array indexing (`arr[i]`), and address arithmetic (`ea + imm`, `ea - imm`). When substituted, the parameter carries the location expression _without_ implicit parentheses, so the op body decides whether to use it as a location or an explicitly dereferenced operand.
+**`ea`** matches a storage-location expression as defined in Section 7.2 of the spec: storage names (`data`/`bin` names), function-local names (as frame slots), field access (`rec.field`), array indexing (`arr[i]`), typed reinterpretation (`<Type>base.tail`), and address arithmetic (`ea + imm`, `ea - imm`). When substituted, the parameter carries the location expression _without_ implicit parentheses, so the op body decides whether to use it as a location or an explicitly dereferenced operand.
 
 The main spec's runtime-atom expression budget applies to `ea` matching. In v0.2, matcher acceptance does not bypass that budget: if a call-site `ea` contains too many runtime atoms, the invocation is rejected before or during semantic validation.
 

--- a/docs/work/current-stream.md
+++ b/docs/work/current-stream.md
@@ -10,16 +10,18 @@ direction.
 - Direct typed `ld` forms remain the active language surface.
 - Grouped and ranged `select case` values are implemented.
 - Parser/grammar convergence work is active again.
-- Typed reinterpretation syntax `<Type>base.tail` is now active design work.
+- Typed reinterpretation syntax `<Type>base.tail` now has accepted design and
+  grammar/spec docs; implementation is the remaining step.
 
 ### Immediate priority
 
 1. Keep the spec, quick guide, and user-facing examples aligned with the
    implemented language.
 2. Continue parser/grammar convergence work.
-3. Define typed reinterpretation syntax as an additive feature on top of the
-   current direct typed-`ld` model using
-   `docs/design/typed-reinterpretation-cast.md` as the design anchor.
+3. Implement typed reinterpretation against the accepted docs set:
+   - `docs/design/typed-reinterpretation-cast.md`
+   - `docs/spec/zax-grammar.ebnf.md`
+   - `docs/spec/zax-spec.md`
 
 ### Deferred until re-planned
 

--- a/docs/work/deferred-work.md
+++ b/docs/work/deferred-work.md
@@ -26,14 +26,12 @@ For each item record:
   - this is separate from current parser/spec cleanup work
 
 ### Typed cast surface `<Type>base.tail`
-- Status: implementation deferred; design active
-- Why deferred: implementation should wait until the active design doc is
-  accepted and the grammar/spec deltas are written
+- Status: implementation deferred; docs accepted
+- Why deferred: implementation should wait for parser/lowering work to be
+  scheduled against the accepted docs set
 - Preconditions:
-  - `docs/design/typed-reinterpretation-cast.md` accepted as the active design
-    basis
-  - grammar form added to `docs/spec/zax-grammar.ebnf.md`
-  - semantic rules added to `docs/spec/zax-spec.md`
+  - parser and lowering implementation tickets created from the accepted docs
+    set
 - Source:
   - GitHub issue `#736 (LANG-02)`
 - Notes:


### PR DESCRIPTION
## Summary
- add the accepted LANG-02 cast form to the grammar companion
- add typed reinterpretation semantics to the spec
- update the quick guide with a minimal cast example and implementation-pending note
- move work docs from active-design wording to accepted-docs / implementation-pending wording

## Scope
- docs only
- no parser, lowering, or test changes

## Key files
- docs/spec/zax-grammar.ebnf.md
- docs/spec/zax-spec.md
- docs/reference/ZAX-quick-guide.md
- docs/work/current-stream.md
- docs/work/deferred-work.md

## Notes
- This PR follows GitHub PR #767 and completes the docs-first phase for GitHub issue #736 (LANG-02).
- The docs now intentionally lead implementation for this feature.
