### PR TITLE
LAYOUT-819: support exact indexed scaling

### DIFF
--- a/src/addressing/steps.ts
+++ b/src/addressing/steps.ts
@@ -171,14 +171,41 @@ const calcEaShift = (shiftCount: number): StepPipeline => [
   step({ kind: 'addHlDe' }),
 ];
 
-export const CALC_EA_WIDE = (elemSize: number): StepPipeline => {
+const getPow2ShiftCount = (elemSize: number): number | undefined => {
+  if (!Number.isInteger(elemSize) || elemSize < 1) return undefined;
   let n = elemSize;
   let shiftCount = 0;
   while (n > 1 && (n & 1) === 0) {
     n >>= 1;
     shiftCount++;
   }
-  return n === 1 ? calcEaShift(shiftCount) : CALC_EA_2();
+  return n === 1 ? shiftCount : undefined;
+};
+
+const calcEaMultiplyOps = (elemSize: number): StepPipeline => {
+  const bits = elemSize.toString(2).slice(1);
+  const pipeline: StepPipeline = [];
+  for (const bit of bits) {
+    pipeline.push(step({ kind: 'addHlHl' }));
+    if (bit === '1') pipeline.push(step({ kind: 'addHlDe' }));
+  }
+  return pipeline;
+};
+
+const calcEaExact = (elemSize: number): StepPipeline => [
+  step({ kind: 'push', reg: 'DE' }),
+  step({ kind: 'ldRegReg', dst: 'd', src: 'h' }),
+  step({ kind: 'ldRegReg', dst: 'e', src: 'l' }),
+  ...calcEaMultiplyOps(elemSize),
+  step({ kind: 'pop', reg: 'DE' }),
+  step({ kind: 'addHlDe' }),
+];
+
+export const CALC_EA_WIDE = (elemSize: number): StepPipeline => {
+  if (!Number.isInteger(elemSize) || elemSize < 1) return CALC_EA_2();
+  if (elemSize === 1) return CALC_EA();
+  const shiftCount = getPow2ShiftCount(elemSize);
+  return shiftCount !== undefined ? calcEaShift(shiftCount) : calcEaExact(elemSize);
 };
 
 // ---------------------------------------------------------------------------

--- a/src/lowering/addressingPipelines.ts
+++ b/src/lowering/addressingPipelines.ts
@@ -56,17 +56,8 @@ export function createAddressingPipelineBuilders(ctx: AddressingPipelineContext)
     }
   };
 
-  const getPow2ShiftCount = (elemSize: number | undefined): number | undefined => {
-    if (elemSize === undefined) return undefined;
-    let n = elemSize;
-    let shiftCount = 0;
-    while (n > 1 && (n & 1) === 0) {
-      n >>= 1;
-      shiftCount++;
-    }
-    if (n !== 1 || shiftCount < 1 || shiftCount > 15) return undefined;
-    return shiftCount;
-  };
+  const isValidExactSize = (elemSize: number | undefined): elemSize is number =>
+    elemSize !== undefined && Number.isInteger(elemSize) && elemSize >= 1;
 
   const buildEaBytePipeline = (ea: EaExprNode, span: SourceSpan): StepPipeline | null => {
     if (ea.kind === 'EaIndex') {
@@ -163,7 +154,7 @@ export function createAddressingPipelineBuilders(ctx: AddressingPipelineContext)
       if (!baseResolved || !baseType || baseType.kind !== 'ArrayType') return null;
       if (baseResolved.kind === 'indirect') return null;
       const elemSize = ctx.sizeOfTypeExpr(baseType.element);
-      if (getPow2ShiftCount(elemSize) === undefined || elemSize === undefined) return null;
+      if (!isValidExactSize(elemSize)) return null;
       const wideElemSize = elemSize;
 
       if (ea.index.kind === 'IndexImm') {
@@ -241,7 +232,7 @@ export function createAddressingPipelineBuilders(ctx: AddressingPipelineContext)
     const scalarKind = resolved.typeExpr ? ctx.resolveScalarKind(resolved.typeExpr) : undefined;
     const elemSize: number | undefined = (resolved as { elemSize?: number }).elemSize ?? 2;
     if (scalarKind !== 'word' && scalarKind !== 'addr') return null;
-    if (getPow2ShiftCount(elemSize) === undefined) return null;
+    if (!isValidExactSize(elemSize)) return null;
     if (resolved.kind === 'abs') return EAW_GLOB_CONST(resolved.baseLower, resolved.addend, elemSize);
     if (resolved.kind === 'stack') return EAW_FVAR_CONST(resolved.ixDisp, 0, elemSize);
     return null;

--- a/src/lowering/valueMaterialization.ts
+++ b/src/lowering/valueMaterialization.ts
@@ -68,7 +68,7 @@ export function createValueMaterializationHelpers(ctx: Context) {
   });
 
   const getPow2ShiftCount = (elemSize: number | undefined): number | undefined => {
-    if (elemSize === undefined) return undefined;
+    if (elemSize === undefined || !Number.isInteger(elemSize) || elemSize < 1) return undefined;
     let n = elemSize;
     let shiftCount = 0;
     while (n > 1 && (n & 1) === 0) {
@@ -77,6 +77,37 @@ export function createValueMaterializationHelpers(ctx: Context) {
     }
     if (n !== 1 || shiftCount > 15) return undefined;
     return shiftCount;
+  };
+
+  const emitExactScaleInHl = (elemSize: number, span: SourceSpan): boolean => {
+    const shiftCount = getPow2ShiftCount(elemSize);
+    if (shiftCount !== undefined) {
+      for (let i = 0; i < shiftCount; i++) {
+        if (!ctx.emitInstr('add', [{ kind: 'Reg', span, name: 'HL' }, { kind: 'Reg', span, name: 'HL' }], span))
+          return false;
+      }
+      return true;
+    }
+
+    if (!Number.isInteger(elemSize) || elemSize < 1) {
+      ctx.diagAt(ctx.diagnostics, span, `Runtime indexing requires a positive exact element size (got ${elemSize}).`);
+      return false;
+    }
+    if (elemSize === 1) return true;
+    if (!ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'DE' }], span)) return false;
+    if (!ctx.emitInstr('ld', [{ kind: 'Reg', span, name: 'D' }, { kind: 'Reg', span, name: 'H' }], span))
+      return false;
+    if (!ctx.emitInstr('ld', [{ kind: 'Reg', span, name: 'E' }, { kind: 'Reg', span, name: 'L' }], span))
+      return false;
+    for (const bit of elemSize.toString(2).slice(1)) {
+      if (!ctx.emitInstr('add', [{ kind: 'Reg', span, name: 'HL' }, { kind: 'Reg', span, name: 'HL' }], span))
+        return false;
+      if (bit === '1') {
+        if (!ctx.emitInstr('add', [{ kind: 'Reg', span, name: 'HL' }, { kind: 'Reg', span, name: 'DE' }], span))
+          return false;
+      }
+    }
+    return ctx.emitInstr('pop', [{ kind: 'Reg', span, name: 'DE' }], span);
   };
 
   const emitLoadWordFromHlAddress = (target: 'HL' | 'DE' | 'BC', span: SourceSpan): boolean => {
@@ -296,8 +327,7 @@ export function createValueMaterializationHelpers(ctx: Context) {
       const baseType = ctx.resolveEaTypeExpr(ea.base);
       if (!baseResolved || !baseType || baseType.kind !== 'ArrayType') return false;
       const elemSize = ctx.sizeOfTypeExpr(baseType.element);
-      const shiftCount = getPow2ShiftCount(elemSize);
-      if (shiftCount === undefined) return false;
+      if (elemSize === undefined || !Number.isInteger(elemSize) || elemSize < 1) return false;
 
       const loadIndexToHL = (): boolean => {
         const index = ea.index;
@@ -332,10 +362,7 @@ export function createValueMaterializationHelpers(ctx: Context) {
       };
 
       if (!loadIndexToHL()) return false;
-      for (let i = 0; i < shiftCount; i++) {
-        if (!ctx.emitInstr('add', [{ kind: 'Reg', span, name: 'HL' }, { kind: 'Reg', span, name: 'HL' }], span))
-          return false;
-      }
+      if (!emitExactScaleInHl(elemSize, span)) return false;
 
       if (baseResolved.kind === 'abs') {
         ctx.emitAbs16Fixup(0x11, baseResolved.baseLower, baseResolved.addend, span);
@@ -576,12 +603,11 @@ export function createValueMaterializationHelpers(ctx: Context) {
         return false;
       }
       const elemSize = ctx.sizeOfTypeExpr(baseType.element);
-      const shiftCount = getPow2ShiftCount(elemSize);
-      if (shiftCount === undefined) {
+      if (elemSize === undefined || !Number.isInteger(elemSize) || elemSize < 1) {
         ctx.diagAt(
           ctx.diagnostics,
           span,
-          `Runtime indexing currently supports element sizes that are powers of two up to $8000 (got ${elemSize}).`,
+          `Runtime indexing requires a positive exact element size (got ${elemSize}).`,
         );
         return false;
       }
@@ -657,10 +683,7 @@ export function createValueMaterializationHelpers(ctx: Context) {
         return false;
       }
 
-      for (let i = 0; i < shiftCount; i++) {
-        if (!ctx.emitInstr('add', [{ kind: 'Reg', span, name: 'HL' }, { kind: 'Reg', span, name: 'HL' }], span))
-          return false;
-      }
+      if (!emitExactScaleInHl(elemSize, span)) return false;
       if (!ctx.emitInstr('push', [{ kind: 'Reg', span, name: 'HL' }], span)) return false;
 
       const baseResolved = ctx.resolveEa(ea.base, span);

--- a/test/pr819_exact_scale_lowering.test.ts
+++ b/test/pr819_exact_scale_lowering.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+
+import { EAW_GLOB_CONST, renderStepPipeline } from '../src/addressing/steps.js';
+import { DiagnosticIds, type Diagnostic } from '../src/diagnostics/types.js';
+import type { AsmOperandNode, EaExprNode, SourceSpan, TypeExprNode } from '../src/frontend/ast.js';
+import { createAddressingPipelineBuilders } from '../src/lowering/addressingPipelines.js';
+import { createValueMaterializationHelpers } from '../src/lowering/valueMaterialization.js';
+import type { EaResolution } from '../src/lowering/eaResolution.js';
+
+const span: SourceSpan = {
+  file: 'pr819.zax',
+  start: { line: 1, column: 1, offset: 0 },
+  end: { line: 1, column: 1, offset: 0 },
+};
+
+const typeName = (name: string): TypeExprNode => ({ kind: 'TypeName', span, name });
+const arrayType = (element: TypeExprNode): TypeExprNode => ({ kind: 'ArrayType', span, element, length: 4 });
+const eaName = (name: string): EaExprNode => ({ kind: 'EaName', span, name });
+
+function renderOperand(operand: AsmOperandNode): string {
+  if (operand.kind === 'Reg') return operand.name;
+  if (operand.kind === 'Imm' && operand.expr.kind === 'ImmLiteral') return `$${operand.expr.value.toString(16).toUpperCase().padStart(4, '0')}`;
+  if (operand.kind !== 'Mem') return operand.kind;
+  const expr = operand.expr;
+  if (expr.kind === 'EaName') return `(${expr.name})`;
+  if ((expr.kind === 'EaAdd' || expr.kind === 'EaSub') && expr.base.kind === 'EaName' && expr.offset.kind === 'ImmLiteral') {
+    const sign = expr.kind === 'EaAdd' ? '+' : '-';
+    return `(${expr.base.name}${sign}${expr.offset.value})`;
+  }
+  return operand.kind;
+}
+
+describe('PR819 exact-scale lowering', () => {
+  it('keeps the power-of-two step path unchanged and adds exact non-pow2 scaling', () => {
+    expect(renderStepPipeline(EAW_GLOB_CONST('glob_tri', 1, 3))).toEqual([
+      'ld de, glob_tri',
+      'ld hl, $0001',
+      'push de',
+      'ld d, h',
+      'ld e, l',
+      'add hl, hl',
+      'add hl, de',
+      'pop de',
+      'add hl, de',
+    ]);
+
+    expect(renderStepPipeline(EAW_GLOB_CONST('glob_pow2', 1, 8))).toEqual([
+      'ld de, glob_pow2',
+      'ld hl, $0001',
+      'add hl, hl',
+      'add hl, hl',
+      'add hl, hl',
+      'add hl, de',
+    ]);
+  });
+
+  it('builds exact structural pipelines for non-pow2 and nested element sizes', () => {
+    const diagnostics: Diagnostic[] = [];
+    const triArray = arrayType(typeName('Tri3'));
+    const outerArray = arrayType(typeName('Outer5'));
+    const resolutions = new Map<string, EaResolution>([
+      ['globtri', { kind: 'abs', baseLower: 'globtri', addend: 0, typeExpr: triArray }],
+      ['frameouter', { kind: 'stack', ixDisp: -12, typeExpr: outerArray }],
+      ['idxw', { kind: 'abs', baseLower: 'idxw', addend: 0, typeExpr: typeName('word') }],
+    ]);
+
+    const helpers = createAddressingPipelineBuilders({
+      diagnostics,
+      diagAt: (_diagnostics, _span, message) => {
+        diagnostics.push({ id: DiagnosticIds.EmitError, severity: 'error', file: span.file, message });
+      },
+      reg8: new Set(['A', 'B', 'C', 'D', 'E', 'H', 'L']),
+      resolveEa: (ea) => (ea.kind === 'EaName' ? resolutions.get(ea.name.toLowerCase()) : undefined),
+      resolveEaTypeExpr: (ea) => (ea.kind === 'EaName' ? resolutions.get(ea.name.toLowerCase())?.typeExpr : undefined),
+      resolveScalarBinding: (name) => (name.toLowerCase() === 'idxw' ? 'word' : undefined),
+      resolveScalarKind: (typeExpr) =>
+        typeExpr.kind === 'TypeName' && (typeExpr.name === 'word' || typeExpr.name === 'addr')
+          ? typeExpr.name
+          : undefined,
+      sizeOfTypeExpr: (typeExpr) => {
+        if (typeExpr.kind !== 'TypeName') return undefined;
+        if (typeExpr.name === 'Tri3') return 3;
+        if (typeExpr.name === 'Outer5') return 5;
+        if (typeExpr.name === 'word' || typeExpr.name === 'addr') return 2;
+        return undefined;
+      },
+      evalImmExpr: () => undefined,
+    });
+
+    const triPipe = helpers.buildEaWordPipeline(
+      { kind: 'EaIndex', span, base: eaName('globTri'), index: { kind: 'IndexReg16', span, reg: 'HL' } },
+      span,
+    );
+    const outerPipe = helpers.buildEaWordPipeline(
+      {
+        kind: 'EaIndex',
+        span,
+        base: eaName('frameOuter'),
+        index: { kind: 'IndexImm', span, value: { kind: 'ImmName', span, name: 'idxw' } },
+      },
+      span,
+    );
+
+    expect(renderStepPipeline(triPipe ?? [])).toEqual([
+      'ld de, globtri',
+      'push de',
+      'ld d, h',
+      'ld e, l',
+      'add hl, hl',
+      'add hl, de',
+      'pop de',
+      'add hl, de',
+    ]);
+    expect(renderStepPipeline(outerPipe ?? [])).toEqual([
+      'ld e, (ix-$0c)',
+      'ld d, (ix-$0b)',
+      'ld hl, (idxw)',
+      'push de',
+      'ld d, h',
+      'ld e, l',
+      'add hl, hl',
+      'add hl, hl',
+      'add hl, de',
+      'pop de',
+      'add hl, de',
+    ]);
+    expect(diagnostics).toEqual([]);
+  });
+
+  it('preserves DE while materializing non-pow2 indexed addresses directly', () => {
+    const diagnostics: Diagnostic[] = [];
+    const emittedInstrs: string[] = [];
+    const absFixups: Array<{ opcode: number; baseLower: string; addend: number }> = [];
+    const triArray = arrayType(typeName('Tri3'));
+
+    const helpers = createValueMaterializationHelpers({
+      diagnostics,
+      diagAt: (_diagnostics, _span, message) => {
+        diagnostics.push({ id: DiagnosticIds.EmitError, severity: 'error', file: span.file, message });
+      },
+      reg8: new Set(['A', 'B', 'C', 'D', 'E', 'H', 'L']),
+      resolveEa: (ea) => {
+        if (ea.kind === 'EaName' && ea.name === 'globTri') {
+          return { kind: 'abs', baseLower: 'globtri', addend: 0, typeExpr: triArray } as const;
+        }
+        return undefined;
+      },
+      resolveEaTypeExpr: (ea) => {
+        if (ea.kind === 'EaName' && ea.name === 'globTri') return triArray;
+        return undefined;
+      },
+      resolveAggregateType: () => undefined,
+      resolveScalarBinding: () => undefined,
+      resolveScalarKind: () => undefined,
+      sizeOfTypeExpr: (typeExpr) => (typeExpr.kind === 'TypeName' && typeExpr.name === 'Tri3' ? 3 : undefined),
+      evalImmExpr: () => undefined,
+      evalImmNoDiag: () => undefined,
+      emitInstr: (head: string, operands: AsmOperandNode[]) => {
+        emittedInstrs.push(`${head} ${operands.map(renderOperand).join(', ')}`.trim());
+        return true;
+      },
+      emitRawCodeBytes: () => {},
+      emitAbs16Fixup: (opcode: number, baseLower: string, addend: number) => {
+        absFixups.push({ opcode, baseLower, addend });
+      },
+      loadImm16ToDE: () => true,
+      loadImm16ToHL: () => true,
+      negateHL: () => true,
+      pushZeroExtendedReg8: () => true,
+      emitStepPipeline: () => true,
+      buildEaBytePipeline: () => null,
+      buildEaWordPipeline: () => null,
+      emitScalarWordLoad: () => false,
+      formatIxDisp: (disp: number) => `${disp >= 0 ? '+' : ''}${disp}`,
+      TEMPLATE_L_ABC: () => [],
+      TEMPLATE_LW_DE: () => [],
+      LOAD_RP_EA: () => [],
+      STORE_RP_EA: () => [],
+    });
+
+    const result = helpers.pushEaAddress(
+      { kind: 'EaIndex', span, base: eaName('globTri'), index: { kind: 'IndexReg8', span, reg: 'C' } },
+      span,
+    );
+
+    expect(result).toBe(true);
+    expect(absFixups).toEqual([{ opcode: 0x11, baseLower: 'globtri', addend: 0 }]);
+    expect(emittedInstrs).toEqual([
+      'ld H, $0000',
+      'ld L, C',
+      'push DE',
+      'ld D, H',
+      'ld E, L',
+      'add HL, HL',
+      'add HL, DE',
+      'pop DE',
+      'add HL, DE',
+      'push HL',
+    ]);
+    expect(diagnostics).toEqual([]);
+  });
+});


### PR DESCRIPTION
Implements GitHub issue #819.\n\nThis adds exact runtime indexed scaling for non-power-of-two element sizes while keeping the existing power-of-two fast path. Non-pow2 scaling now uses an algorithmic add-chain and preserves DE on the stack only for that path.\n\nVerification:\n- npm run typecheck\n- npx vitest run test/pr819_exact_scale_lowering.test.ts test/pr711_wide_eaw.test.ts test/pr509_addressing_pipeline_builders.test.ts test/addressing_model_steps.test.ts\n- npx vitest run test/pr412_runtime_index_matrix.test.ts test/smoke_language_tour_compile.test.ts