### PR TITLE
GRAMMAR-04: centralize legacy return keywords

### DIFF
--- a/src/frontend/grammarData.ts
+++ b/src/frontend/grammarData.ts
@@ -31,6 +31,8 @@ export const ALL_REGISTER_NAMES = new Set<string>([
 export const INDEX_REG8_NAMES = new Set<string>(REGISTERS_8);
 export const INDEX_REG16_NAMES = new Set<string>(['HL', 'DE', 'BC']);
 export const RETURN_REGISTERS = new Set<string>(['HL', 'DE', 'BC', 'AF']);
+export const LEGACY_RETURN_KEYWORD_LIST = ['VOID', 'BYTE', 'WORD', 'LONG', 'VERYLONG', 'NONE', 'FLAGS'] as const;
+export const LEGACY_RETURN_KEYWORDS = new Set<string>(LEGACY_RETURN_KEYWORD_LIST);
 
 export const CONDITION_CODE_LIST = ['z', 'nz', 'c', 'nc', 'pe', 'po', 'm', 'p'] as const;
 export const CONDITION_CODES = new Set<string>(CONDITION_CODE_LIST);

--- a/src/frontend/parseModuleCommon.ts
+++ b/src/frontend/parseModuleCommon.ts
@@ -7,7 +7,7 @@ import {
   parseTypeExprFromText,
 } from './parseImm.js';
 import { parseEaExprFromText } from './parseOperands.js';
-import { RETURN_REGISTERS, TOP_LEVEL_KEYWORDS } from './grammarData.js';
+import { LEGACY_RETURN_KEYWORDS, RETURN_REGISTERS, TOP_LEVEL_KEYWORDS } from './grammarData.js';
 
 export { TOP_LEVEL_KEYWORDS } from './grammarData.js';
 
@@ -148,11 +148,10 @@ export function parseReturnRegsFromText(
     .filter((t) => t.length > 0);
   if (tokens.length === 0) return { regs: [] };
 
-  const legacyKeywords = new Set(['VOID', 'BYTE', 'WORD', 'LONG', 'VERYLONG', 'NONE', 'FLAGS']);
   const seen = new Set<string>();
   for (const t of tokens) {
     const upper = t.toUpperCase();
-    if (legacyKeywords.has(upper)) {
+    if (LEGACY_RETURN_KEYWORDS.has(upper)) {
       diag(
         diagnostics,
         modulePath,


### PR DESCRIPTION
## Summary\n- move legacy return keyword list into grammarData\n- reuse shared set in parseModuleCommon\n\n## Testing\n- npm run typecheck