### PR TITLE
MOVE-03: lower move via typed ld

### DIFF
--- a/src/lowering/asmInstructionLowering.ts
+++ b/src/lowering/asmInstructionLowering.ts
@@ -356,6 +356,16 @@ export function createAsmInstructionLoweringHelpers(ctx: Context) {
       }
     }
 
+    if (head === 'move') {
+      const moveAsLd: AsmInstructionNode = { ...asmItem, head: 'ld' };
+      if (ctx.lowerLdWithEa(moveAsLd)) {
+        ctx.syncToFlow();
+        return;
+      }
+      ctx.diagAt(ctx.diagnostics, asmItem.span, `"move" form is not supported.`);
+      return;
+    }
+
     if (ctx.lowerLdWithEa(asmItem)) {
       ctx.syncToFlow();
       return;

--- a/test/pr780_move_lowering_integration.test.ts
+++ b/test/pr780_move_lowering_integration.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { createAsmInstructionLoweringHelpers } from '../src/lowering/asmInstructionLowering.js';
+import type { AsmInstructionNode, AsmOperandNode, SourceSpan } from '../src/frontend/ast.js';
+
+const span: SourceSpan = {
+  file: 'fixture.zax',
+  start: { line: 1, column: 1, offset: 0 },
+  end: { line: 1, column: 1, offset: 0 },
+};
+
+describe('PR780 move lowering integration', () => {
+  it('routes move through typed ld lowering', () => {
+    const received: AsmInstructionNode[] = [];
+    const helper = createAsmInstructionLoweringHelpers({
+      diagnostics: [],
+      diagAt: () => {},
+      emitInstr: () => true,
+      emitRawCodeBytes: () => {},
+      emitAbs16Fixup: () => {},
+      emitAbs16FixupPrefixed: () => {},
+      emitRel8Fixup: () => {},
+      conditionOpcodeFromName: () => undefined,
+      conditionNameFromOpcode: () => undefined,
+      callConditionOpcodeFromName: () => undefined,
+      jrConditionOpcodeFromName: () => undefined,
+      conditionOpcode: () => undefined,
+      symbolicTargetFromExpr: () => undefined,
+      evalImmExpr: () => undefined,
+      resolveScalarBinding: () => undefined,
+      diagIfRetStackImbalanced: () => {},
+      diagIfCallStackUnverifiable: () => {},
+      warnIfRawCallTargetsTypedCallable: () => {},
+      lowerLdWithEa: (inst) => {
+        received.push(inst);
+        return true;
+      },
+      emitVirtualReg16Transfer: () => false,
+      emitSyntheticEpilogue: false,
+      epilogueLabel: '__zax_epilogue_0',
+      emitJumpTo: () => {},
+      emitJumpCondTo: () => {},
+      syncToFlow: () => {},
+      flowRef: { current: { reachable: true } },
+    });
+
+    const moveItem: AsmInstructionNode = {
+      kind: 'AsmInstruction',
+      span,
+      head: 'move',
+      operands: [
+        { kind: 'Reg', span, name: 'A' },
+        { kind: 'Ea', span, expr: { kind: 'EaName', span, name: 'x' } },
+      ] satisfies AsmOperandNode[],
+    };
+
+    helper.lowerAsmInstructionDispatcher(moveItem);
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({
+      kind: 'AsmInstruction',
+      head: 'ld',
+      operands: [
+        { kind: 'Reg', name: 'A' },
+        { kind: 'Ea', expr: { kind: 'EaName', name: 'x' } },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
Implements GitHub issue #780 (MOVE-03): lower move by reusing typed ld lowering.\n\nScope: lowering + tests only.\n\nVerification:\n- npm run typecheck\n- npx vitest run test/pr780_move_lowering_integration.test.ts test/pr532_asm_instruction_lowering_integration.test.ts\n- npx vitest run test/smoke_language_tour_compile.test.ts