### PR TITLE
rewrite README as comprehensive feature introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,14 +350,12 @@ func update_sprite(idx: byte): void
 end
 ```
 
-Composite types use exact semantic sizes — the sum of their field sizes with no rounding. Use `sizeof` and `offsetof` for all layout constants; they update automatically when type definitions change:
+Composite types use exact semantic sizes. Use `sizeof` and `offsetof` for all layout constants; they update automatically when type definitions change:
 
 ```zax
 const SpriteSize  = sizeof(Sprite)           ; = 6 (pos: 4, tile: 1, flags: 1)
 const FlagsOffset = offsetof(Sprite, flags)  ; = 5 (after pos: 4, tile: 1)
 ```
-
-Power-of-two composite sizes remain a runtime performance consideration: when `sizeof(element)` is a power of two, array indexing can use a pure `ADD HL, HL` shift chain. For non-power-of-two strides the compiler uses a shift/add sequence. Explicit pad fields can be added to a record when a power-of-two total is required for performance or an external binary layout.
 
 Unions overlay fields at the same base address. All fields refer to the same memory; the programmer selects the interpretation in use:
 


### PR DESCRIPTION
## Summary

- Replaces the existing README with a full tour of ZAX's current feature surface, structured as the user's first impression of the language
- Opens with a clear paradigm statement and a working first-look example using the correct `move`/`ld` split
- Covers every major language feature with accurate, compilable code snippets drawn from the live test fixtures and language-tour examples

## What's covered

| Section | Key points shown |
| ------- | ---------------- |
| Typed storage & `move` | Value semantics, `@path` address-of, `<Type>base.tail` typed reinterpretation |
| Functions | IX-anchored frame, explicit return register annotation (`: HL`), callee-save contract, `extern func` |
| Control flow | `if`/`else`, `while` (flag discipline), `repeat...until`, `select`/`case` with grouped values and inclusive ranges |
| Op system | Multi-overload example, fixed vs class matcher resolution, op composition, hygienic labels |
| Records/arrays/unions | Place expressions, `sizeof`/`offsetof`, composite indexing, `@path` on arrays |
| Raw data directives | `db`/`dw`/`ds` in data sections |
| Compile-time expressions | `const`, `enum`, literal forms, operator precedence |
| Modules | `import`, `export`, global namespace rules |
| Project status | Reflects current implementation state including active exact-size layout work |

## Code accuracy

All snippets were verified against:
- `docs/work/current-stream.md` (ground truth for implemented features)
- `docs/reference/ZAX-quick-guide.md`
- Live test fixtures (`pr770_typed_reinterpretation_positive.zax`, `pr786_raw_data_lowering.zax`, `pr738_select_case_range_group_reg8.zax`)
- `examples/language-tour/` examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)