### PR TITLE
docs: fix local var examples in move rationale

### DIFF
--- a/docs/design/move-vs-ld-language-rationale.md
+++ b/docs/design/move-vs-ld-language-rationale.md
@@ -772,7 +772,9 @@ Current style:
 
 ```zax
 func bump()
-  var x: byte
+  var
+    x: byte = 2
+  end
   ld a, x
   inc a
   ld x, a
@@ -783,7 +785,9 @@ Proposed split:
 
 ```zax
 func bump()
-  var x: byte
+  var
+    x: byte = 2
+  end
   move a, x
   inc a
   move x, a


### PR DESCRIPTION
## Summary
- fix invalid local declaration syntax in the `move` vs `ld` rationale examples
- use the current `var ... end` block form in both the current-style and proposed-style examples

## Scope
- docs only
- no code changes