### PR TITLE
COURSE-838: add tranche 4 examples

### DIFF
--- a/examples/course/unit3/bit_reverse.zax
+++ b/examples/course/unit3/bit_reverse.zax
@@ -1,0 +1,57 @@
+; bit_reverse.zax
+;
+; Source/problem: reverse the bit order of one byte.
+; Unit 3 example: a local op for the append-low-bit idiom.
+
+op append_low_bit(reversed_reg: A, source_reg: B)
+  add a, a
+  bit 0, b
+  if NZ
+    or 1
+  end
+end
+
+export func bit_reverse_demo(): HL
+  var
+    source_value: byte = $96
+    reversed_value: byte = 0
+    bit_count: byte = 8
+  end
+
+  ld a, 1
+  or a
+  while NZ
+    move a, bit_count
+    or a
+    if Z
+      ld h, 0
+      move a, reversed_value
+      ld l, a
+      ret
+    end
+
+    move a, reversed_value
+    move b, source_value
+    append_low_bit a, b
+    move reversed_value, a
+
+    move a, source_value
+    srl a
+    move source_value, a
+
+    move a, bit_count
+    dec a
+    move bit_count, a
+
+    ld a, 1
+    or a
+  end
+
+  ld h, 0
+  move a, reversed_value
+  ld l, a
+end
+
+export func main()
+  bit_reverse_demo
+end

--- a/examples/course/unit3/getbits.zax
+++ b/examples/course/unit3/getbits.zax
@@ -1,0 +1,82 @@
+; getbits.zax
+;
+; Source/problem: extract a bit-field from one byte.
+; Unit 3 example: shift down, then rebuild the requested width.
+
+export func getbits_demo(): HL
+  var
+    working_value: byte = $B6
+    offset_value: byte = 2
+    width_value: byte = 3
+    result_value: byte = 0
+    bit_mask: byte = 1
+  end
+
+  ld a, 1
+  or a
+  while NZ
+    move a, offset_value
+    or a
+    if Z
+      ld a, 0
+      or a
+    end
+    if NZ
+      move a, working_value
+      srl a
+      move working_value, a
+
+      move a, offset_value
+      dec a
+      move offset_value, a
+
+      ld a, 1
+      or a
+    end
+  end
+
+  ld a, 1
+  or a
+  while NZ
+    move a, width_value
+    or a
+    if Z
+      ld h, 0
+      move a, result_value
+      ld l, a
+      ret
+    end
+
+    move a, working_value
+    and 1
+    if NZ
+      move a, result_value
+      move b, bit_mask
+      or b
+      move result_value, a
+    end
+
+    move a, working_value
+    srl a
+    move working_value, a
+
+    move a, bit_mask
+    add a, a
+    move bit_mask, a
+
+    move a, width_value
+    dec a
+    move width_value, a
+
+    ld a, 1
+    or a
+  end
+
+  ld h, 0
+  move a, result_value
+  ld l, a
+end
+
+export func main()
+  getbits_demo
+end

--- a/examples/course/unit3/parity.zax
+++ b/examples/course/unit3/parity.zax
@@ -1,0 +1,47 @@
+; parity.zax
+;
+; Source/problem: compute odd parity for one byte.
+; Unit 3 example: toggle a parity bit while shifting through the source.
+
+export func parity_demo(): HL
+  var
+    working_value: byte = $D3
+    parity_value: byte = 0
+  end
+
+  ld a, 1
+  or a
+  while NZ
+    move a, working_value
+    or a
+    if Z
+      ld h, 0
+      move a, parity_value
+      ld l, a
+      ret
+    end
+
+    move a, working_value
+    and 1
+    if NZ
+      move a, parity_value
+      xor 1
+      move parity_value, a
+    end
+
+    move a, working_value
+    srl a
+    move working_value, a
+
+    ld a, 1
+    or a
+  end
+
+  ld h, 0
+  move a, parity_value
+  ld l, a
+end
+
+export func main()
+  parity_demo
+end

--- a/examples/course/unit3/popcount.zax
+++ b/examples/course/unit3/popcount.zax
@@ -1,0 +1,47 @@
+; popcount.zax
+;
+; Source/problem: count the set bits in one byte.
+; Unit 3 example: bit tests plus repeated right shifts.
+
+export func popcount_demo(): HL
+  var
+    working_value: byte = $B6
+    count_value: byte = 0
+  end
+
+  ld a, 1
+  or a
+  while NZ
+    move a, working_value
+    or a
+    if Z
+      ld h, 0
+      move a, count_value
+      ld l, a
+      ret
+    end
+
+    move a, working_value
+    and 1
+    if NZ
+      move a, count_value
+      inc a
+      move count_value, a
+    end
+
+    move a, working_value
+    srl a
+    move working_value, a
+
+    ld a, 1
+    or a
+  end
+
+  ld h, 0
+  move a, count_value
+  ld l, a
+end
+
+export func main()
+  popcount_demo
+end

--- a/examples/course/unit5/array_reverse_recursive.zax
+++ b/examples/course/unit5/array_reverse_recursive.zax
@@ -1,0 +1,63 @@
+; array_reverse_recursive.zax
+;
+; Source/problem: recursive in-place array reversal.
+; Unit 5 example: recurse toward the middle while swapping endpoints.
+
+const LastIndex = 5
+
+section data vars at $8000
+  numbers: byte[6] = { 1, 2, 3, 4, 5, 6 }
+end
+
+func swap_values(left_index: byte, right_index: byte)
+  var
+    left_value: byte = 0
+    right_value: byte = 0
+  end
+
+  move l, left_index
+  move a, numbers[L]
+  move left_value, a
+
+  move l, right_index
+  move a, numbers[L]
+  move right_value, a
+
+  move l, left_index
+  move a, right_value
+  move numbers[L], a
+
+  move l, right_index
+  move a, left_value
+  move numbers[L], a
+end
+
+func reverse_range(left_index: byte, right_index: byte)
+  var
+    next_left: byte = 0
+    next_right: byte = 0
+  end
+
+  move a, left_index
+  move b, right_index
+  cp b
+  if NC
+    ret
+  end
+
+  swap_values left_index, right_index
+
+  move a, left_index
+  inc a
+  move next_left, a
+
+  move a, right_index
+  dec a
+  move next_right, a
+
+  reverse_range next_left, next_right
+end
+
+export func main()
+  reverse_range 0, LastIndex
+end

--- a/examples/course/unit5/array_sum_recursive.zax
+++ b/examples/course/unit5/array_sum_recursive.zax
@@ -1,0 +1,43 @@
+; array_sum_recursive.zax
+;
+; Source/problem: recursive sum of a byte array.
+; Unit 5 example: recurse on the tail and add the current element on unwind.
+
+const ItemCount = 6
+
+section data vars at $8000
+  numbers: byte[6] = { 3, 1, 4, 1, 5, 9 }
+end
+
+func sum_from(index_value: byte): HL
+  var
+    next_index: byte = 0
+    current_value: byte = 0
+  end
+
+  move a, index_value
+  cp ItemCount
+  if Z
+    ld hl, 0
+    ret
+  end
+
+  move l, index_value
+  move a, numbers[L]
+  move current_value, a
+
+  move a, index_value
+  inc a
+  move next_index, a
+
+  sum_from next_index
+
+  move a, current_value
+  ld e, a
+  ld d, 0
+  add hl, de
+end
+
+export func main()
+  sum_from 0
+end

--- a/examples/course/unit5/hanoi.zax
+++ b/examples/course/unit5/hanoi.zax
@@ -1,0 +1,38 @@
+; hanoi.zax
+;
+; Source/problem: Tower of Hanoi move counting.
+; Unit 5 example: direct recursive decomposition with local frame state.
+
+func hanoi_count(disks_count: byte, source_peg: byte, spare_peg: byte, target_peg: byte): HL
+  var
+    reduced_count: byte = 0
+    left_count: word = 0
+    right_count: word = 0
+  end
+
+  move a, disks_count
+  or a
+  if Z
+    ld hl, 0
+    ret
+  end
+
+  move a, disks_count
+  dec a
+  move reduced_count, a
+
+  hanoi_count reduced_count, source_peg, target_peg, spare_peg
+  move left_count, hl
+
+  hanoi_count reduced_count, spare_peg, source_peg, target_peg
+  move right_count, hl
+
+  move hl, left_count
+  inc hl
+  move de, right_count
+  add hl, de
+end
+
+export func main()
+  hanoi_count 4, 1, 2, 3
+end


### PR DESCRIPTION
Closes #838

## Summary
- add Unit 3 bit-pattern examples with local bitwise idioms
- add Unit 5 recursion examples for arrays and Hanoi move counting
- keep helpers inline so the tranche stays self-contained

## Verification
- npm run typecheck
- for f in examples/course/unit3/*.zax examples/course/unit5/*.zax; do npm run zax -- "$f"; done