### PR TITLE
MOVE-06: drop transition-only move/ld tests

### DIFF
--- a/test/pr779_move_parser.test.ts
+++ b/test/pr779_move_parser.test.ts
@@ -73,16 +73,4 @@ describe('PR779 move parser/AST support', () => {
     expect(parsed.diagnostics[0]?.message).toContain('move');
   });
 
-  it('keeps existing typed ld parsing intact', () => {
-    const parsed = parse('ld a, words[idx]');
-    expect(parsed.diagnostics).toEqual([]);
-    expect(parsed.instr).toMatchObject({
-      kind: 'AsmInstruction',
-      head: 'ld',
-      operands: [
-        { kind: 'Reg', name: 'A' },
-        { kind: 'Ea', expr: { kind: 'EaIndex' } },
-      ],
-    });
-  });
 });

--- a/test/pr780_move_lowering_integration.test.ts
+++ b/test/pr780_move_lowering_integration.test.ts
@@ -10,7 +10,7 @@ const span: SourceSpan = {
 };
 
 describe('PR780 move lowering integration', () => {
-  it('routes move through typed ld lowering', () => {
+  it('routes move through shared lowering path', () => {
     const received: AsmInstructionNode[] = [];
     const helper = createAsmInstructionLoweringHelpers({
       diagnostics: [],


### PR DESCRIPTION
## Summary\n- remove transition-only typed-ld parser expectation\n- clarify move lowering test description\n\n## Testing\n- npm run typecheck\n- npx vitest run test/pr779_move_parser.test.ts test/pr780_move_lowering_integration.test.ts