### PR TITLE
docs: ZAX algorithms course outline

### DIFF
--- a/docs/design/zax-algorithms-course.md
+++ b/docs/design/zax-algorithms-course.md
@@ -520,20 +520,24 @@ section data heap at $8400
   nodes: Node[16]    ; fixed-size pool — no dynamic allocation
 end
 
-; traverse the list starting at HL, summing values
+; traverse the list starting at head, summing values
 func list_sum(head: addr): HL
   var
     total: word = 0
   end
-  move hl, head
-  or a              ; test for null (HL = 0 means end)
+  move hl, head          ; HL = current node pointer
+  ld a, h
+  or l                   ; set Z if HL == 0 (null)
   while NZ
-    move de, <Node>hl.value    ; read value field
+    push hl                        ; save current node pointer
+    move de, <Node>hl.value        ; DE = value of current node
     move hl, total
     add hl, de
-    move total, hl
-    move hl, <Node>hl.next     ; advance to next node
-    or a                       ; test next pointer for null
+    move total, hl                 ; accumulate into total
+    pop hl                         ; restore current node pointer
+    move hl, <Node>hl.next         ; HL = next node pointer
+    ld a, h
+    or l                           ; set Z if next pointer is null
   end
   move hl, total
 end
@@ -632,9 +636,9 @@ than speculation.
 | Example Gap | Status |
 |---|---|
 | RPN calculator / quicksort software stack | Stack-typed local or push/pop op idiom — not yet on roadmap |
-| Linked list, BST — untyped `ptr` fields, explicit casts, null-as-zero convention | Pointer-typing ergonomics — Tier 2 friction; self-referential record declarations would resolve, not yet on roadmap |
+| Linked list, BST — untyped `ptr` fields, explicit casts, null-as-zero convention | Pointer-typing ergonomics — Tier 2 friction; self-referential record declarations would improve precision, not yet on roadmap |
 | Eight queens labeled exit | `break` / named exit — not yet on roadmap; course surfaces this |
-| Word frequency string ops | Standard `op` library — not yet on roadmap |
+| Word frequency string ops | Standard `op` library — library workstream, separate from language/compiler roadmap |
 | Ring buffer with exact-size sizeof | Exact-size layout stream (#817–820) — active |
 
 Note: typed reinterpretation (`<Type>base.tail`) and grouped/ranged `select


### PR DESCRIPTION
## Summary

- Adds `docs/design/zax-algorithms-course.md` — a course design document structured around K&R (*The C Programming Language*) and Wirth (*Algorithms + Data Structures = Programs*) classic algorithms
- Frames the course as a **language feedback instrument**: each algorithm that resists clean ZAX expression is a direct roadmap input
- Covers goals, a 7-rule style guide, a four-tier algorithm catalogue (40+ named algorithms), and explicit mapping from friction points to existing roadmap streams
- Surfaces four gaps not currently on any roadmap: labeled break/named exit, standard `op` library, stack-typed locals, self-referential record types

## What this is not

This is a design and planning document, not an implementation. No compiler code changes. No spec changes.

## Test plan

- [ ] Read the document end-to-end and verify the algorithm catalogue tiers are coherent
- [ ] Check that roadmap connections in §6 match the current plan streams
- [ ] Confirm style guide rules (§4) are compatible with the current ZAX surface
- [ ] Note any algorithms that belong in a different tier than assigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)