### PR TITLE
ADDR-EXPR-03: lower move address-of sources

### DIFF
--- a/src/lowering/asmInstructionLowering.ts
+++ b/src/lowering/asmInstructionLowering.ts
@@ -1,5 +1,5 @@
 import type { Diagnostic } from '../diagnostics/types.js';
-import type { AsmInstructionNode, AsmOperandNode } from '../frontend/ast.js';
+import type { AsmInstructionNode, AsmOperandNode, EaExprNode } from '../frontend/ast.js';
 
 type DiagAt = (diagnostics: Diagnostic[], span: AsmInstructionNode['span'], message: string) => void;
 
@@ -52,7 +52,9 @@ type Context = {
     symbolicTarget: { baseLower: string; addend: number } | undefined,
   ) => void;
   lowerLdWithEa: (asmItem: AsmInstructionNode) => boolean;
+  pushEaAddress: (ea: EaExprNode, span: AsmInstructionNode['span']) => boolean;
   emitVirtualReg16Transfer: (asmItem: AsmInstructionNode) => boolean;
+  reg16: Set<string>;
   emitSyntheticEpilogue: boolean;
   epilogueLabel: string;
   emitJumpTo: (label: string, span: AsmInstructionNode['span']) => void;
@@ -368,6 +370,23 @@ export function createAsmInstructionLoweringHelpers(ctx: Context) {
     }
 
     if (head === 'move') {
+      const dst = asmItem.operands[0];
+      const src = asmItem.operands[1];
+      if (src?.kind === 'Ea' && src.explicitAddressOf) {
+        if (!dst || dst.kind !== 'Reg' || !ctx.reg16.has(dst.name.toUpperCase())) {
+          ctx.diagAt(
+            ctx.diagnostics,
+            asmItem.span,
+            `"move" address-of source requires a 16-bit register destination.`,
+          );
+          return;
+        }
+        if (!ctx.pushEaAddress(src.expr, asmItem.span)) return;
+        if (!ctx.emitInstr('pop', [{ kind: 'Reg', span: asmItem.span, name: dst.name.toUpperCase() }], asmItem.span))
+          return;
+        ctx.syncToFlow();
+        return;
+      }
       const moveAsLd: AsmInstructionNode = { ...asmItem, head: 'ld' };
       if (ctx.lowerLdWithEa(moveAsLd)) {
         ctx.syncToFlow();

--- a/src/lowering/functionLowering.ts
+++ b/src/lowering/functionLowering.ts
@@ -652,7 +652,9 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
       );
     },
     lowerLdWithEa,
+    pushEaAddress,
     emitVirtualReg16Transfer,
+    reg16,
     emitSyntheticEpilogue,
     epilogueLabel,
     emitJumpTo,

--- a/test/pr532_asm_instruction_lowering_integration.test.ts
+++ b/test/pr532_asm_instruction_lowering_integration.test.ts
@@ -56,7 +56,9 @@ describe('PR532 asm instruction lowering integration', () => {
         if (target) events.push(`warn:${target.baseLower}`);
       },
       lowerLdWithEa: () => false,
+      pushEaAddress: () => false,
       emitVirtualReg16Transfer: () => false,
+      reg16: new Set(['BC', 'DE', 'HL']),
       emitSyntheticEpilogue: true,
       epilogueLabel: '__zax_epilogue_0',
       emitJumpTo: (label) => {

--- a/test/pr780_move_lowering_integration.test.ts
+++ b/test/pr780_move_lowering_integration.test.ts
@@ -35,7 +35,9 @@ describe('PR780 move lowering integration', () => {
         received.push(inst);
         return true;
       },
+      pushEaAddress: () => false,
       emitVirtualReg16Transfer: () => false,
+      reg16: new Set(['BC', 'DE', 'HL']),
       emitSyntheticEpilogue: false,
       epilogueLabel: '__zax_epilogue_0',
       emitJumpTo: () => {},

--- a/test/pr781_ld_typed_storage_migration_diag.test.ts
+++ b/test/pr781_ld_typed_storage_migration_diag.test.ts
@@ -47,7 +47,9 @@ describe('PR781 ld typed-storage migration diagnostics', () => {
         ldCalled = true;
         return false;
       },
+      pushEaAddress: () => false,
       emitVirtualReg16Transfer: () => false,
+      reg16: new Set(['BC', 'DE', 'HL']),
       emitSyntheticEpilogue: false,
       epilogueLabel: '__zax_epilogue_0',
       emitJumpTo: () => {},

--- a/test/pr799_addr_expr_lowering.test.ts
+++ b/test/pr799_addr_expr_lowering.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+
+import { DiagnosticIds } from '../src/diagnostics/types.js';
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { createAsmInstructionLoweringHelpers } from '../src/lowering/asmInstructionLowering.js';
+import type { AsmInstructionNode, AsmOperandNode, EaExprNode, SourceSpan } from '../src/frontend/ast.js';
+
+const span: SourceSpan = {
+  file: 'fixture.zax',
+  start: { line: 1, column: 1, offset: 0 },
+  end: { line: 1, column: 1, offset: 0 },
+};
+
+describe('PR799 move address-of lowering', () => {
+  it('lowers move rr, @path by pushing the address and popping into rr', () => {
+    const diagnostics: Diagnostic[] = [];
+    const instrs: string[] = [];
+    let pushed: EaExprNode | undefined;
+    let lowerLdCalled = false;
+
+    const helper = createAsmInstructionLoweringHelpers({
+      diagnostics,
+      diagAt: (_diags, _span, message) => {
+        diagnostics.push({
+          id: DiagnosticIds.EmitError,
+          severity: 'error',
+          message,
+          file: span.file,
+          line: span.start.line,
+          column: span.start.column,
+        });
+      },
+      emitInstr: (head, operands) => {
+        const dst = operands[0]?.kind === 'Reg' ? operands[0].name : '?';
+        instrs.push(`${head}:${dst}`);
+        return true;
+      },
+      emitRawCodeBytes: () => {},
+      emitAbs16Fixup: () => {},
+      emitAbs16FixupPrefixed: () => {},
+      emitRel8Fixup: () => {},
+      conditionOpcodeFromName: () => undefined,
+      conditionNameFromOpcode: () => undefined,
+      callConditionOpcodeFromName: () => undefined,
+      jrConditionOpcodeFromName: () => undefined,
+      conditionOpcode: () => undefined,
+      symbolicTargetFromExpr: () => undefined,
+      evalImmExpr: () => undefined,
+      resolveScalarBinding: () => undefined,
+      diagIfRetStackImbalanced: () => {},
+      diagIfCallStackUnverifiable: () => {},
+      warnIfRawCallTargetsTypedCallable: () => {},
+      lowerLdWithEa: () => {
+        lowerLdCalled = true;
+        return false;
+      },
+      pushEaAddress: (ea) => {
+        pushed = ea;
+        return true;
+      },
+      emitVirtualReg16Transfer: () => false,
+      reg16: new Set(['BC', 'DE', 'HL']),
+      emitSyntheticEpilogue: false,
+      epilogueLabel: '__zax_epilogue_0',
+      emitJumpTo: () => {},
+      emitJumpCondTo: () => {},
+      syncToFlow: () => {},
+      flowRef: { current: { reachable: true } },
+    });
+
+    const moveItem: AsmInstructionNode = {
+      kind: 'AsmInstruction',
+      span,
+      head: 'move',
+      operands: [
+        { kind: 'Reg', span, name: 'HL' },
+        {
+          kind: 'Ea',
+          span,
+          expr: { kind: 'EaName', span, name: 'x' },
+          explicitAddressOf: true,
+        },
+      ] satisfies AsmOperandNode[],
+    };
+
+    helper.lowerAsmInstructionDispatcher(moveItem);
+
+    expect(lowerLdCalled).toBe(false);
+    expect(diagnostics).toHaveLength(0);
+    expect(pushed).toMatchObject({ kind: 'EaName', name: 'x' });
+    expect(instrs).toContain('pop:HL');
+  });
+
+  it('diagnoses move address-of with a non-16-bit register destination', () => {
+    const diagnostics: Diagnostic[] = [];
+    let pushCalled = false;
+
+    const helper = createAsmInstructionLoweringHelpers({
+      diagnostics,
+      diagAt: (_diags, _span, message) => {
+        diagnostics.push({
+          id: DiagnosticIds.EmitError,
+          severity: 'error',
+          message,
+          file: span.file,
+          line: span.start.line,
+          column: span.start.column,
+        });
+      },
+      emitInstr: () => true,
+      emitRawCodeBytes: () => {},
+      emitAbs16Fixup: () => {},
+      emitAbs16FixupPrefixed: () => {},
+      emitRel8Fixup: () => {},
+      conditionOpcodeFromName: () => undefined,
+      conditionNameFromOpcode: () => undefined,
+      callConditionOpcodeFromName: () => undefined,
+      jrConditionOpcodeFromName: () => undefined,
+      conditionOpcode: () => undefined,
+      symbolicTargetFromExpr: () => undefined,
+      evalImmExpr: () => undefined,
+      resolveScalarBinding: () => undefined,
+      diagIfRetStackImbalanced: () => {},
+      diagIfCallStackUnverifiable: () => {},
+      warnIfRawCallTargetsTypedCallable: () => {},
+      lowerLdWithEa: () => false,
+      pushEaAddress: () => {
+        pushCalled = true;
+        return true;
+      },
+      emitVirtualReg16Transfer: () => false,
+      reg16: new Set(['BC', 'DE', 'HL']),
+      emitSyntheticEpilogue: false,
+      epilogueLabel: '__zax_epilogue_0',
+      emitJumpTo: () => {},
+      emitJumpCondTo: () => {},
+      syncToFlow: () => {},
+      flowRef: { current: { reachable: true } },
+    });
+
+    const moveItem: AsmInstructionNode = {
+      kind: 'AsmInstruction',
+      span,
+      head: 'move',
+      operands: [
+        { kind: 'Reg', span, name: 'A' },
+        {
+          kind: 'Ea',
+          span,
+          expr: { kind: 'EaName', span, name: 'x' },
+          explicitAddressOf: true,
+        },
+      ] satisfies AsmOperandNode[],
+    };
+
+    helper.lowerAsmInstructionDispatcher(moveItem);
+
+    expect(pushCalled).toBe(false);
+    expect(diagnostics.map((d) => d.message)).toContain(
+      '"move" address-of source requires a 16-bit register destination.',
+    );
+  });
+});


### PR DESCRIPTION
## Summary\n- lower move @path by materializing address into 16-bit reg\n- reject non-16-bit destinations for move address-of\n- add focused lowering tests and update asm lowering helper contexts\n\n## Testing\n- npm run typecheck\n- npx vitest run test/pr799_addr_expr_lowering.test.ts test/pr780_move_lowering_integration.test.ts test/pr781_ld_typed_storage_migration_diag.test.ts test/pr532_asm_instruction_lowering_integration.test.ts