### PR TITLE
RAW-03: lower raw data declarations

### DIFF
--- a/src/lowering/programLowering.ts
+++ b/src/lowering/programLowering.ts
@@ -13,6 +13,7 @@ import type {
   ModuleFileNode,
   ModuleItemNode,
   NamedSectionNode,
+  RawDataDeclNode,
   OpDeclNode,
   ProgramNode,
   SectionItemNode,
@@ -271,6 +272,10 @@ export function preScanProgramDeclarations(ctx: Context): PrescanResult {
       ctx.storageTypes.set(lower, decl.typeExpr);
       const scalar = ctx.resolveScalarKind(decl.typeExpr);
       if (!scalar) ctx.rawAddressSymbols.add(lower);
+    } else if (item.kind === 'RawDataDecl') {
+      if (namedSection && namedSection.section !== 'data') return;
+      const decl = item as RawDataDeclNode;
+      ctx.rawAddressSymbols.add(decl.name.toLowerCase());
     }
   };
 
@@ -446,6 +451,108 @@ export function lowerProgramDeclarations(ctx: Context, _prescan: PrescanResult):
     }
     ctx.pending.push({ kind: 'data', name: binDecl.name, section: 'data', offset: ctx.dataOffsetRef.current, file: binDecl.span.file, line: binDecl.span.start.line, scope: 'global' });
     for (const b of blob) ctx.dataBytes.set(ctx.dataOffsetRef.current++, b & 0xff);
+  };
+  const symbolicTargetFromExpr = (
+    expr: ImmExprNode,
+  ): { baseLower: string; addend: number } | undefined => {
+    if (expr.kind === 'ImmName') return { baseLower: expr.name.toLowerCase(), addend: 0 };
+    if (expr.kind !== 'ImmBinary') return undefined;
+    if (expr.op !== '+' && expr.op !== '-') return undefined;
+
+    const leftName = expr.left.kind === 'ImmName' ? expr.left.name.toLowerCase() : undefined;
+    const rightName = expr.right.kind === 'ImmName' ? expr.right.name.toLowerCase() : undefined;
+
+    if (leftName) {
+      const right = ctx.evalImmExpr(expr.right, ctx.env, ctx.diagnostics);
+      if (right === undefined) return undefined;
+      return { baseLower: leftName, addend: expr.op === '+' ? right : -right };
+    }
+
+    if (expr.op === '+' && rightName) {
+      const left = ctx.evalImmExpr(expr.left, ctx.env, ctx.diagnostics);
+      if (left === undefined) return undefined;
+      return { baseLower: rightName, addend: left };
+    }
+
+    return undefined;
+  };
+  const lowerRawDataDecl = (
+    decl: RawDataDeclNode,
+    namedSection?: { node: NamedSectionNode; sink: NamedSectionContributionSink },
+  ): void => {
+    if (!namedSection || namedSection.node.section !== 'data') {
+      const sectionName = namedSection?.node.name ?? 'module scope';
+      ctx.diag(
+        ctx.diagnostics,
+        decl.span.file,
+        `Raw data declarations are only allowed inside data sections${namedSection ? ` like "${sectionName}"` : ''}.`,
+      );
+      return;
+    }
+
+    const okToDeclareSymbol = !ctx.taken.has(decl.name);
+    if (!okToDeclareSymbol) {
+      ctx.diag(ctx.diagnostics, decl.span.file, `Duplicate symbol name "${decl.name}".`);
+    } else {
+      ctx.taken.add(decl.name);
+      namedSection.sink.pendingSymbols.push({
+        kind: 'data',
+        name: decl.name,
+        section: namedSection.node.section,
+        offset: namedSection.sink.offset,
+        file: decl.span.file,
+        line: decl.span.start.line,
+        scope: 'global',
+      });
+    }
+
+    const emitByte = (b: number): void => {
+      namedSection.sink.bytes.set(namedSection.sink.offset, b & 0xff);
+      namedSection.sink.offset++;
+    };
+    const emitWord = (w: number): void => {
+      emitByte(w & 0xff);
+      emitByte((w >> 8) & 0xff);
+    };
+
+    if (decl.directive === 'ds') {
+      const size = ctx.evalImmExpr(decl.size, ctx.env, ctx.diagnostics);
+      if (size === undefined) {
+        ctx.diag(ctx.diagnostics, decl.span.file, `Failed to evaluate raw data size for "${decl.name}".`);
+        return;
+      }
+      if (size < 0) {
+        ctx.diag(ctx.diagnostics, decl.span.file, `Raw data size for "${decl.name}" must be non-negative.`);
+        return;
+      }
+      for (let i = 0; i < size; i++) emitByte(0);
+      return;
+    }
+
+    for (const value of decl.values) {
+      const v = ctx.evalImmExpr(value, ctx.env, ctx.diagnostics);
+      if (v !== undefined) {
+        if (decl.directive === 'db') emitByte(v);
+        else emitWord(v);
+        continue;
+      }
+      if (decl.directive === 'dw') {
+        const symbolic = symbolicTargetFromExpr(value);
+        if (symbolic) {
+          namedSection.sink.fixups.push({
+            offset: namedSection.sink.offset,
+            baseLower: symbolic.baseLower,
+            addend: symbolic.addend,
+            file: decl.span.file,
+          });
+          emitWord(0);
+          continue;
+        }
+      }
+      ctx.diag(ctx.diagnostics, decl.span.file, `Failed to evaluate raw data value for "${decl.name}".`);
+      if (decl.directive === 'db') emitByte(0);
+      else emitWord(0);
+    }
   };
   const lowerItem = (
     item: ModuleItemNode | SectionItemNode,
@@ -647,6 +754,11 @@ export function lowerProgramDeclarations(ctx: Context, _prescan: PrescanResult):
           startupInitActions: namedSection.sink.startupInitActions,
         },
       );
+      return;
+    }
+
+    if (item.kind === 'RawDataDecl') {
+      lowerRawDataDecl(item as RawDataDeclNode, namedSection);
       return;
     }
 

--- a/test/fixtures/pr786_raw_data_lowering.zax
+++ b/test/fixtures/pr786_raw_data_lowering.zax
@@ -1,0 +1,27 @@
+section data vars at $0100
+  table:
+  db 1, 2, 3
+  words:
+  dw $1234, $5678
+  gap:
+  ds 2
+  ptrs:
+  dw handler_a, handler_b
+end
+
+section code text at $0000
+export func handler_a()
+  ret
+end
+
+export func handler_b()
+  ret
+end
+
+export func main()
+  ld hl, table
+  ld a, (table)
+  ld (table), a
+  ret
+end
+end

--- a/test/pr786_raw_data_lowering.test.ts
+++ b/test/pr786_raw_data_lowering.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact, D8mArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const getSymbolAddress = (d8m: D8mArtifact, name: string): number => {
+  const symbols = d8m.json.symbols as Array<{ name: string; address?: number }>;
+  const found = symbols.find((s) => s.name === name);
+  if (!found || found.address === undefined) {
+    throw new Error(`Missing symbol ${name}`);
+  }
+  return found.address;
+};
+
+const getBinBase = (d8m: D8mArtifact): number => {
+  const segments = d8m.json.segments as Array<{ start: number; end: number }>;
+  return Math.min(...segments.map((s) => s.start));
+};
+
+describe('PR786 raw data lowering', () => {
+  it('emits raw bytes/words/space and resolves fixups', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr786_raw_data_lowering.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+
+    const d8m = res.artifacts.find((a): a is D8mArtifact => a.kind === 'd8m');
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(d8m).toBeDefined();
+    expect(bin).toBeDefined();
+    if (!d8m || !bin) throw new Error('missing artifacts');
+
+    const table = getSymbolAddress(d8m, 'table');
+    const words = getSymbolAddress(d8m, 'words');
+    const gap = getSymbolAddress(d8m, 'gap');
+    const ptrs = getSymbolAddress(d8m, 'ptrs');
+    const handlerA = getSymbolAddress(d8m, 'handler_a');
+    const handlerB = getSymbolAddress(d8m, 'handler_b');
+
+    expect(table).toBe(0x0100);
+    expect(words).toBe(0x0103);
+    expect(gap).toBe(0x0107);
+    expect(ptrs).toBe(0x0109);
+
+    const base = getBinBase(d8m);
+    const byteAt = (addr: number): number => bin.bytes[addr - base] ?? 0;
+    const wordAt = (addr: number): number => byteAt(addr) | (byteAt(addr + 1) << 8);
+
+    expect([byteAt(table), byteAt(table + 1), byteAt(table + 2)]).toEqual([1, 2, 3]);
+    expect([byteAt(words), byteAt(words + 1), byteAt(words + 2), byteAt(words + 3)]).toEqual([
+      0x34,
+      0x12,
+      0x78,
+      0x56,
+    ]);
+    expect([byteAt(gap), byteAt(gap + 1)]).toEqual([0, 0]);
+    expect(wordAt(ptrs)).toBe(handlerA & 0xffff);
+    expect(wordAt(ptrs + 2)).toBe(handlerB & 0xffff);
+  });
+});


### PR DESCRIPTION
## Summary\n- lower raw data declarations in named data sections (db/dw/ds)\n- register raw labels as raw-address symbols\n- add fixture + test coverage for raw emission + fixups\n\n## Testing\n- npm run typecheck\n- npx vitest run test/pr786_raw_data_lowering.test.ts test/pr576_unified_data_sections.test.ts