### PR TITLE
GRAMMAR-03: align grammar with current syntax

### DIFF
--- a/docs/spec/zax-grammar.ebnf.md
+++ b/docs/spec/zax-grammar.ebnf.md
@@ -154,8 +154,10 @@ instr_line      = z80_instruction
                 | asm_label
                 | local_jump ;
 
-move_stmt       = "move" , move_operand , "," , move_operand ;
-move_operand    = move_reg | ea_expr | move_addr ;
+move_stmt       = "move" , move_reg , "," , move_src
+                | "move" , move_path , "," , move_reg ;
+move_src        = move_addr | move_path ;
+move_path       = ea_expr ;
 move_reg        = reg8 | reg16 | "AF" | "SP" | "IXH" | "IXL" | "IYH" | "IYL" ;
 move_addr       = "@" , ea_expr ;  (* move_addr is only valid as the source operand in v1 *)
 


### PR DESCRIPTION
## Summary\n- add move instruction head and move-only address-of form\n- add raw data directives and raw labels in section data\n- allow bare asm labels\n- add char literals and qualified imm names\n- define reg8/reg16 terminals used by the grammar\n\n## Testing\n- docs-only change