### PR TITLE
PARSER-07: parse typed reinterpretation syntax

### DIFF
--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -445,6 +445,7 @@ export type ImmExprNode =
  */
 export type EaExprNode =
   | { kind: 'EaName'; span: SourceSpan; name: string }
+  | { kind: 'EaReinterpret'; span: SourceSpan; typeExpr: TypeExprNode; base: EaExprNode }
   | { kind: 'EaField'; span: SourceSpan; base: EaExprNode; field: string }
   | { kind: 'EaIndex'; span: SourceSpan; base: EaExprNode; index: EaIndexNode }
   | { kind: 'EaAdd'; span: SourceSpan; base: EaExprNode; offset: ImmExprNode }

--- a/src/frontend/parseOperands.ts
+++ b/src/frontend/parseOperands.ts
@@ -7,20 +7,29 @@ import type {
 } from './ast.js';
 import type { Diagnostic } from '../diagnostics/types.js';
 import { DiagnosticIds } from '../diagnostics/types.js';
-import { immLiteral, parseImmExprFromText, parseNumberLiteral } from './parseImm.js';
+import {
+  immLiteral,
+  parseImmExprFromText,
+  parseNumberLiteral,
+  parseTypeExprFromText,
+} from './parseImm.js';
 import { parseDiag as diag, parseDiagAtWithId } from './parseDiagnostics.js';
 import { ALL_REGISTER_NAMES, INDEX_REG16_NAMES, INDEX_REG8_NAMES } from './grammarData.js';
 
-function parseBalancedBracketContent(text: string): { inside: string; rest: string } | undefined {
-  if (!text.startsWith('[')) return undefined;
+function parseBalancedContent(
+  text: string,
+  open: '[' | '(',
+  close: ']' | ')',
+): { inside: string; rest: string } | undefined {
+  if (!text.startsWith(open)) return undefined;
   let depth = 0;
   for (let i = 0; i < text.length; i++) {
     const ch = text[i]!;
-    if (ch === '[') {
+    if (ch === open) {
       depth++;
       continue;
     }
-    if (ch !== ']') continue;
+    if (ch !== close) continue;
     depth--;
     if (depth === 0) {
       return {
@@ -33,9 +42,144 @@ function parseBalancedBracketContent(text: string): { inside: string; rest: stri
   return undefined;
 }
 
+function parseBalancedBracketContent(text: string): { inside: string; rest: string } | undefined {
+  return parseBalancedContent(text, '[', ']');
+}
+
+function parseBalancedParenContent(text: string): { inside: string; rest: string } | undefined {
+  return parseBalancedContent(text, '(', ')');
+}
+
 export function canonicalRegisterToken(token: string): string {
   if (/^af'$/i.test(token)) return "AF'";
   return token.toUpperCase();
+}
+
+type ParsedEaSegments = {
+  expr: EaExprNode;
+  rest: string;
+  sawSegment: boolean;
+};
+
+function parseEaSegments(
+  filePath: string,
+  expr: EaExprNode,
+  initialRest: string,
+  exprSpan: SourceSpan,
+  diagnostics: Diagnostic[],
+): ParsedEaSegments | undefined {
+  let rest = initialRest.trimStart();
+  let sawSegment = false;
+
+  while (rest.length > 0) {
+    if (rest.startsWith('.')) {
+      const m = /^\.([A-Za-z_][A-Za-z0-9_]*)/.exec(rest);
+      if (!m) return undefined;
+      expr = { kind: 'EaField', span: exprSpan, base: expr, field: m[1]! };
+      rest = rest.slice(m[0].length).trimStart();
+      sawSegment = true;
+      continue;
+    }
+    if (rest.startsWith('[')) {
+      const bracket = parseBalancedBracketContent(rest);
+      if (!bracket) return undefined;
+      const index = parseEaIndexFromText(filePath, bracket.inside, exprSpan, diagnostics);
+      if (!index) return undefined;
+      expr = { kind: 'EaIndex', span: exprSpan, base: expr, index };
+      rest = bracket.rest.trimStart();
+      sawSegment = true;
+      continue;
+    }
+    break;
+  }
+
+  return { expr, rest, sawSegment };
+}
+
+function parseTypedReinterpretBaseAtom(
+  text: string,
+  exprSpan: SourceSpan,
+): { base: EaExprNode; rest: string } | undefined {
+  const regMatch = /^(HL|DE|BC|IX|IY)(?=$|[^A-Za-z0-9_'])/i.exec(text);
+  if (regMatch) {
+    return {
+      base: { kind: 'EaName', span: exprSpan, name: canonicalRegisterToken(regMatch[1]!) },
+      rest: text.slice(regMatch[0].length).trimStart(),
+    };
+  }
+
+  const nameMatch = /^([A-Za-z_][A-Za-z0-9_]*)/.exec(text);
+  if (!nameMatch) return undefined;
+  if (ALL_REGISTER_NAMES.has(canonicalRegisterToken(nameMatch[1]!))) return undefined;
+  return {
+    base: { kind: 'EaName', span: exprSpan, name: nameMatch[1]! },
+    rest: text.slice(nameMatch[0].length).trimStart(),
+  };
+}
+
+function parseTypedReinterpretBase(
+  filePath: string,
+  text: string,
+  exprSpan: SourceSpan,
+  diagnostics: Diagnostic[],
+): { base: EaExprNode; rest: string } | undefined {
+  const trimmed = text.trimStart();
+  if (!trimmed.startsWith('(')) {
+    return parseTypedReinterpretBaseAtom(trimmed, exprSpan);
+  }
+
+  const grouped = parseBalancedParenContent(trimmed);
+  if (!grouped) return undefined;
+  const inner = grouped.inside.trim();
+  const atom = parseTypedReinterpretBaseAtom(inner, exprSpan);
+  if (!atom) return undefined;
+  const opMatch = /^([+-])\s*(.+)$/.exec(atom.rest);
+  if (!opMatch) return undefined;
+  const offset = parseImmExprFromText(filePath, opMatch[2]!, exprSpan, diagnostics, false);
+  if (!offset) return undefined;
+
+  return {
+    base:
+      opMatch[1] === '+'
+        ? { kind: 'EaAdd', span: exprSpan, base: atom.base, offset }
+        : { kind: 'EaSub', span: exprSpan, base: atom.base, offset },
+    rest: grouped.rest.trimStart(),
+  };
+}
+
+function parseTypedReinterpretHead(
+  filePath: string,
+  text: string,
+  exprSpan: SourceSpan,
+  diagnostics: Diagnostic[],
+): { expr: EaExprNode; rest: string } | undefined {
+  if (!text.startsWith('<')) return undefined;
+  const closeIndex = text.indexOf('>');
+  if (closeIndex <= 1) return undefined;
+
+  const typeText = text.slice(1, closeIndex).trim();
+  const typeExpr = parseTypeExprFromText(typeText, exprSpan, {
+    allowInferredArrayLength: false,
+  });
+  if (!typeExpr) return undefined;
+
+  const parsedBase = parseTypedReinterpretBase(
+    filePath,
+    text.slice(closeIndex + 1),
+    exprSpan,
+    diagnostics,
+  );
+  if (!parsedBase) return undefined;
+
+  const segments = parseEaSegments(
+    filePath,
+    { kind: 'EaReinterpret', span: exprSpan, typeExpr, base: parsedBase.base },
+    parsedBase.rest,
+    exprSpan,
+    diagnostics,
+  );
+  if (!segments || !segments.sawSegment) return undefined;
+  return { expr: segments.expr, rest: segments.rest };
 }
 
 export function parseEaIndexFromText(
@@ -108,29 +252,22 @@ export function parseEaExprFromText(
   diagnostics: Diagnostic[],
 ): EaExprNode | undefined {
   let rest = exprText.trim();
-  const baseMatch = /^([A-Za-z_][A-Za-z0-9_]*)/.exec(rest);
-  if (!baseMatch) return undefined;
-  let expr: EaExprNode = { kind: 'EaName', span: exprSpan, name: baseMatch[1]! };
-  rest = rest.slice(baseMatch[0].length).trimStart();
+  let expr: EaExprNode;
 
-  while (rest.length > 0) {
-    if (rest.startsWith('.')) {
-      const m = /^\.([A-Za-z_][A-Za-z0-9_]*)/.exec(rest);
-      if (!m) return undefined;
-      expr = { kind: 'EaField', span: exprSpan, base: expr, field: m[1]! };
-      rest = rest.slice(m[0].length).trimStart();
-      continue;
-    }
-    if (rest.startsWith('[')) {
-      const bracket = parseBalancedBracketContent(rest);
-      if (!bracket) return undefined;
-      const index = parseEaIndexFromText(filePath, bracket.inside, exprSpan, diagnostics);
-      if (!index) return undefined;
-      expr = { kind: 'EaIndex', span: exprSpan, base: expr, index };
-      rest = bracket.rest.trimStart();
-      continue;
-    }
-    break;
+  const reinterpret = parseTypedReinterpretHead(filePath, rest, exprSpan, diagnostics);
+  if (reinterpret) {
+    expr = reinterpret.expr;
+    rest = reinterpret.rest;
+  } else {
+    const baseMatch = /^([A-Za-z_][A-Za-z0-9_]*)/.exec(rest);
+    if (!baseMatch) return undefined;
+    expr = { kind: 'EaName', span: exprSpan, name: baseMatch[1]! };
+    rest = rest.slice(baseMatch[0].length).trimStart();
+
+    const segments = parseEaSegments(filePath, expr, rest, exprSpan, diagnostics);
+    if (!segments) return undefined;
+    expr = segments.expr;
+    rest = segments.rest;
   }
 
   if (rest.length > 0) {

--- a/src/lowering/asmUtils.ts
+++ b/src/lowering/asmUtils.ts
@@ -26,6 +26,8 @@ export function cloneEaExpr(ea: EaExprNode): EaExprNode {
   switch (ea.kind) {
     case 'EaName':
       return { ...ea };
+    case 'EaReinterpret':
+      return { ...ea, base: cloneEaExpr(ea.base) };
     case 'EaField':
       return { ...ea, base: cloneEaExpr(ea.base) };
     case 'EaIndex':
@@ -63,6 +65,7 @@ export function cloneOperand(op: AsmOperandNode): AsmOperandNode {
 
 export function flattenEaDottedName(ea: EaExprNode): string | undefined {
   if (ea.kind === 'EaName') return ea.name;
+  if (ea.kind === 'EaReinterpret') return undefined;
   if (ea.kind === 'EaField') {
     const base = flattenEaDottedName(ea.base);
     return base ? `${base}.${ea.field}` : undefined;

--- a/src/lowering/ldFormSelection.ts
+++ b/src/lowering/ldFormSelection.ts
@@ -108,6 +108,8 @@ export function createLdFormSelectionHelpers(ctx: LdFormSelectionContext) {
     switch (ea.kind) {
       case 'EaName':
         return isRegisterToken(ea.name) && !isBoundEaName(ea.name);
+      case 'EaReinterpret':
+        return hasRegisterLikeEaBase(ea.base);
       case 'EaField':
         return hasRegisterLikeEaBase(ea.base);
       case 'EaIndex':

--- a/src/lowering/runtimeAtomBudget.ts
+++ b/src/lowering/runtimeAtomBudget.ts
@@ -61,6 +61,8 @@ export function createRuntimeAtomBudgetHelpers(ctx: RuntimeAtomBudgetContext) {
         return ctx.resolveScalarBinding(ea.name) || runtimeAtomRegisterNames.has(ea.name.toUpperCase())
           ? 1
           : 0;
+      case 'EaReinterpret':
+        return countRuntimeAtomsInEaExpr(ea.base);
       case 'EaField':
         return countRuntimeAtomsInEaExpr(ea.base);
       case 'EaAdd':
@@ -107,6 +109,8 @@ export function createRuntimeAtomBudgetHelpers(ctx: RuntimeAtomBudgetContext) {
         if (isBoundStorageName) return 0;
         return runtimeAtomRegisterNames.has(ea.name.toUpperCase()) ? 1 : 0;
       }
+      case 'EaReinterpret':
+        return countRuntimeAtomsForDirectCallSiteEa(ea.base);
       case 'EaField':
         return countRuntimeAtomsForDirectCallSiteEa(ea.base);
       case 'EaAdd':

--- a/test/pr769_typed_reinterpretation_parser.test.ts
+++ b/test/pr769_typed_reinterpretation_parser.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { parseImmExprFromText } from '../src/frontend/parseImm.js';
+import { parseAsmOperand, parseEaExprFromText } from '../src/frontend/parseOperands.js';
+import { makeSourceFile, span } from '../src/frontend/source.js';
+
+describe('PR769 typed reinterpretation parser', () => {
+  const file = makeSourceFile('pr769_typed_reinterpretation_parser.zax', '');
+  const zeroSpan = span(file, 0, 0);
+
+  it('parses typed reinterpretation as an ea storage-path head', () => {
+    const diagnostics: Diagnostic[] = [];
+
+    expect(parseAsmOperand(file.path, '<Sprite>hl.flags', zeroSpan, diagnostics)).toMatchObject({
+      kind: 'Ea',
+      expr: {
+        kind: 'EaField',
+        field: 'flags',
+        base: {
+          kind: 'EaReinterpret',
+          typeExpr: { kind: 'TypeName', name: 'Sprite' },
+          base: { kind: 'EaName', name: 'HL' },
+        },
+      },
+    });
+
+    expect(parseAsmOperand(file.path, '<Header>ptr.checksum', zeroSpan, diagnostics)).toMatchObject(
+      {
+        kind: 'Ea',
+        expr: {
+          kind: 'EaField',
+          field: 'checksum',
+          base: {
+            kind: 'EaReinterpret',
+            typeExpr: { kind: 'TypeName', name: 'Header' },
+            base: { kind: 'EaName', name: 'ptr' },
+          },
+        },
+      },
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  it('parses parenthesized reinterpret bases with indexed tails', () => {
+    const diagnostics: Diagnostic[] = [];
+    const expr = parseEaExprFromText(
+      file.path,
+      '<TileMap>(map_base + 32)[row][col]',
+      zeroSpan,
+      diagnostics,
+    );
+
+    expect(diagnostics).toEqual([]);
+    expect(expr).toMatchObject({
+      kind: 'EaIndex',
+      index: { kind: 'IndexImm', value: { kind: 'ImmName', name: 'col' } },
+      base: {
+        kind: 'EaIndex',
+        index: { kind: 'IndexImm', value: { kind: 'ImmName', name: 'row' } },
+        base: {
+          kind: 'EaReinterpret',
+          typeExpr: { kind: 'TypeName', name: 'TileMap' },
+          base: {
+            kind: 'EaAdd',
+            base: { kind: 'EaName', name: 'map_base' },
+            offset: { kind: 'ImmLiteral', value: 32 },
+          },
+        },
+      },
+    });
+  });
+
+  it('keeps reinterpretation in ea precedence instead of imm cast parsing', () => {
+    const diagnostics: Diagnostic[] = [];
+
+    expect(
+      parseEaExprFromText(file.path, '<Sprite>hl.flags + 2', zeroSpan, diagnostics),
+    ).toMatchObject({
+      kind: 'EaAdd',
+      base: {
+        kind: 'EaField',
+        base: { kind: 'EaReinterpret' },
+      },
+      offset: { kind: 'ImmLiteral', value: 2 },
+    });
+    expect(
+      parseImmExprFromText(file.path, '<Sprite>hl.flags', zeroSpan, diagnostics, false),
+    ).toBeUndefined();
+    expect(diagnostics).toEqual([]);
+  });
+
+  it('rejects v1 reinterpret forms without a tail or with invalid bases', () => {
+    const diagnostics: Diagnostic[] = [];
+
+    expect(parseEaExprFromText(file.path, '<Sprite>hl', zeroSpan, diagnostics)).toBeUndefined();
+    expect(parseEaExprFromText(file.path, '<Sprite>af.flags', zeroSpan, diagnostics)).toBeUndefined();
+    expect(
+      parseEaExprFromText(file.path, '<Sprite>(<Header>hl.flags + 1).x', zeroSpan, diagnostics),
+    ).toBeUndefined();
+    expect(diagnostics).toEqual([]);
+  });
+});


### PR DESCRIPTION
Implements GitHub issue #769 (PARSER-07).

This adds parser and AST support for the accepted v1 typed reinterpretation syntax `<Type>base.tail` in the `ea` / storage-path grammar.

GitHub issue #770 (LOWER-01) remains out of scope and blocked.

Verification run:
- `npm run typecheck`
- `npx vitest run test/pr769_typed_reinterpretation_parser.test.ts`
- `npx vitest run test/pr476_parse_operands_helpers.test.ts test/pr252_parser_register_token_canonicalization.test.ts test/parser_nested_index.test.ts`