### PR TITLE
docs: streamline move vs ld rationale

### DIFF
--- a/docs/design/move-vs-ld-language-rationale.md
+++ b/docs/design/move-vs-ld-language-rationale.md
@@ -1,7 +1,7 @@
 # `move` vs `ld` Language Rationale
 
 **Date:** 2026-03-13
-**Status:** Draft discussion paper
+**Status:** Direction accepted; implementation planning pending
 **Source:** Post-`LANG-02` language-boundary review
 
 This paper asks whether ZAX should stop overloading `ld` with typed variable


### PR DESCRIPTION
## Summary
- tighten the `move` vs `ld` discussion paper for clarity and remove repetition
- state the current decision inputs explicitly: `move` chosen, hard-break migration, raw data directives later
- keep the same seven-section structure while making the argument more direct

## Scope
- docs only
- no code changes