### PR TITLE
GRAMMAR-04: centralize matcher kind mapping

### DIFF
--- a/src/frontend/grammarData.ts
+++ b/src/frontend/grammarData.ts
@@ -91,3 +91,14 @@ export const MATCHER_TYPE_LIST = [
   'mem16',
 ] as const;
 export const MATCHER_TYPES = new Set<string>(MATCHER_TYPE_LIST);
+export const MATCHER_KIND_BY_TYPE: Readonly<Record<(typeof MATCHER_TYPE_LIST)[number], 'MatcherReg8' | 'MatcherReg16' | 'MatcherIdx16' | 'MatcherCc' | 'MatcherImm8' | 'MatcherImm16' | 'MatcherEa' | 'MatcherMem8' | 'MatcherMem16'>> = {
+  reg8: 'MatcherReg8',
+  reg16: 'MatcherReg16',
+  idx16: 'MatcherIdx16',
+  cc: 'MatcherCc',
+  imm8: 'MatcherImm8',
+  imm16: 'MatcherImm16',
+  ea: 'MatcherEa',
+  mem8: 'MatcherMem8',
+  mem16: 'MatcherMem16',
+};

--- a/src/frontend/parseParams.ts
+++ b/src/frontend/parseParams.ts
@@ -2,7 +2,7 @@ import type { OpMatcherNode, OpParamNode, ParamNode, SourceSpan, TypeExprNode } 
 import type { Diagnostic } from '../diagnostics/types.js';
 import { parseDiag as diag } from './parseDiagnostics.js';
 import { parseTypeExprFromText } from './parseImm.js';
-import { MATCHER_TYPES } from './grammarData.js';
+import { MATCHER_KIND_BY_TYPE, MATCHER_TYPES } from './grammarData.js';
 
 export type ParseParamsContext = {
   isReservedTopLevelName: (name: string) => boolean;
@@ -91,23 +91,11 @@ export function parseParamsFromText(
   return out;
 }
 
-const MATCHER_KIND_BY_TYPE: Readonly<Record<string, MatcherKind>> = {
-  reg8: 'MatcherReg8',
-  reg16: 'MatcherReg16',
-  idx16: 'MatcherIdx16',
-  cc: 'MatcherCc',
-  imm8: 'MatcherImm8',
-  imm16: 'MatcherImm16',
-  ea: 'MatcherEa',
-  mem8: 'MatcherMem8',
-  mem16: 'MatcherMem16',
-};
-
 function parseOpMatcherFromText(matcherText: string, matcherSpan: SourceSpan): OpMatcherNode {
   const t = matcherText.trim();
   const lower = t.toLowerCase();
   if (!MATCHER_TYPES.has(lower)) return { kind: 'MatcherFixed', span: matcherSpan, token: t };
-  return { kind: MATCHER_KIND_BY_TYPE[lower]!, span: matcherSpan };
+  return { kind: MATCHER_KIND_BY_TYPE[lower as keyof typeof MATCHER_KIND_BY_TYPE], span: matcherSpan };
 }
 
 export function parseOpParamsFromText(


### PR DESCRIPTION
## Summary\n- move op matcher kind mapping into grammarData\n- parseParams now consumes shared matcher table\n\n## Testing\n- npm run typecheck