### PR TITLE
ci: fix docs-fast base fetch on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
     timeout-minutes: 6
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- give the `docs (fast)` job full history so it can diff PR base/head commits reliably
- fix the current docs-only failure mode caused by missing base commits under shallow checkout
- keep docs-only PRs trivial when there is no real content problem

## Problem
The current `docs (fast)` job checks out with the default shallow clone, then runs:
- `git diff --name-only "$base_sha" "$head_sha"`

On docs-only PRs this can fail with:
- `fatal: bad object <base sha>`

because the base commit is not present locally.
