### PR TITLE
docs: finalize exact-size indexing docs

### DIFF
--- a/docs/reference/ZAX-quick-guide.md
+++ b/docs/reference/ZAX-quick-guide.md
@@ -229,7 +229,7 @@ There is no implicit power-of-two padding in semantic layout. Power-of-two sizes
 The Z80 has no hardware multiply instruction. Indexing into an array of composites requires computing `base + i × sizeof(element)`.
 
 - When `sizeof(element)` is a power of two, lowering can use a pure shift chain (`ADD HL,HL`).
-- When `sizeof(element)` is not a power of two, lowering needs an exact shift/add sequence. That lowering work is staged separately; exact size is already the semantic rule.
+- When `sizeof(element)` is not a power of two, lowering emits an exact shift/add sequence derived from the constant element size.
 
 So power-of-two sizes remain a performance consideration, but they are no longer part of semantic layout.
 
@@ -238,7 +238,7 @@ So power-of-two sizes remain a performance consideration, but they are no longer
 Both are compile-time built-ins:
 
 ```zax
-const SpriteSize   = sizeof(Sprite)          ; = 8
+const SpriteSize   = sizeof(Sprite)          ; = 5
 const TileOffset   = offsetof(Sprite, tile)  ; = 2  (1 + 1)
 const FlagsOffset  = offsetof(Sprite, flags) ; = 3  (1 + 1 + 1)
 ```
@@ -1590,7 +1590,7 @@ const BrYOff = offsetof(Rect, bottomRight.y)   ; = 6
 
 ### 9.5 Arrays of Records
 
-When you declare an array of a record type, the element stride is the exact `sizeof(record)`. Power-of-two sizes remain the fast path; exact-size runtime scaling is being completed as a lowering follow-up.
+When you declare an array of a record type, the element stride is the exact `sizeof(record)`. Power-of-two sizes remain the fast path, but non-power-of-two sizes also lower through an exact shift/add sequence.
 
 ```zax
 const MaxSprites = 16
@@ -1613,7 +1613,7 @@ loop:
 end
 ```
 
-The index here is `HL` holding a 0-based element number (0..15). The semantic stride is `sizeof(Sprite) = 5`. Power-of-two strides still use a pure shift chain; non-power-of-two runtime indexed lowering is being completed separately in GitHub issue #819.
+The index here is `HL` holding a 0-based element number (0..15). The semantic stride is `sizeof(Sprite) = 5`. Power-of-two strides still use a pure shift chain; non-power-of-two strides use a longer exact shift/add sequence.
 
 **`sizeof(Sprite[MaxSprites])` = 16 × 5 = 80 bytes.**
 

--- a/docs/reference/arrays.md
+++ b/docs/reference/arrays.md
@@ -374,9 +374,7 @@ Array indexing computes `base + index * element_size`. When the element size is 
 
 **Element size 3, 5, 6, 7 (odd-sized records).** These require a multiply-by-constant sequence. For element size 3: `add hl, hl` (×2) then `add hl, de` where DE holds the original index (×2 + ×1 = ×3). This requires keeping the original index in a second register, which costs a register pair. For element size 5: `add hl, hl; add hl, hl` (×4) then `add hl, de` (×4 + ×1 = ×5). The general pattern is shift-and-add decomposition.
 
-For element sizes that don't decompose into a short shift-and-add chain, the compiler may reject the form or emit a runtime multiply loop. In v0.1, the spec does not guarantee lowering for arbitrary element sizes (see Section 6.1.1 non-guarantees). Programmers should prefer power-of-two element sizes for performance-critical arrays, and the language's record padding story (currently: records are packed, no implicit padding) means the programmer is responsible for sizing records to favorable widths if indexing performance matters.
-
-**Design recommendation for the spec:** document that array element sizes that are powers of two receive efficient scaling, and that other sizes may result in longer or rejected lowering sequences. This sets expectations without overcommitting the compiler.
+Current lowering implements exact constant-size scaling for any positive element size using an unrolled shift/add chain. Power-of-two sizes stay on the shorter pure-shift fast path; non-power-of-two sizes preserve `DE` while materializing the longer exact sequence. Programmers should still prefer power-of-two element sizes in hot loops when the extra instructions matter, but exact semantic layout is no longer constrained by that performance consideration.
 
 ---
 

--- a/docs/reference/source-overview.md
+++ b/docs/reference/source-overview.md
@@ -204,8 +204,7 @@ then ZAX bindings), mirroring the spec but implemented ad hoc.
 
 `semantics/layout.ts` implements:
 
-- `sizeOfTypeExpr` — returns the power-of-2 padded storage size
-- `storageInfoForTypeExpr` — returns `{ preRoundSize, storageSize }` pair
+- `sizeOfTypeExpr` — returns the exact semantic size
 - `offsetOfPathInTypeExpr` — resolves `offsetof(T, a.b[2])` paths to byte offsets
 
 Type resolution is recursive with cycle detection via `visiting` sets.

--- a/docs/spec/zax-spec.md
+++ b/docs/spec/zax-spec.md
@@ -1622,7 +1622,7 @@ This appendix tracks migration-coverage status against the normative language ru
 ### C.1 Breaking Changes Checklist
 
 - [x] Composite semantic sizes are exact for arrays/records/unions; `sizeof` and layout use exact size. (Sections 4.1, 5.1, 5.2, 5.3, 11.1)
-- [x] Current runtime-indexed composite lowering still uses the shift-only fast path; exact-size non-power-of-two runtime scaling is tracked in GitHub issue #819. (Sections 5.1, 11.1)
+- [x] Current runtime-indexed composite lowering uses exact semantic element sizes, keeping the shift-only fast path for power-of-two strides and exact shift/add scaling for other positive constant sizes. (Sections 5.1, 11.1)
 - [x] `arr[HL]` is a 16-bit direct index; indirect byte-at-HL indexing uses `arr[(HL)]`. (Sections 5.1, 11.1, 11.2)
 - [x] Typed scalar variables use value semantics; legacy scalar paren-dereference examples are removed from normative guidance. (Sections 6.1, 7, 11.1, 11.2)
 - [x] Enum members require qualification (`EnumType.Member`); unqualified members are compile errors. (Sections 4.3, 11.1, 11.3)


### PR DESCRIPTION
Closes the remaining docs drift after the exact-size layout/indexing stream.

Updates the quick guide, arrays reference, source overview, and spec so they describe the landed exact-size semantics and exact shift/add lowering behavior.