### PR TITLE
docs: add raw data and label semantics design

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Current active design docs:
 - `docs/design/move-vs-ld-language-rationale.md`
 - `docs/design/type-system-reform-plan.md`
 - `docs/design/typed-reinterpretation-cast.md`
+- `docs/design/raw-data-and-label-semantics.md`
 
 These documents are not normative language authority. They describe current direction, decisions, and unresolved design work.
 

--- a/docs/design/raw-data-and-label-semantics.md
+++ b/docs/design/raw-data-and-label-semantics.md
@@ -1,0 +1,228 @@
+# RAW-01: raw data directives and label semantics
+
+Status: Draft discussion paper
+Scope: define the raw-data complement to the `move`/`ld` split
+Purpose: decide how ZAX represents classic assembler-style labels and raw memory layouts without collapsing typed storage back into overloaded `ld`
+
+## Contents
+- [1. Problem statement](#1-problem-statement)
+- [2. Chosen direction](#2-chosen-direction)
+- [3. Symbol classes](#3-symbol-classes)
+- [4. Raw data directive family](#4-raw-data-directive-family)
+- [5. Exact `ld`/`move` semantic split](#5-exact-ldmove-semantic-split)
+- [6. Namespace and symbol resolution](#6-namespace-and-symbol-resolution)
+- [7. Examples](#7-examples)
+- [8. Grammar impact](#8-grammar-impact)
+- [9. Staged implementation plan](#9-staged-implementation-plan)
+- [10. Non-goals](#10-non-goals)
+
+## 1. Problem statement
+
+The `move` split fixed one problem: typed globals, locals, arguments, fields, and indexes no longer overload a core Z80 mnemonic. `move` now owns typed storage transfer, while `ld` is free to return to classic assembler semantics.
+
+That split leaves a second gap unresolved. ZAX still has no explicit first-class way to author arbitrary raw memory layouts in the classic assembler style. Typed storage is good for variables and structured data. It is not a full replacement for packed tables, byte streams, patch areas, mixed records, or hand-authored memory maps.
+
+This stream fills that gap by adding a raw-data declaration family that creates address-semantics symbols. Once those symbols exist, classic `ld` can operate on them as labels rather than as variables.
+
+## 2. Chosen direction
+
+The chosen direction is:
+
+- keep typed storage declarations and `move` exactly as the typed value/storage layer
+- add a separate raw-data declaration family for assembler-style layouts
+- treat symbols produced by that family as address-semantics labels
+- keep classic `ld` semantics for those labels
+
+This is not a return to overloaded `ld`. It is the opposite. The language becomes cleaner because typed storage and raw labels come from different declaration families and therefore carry different semantics.
+
+## 3. Symbol classes
+
+This stream makes the symbol-class split explicit.
+
+ZAX has three relevant symbol classes:
+
+1. typed storage symbols
+   - produced by typed globals, locals, arguments, and other typed storage declarations
+   - bare use means stored value semantics
+   - transfer uses `move`, not `ld`
+
+2. code labels
+   - produced by control-flow labeling
+   - bare use means branch/call target semantics
+
+3. raw data labels
+   - produced by raw data directives such as `db`, `dw`, and `ds`
+   - bare use means address semantics in the classic assembler sense
+   - `ld` operates on them as labels, not as typed variables
+
+The critical rule is declaration-driven semantics. The parser and later semantic passes must not guess from use site alone. The declaration family determines symbol class.
+
+## 4. Raw data directive family
+
+The design direction is to adopt a conventional assembler family:
+
+- `db` for bytes
+- `dw` for words
+- `ds` for reserved space
+
+These directives are intentionally lower-level than typed storage declarations.
+
+They are suitable for:
+- packed tables
+- irregular byte streams
+- jump tables
+- patch regions
+- hardware-facing layouts
+- mixed-width data that does not justify or fit typed storage
+
+They are not typed variables. They do not produce value-semantics storage symbols.
+
+A raw data declaration should create a label at the current assembly location and then emit or reserve bytes from that point.
+
+Representative shape:
+
+```zax
+section data tables at $4000
+  sprite_table:
+    db $10, $20, $30, $40
+
+  jump_table:
+    dw handler_a, handler_b, handler_c
+
+  scratch:
+    ds 32
+end
+```
+
+The exact line grammar can be refined in `RAW-02`, but the declaration family itself should stay conventional.
+
+## 5. Exact `ld`/`move` semantic split
+
+After this stream, the intended split is:
+
+- `move` handles register ↔ typed-storage transfer
+- `ld` handles classic assembler semantics, including raw labels
+
+Examples:
+
+```zax
+var
+  x: byte = 2
+end
+move a, x
+move x, a
+```
+
+That remains typed-storage code and never uses raw-label semantics.
+
+By contrast:
+
+```zax
+table:
+  db 1, 2, 3, 4
+
+ld hl, table      ; load label/address according to classic semantics
+ld a, (table)     ; load first byte from raw memory at label
+ld (table), a     ; store first byte to raw memory at label
+```
+
+That is classic assembler behavior. The symbol `table` is not a variable. It is a raw label.
+
+This stream does not make `move` understand raw labels. That would collapse the boundary again.
+
+## 6. Namespace and symbol resolution
+
+The simplest coherent rule is one symbol namespace with declaration-class tracking.
+
+That means:
+- a typed global, a raw data label, and a code label cannot reuse the same name in the same scope
+- symbol resolution returns both the symbol and its class
+- operand semantics then branch on symbol class
+
+This avoids two bad outcomes:
+- separate namespaces that let the same spelling mean different things in one scope
+- use-site guessing where the compiler infers “this looks label-like” versus “this looks variable-like”
+
+The declaration decides the class. The class decides the semantics.
+
+## 7. Examples
+
+Typed storage remains on the `move` side:
+
+```zax
+section data vars at $4000
+  counter: byte = 1
+end
+
+move a, counter
+inc a
+move counter, a
+```
+
+Raw data uses label semantics:
+
+```zax
+section data tables at $4100
+  table:
+    db 1, 2, 3, 4
+end
+
+ld hl, table
+ld a, (table)
+```
+
+The mixed case is the point of the reform:
+
+```zax
+section data vars at $4200
+  value: word = $1234
+end
+
+section data tables at $4300
+  lut:
+    dw $1111, $2222, $3333
+end
+
+move hl, value    ; typed storage value semantics
+ld de, lut        ; raw label/address semantics
+```
+
+This is exactly the distinction the current language lacks.
+
+## 8. Grammar impact
+
+This stream should be treated as part of grammar reform, not as an isolated feature.
+
+The grammar needs an explicit raw-data declaration family rather than another overloaded use of existing typed storage productions. The key parser consequence is not complexity of the directives themselves; it is preserving the declaration-class distinction into the AST and later symbol table.
+
+In practice, `RAW-02` should add dedicated productions for labeled raw data blocks/lines rather than trying to parse them through typed variable declarations.
+
+## 9. Staged implementation plan
+
+Stage 1: accept this design direction in docs.
+
+Stage 2: `RAW-02`
+- add parser and AST support for the raw data directive family
+- preserve raw-label symbol class in the AST
+
+Stage 3: `RAW-03`
+- emit raw bytes/words/reserved space
+- produce raw address-semantics labels in semantic resolution
+- integrate classic `ld` behavior over those labels
+
+Stage 4: examples and reference updates
+- add a small set of raw-data examples
+- show typed storage and raw labels side by side
+- keep the distinction explicit in the quick guide and spec
+
+## 10. Non-goals
+
+This stream does not do any of the following:
+
+- restore typed-storage semantics to `ld`
+- redesign `move`
+- add address-of `@place`
+- add full pointer arithmetic
+- add assembler-time expression power beyond what the current language already supports
+
+Those are separate concerns. `RAW-01` is specifically about introducing a raw-label declaration family and making classic `ld` semantics meaningful for that family.

--- a/docs/work/current-stream.md
+++ b/docs/work/current-stream.md
@@ -17,11 +17,8 @@ direction.
 
 1. Keep the spec, quick guide, and user-facing examples aligned with the
    implemented language.
-2. Continue parser/grammar convergence work.
-3. Do a post-landing cleanup pass for `LANG-02`:
-   - confirm spec/reference wording matches shipped behavior
-   - close or refresh any still-open implementation tickets
-   - fold any remaining reviewer guidance back into the docs set
+2. Finish `RAW-01` design work before starting raw-data implementation.
+3. Continue parser/grammar convergence work.
 
 ### Deferred until re-planned
 

--- a/docs/work/deferred-work.md
+++ b/docs/work/deferred-work.md
@@ -37,3 +37,14 @@ For each item record:
   - GitHub issue `#736 (LANG-02)`
 - Notes:
   - landed as additive language work, not as part of an `addr` revival
+
+### `@place` address-of expression
+- Status: deferred
+- Why deferred: address-of semantics should follow the raw-label/raw-data design, not precede it
+- Preconditions:
+  - `RAW-01` accepted
+  - `RAW-02` and `RAW-03` far enough along to define address-valued forms cleanly
+- Source:
+  - GitHub issue `#788 (ADDR-EXPR-01)`
+- Notes:
+  - do not smuggle `@...` back into `move` before raw address semantics are settled


### PR DESCRIPTION
## Summary
- add the RAW-01 design paper for raw data directives and raw label semantics
- update docs indexes and current-stream priority to point at RAW-01
- record @place as deferred until raw address semantics are designed

## Scope
Docs-only design work ahead of RAW implementation.