### PR TITLE
docs: align spec and quick guide to exact-size semantics

### DIFF
--- a/docs/reference/ZAX-quick-guide.md
+++ b/docs/reference/ZAX-quick-guide.md
@@ -1613,7 +1613,7 @@ loop:
 end
 ```
 
-The index here is `HL` holding a 0-based element number (0..15). The compiler emits the shift chain for `HL × sizeof(Sprite)` — three `ADD HL, HL` for a stride of 8 — then adds the field offset for `.x` (which is 0, so no extra add).
+The index here is `HL` holding a 0-based element number (0..15). The semantic stride is `sizeof(Sprite) = 5`. Power-of-two strides still use a pure shift chain; non-power-of-two runtime indexed lowering is being completed separately in GitHub issue #819.
 
 **`sizeof(Sprite[MaxSprites])` = 16 × 5 = 80 bytes.**
 

--- a/docs/spec/zax-spec.md
+++ b/docs/spec/zax-spec.md
@@ -1492,7 +1492,7 @@ next_char
 - Compilers must emit an error for unqualified enum member references.
 - Compilers must emit an error when index expressions use unsupported forms for v0.2 grammar/semantics.
 - Compilers should emit diagnostics that distinguish typed-call boundary guarantees from raw Z80 `call` behavior.
-- Compilers may warn about non-power-of-two composite sizes only as a code-generation cost hint, not as a layout rule.
+- Padding warnings tied to power-of-two semantic layout are retired. Future non-power-of-two cost hints, if added, are advisory lowering diagnostics rather than layout rules.
 - Compilers must emit an error for typed alias forms (`name: Type = rhs`) in function-local `var`.
 - Compilers must emit an error for non-scalar local storage declarations without alias initialization.
 
@@ -1622,7 +1622,7 @@ This appendix tracks migration-coverage status against the normative language ru
 ### C.1 Breaking Changes Checklist
 
 - [x] Composite semantic sizes are exact for arrays/records/unions; `sizeof` and layout use exact size. (Sections 4.1, 5.1, 5.2, 5.3, 11.1)
-- [x] Runtime index scaling is shift-only (`ADD HL,HL` chains); no multiply-based lowering for indexed composite access. (Sections 5.1, 11.1)
+- [x] Current runtime-indexed composite lowering still uses the shift-only fast path; exact-size non-power-of-two runtime scaling is tracked in GitHub issue #819. (Sections 5.1, 11.1)
 - [x] `arr[HL]` is a 16-bit direct index; indirect byte-at-HL indexing uses `arr[(HL)]`. (Sections 5.1, 11.1, 11.2)
 - [x] Typed scalar variables use value semantics; legacy scalar paren-dereference examples are removed from normative guidance. (Sections 6.1, 7, 11.1, 11.2)
 - [x] Enum members require qualification (`EnumType.Member`); unqualified members are compile errors. (Sections 4.3, 11.1, 11.3)


### PR DESCRIPTION
## What
- update the normative spec from rounded composite storage to exact semantic sizes
- update the quick guide to remove power-of-two layout rules and padding guidance
- remove `--type-padding-warn` from the quick-guide CLI surface
- note that non-power-of-two runtime indexed lowering is a separate follow-up in GitHub issue #819

## Why
GitHub PR #821 changes semantic layout from rounded storage size to exact size. The docs must move with that change; this is not optional cleanup.

## Scope
- docs only
- based on `codex/layout-818-exact-size-semantics` so it can land with the exact-size semantic change
