### PR TITLE
Assign: lower := stage 1 forms

### DIFF
--- a/src/frontend/parseFunc.ts
+++ b/src/frontend/parseFunc.ts
@@ -338,7 +338,7 @@ export function parseTopLevelFuncDecl(
         ? span(file, lineOffset + contentStart, lineOffset + withoutComment.length)
         : fullSpan;
 
-    const labelMatch = /^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.*)$/.exec(content);
+    const labelMatch = /^([A-Za-z_][A-Za-z0-9_]*)\s*:(?!\=)\s*(.*)$/.exec(content);
     if (labelMatch) {
       const label = labelMatch[1]!;
       const remainder = labelMatch[2] ?? '';

--- a/src/frontend/parseOp.ts
+++ b/src/frontend/parseOp.ts
@@ -134,7 +134,7 @@ export function parseTopLevelOpDecl(
     const contentStart = rawNoComment.indexOf(content);
     const contentSpan =
       contentStart >= 0 ? span(file, so + contentStart, so + rawNoComment.length) : fullSpan;
-    const labelMatch = /^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.*)$/.exec(content);
+    const labelMatch = /^([A-Za-z_][A-Za-z0-9_]*)\s*:(?!\=)\s*(.*)$/.exec(content);
     if (labelMatch) {
       const label = labelMatch[1]!;
       const remainder = labelMatch[2] ?? '';

--- a/src/lowering/asmInstructionLowering.ts
+++ b/src/lowering/asmInstructionLowering.ts
@@ -474,8 +474,7 @@ export function createAsmInstructionLoweringHelpers(ctx: Context) {
         return;
       }
       if (dst.kind === 'Ea' || src.kind === 'Ea') {
-        const assignAsLd: AsmInstructionNode = { ...asmItem, head: 'ld' };
-        if (ctx.lowerLdWithEa(assignAsLd)) {
+        if (ctx.lowerLdWithEa(asmItem)) {
           ctx.syncToFlow();
           return;
         }

--- a/src/lowering/ldEncoding.ts
+++ b/src/lowering/ldEncoding.ts
@@ -122,6 +122,7 @@ export function createLdEncodingHelpers(ctx: LdEncodingContext) {
 
   const emitLdForm = (form: LdForm): boolean => {
     const { inst, dst, src, dstResolved, srcResolved, dstScalarExact, srcScalarExact, scalarMemToMem } = form;
+    const isAssignmentForm = inst.head.toLowerCase() === ':=';
 
     const ixDispMem = (disp: number): AsmOperandNode => ({
       kind: 'Mem',
@@ -137,6 +138,86 @@ export function createLdEncodingHelpers(ctx: LdEncodingContext) {
             },
     });
 
+    const emitByteMemLoadToReg8 = (regUp: string): boolean => {
+      const d = reg8Code.get(regUp);
+      if (d === undefined || src.kind !== 'Mem') return false;
+
+      if (srcResolved?.kind === 'abs' && srcResolved.addend === 0) {
+        if (!emitInstr('push', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span)) return false;
+        emitAbs16Fixup(0x3a, srcResolved.baseLower, 0, inst.span);
+        if (
+          !emitInstr(
+            'ld',
+            [
+              { kind: 'Reg', span: inst.span, name: regUp },
+              { kind: 'Reg', span: inst.span, name: 'A' },
+            ],
+            inst.span,
+          )
+        ) {
+          return false;
+        }
+        return emitInstr('pop', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span);
+      }
+
+      if (srcResolved?.kind === 'stack' && srcResolved.ixDisp >= -0x80 && srcResolved.ixDisp <= 0x7f) {
+        if (regUp === 'H' || regUp === 'L') {
+          if (
+            !emitInstr(
+              'ex',
+              [
+                { kind: 'Reg', span: inst.span, name: 'DE' },
+                { kind: 'Reg', span: inst.span, name: 'HL' },
+              ],
+              inst.span,
+            )
+          ) {
+            return false;
+          }
+          if (
+            !emitInstr(
+              'ld',
+              [
+                { kind: 'Reg', span: inst.span, name: regUp === 'H' ? 'D' : 'E' },
+                ixDispMem(srcResolved.ixDisp),
+              ],
+              inst.span,
+            )
+          ) {
+            return false;
+          }
+          return emitInstr(
+            'ex',
+            [
+              { kind: 'Reg', span: inst.span, name: 'DE' },
+              { kind: 'Reg', span: inst.span, name: 'HL' },
+            ],
+            inst.span,
+          );
+        }
+
+        emitRawCodeBytes(
+          Uint8Array.of(0xdd, 0x46 + (d << 3), srcResolved.ixDisp & 0xff),
+          inst.span.file,
+          `ld ${regUp}, (ix${formatIxDisp(srcResolved.ixDisp)})`,
+        );
+        return true;
+      }
+
+      const eaPipe = buildEaBytePipeline(src.expr, inst.span);
+      if (eaPipe) {
+        let templated: StepPipeline | null = null;
+        if (regUp === 'A' || regUp === 'B' || regUp === 'C') templated = TEMPLATE_L_ABC(regUp, eaPipe);
+        else if (regUp === 'H' || regUp === 'L') templated = TEMPLATE_L_HL(regUp as 'H' | 'L', eaPipe);
+        else if (regUp === 'D' || regUp === 'E') templated = TEMPLATE_L_DE(regUp as 'D' | 'E', eaPipe);
+        if (templated && emitStepPipeline(templated, inst.span)) return true;
+      }
+
+      if (!materializeEaAddressToHL(src.expr, inst.span)) return false;
+      emitRawCodeBytes(Uint8Array.of(0x46 + (d << 3)), inst.span.file, `ld ${regUp}, (hl)`);
+      return true;
+    };
+
     if (dst.kind === 'Reg' && src.kind === 'Mem') {
       if (form.srcHasRegisterLikeEaBase) return false;
       if (form.srcIsIxIyDispMem && reg8Code.has(dst.name.toUpperCase())) return false;
@@ -149,85 +230,23 @@ export function createLdEncodingHelpers(ctx: LdEncodingContext) {
       const regUp = dst.name.toUpperCase();
       const d = reg8Code.get(regUp);
       if (d !== undefined) {
-        if (srcResolved?.kind === 'abs' && srcResolved.addend === 0) {
-          if (!emitInstr('push', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span)) return false;
-          emitAbs16Fixup(0x3a, srcResolved.baseLower, 0, inst.span);
-          if (
-            !emitInstr(
-              'ld',
-              [
-                { kind: 'Reg', span: inst.span, name: regUp },
-                { kind: 'Reg', span: inst.span, name: 'A' },
-              ],
-              inst.span,
-            )
-          ) {
-            return false;
-          }
-          return emitInstr('pop', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span);
-        }
-
-        if (srcResolved?.kind === 'stack' && srcResolved.ixDisp >= -0x80 && srcResolved.ixDisp <= 0x7f) {
-          if (regUp === 'H' || regUp === 'L') {
-            if (
-              !emitInstr(
-                'ex',
-                [
-                  { kind: 'Reg', span: inst.span, name: 'DE' },
-                  { kind: 'Reg', span: inst.span, name: 'HL' },
-                ],
-                inst.span,
-              )
-            ) {
-              return false;
-            }
-            if (
-              !emitInstr(
-                'ld',
-                [
-                  { kind: 'Reg', span: inst.span, name: regUp === 'H' ? 'D' : 'E' },
-                  ixDispMem(srcResolved.ixDisp),
-                ],
-                inst.span,
-              )
-            ) {
-              return false;
-            }
-            return emitInstr(
-              'ex',
-              [
-                { kind: 'Reg', span: inst.span, name: 'DE' },
-                { kind: 'Reg', span: inst.span, name: 'HL' },
-              ],
-              inst.span,
-            );
-          }
-
-          emitRawCodeBytes(
-            Uint8Array.of(0xdd, 0x46 + (d << 3), srcResolved.ixDisp & 0xff),
-            inst.span.file,
-            `ld ${regUp}, (ix${formatIxDisp(srcResolved.ixDisp)})`,
-          );
-          return true;
-        }
-
-        const eaPipe = buildEaBytePipeline(src.expr, inst.span);
-        if (eaPipe) {
-          let templated: StepPipeline | null = null;
-          if (regUp === 'A' || regUp === 'B' || regUp === 'C') templated = TEMPLATE_L_ABC(regUp, eaPipe);
-          else if (regUp === 'H' || regUp === 'L') templated = TEMPLATE_L_HL(regUp as 'H' | 'L', eaPipe);
-          else if (regUp === 'D' || regUp === 'E') templated = TEMPLATE_L_DE(regUp as 'D' | 'E', eaPipe);
-          if (templated && emitStepPipeline(templated, inst.span)) return true;
-        }
-
-        if (!materializeEaAddressToHL(src.expr, inst.span)) return false;
-        emitRawCodeBytes(Uint8Array.of(0x46 + (d << 3)), inst.span.file, `ld ${regUp}, (hl)`);
-        return true;
+        return emitByteMemLoadToReg8(regUp);
       }
 
       const r16 = dst.name.toUpperCase();
       if (r16 === 'HL') {
         if (srcScalarExact === 'byte') {
+          if (isAssignmentForm) {
+            if (
+              !emitInstr(
+                'ld',
+                [{ kind: 'Reg', span: inst.span, name: 'H' }, { kind: 'Imm', span: inst.span, expr: { kind: 'ImmLiteral', span: inst.span, value: 0 } }],
+                inst.span,
+              )
+            )
+              return false;
+            return emitByteMemLoadToReg8('L');
+          }
           diagAt(diagnostics, inst.span, 'Word register load requires a word-typed source.');
           return true;
         }
@@ -246,6 +265,17 @@ export function createLdEncodingHelpers(ctx: LdEncodingContext) {
       }
       if (r16 === 'DE') {
         if (srcScalarExact === 'byte') {
+          if (isAssignmentForm) {
+            if (
+              !emitInstr(
+                'ld',
+                [{ kind: 'Reg', span: inst.span, name: 'D' }, { kind: 'Imm', span: inst.span, expr: { kind: 'ImmLiteral', span: inst.span, value: 0 } }],
+                inst.span,
+              )
+            )
+              return false;
+            return emitByteMemLoadToReg8('E');
+          }
           diagAt(diagnostics, inst.span, 'Word register load requires a word-typed source.');
           return true;
         }
@@ -264,6 +294,17 @@ export function createLdEncodingHelpers(ctx: LdEncodingContext) {
       }
       if (r16 === 'BC') {
         if (srcScalarExact === 'byte') {
+          if (isAssignmentForm) {
+            if (
+              !emitInstr(
+                'ld',
+                [{ kind: 'Reg', span: inst.span, name: 'B' }, { kind: 'Imm', span: inst.span, expr: { kind: 'ImmLiteral', span: inst.span, value: 0 } }],
+                inst.span,
+              )
+            )
+              return false;
+            return emitByteMemLoadToReg8('C');
+          }
           diagAt(diagnostics, inst.span, 'Word register load requires a word-typed source.');
           return true;
         }

--- a/src/lowering/ldFormSelection.ts
+++ b/src/lowering/ldFormSelection.ts
@@ -138,7 +138,8 @@ export function createLdFormSelectionHelpers(ctx: LdFormSelectionContext) {
       ((op.expr.kind === 'EaAdd' || op.expr.kind === 'EaSub') && isIxIyBaseEa(op.expr.base)));
 
   const analyzeLdInstruction = (inst: AsmInstructionNode): LdForm | null => {
-    if (inst.head.toLowerCase() !== 'ld' || inst.operands.length !== 2) return null;
+    const head = inst.head.toLowerCase();
+    if ((head !== 'ld' && head !== ':=') || inst.operands.length !== 2) return null;
 
     const dst = coerceValueOperand(inst.operands[0]!);
     const src = coerceValueOperand(inst.operands[1]!);

--- a/test/fixtures/pr863_assignment_byte_widening.zax
+++ b/test/fixtures/pr863_assignment_byte_widening.zax
@@ -1,0 +1,15 @@
+section data vars at $2000
+  parity_value: byte
+  widened_hl: word
+  widened_de: word
+end
+
+section code boot at $0100
+  export func main()
+    hl := parity_value
+    widened_hl := hl
+
+    de := parity_value
+    widened_de := de
+  end
+end

--- a/test/pr863_assignment_byte_widening_integration.test.ts
+++ b/test/pr863_assignment_byte_widening_integration.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { AsmArtifact } from '../src/formats/types.js';
+
+describe('PR863 := byte storage widening integration', () => {
+  it('widens byte storage into register pairs under :=', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr863_assignment_byte_widening.zax');
+    const res = await compile(
+      entry,
+      { emitAsm: true, emitBin: false, emitHex: false, emitListing: false, emitD8m: false },
+      { formats: defaultFormatWriters },
+    );
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+
+    const asm = res.artifacts.find((a): a is AsmArtifact => a.kind === 'asm');
+    expect(asm).toBeDefined();
+    const text = asm!.text.toUpperCase();
+
+    expect(text).toContain('LD H, $0000');
+    expect(text).toContain('LD L, A');
+    expect(text).toContain('LD D, $0000');
+    expect(text).toContain('LD E, A');
+    expect(text).not.toContain('WORD REGISTER LOAD REQUIRES A WORD-TYPED SOURCE');
+  });
+});

--- a/test/pr863_assignment_lowering.test.ts
+++ b/test/pr863_assignment_lowering.test.ts
@@ -97,7 +97,7 @@ describe('PR863 := lowering', () => {
     expect(diagnostics).toEqual([]);
     expect(loweredLd).toHaveLength(1);
     expect(loweredLd[0]).toMatchObject({
-      head: 'ld',
+      head: ':=',
       operands: [
         { kind: 'Reg', name: 'A' },
         { kind: 'Ea', expr: { kind: 'EaName', name: 'x' } },


### PR DESCRIPTION
Implements GitHub issue #863.

Scope:
- lowering for Stage 1 `:=` forms
- reuses existing typed-storage move/ld lowering where possible
- adds direct lowering for register immediates, pair copies, byte-to-pair widening, and `@path` RHS into reg16

Verification:
- `npm run typecheck`
- `npx vitest run test/pr863_assignment_lowering.test.ts test/pr862_assignment_parser.test.ts test/pr780_move_lowering_integration.test.ts test/pr799_addr_expr_lowering.test.ts`