### PR TITLE
MOVE-02: add move parser validation

### DIFF
--- a/src/frontend/parseOperands.ts
+++ b/src/frontend/parseOperands.ts
@@ -447,17 +447,7 @@ function parseMoveOperand(
   if (t.length === 0) return undefined;
 
   if (t.startsWith('@')) {
-    const placeText = t.slice(1).trim();
-    if (placeText.length === 0) {
-      diag(diagnostics, filePath, `Invalid "move" operand "${t}": expected @<place>.`, {
-        line: operandSpan.start.line,
-        column: operandSpan.start.column,
-      });
-      return undefined;
-    }
-    const ea = parseEaExprFromText(filePath, placeText, operandSpan, diagnostics);
-    if (ea) return { kind: 'Ea', span: operandSpan, expr: ea, explicitAddressOf: true };
-    diag(diagnostics, filePath, `Invalid "move" operand "${t}": expected @<place>.`, {
+    diag(diagnostics, filePath, `"move" does not accept address-of operands`, {
       line: operandSpan.start.line,
       column: operandSpan.start.column,
     });

--- a/test/pr779_move_parser.test.ts
+++ b/test/pr779_move_parser.test.ts
@@ -67,6 +67,12 @@ describe('PR779 move parser/AST support', () => {
     expect(parsed.diagnostics[0]?.message).toContain('move');
   });
 
+  it('rejects address-of operands', () => {
+    const parsed = parse('move a, @x');
+    expect(parsed.diagnostics.length).toBeGreaterThan(0);
+    expect(parsed.diagnostics[0]?.message).toContain('move');
+  });
+
   it('keeps existing typed ld parsing intact', () => {
     const parsed = parse('ld a, words[idx]');
     expect(parsed.diagnostics).toEqual([]);


### PR DESCRIPTION
Implements GitHub issue #779 (MOVE-02): parser/AST support for move with strict operand validation.\n\nScope: parser + tests only.\n\nVerification:\n- npm run typecheck\n- npx vitest run test/pr779_move_parser.test.ts