### PR TITLE
examples: fix HL/L register-overlap bugs in push_value and enqueue

### DIFF
--- a/examples/course/unit4/ring_buffer.zax
+++ b/examples/course/unit4/ring_buffer.zax
@@ -37,11 +37,11 @@ func enqueue(entry_value: byte, entry_stamp: word)
     ret
   end
 
-  move l, tail_slot
+  move b, tail_slot
   move a, entry_value
-  move entries[L].value, a
+  move entries[B].value, a
   move hl, entry_stamp
-  move entries[L].stamp, hl
+  move entries[B].stamp, hl
 
   next_slot tail_slot
   ld a, l

--- a/examples/course/unit6/rpn_calculator.zax
+++ b/examples/course/unit6/rpn_calculator.zax
@@ -16,12 +16,11 @@ section data vars at $8000
 end
 
 func push_value(value_word: word)
-  move a, stack_depth
-  ld l, a
   move hl, value_word
-  move value_stack[L], hl
-
   move a, stack_depth
+  ld b, a
+  move value_stack[B], hl
+
   inc a
   move stack_depth, a
 end


### PR DESCRIPTION
## Summary

Two course examples had a latent register-overlap bug: the programmer set L as an array index, then loaded a **word** fvar into HL. Loading a word fvar emits `ex de, hl / ld e, (ix+d) / ld d, (ix+d+1) / ex de, hl`, which overwrites L with the low byte of the loaded value. The subsequent indexed store then used the wrong slot.

### Affected files

**`unit6/rpn_calculator.zax` — `push_value`**

Old:
```zax
move a, stack_depth
ld l, a              ; L = stack_depth
move hl, value_word  ; word fvar load — overwrites L!
move value_stack[L], hl  ; L = low byte of value_word, not stack_depth
```

Fix: load `value_word` into HL first, then capture `stack_depth` into B. B is not part of HL and survives the word-fvar load intact. Also drops the redundant second load of `stack_depth` (A is still valid).

**`unit4/ring_buffer.zax` — `enqueue`**

Old:
```zax
move l, tail_slot         ; L = tail_slot
move a, entry_value
move entries[L].value, a  ; OK
move hl, entry_stamp      ; word fvar load — overwrites L!
move entries[L].stamp, hl ; L = low byte of entry_stamp, not tail_slot
```

Fix: use B throughout for the tail_slot index.

### Why only these two

Byte fvar loads (`move a, byte_fvar`) emit `ld a, (ix+d)` — a single instruction that does not touch HL. The common `ld h, 0 / move a, byte_fvar / ld l, a` return pattern in unit1–unit3 files is therefore safe. Only **word** fvar loads go through the ex/ld/ld/ex sequence that clobbers HL.

## Test plan

- [ ] `npm run zax -- examples/course/unit6/rpn_calculator.zax` — assembles clean
- [ ] `npm run zax -- examples/course/unit4/ring_buffer.zax` — assembles clean
- [ ] Verify `push_value` now stores into the correct `value_stack` slot
- [ ] Verify `enqueue` now stores both fields into the correct `entries` slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)