### PR TITLE
LOWER-01: implement typed reinterpretation lowering

### DIFF
--- a/src/lowering/eaResolution.ts
+++ b/src/lowering/eaResolution.ts
@@ -31,6 +31,68 @@ export function createEaResolutionHelpers(ctx: EaResolutionContext) {
   const resolveAliasTarget = (nameLower: string): EaExprNode | undefined =>
     ctx.getLocalAliasTargets().get(nameLower) ?? ctx.moduleAliasTargets.get(nameLower);
 
+  const reinterpretBaseMessage = (base: EaExprNode): string => {
+    if (base.kind === 'EaName') {
+      return `Invalid reinterpret base "${base.name}": expected HL/DE/BC/IX/IY, a scalar word/addr name, or a parenthesized base +/- imm form built from one of those.`;
+    }
+    return 'Invalid reinterpret base: expected HL/DE/BC/IX/IY, a scalar word/addr name, or a parenthesized base +/- imm form built from one of those.';
+  };
+
+  const hasKnownType = (typeExpr: TypeExprNode): boolean =>
+    ctx.resolveScalarKind(typeExpr) !== undefined ||
+    ctx.resolveAggregateType(typeExpr) !== undefined ||
+    ctx.sizeOfTypeExpr(typeExpr) !== undefined;
+
+  const resolveReinterpretStackBase = (
+    expr: EaExprNode,
+  ): { kind: 'indirect'; ixDisp: number; addend: number } | { kind: 'runtime' } | { kind: 'invalid'; message: string } => {
+    switch (expr.kind) {
+      case 'EaName': {
+        const upper = expr.name.toUpperCase();
+        if (upper === 'HL' || upper === 'DE' || upper === 'BC' || upper === 'IX' || upper === 'IY') {
+          return { kind: 'runtime' };
+        }
+
+        const lower = expr.name.toLowerCase();
+        const slotOff = ctx.stackSlotOffsets.get(lower);
+        if (slotOff !== undefined) {
+          const slotType = ctx.stackSlotTypes.get(lower);
+          const scalar = slotType ? ctx.resolveScalarKind(slotType) : undefined;
+          if (scalar === 'word' || scalar === 'addr') {
+            return { kind: 'indirect', ixDisp: slotOff, addend: 0 };
+          }
+          return { kind: 'invalid', message: reinterpretBaseMessage(expr) };
+        }
+
+        const storageType = ctx.storageTypes.get(lower);
+        if (storageType) {
+          const scalar = ctx.resolveScalarKind(storageType);
+          if (scalar === 'word' || scalar === 'addr') return { kind: 'runtime' };
+          return { kind: 'invalid', message: reinterpretBaseMessage(expr) };
+        }
+
+        if (resolveAliasTarget(lower)) return { kind: 'runtime' };
+        return { kind: 'invalid', message: reinterpretBaseMessage(expr) };
+      }
+      case 'EaAdd':
+      case 'EaSub': {
+        const base = resolveReinterpretStackBase(expr.base);
+        if (base.kind !== 'indirect') return base;
+        const delta = ctx.evalImmNoDiag(expr.offset);
+        if (delta === undefined) {
+          return { kind: 'invalid', message: reinterpretBaseMessage(expr.base) };
+        }
+        return {
+          kind: 'indirect',
+          ixDisp: base.ixDisp,
+          addend: base.addend + (expr.kind === 'EaAdd' ? delta : -delta),
+        };
+      }
+      default:
+        return { kind: 'invalid', message: reinterpretBaseMessage(expr) };
+    }
+  };
+
   const resolveEa = (ea: EaExprNode, span: SourceSpan): EaResolution | undefined => {
     const go = (expr: EaExprNode, visitingAliases: Set<string>): EaResolution | undefined => {
       switch (expr.kind) {
@@ -66,6 +128,18 @@ export function createEaResolutionHelpers(ctx: EaResolutionContext) {
           }
           const typeExpr = ctx.storageTypes.get(baseLower);
           return { kind: 'abs', baseLower, addend: 0, ...(typeExpr ? { typeExpr } : {}) };
+        }
+        case 'EaReinterpret': {
+          if (!hasKnownType(expr.typeExpr)) return undefined;
+          const base = resolveReinterpretStackBase(expr.base);
+          if (base.kind === 'invalid') return undefined;
+          if (base.kind === 'runtime') return undefined;
+          return {
+            kind: 'indirect',
+            ixDisp: base.ixDisp,
+            addend: base.addend,
+            typeExpr: expr.typeExpr,
+          };
         }
         case 'EaAdd':
         case 'EaSub': {

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -75,7 +75,7 @@ import type {
 } from '../frontend/ast.js';
 import type { CompileEnv } from '../semantics/env.js';
 import { evalImmExpr } from '../semantics/env.js';
-import { sizeOfTypeExpr } from '../semantics/layout.js';
+import { preRoundSizeOfTypeExpr, sizeOfTypeExpr } from '../semantics/layout.js';
 import { encodeInstruction } from '../z80/encode.js';
 import type { NonBankedSectionKeyCollection } from '../sectionKeys.js';
 import type { Callable, PendingSymbol, SectionKind, SourceSegmentTag } from './loweringTypes.js';
@@ -595,9 +595,11 @@ export function emitProgram(
     reg8,
     resolveEa,
     resolveEaTypeExpr,
+    resolveAggregateType,
     resolveScalarBinding,
     resolveScalarKind,
     sizeOfTypeExpr: (typeExpr) => sizeOfTypeExpr(typeExpr, env, diagnostics),
+    preRoundSizeOfTypeExpr: (typeExpr) => preRoundSizeOfTypeExpr(typeExpr, env, diagnostics),
     evalImmExpr: (expr) => evalImmExpr(expr, env, diagnostics),
     evalImmNoDiag,
     emitInstr,

--- a/src/lowering/ldFormSelection.ts
+++ b/src/lowering/ldFormSelection.ts
@@ -109,7 +109,7 @@ export function createLdFormSelectionHelpers(ctx: LdFormSelectionContext) {
       case 'EaName':
         return isRegisterToken(ea.name) && !isBoundEaName(ea.name);
       case 'EaReinterpret':
-        return hasRegisterLikeEaBase(ea.base);
+        return false;
       case 'EaField':
         return hasRegisterLikeEaBase(ea.base);
       case 'EaIndex':

--- a/src/lowering/typeResolution.ts
+++ b/src/lowering/typeResolution.ts
@@ -129,6 +129,8 @@ export function createTypeResolutionHelpers(ctx: TypeResolutionContext) {
     switch (ea.kind) {
       case 'EaName':
         return ea.name;
+      case 'EaReinterpret':
+        return resolveEaBaseName(ea.base);
       case 'EaField':
       case 'EaIndex':
       case 'EaAdd':
@@ -162,6 +164,10 @@ export function createTypeResolutionHelpers(ctx: TypeResolutionContext) {
       case 'EaAdd':
       case 'EaSub':
         return resolveEaTypeExprInternal(ea.base, visitingAliases);
+      case 'EaReinterpret': {
+        const resolved = unwrapTypeAlias(ea.typeExpr);
+        return resolved ?? ea.typeExpr;
+      }
       case 'EaField': {
         const baseType = resolveEaTypeExprInternal(ea.base, visitingAliases);
         if (!baseType) return undefined;

--- a/src/lowering/valueMaterialization.ts
+++ b/src/lowering/valueMaterialization.ts
@@ -11,9 +11,13 @@ type Context = {
   reg8: Set<string>;
   resolveEa: (ea: EaExprNode, span: SourceSpan) => EaResolution | undefined;
   resolveEaTypeExpr: (ea: EaExprNode) => TypeExprNode | undefined;
+  resolveAggregateType: (
+    typeExpr: TypeExprNode,
+  ) => { kind: 'record' | 'union'; fields: import('../frontend/ast.js').RecordFieldNode[] } | undefined;
   resolveScalarBinding: (name: string) => 'byte' | 'word' | 'addr' | undefined;
   resolveScalarKind: (typeExpr: TypeExprNode) => 'byte' | 'word' | 'addr' | undefined;
   sizeOfTypeExpr: (typeExpr: TypeExprNode) => number | undefined;
+  preRoundSizeOfTypeExpr: (typeExpr: TypeExprNode) => number | undefined;
   evalImmExpr: (expr: ImmExprNode) => number | undefined;
   evalImmNoDiag: (expr: ImmExprNode) => number | undefined;
   emitInstr: (head: string, operands: AsmOperandNode[], span: SourceSpan) => boolean;
@@ -41,6 +45,13 @@ type Context = {
 };
 
 export function createValueMaterializationHelpers(ctx: Context) {
+  const reinterpretBaseMessage = (base: EaExprNode): string => {
+    if (base.kind === 'EaName') {
+      return `Invalid reinterpret base "${base.name}": expected HL/DE/BC/IX/IY, a scalar word/addr name, or a parenthesized base +/- imm form built from one of those.`;
+    }
+    return 'Invalid reinterpret base: expected HL/DE/BC/IX/IY, a scalar word/addr name, or a parenthesized base +/- imm form built from one of those.';
+  };
+
   const ixDispMemExpr = (disp: number, span: SourceSpan): EaExprNode =>
     disp === 0
       ? { kind: 'EaName', span, name: 'IX' }
@@ -82,6 +93,91 @@ export function createValueMaterializationHelpers(ctx: Context) {
     ctx.emitStepPipeline(ctx.STORE_RP_EA(source), span);
 
   let pushEaAddress: (ea: EaExprNode, span: SourceSpan) => boolean;
+
+  const materializeRuntimeAddressBaseToHL = (base: EaExprNode, span: SourceSpan): boolean => {
+    switch (base.kind) {
+      case 'EaName': {
+        const upper = base.name.toUpperCase();
+        if (upper === 'HL') return true;
+        if (upper === 'DE' || upper === 'BC') {
+          const hi = upper === 'DE' ? 'D' : 'B';
+          const lo = upper === 'DE' ? 'E' : 'C';
+          return (
+            ctx.emitInstr('ld', [{ kind: 'Reg', span, name: 'H' }, { kind: 'Reg', span, name: hi }], span) &&
+            ctx.emitInstr('ld', [{ kind: 'Reg', span, name: 'L' }, { kind: 'Reg', span, name: lo }], span)
+          );
+        }
+        if (upper === 'IX' || upper === 'IY') {
+          return (
+            ctx.emitInstr('push', [{ kind: 'Reg', span, name: upper }], span) &&
+            ctx.emitInstr('pop', [{ kind: 'Reg', span, name: 'HL' }], span)
+          );
+        }
+
+        const scalar = ctx.resolveScalarBinding(base.name);
+        if (scalar === 'word' || scalar === 'addr') {
+          const resolved = ctx.resolveEa(base, span);
+          if (ctx.emitScalarWordLoad('HL', resolved, span)) return true;
+          if (resolved?.kind === 'abs') {
+            ctx.emitAbs16Fixup(0x2a, resolved.baseLower, resolved.addend, span);
+            return true;
+          }
+        }
+
+        ctx.diagAt(ctx.diagnostics, span, reinterpretBaseMessage(base));
+        return false;
+      }
+      case 'EaAdd':
+      case 'EaSub': {
+        if (!materializeRuntimeAddressBaseToHL(base.base, span)) return false;
+        const delta = ctx.evalImmExpr(base.offset);
+        if (delta === undefined) return false;
+        const addend = (base.kind === 'EaAdd' ? delta : -delta) & 0xffff;
+        if (addend === 0) return true;
+        if (!ctx.loadImm16ToDE(addend, span)) return false;
+        return ctx.emitInstr('add', [{ kind: 'Reg', span, name: 'HL' }, { kind: 'Reg', span, name: 'DE' }], span);
+      }
+      default:
+        ctx.diagAt(ctx.diagnostics, span, reinterpretBaseMessage(base));
+        return false;
+    }
+  };
+
+  const fieldOffsetInBaseType = (
+    baseType: TypeExprNode,
+    fieldName: string,
+    span: SourceSpan,
+  ): number | undefined => {
+    const agg = ctx.resolveAggregateType(baseType);
+    if (!agg) {
+      const known = ctx.sizeOfTypeExpr(baseType) !== undefined || ctx.resolveScalarKind(baseType) !== undefined;
+      ctx.diagAt(
+        ctx.diagnostics,
+        span,
+        known
+          ? `Field access ".${fieldName}" requires a record or union type.`
+          : `Unknown reinterpret cast type "${baseType.kind === 'TypeName' ? baseType.name : 'type'}".`,
+      );
+      return undefined;
+    }
+
+    let offset = 0;
+    for (const field of agg.fields) {
+      if (field.name === fieldName) return offset;
+      if (agg.kind === 'record') {
+        const fieldSize = ctx.preRoundSizeOfTypeExpr(field.typeExpr);
+        if (fieldSize === undefined) return undefined;
+        offset += fieldSize;
+      }
+    }
+
+    ctx.diagAt(
+      ctx.diagnostics,
+      span,
+      `${agg.kind === 'union' ? 'Unknown union field' : 'Unknown record field'} "${fieldName}".`,
+    );
+    return undefined;
+  };
 
   const materializeResolvedAddressToHL = (resolved: EaResolution, span: SourceSpan): boolean => {
     if (resolved.kind === 'abs') {
@@ -424,6 +520,30 @@ export function createValueMaterializationHelpers(ctx: Context) {
         return true;
       };
 
+      if (ea.kind === 'EaReinterpret') {
+        if (!materializeRuntimeAddressBaseToHL(ea.base, span)) return false;
+        return ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'HL' }], span);
+      }
+
+      if (ea.kind === 'EaField') {
+        const baseType = ctx.resolveEaTypeExpr(ea.base);
+        if (!baseType) {
+          ctx.diagAt(ctx.diagnostics, span, `Cannot resolve field "${ea.field}" without a typed base.`);
+          return false;
+        }
+        const fieldOffset = fieldOffsetInBaseType(baseType, ea.field, span);
+        if (fieldOffset === undefined) return false;
+        if (!pushEaAddress(ea.base, span)) return false;
+        if (!ctx.emitInstr('pop', [{ kind: 'Reg', span, name: 'HL' }], span)) return false;
+        if (fieldOffset !== 0) {
+          if (!ctx.loadImm16ToDE(fieldOffset & 0xffff, span)) return false;
+          if (!ctx.emitInstr('add', [{ kind: 'Reg', span, name: 'HL' }, { kind: 'Reg', span, name: 'DE' }], span)) {
+            return false;
+          }
+        }
+        return ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'HL' }], span);
+      }
+
       if (ea.kind !== 'EaIndex' && ea.kind !== 'EaAdd' && ea.kind !== 'EaSub') return false;
       if (ea.kind === 'EaAdd' || ea.kind === 'EaSub') {
         if (!pushEaAddress(ea.base, span)) return false;
@@ -438,8 +558,22 @@ export function createValueMaterializationHelpers(ctx: Context) {
       }
 
       const baseType = ctx.resolveEaTypeExpr(ea.base);
-      if (!baseType || baseType.kind !== 'ArrayType') {
-        ctx.diagAt(ctx.diagnostics, span, `Unsupported ea argument: cannot lower indexed address.`);
+      if (!baseType) {
+        ctx.diagAt(ctx.diagnostics, span, `Cannot resolve indexing without a typed base.`);
+        return false;
+      }
+      if (baseType.kind !== 'ArrayType') {
+        const known =
+          ctx.sizeOfTypeExpr(baseType) !== undefined ||
+          ctx.resolveScalarKind(baseType) !== undefined ||
+          ctx.resolveAggregateType(baseType) !== undefined;
+        ctx.diagAt(
+          ctx.diagnostics,
+          span,
+          known
+            ? 'Indexing requires an array type.'
+            : `Unknown reinterpret cast type "${baseType.kind === 'TypeName' ? baseType.name : 'type'}".`,
+        );
         return false;
       }
       const elemSize = ctx.sizeOfTypeExpr(baseType.element);

--- a/test/fixtures/pr770_typed_reinterpretation_positive.zax
+++ b/test/fixtures/pr770_typed_reinterpretation_positive.zax
@@ -1,0 +1,34 @@
+type Pair
+  x: byte
+  y: byte
+end
+
+type Header
+  pad: byte
+  flags: byte
+  pair: Pair
+end
+
+func touch_pair(p: Pair)
+  ld a, p.y
+  inc a
+  ld p.y, a
+end
+
+op bump(slot: ea)
+  ld a, slot
+  inc a
+  ld slot, a
+end
+
+export func main(ptr: addr)
+  ld hl, ptr
+  ld a, <Header>hl.flags
+
+  ld de, ptr
+  ld a, 1
+  ld <Header>de.flags, a
+
+  bump <Header>hl.flags
+  touch_pair <Header>ptr.pair
+end

--- a/test/pr531_value_materialization_helpers.test.ts
+++ b/test/pr531_value_materialization_helpers.test.ts
@@ -27,9 +27,11 @@ function makeContext() {
       return undefined;
     },
     resolveEaTypeExpr: (_ea: EaExprNode) => undefined as TypeExprNode | undefined,
+    resolveAggregateType: (_typeExpr: TypeExprNode) => undefined,
     resolveScalarBinding: (_name: string) => undefined,
     resolveScalarKind: (_typeExpr: TypeExprNode) => undefined,
     sizeOfTypeExpr: (_typeExpr: TypeExprNode) => undefined,
+    preRoundSizeOfTypeExpr: (_typeExpr: TypeExprNode) => undefined,
     evalImmExpr: () => undefined,
     evalImmNoDiag: () => undefined,
     emitInstr: (head: string, operands: AsmOperandNode[]) => {

--- a/test/pr710_indirect_ea_consumers.test.ts
+++ b/test/pr710_indirect_ea_consumers.test.ts
@@ -42,12 +42,14 @@ describe('#710 indirect ea consumers', () => {
         return undefined;
       },
       resolveEaTypeExpr: () => undefined,
+      resolveAggregateType: () => undefined,
       resolveScalarBinding: () => undefined,
       resolveScalarKind: (typeExpr) =>
         typeExpr.kind === 'TypeName' && (typeExpr.name === 'byte' || typeExpr.name === 'word' || typeExpr.name === 'addr')
           ? typeExpr.name
           : undefined,
       sizeOfTypeExpr: () => undefined,
+      preRoundSizeOfTypeExpr: () => undefined,
       evalImmExpr: () => undefined,
       evalImmNoDiag: () => undefined,
       emitInstr: (head, operands) => {

--- a/test/pr711_wide_eaw.test.ts
+++ b/test/pr711_wide_eaw.test.ts
@@ -137,12 +137,14 @@ describe('#711 wide EAW scaling', () => {
         if (ea.kind === 'EaName' && ea.name === 'globHuge') return hugeArray;
         return undefined;
       },
+      resolveAggregateType: () => undefined,
       resolveScalarBinding: () => undefined,
       resolveScalarKind: () => undefined,
       sizeOfTypeExpr: (typeExpr) => {
         if (typeExpr.kind === 'TypeName' && typeExpr.name === 'wide32768') return 0x8000;
         return undefined;
       },
+      preRoundSizeOfTypeExpr: () => undefined,
       evalImmExpr: () => undefined,
       evalImmNoDiag: () => undefined,
       emitInstr: (head: string, operands: AsmOperandNode[]) => {

--- a/test/pr770_typed_reinterpretation_diagnostics.test.ts
+++ b/test/pr770_typed_reinterpretation_diagnostics.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AsmOperandNode, EaExprNode, RecordFieldNode, SourceSpan, TypeExprNode } from '../src/frontend/ast.js';
+import { createValueMaterializationHelpers } from '../src/lowering/valueMaterialization.js';
+
+const span: SourceSpan = {
+  file: 'pr770.zax',
+  start: { line: 1, column: 1, offset: 0 },
+  end: { line: 1, column: 1, offset: 0 },
+};
+
+const typeName = (name: string): TypeExprNode => ({ kind: 'TypeName', span, name });
+const eaName = (name: string): EaExprNode => ({ kind: 'EaName', span, name });
+
+function reinterpret(typeExpr: TypeExprNode, base: EaExprNode): EaExprNode {
+  return { kind: 'EaReinterpret', span, typeExpr, base };
+}
+
+function makeHelpers() {
+  const diagnostics: Array<{ message: string }> = [];
+  const headerType: { kind: 'record'; fields: RecordFieldNode[] } = {
+    kind: 'record' as const,
+    fields: [
+      { kind: 'RecordField', span, name: 'pad', typeExpr: typeName('byte') },
+      { kind: 'RecordField', span, name: 'flags', typeExpr: typeName('byte') },
+    ],
+  };
+
+  return {
+    diagnostics,
+    helpers: createValueMaterializationHelpers({
+      diagnostics: diagnostics as never[],
+      diagAt: (_diagnostics, _span, message) => {
+        diagnostics.push({ message });
+      },
+      reg8: new Set(['A', 'B', 'C', 'D', 'E', 'H', 'L']),
+      resolveEa: () => undefined,
+      resolveEaTypeExpr: (ea) => {
+        switch (ea.kind) {
+          case 'EaReinterpret':
+            return ea.typeExpr;
+          case 'EaField':
+            if (ea.base.kind === 'EaReinterpret' && ea.base.typeExpr.kind === 'TypeName' && ea.base.typeExpr.name === 'Header' && ea.field === 'flags') {
+              return typeName('byte');
+            }
+            return undefined;
+          case 'EaIndex':
+            return undefined;
+          default:
+            return undefined;
+        }
+      },
+      resolveAggregateType: (typeExpr) => {
+        if (typeExpr.kind === 'TypeName' && typeExpr.name === 'Header') return headerType;
+        return undefined;
+      },
+      resolveScalarBinding: (name) => {
+        if (name === 'byteSlot') return 'byte';
+        return undefined;
+      },
+      resolveScalarKind: (typeExpr) =>
+        typeExpr.kind === 'TypeName' && (typeExpr.name === 'byte' || typeExpr.name === 'word' || typeExpr.name === 'addr')
+          ? typeExpr.name
+          : undefined,
+      sizeOfTypeExpr: (typeExpr) => {
+        if (typeExpr.kind !== 'TypeName') return undefined;
+        if (typeExpr.name === 'byte') return 1;
+        if (typeExpr.name === 'word' || typeExpr.name === 'addr') return 2;
+        if (typeExpr.name === 'Header') return 2;
+        return undefined;
+      },
+      preRoundSizeOfTypeExpr: (typeExpr) => {
+        if (typeExpr.kind === 'TypeName' && typeExpr.name === 'byte') return 1;
+        return undefined;
+      },
+      evalImmExpr: (expr) => (expr.kind === 'ImmLiteral' ? expr.value : undefined),
+      evalImmNoDiag: (expr) => (expr.kind === 'ImmLiteral' ? expr.value : undefined),
+      emitInstr: (_head: string, _operands: AsmOperandNode[]) => true,
+      emitRawCodeBytes: () => {},
+      emitAbs16Fixup: () => {},
+      loadImm16ToDE: () => true,
+      loadImm16ToHL: () => true,
+      negateHL: () => true,
+      pushZeroExtendedReg8: () => true,
+      emitStepPipeline: () => true,
+      buildEaBytePipeline: () => null,
+      buildEaWordPipeline: () => null,
+      emitScalarWordLoad: () => false,
+      formatIxDisp: (disp: number) => `${disp >= 0 ? '+' : ''}${disp}`,
+      TEMPLATE_L_ABC: () => [],
+      TEMPLATE_LW_DE: () => [],
+      LOAD_RP_EA: () => [],
+      STORE_RP_EA: () => [],
+    }),
+  };
+}
+
+describe('LOWER-01 typed reinterpretation diagnostics', () => {
+  it('diagnoses invalid v1 reinterpretation combinations clearly', () => {
+    const { diagnostics, helpers } = makeHelpers();
+
+    expect(
+      helpers.pushEaAddress(
+        { kind: 'EaField', span, base: reinterpret(typeName('Header'), eaName('byteSlot')), field: 'flags' },
+        span,
+      ),
+    ).toBe(false);
+    expect(
+      helpers.pushEaAddress(
+        { kind: 'EaField', span, base: reinterpret(typeName('word'), eaName('HL')), field: 'flags' },
+        span,
+      ),
+    ).toBe(false);
+    expect(
+      helpers.pushEaAddress(
+        {
+          kind: 'EaIndex',
+          span,
+          base: reinterpret(typeName('Header'), eaName('HL')),
+          index: { kind: 'IndexImm', span, value: { kind: 'ImmLiteral', span, value: 0 } },
+        },
+        span,
+      ),
+    ).toBe(false);
+    expect(
+      helpers.pushEaAddress(
+        { kind: 'EaField', span, base: reinterpret(typeName('Missing'), eaName('HL')), field: 'flags' },
+        span,
+      ),
+    ).toBe(false);
+
+    expect(diagnostics.map((d) => d.message)).toContain(
+      'Invalid reinterpret base "byteSlot": expected HL/DE/BC/IX/IY, a scalar word/addr name, or a parenthesized base +/- imm form built from one of those.',
+    );
+    expect(diagnostics.map((d) => d.message)).toContain(
+      'Field access ".flags" requires a record or union type.',
+    );
+    expect(diagnostics.map((d) => d.message)).toContain('Indexing requires an array type.');
+    expect(diagnostics.map((d) => d.message)).toContain('Unknown reinterpret cast type "Missing".');
+  });
+});

--- a/test/pr770_typed_reinterpretation_integration.test.ts
+++ b/test/pr770_typed_reinterpretation_integration.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { AsmArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('LOWER-01 typed reinterpretation integration', () => {
+  it('lowers scalar load/store, aggregate continuation, and ea-op use through reinterpretation', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr770_typed_reinterpretation_positive.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+
+    const asm = res.artifacts.find((artifact): artifact is AsmArtifact => artifact.kind === 'asm');
+    expect(asm).toBeDefined();
+
+    const text = asm!.text.toUpperCase();
+    expect(text).toContain('LD A, (HL)');
+    expect(text).toContain('LD H, D');
+    expect(text).toContain('LD L, E');
+    expect(text).toContain('LD (HL), A');
+    expect(text).toContain('CALL TOUCH_PAIR');
+    expect(text).toContain('ADD HL, DE');
+  });
+});


### PR DESCRIPTION
Implements GitHub issue #770 (LOWER-01).

Umbrella: GitHub issue #736 (LANG-02)
Parser prerequisite: GitHub issue #769 (PARSER-07), merged via GitHub PR #771 and not in scope here.

Summary
- adds typed reinterpretation type resolution for `EaReinterpret`
- lowers reinterpret-based field/index storage paths in scalar and aggregate contexts
- aligns ld-form handling so reinterpretation paths use typed lowering instead of raw register-like rejection
- adds focused LOWER-01 integration and diagnostics coverage

Verification run
- `npm run typecheck`
- `npm test -- --run test/pr770_typed_reinterpretation_integration.test.ts test/pr770_typed_reinterpretation_diagnostics.test.ts test/pr507_ea_resolution_helpers.test.ts test/pr509_ea_materialization_helpers.test.ts test/pr531_value_materialization_helpers.test.ts test/pr693_ld_form_selection.test.ts test/pr710_indirect_ea_consumers.test.ts test/pr711_wide_eaw.test.ts`
- `npm test`

Notes
- no goldens/examples were regenerated
- no merge performed; awaiting review