### PR TITLE
Assign: parse reg8 := forms

### DIFF
--- a/src/frontend/parseOperands.ts
+++ b/src/frontend/parseOperands.ts
@@ -16,7 +16,7 @@ import {
 import { parseDiag as diag, parseDiagAtWithId } from './parseDiagnostics.js';
 import { ALL_REGISTER_NAMES, INDEX_REG16_NAMES, INDEX_REG8_NAMES } from './grammarData.js';
 
-const ASSIGNMENT_REGISTER_NAMES = new Set<string>(['A', 'BC', 'DE', 'HL']);
+const ASSIGNMENT_REGISTER_NAMES = new Set<string>(['A', 'B', 'C', 'D', 'E', 'H', 'L', 'BC', 'DE', 'HL']);
 
 function parseBalancedContent(
   text: string,

--- a/test/pr862_assignment_parser.test.ts
+++ b/test/pr862_assignment_parser.test.ts
@@ -111,7 +111,7 @@ describe('PR862 := assignment parser/AST support', () => {
   });
 
   it('rejects indirect, partial, and unsupported assignment forms', () => {
-    for (const text of ['(hl) := a', 'a := (hl)', 'h := d', 'l := a', 'x := y', 'x := @y']) {
+    for (const text of ['(hl) := a', 'a := (hl)', 'ixh := a', 'iyl := a', 'x := y', 'x := @y']) {
       const parsed = parse(text);
       expect(parsed.instr).toBeUndefined();
       expect(parsed.diagnostics.length).toBeGreaterThan(0);

--- a/test/pr868_assignment_reg8_parser.test.ts
+++ b/test/pr868_assignment_reg8_parser.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { makeSourceFile, span } from '../src/frontend/source.js';
+import { parseAsmInstruction } from '../src/frontend/parseOperands.js';
+
+describe('PR868 := reg8 parser support', () => {
+  const file = makeSourceFile('pr868_assignment_reg8_parser.zax', '');
+  const zeroSpan = span(file, 0, 0);
+
+  function parse(
+    text: string,
+  ): { instr: ReturnType<typeof parseAsmInstruction>; diagnostics: Diagnostic[] } {
+    const diagnostics: Diagnostic[] = [];
+    const instr = parseAsmInstruction(file.path, text, zeroSpan, diagnostics);
+    return { instr, diagnostics };
+  }
+
+  it('accepts reg8 typed storage loads and stores', () => {
+    for (const text of ['b := count', 'l := idx', 'b := arr[idx]', 'flags := b']) {
+      const parsed = parse(text);
+      expect(parsed.diagnostics).toEqual([]);
+      expect(parsed.instr?.head).toBe(':=');
+    }
+  });
+
+  it('accepts reg8 immediate assignments', () => {
+    for (const text of ['l := 0', 'b := 1', 'h := 2', 'e := 3']) {
+      const parsed = parse(text);
+      expect(parsed.diagnostics).toEqual([]);
+      expect(parsed.instr).toMatchObject({
+        kind: 'AsmInstruction',
+        head: ':=',
+        operands: [{ kind: 'Reg' }, { kind: 'Imm' }],
+      });
+    }
+  });
+
+  it('keeps raw indirect forms rejected', () => {
+    for (const text of ['a := (hl)', '(hl) := a', '(ix+4) := a']) {
+      const parsed = parse(text);
+      expect(parsed.instr).toBeUndefined();
+      expect(parsed.diagnostics.length).toBeGreaterThan(0);
+      expect(parsed.diagnostics[0]?.message).toContain(':=');
+    }
+  });
+
+  it('keeps existing stage 1 pair forms accepted', () => {
+    for (const text of ['hl := de', 'hl := 0', 'de := a', 'hl := @x']) {
+      const parsed = parse(text);
+      expect(parsed.diagnostics).toEqual([]);
+      expect(parsed.instr?.head).toBe(':=');
+    }
+  });
+});


### PR DESCRIPTION
Implements GitHub issue #868.

Scope:
- parser-only extension for reg8 `:=` typed byte transfers
- keeps existing Stage 1 pair forms intact
- no lowering changes

Verification:
- `npm run typecheck`
- `npx vitest run test/pr868_assignment_reg8_parser.test.ts test/pr862_assignment_parser.test.ts test/pr476_parse_asm_statements_helpers.test.ts`