### PR TITLE
docs: update LANG-02 status after landing

### DIFF
--- a/docs/design/typed-reinterpretation-cast.md
+++ b/docs/design/typed-reinterpretation-cast.md
@@ -1,10 +1,10 @@
 # Typed Reinterpretation Cast (`LANG-02`)
 
 **Date:** 2026-03-12
-**Status:** Active design proposal
+**Status:** Accepted design; implementation landed on `main`
 **Source:** GitHub issue `#736 (LANG-02)`
 
-This document defines the intended source-language shape for typed
+This document defines the accepted source-language shape for typed
 reinterpretation using angle-bracket cast syntax:
 
 ```zax
@@ -12,7 +12,7 @@ reinterpretation using angle-bracket cast syntax:
 ```
 
 It replaces the scattered historical cast notes in archived addressing
-documents and serves as the single active design anchor for `LANG-02`.
+documents and serves as the retained design record for `LANG-02`.
 
 ---
 

--- a/docs/work/current-stream.md
+++ b/docs/work/current-stream.md
@@ -10,18 +10,18 @@ direction.
 - Direct typed `ld` forms remain the active language surface.
 - Grouped and ranged `select case` values are implemented.
 - Parser/grammar convergence work is active again.
-- Typed reinterpretation syntax `<Type>base.tail` now has accepted design and
-  grammar/spec docs; implementation is the remaining step.
+- Typed reinterpretation syntax `<Type>base.tail` is now implemented on
+  `main`, with parser and lowering landed.
 
 ### Immediate priority
 
 1. Keep the spec, quick guide, and user-facing examples aligned with the
    implemented language.
 2. Continue parser/grammar convergence work.
-3. Implement typed reinterpretation against the accepted docs set:
-   - `docs/design/typed-reinterpretation-cast.md`
-   - `docs/spec/zax-grammar.ebnf.md`
-   - `docs/spec/zax-spec.md`
+3. Do a post-landing cleanup pass for `LANG-02`:
+   - confirm spec/reference wording matches shipped behavior
+   - close or refresh any still-open implementation tickets
+   - fold any remaining reviewer guidance back into the docs set
 
 ### Deferred until re-planned
 

--- a/docs/work/deferred-work.md
+++ b/docs/work/deferred-work.md
@@ -26,13 +26,14 @@ For each item record:
   - this is separate from current parser/spec cleanup work
 
 ### Typed cast surface `<Type>base.tail`
-- Status: implementation deferred; docs accepted
-- Why deferred: implementation should wait for parser/lowering work to be
-  scheduled against the accepted docs set
+- Status: landed; monitor follow-up cleanup only
+- Why deferred: the feature itself is no longer deferred, but any further
+  expansion beyond the accepted v1 shape should wait until post-landing review
+  is complete
 - Preconditions:
-  - parser and lowering implementation tickets created from the accepted docs
-    set
+  - post-landing docs/spec cleanup completed
+  - any remaining `LANG-02` implementation tickets closed or re-scoped
 - Source:
   - GitHub issue `#736 (LANG-02)`
 - Notes:
-  - intended as additive language work, not as part of an `addr` revival
+  - landed as additive language work, not as part of an `addr` revival


### PR DESCRIPTION
Docs-only follow-up after LANG-02 landed.\n\nUpdates the retained design note and work tracking docs so they reflect that typed reinterpretation is now implemented on main, and shifts the immediate priority to post-landing cleanup rather than implementation planning.