### PR TITLE
docs: tighten pointer traversal examples

### DIFF
--- a/docs/reference/ZAX-quick-guide.md
+++ b/docs/reference/ZAX-quick-guide.md
@@ -357,13 +357,13 @@ address values:
 ```zax
 move a, <Sprite>hl.flags
 move hl, <Header>ptr.checksum
+move a, <ListNode>current_ptr.value
 ```
 
-The cast does not permanently type `HL` or `ptr`. It only supplies a typed
-storage base for the following field/index path.
-
-Implementation note: this surface is now part of the accepted language docs,
-but compiler support may lag while implementation work catches up.
+The cast does not permanently type `HL`, `ptr`, or `current_ptr`. It only
+supplies a typed storage base for the following field/index path. When the base
+is already held in an `addr` or `word` scalar, prefer the direct form above
+instead of first copying it through `HL`.
 
 ### 3.6 Combining Field Access and Indexing
 

--- a/examples/course/unit7/bst.zax
+++ b/examples/course/unit7/bst.zax
@@ -1,7 +1,8 @@
 ; bst.zax
 ;
 ; Source/problem: search a binary search tree using addr-linked records.
-; Unit 7 example: pointer-typed traversal pressure with recursive descent.
+; Unit 7 example: recursive traversal using direct typed reinterpretation from
+; an addr parameter.
 
 type TreeNode
   value: byte
@@ -59,7 +60,7 @@ func bst_contains(node_ptr: addr, target_value: byte): HL
     ret
   end
 
-  move a, <TreeNode>hl.value
+  move a, <TreeNode>node_ptr.value
   move b, target_value
   cp b
   if Z
@@ -67,14 +68,12 @@ func bst_contains(node_ptr: addr, target_value: byte): HL
     ret
   end
   if C
-    move hl, node_ptr
-    move hl, <TreeNode>hl.right
+    move hl, <TreeNode>node_ptr.right
     bst_contains hl, target_value
     ret
   end
 
-  move hl, node_ptr
-  move hl, <TreeNode>hl.left
+  move hl, <TreeNode>node_ptr.left
   bst_contains hl, target_value
 end
 

--- a/examples/course/unit7/linked_list.zax
+++ b/examples/course/unit7/linked_list.zax
@@ -1,7 +1,8 @@
 ; linked_list.zax
 ;
 ; Source/problem: traverse and sum a singly-linked list.
-; Unit 7 example: actual pointer typing through addr links plus typed reinterpretation.
+; Unit 7 example: addr-linked traversal using direct typed reinterpretation from
+; an addr local.
 
 type ListNode
   value: byte
@@ -55,15 +56,14 @@ export func list_sum(): HL
       ret
     end
 
-    move a, <ListNode>hl.value
+    move a, <ListNode>current_ptr.value
     ld e, a
     ld d, 0
     move hl, total_value
     add hl, de
     move total_value, hl
 
-    move hl, current_ptr
-    move hl, <ListNode>hl.next
+    move hl, <ListNode>current_ptr.next
     move current_ptr, hl
 
     ld a, 1


### PR DESCRIPTION
## Summary
- update the Unit 7 course examples to use direct typed reinterpretation from `addr` locals and parameters
- add an explicit quick-guide example for pointer traversal through an `addr` scalar
- document the direct form as the preferred current idiom instead of bouncing through `HL`

## Verification
- `npm run zax -- examples/course/unit7/linked_list.zax`
- `npm run zax -- examples/course/unit7/bst.zax`
