### PR TITLE
GRAMMAR-02: prune invalid @ forms

### DIFF
--- a/test/pr798_addr_expr_parser.test.ts
+++ b/test/pr798_addr_expr_parser.test.ts
@@ -46,6 +46,8 @@ section code text at $0000
 export func main()
   move hl, @@x
   move hl, @(@x)
+  move hl, @(array[i])
+  move hl, array[@i]
   ret
 end
 end


### PR DESCRIPTION
## Summary\n- tighten address-of parser tests to reject additional invalid @ forms\n- no parser behavior changes beyond existing move-only rules\n\n## Testing\n- npm run typecheck\n- npx vitest run test/pr798_addr_expr_parser.test.ts