### PR TITLE
docs: sweep move to := after reg8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ Field and array access compose as place expressions. The compiler lowers them to
 
 ```zax
 func update_sprite(idx: byte): void
-  move l, idx
+  l := idx
   a := sprites[L].flags    ; load flags field of sprites[idx]
   set 0, a
   sprites[L].flags := a    ; write back
@@ -503,7 +503,7 @@ Output is deterministic: given the same source and the same compiler flags, the 
 
 ZAX is under active development. The compiler is a Node.js CLI tool; the end-to-end pipeline (lex → parse → lower → encode → emit) is functional and produces `.bin`, `.hex`, `.d8dbg.json`, `.lst`, and `.asm` output.
 
-What works today: single and multi-module compilation, functions with typed parameters and locals, IX-anchored frame calling conventions, structured control flow, the op system, records/unions/arrays, named `section code`/`section data` blocks, typed storage via `:=` (with transitional `move`), `@path` address-of, `<Type>base.tail` typed reinterpretation, grouped and ranged `select case`, raw data directives (`db`/`dw`/`ds`), compile-time expressions, forward references and fixups, and a growing slice of the Z80 instruction set.
+What works today: single and multi-module compilation, functions with typed parameters and locals, IX-anchored frame calling conventions, structured control flow, the op system, records/unions/arrays, named `section code`/`section data` blocks, typed storage via `:=`, `@path` address-of, `<Type>base.tail` typed reinterpretation, grouped and ranged `select case`, raw data directives (`db`/`dw`/`ds`), compile-time expressions, forward references and fixups, and a growing slice of the Z80 instruction set.
 
 Active work: exact-size runtime indexing for non-power-of-two composite strides (issues #817–820), broader ISA coverage, and Debug80 integration.
 

--- a/docs/reference/ZAX-quick-guide.md
+++ b/docs/reference/ZAX-quick-guide.md
@@ -380,14 +380,14 @@ section data sprites_data at $8200
 end
 
 func step_sprite(idx: byte): void
-  move l, idx            ; put index in L (8-bit register)
+  l := idx            ; put index in L (8-bit register)
   a := sprites[L].x   ; read x field of sprites[L]
   inc a
   sprites[L].x := a   ; write back
 end
 ```
 
-The compiler emits the shift chain for the outer index (`sizeof(Sprite) = 8` → three `ADD HL, HL`), then adds the field offset for `.x` (which is 0, so no additional add is needed here). The partial-register load `move l, idx` stays on `move` in Stage 1 because `:=` is currently limited to whole-register destinations.
+The compiler emits the shift chain for the outer index (`sizeof(Sprite) = 8` → three `ADD HL, HL`), then adds the field offset for `.x` (which is 0, so no additional add is needed here).
 
 ### 3.7 Address Arithmetic
 
@@ -620,7 +620,7 @@ Use `repeat ... until` when:
 
 ```zax
 ; Decrement B from some value down to zero
-move b, count
+b := count
 repeat
   ; ... do work ...
   dec b             ; sets Z when B reaches 0
@@ -1016,7 +1016,7 @@ func sum_bytes(data: addr, count: byte): word
   hl := data
   ptr := hl
 
-  move b, count       ; loop counter in B
+  b := count       ; loop counter in B
   ld hl, 0            ; running total in HL
 
 loop:
@@ -1512,7 +1512,7 @@ Records must contain at least one field — an empty `type ... end` is a compile
 
 ### 9.2 Field Access and Value Semantics
 
-`rec.field` is a **place expression** — a typed field location. In value/store contexts (`:=`, transitional `move`, typed call arguments), the compiler inserts the required load or store automatically:
+`rec.field` is a **place expression** — a typed field location. In value/store contexts (`:=`, typed call arguments), the compiler inserts the required load or store automatically:
 
 ```zax
 section data vars at $8000
@@ -2115,13 +2115,13 @@ end
 
 func uart_send(ch: byte): void
   uart_wait_tx         ; inline poll — no call overhead
-  move uart.tx_data, ch  ; write via value semantics
+  uart.tx_data := ch  ; write via value semantics
   ret
 end
 
 func uart_recv(): byte
   uart_wait_rx
-  move l, uart.rx_data   ; result in L (byte return channel)
+  l := uart.rx_data   ; result in L (byte return channel)
   ret
 end
 ```

--- a/docs/reference/arrays.md
+++ b/docs/reference/arrays.md
@@ -5,7 +5,7 @@ Date: 2026-02-21.
 
 This document works through the concrete lowering strategies for effective-address computation in ZAX, given the decision to use IX as a permanent frame pointer. It covers every combination of base and offset provenance (register, local/arg variable, global symbol), for both 8-bit and 16-bit offsets, with approximate T-state costs and practical guidance for the compiler and the programmer.
 
-The focus is array indexing (`arr[i]`) and field access on records, but the same machinery applies to any `ea + offset` computation used internally by lowering. Examples use the current `:=`-based value-semantics model, with transitional `move` still used for partial-register cases: `arr[i]` / `rec.field` are source-level storage accesses, while lowered Z80 examples may still show `(addr)` forms to make the emitted code explicit.
+The focus is array indexing (`arr[i]`) and field access on records, but the same machinery applies to any `ea + offset` computation used internally by lowering. Examples use the current `:=`-based value-semantics model: `arr[i]` / `rec.field` are source-level storage accesses, while lowered Z80 examples may still show `(addr)` forms to make the emitted code explicit.
 
 ---
 

--- a/examples/course/unit1/binary_search.zax
+++ b/examples/course/unit1/binary_search.zax
@@ -46,7 +46,7 @@ func binary_search(target_value: byte): HL
     probe_value := a
 
     a := target_value
-    move b, probe_value
+    b := probe_value
     cp b
     if Z
       hl := mid_index

--- a/examples/course/unit1/bubble_sort.zax
+++ b/examples/course/unit1/bubble_sort.zax
@@ -16,19 +16,19 @@ func swap_values(left_index: byte, right_index: byte)
     right_value: byte = 0
   end
 
-  move l, left_index
+  l := left_index
   a := values[L]
   left_value := a
 
-  move l, right_index
+  l := right_index
   a := values[L]
   right_value := a
 
-  move l, left_index
+  l := left_index
   a := right_value
   values[L] := a
 
-  move l, right_index
+  l := right_index
   a := left_value
   values[L] := a
 end
@@ -45,13 +45,13 @@ func bubble_pass(last_index: byte)
   or a
   while NZ
     a := inner_index
-    move b, last_index
+    b := last_index
     cp b
     if NC
       ret
     end
 
-    move l, inner_index
+    l := inner_index
     a := values[L]
     left_value := a
 
@@ -59,12 +59,12 @@ func bubble_pass(last_index: byte)
     inc a
     next_index := a
 
-    move l, next_index
+    l := next_index
     a := values[L]
     right_value := a
 
     a := left_value
-    move b, right_value
+    b := right_value
     cp b
     if NC
       if NZ

--- a/examples/course/unit1/insertion_sort.zax
+++ b/examples/course/unit1/insertion_sort.zax
@@ -28,27 +28,27 @@ func insert_hole(scan_index: byte, hold_value: byte)
   dec a
   prior_index := a
 
-  move l, prior_index
+  l := prior_index
   a := values[L]
   left_value := a
 
   a := left_value
-  move b, hold_value
+  b := hold_value
   cp b
   if C
-    move l, scan_index
+    l := scan_index
     a := hold_value
     values[L] := a
     ret
   end
   if Z
-    move l, scan_index
+    l := scan_index
     a := hold_value
     values[L] := a
     ret
   end
 
-  move l, scan_index
+  l := scan_index
   a := left_value
   values[L] := a
 
@@ -70,7 +70,7 @@ export func insertion_sort()
       ret
     end
 
-    move l, outer_index
+    l := outer_index
     a := values[L]
     hold_value := a
 

--- a/examples/course/unit1/linear_search.zax
+++ b/examples/course/unit1/linear_search.zax
@@ -25,12 +25,12 @@ func linear_search(target_value: byte): HL
       ret
     end
 
-    move l, scan_index
+    l := scan_index
     a := values[L]
     probe_value := a
 
     a := target_value
-    move b, probe_value
+    b := probe_value
     cp b
     if Z
       ld h, 0

--- a/examples/course/unit1/prime_sieve.zax
+++ b/examples/course/unit1/prime_sieve.zax
@@ -25,7 +25,7 @@ export func prime_sieve()
       ret
     end
 
-    move l, factor_index
+    l := factor_index
     a := is_prime[L]
     or a
     if Z
@@ -38,7 +38,7 @@ export func prime_sieve()
 
     if NZ
       a := factor_index
-      move b, factor_index
+      b := factor_index
       add a, b
       multiple_index := a
 
@@ -52,12 +52,12 @@ export func prime_sieve()
           or a
         end
         if C
-          move l, multiple_index
+          l := multiple_index
           ld a, 0
           is_prime[L] := a
 
           a := multiple_index
-          move b, factor_index
+          b := factor_index
           add a, b
           multiple_index := a
 

--- a/examples/course/unit1/selection_sort.zax
+++ b/examples/course/unit1/selection_sort.zax
@@ -16,19 +16,19 @@ func swap_values(left_index: byte, right_index: byte)
     right_value: byte = 0
   end
 
-  move l, left_index
+  l := left_index
   a := values[L]
   left_value := a
 
-  move l, right_index
+  l := right_index
   a := values[L]
   right_value := a
 
-  move l, left_index
+  l := left_index
   a := right_value
   values[L] := a
 
-  move l, right_index
+  l := right_index
   a := left_value
   values[L] := a
 end
@@ -45,7 +45,7 @@ func find_min_index(start_index: byte, last_index: byte): HL
   best_index := a
   current_index := a
 
-  move l, start_index
+  l := start_index
   a := values[L]
   best_value := a
 
@@ -53,7 +53,7 @@ func find_min_index(start_index: byte, last_index: byte): HL
   or a
   while NZ
     a := current_index
-    move b, last_index
+    b := last_index
     cp b
     if C
       ; continue
@@ -70,12 +70,12 @@ func find_min_index(start_index: byte, last_index: byte): HL
       end
     end
 
-    move l, current_index
+    l := current_index
     a := values[L]
     current_value := a
 
     a := current_value
-    move b, best_value
+    b := best_value
     cp b
     if C
       a := current_index
@@ -117,7 +117,7 @@ export func selection_sort()
     min_index := a
 
     a := min_index
-    move b, outer_index
+    b := outer_index
     cp b
     if Z
       ; already in place

--- a/examples/course/unit2/itoa.zax
+++ b/examples/course/unit2/itoa.zax
@@ -101,7 +101,7 @@ export func itoa_demo()
       add a, '0'
       digit_value := a
 
-      move l, write_index
+      l := write_index
       a := digit_value
       reverse_digits[L] := a
 
@@ -123,7 +123,7 @@ export func itoa_demo()
     a := write_index
     or a
     if Z
-      move l, read_index
+      l := read_index
       ld a, 0
       output_text[L] := a
       ret
@@ -133,11 +133,11 @@ export func itoa_demo()
     dec a
     write_index := a
 
-    move l, write_index
+    l := write_index
     a := reverse_digits[L]
     digit_value := a
 
-    move l, read_index
+    l := read_index
     a := digit_value
     output_text[L] := a
 

--- a/examples/course/unit2/strcmp.zax
+++ b/examples/course/unit2/strcmp.zax
@@ -26,7 +26,7 @@ export func strcmp_demo(): HL
     right_char := a
 
     a := left_char
-    move b, right_char
+    b := right_char
     cp b
     if C
       ld hl, $FFFF

--- a/examples/course/unit3/bit_reverse.zax
+++ b/examples/course/unit3/bit_reverse.zax
@@ -31,7 +31,7 @@ export func bit_reverse_demo(): HL
     end
 
     a := reversed_value
-    move b, source_value
+    b := source_value
     append_low_bit a, b
     reversed_value := a
 

--- a/examples/course/unit3/getbits.zax
+++ b/examples/course/unit3/getbits.zax
@@ -51,7 +51,7 @@ export func getbits_demo(): HL
     and 1
     if NZ
       a := result_value
-      move b, bit_mask
+      b := bit_mask
       or b
       result_value := a
     end

--- a/examples/course/unit4/ring_buffer.zax
+++ b/examples/course/unit4/ring_buffer.zax
@@ -37,7 +37,7 @@ func enqueue(entry_value: byte, entry_stamp: word)
     ret
   end
 
-  move b, tail_slot
+  b := tail_slot
   a := entry_value
   entries[B].value := a
   hl := entry_stamp
@@ -64,7 +64,7 @@ func dequeue(): HL
     ret
   end
 
-  move l, head_slot
+  l := head_slot
   a := entries[L].value
   removed_value := a
 

--- a/examples/course/unit5/array_reverse_recursive.zax
+++ b/examples/course/unit5/array_reverse_recursive.zax
@@ -15,19 +15,19 @@ func swap_values(left_index: byte, right_index: byte)
     right_value: byte = 0
   end
 
-  move l, left_index
+  l := left_index
   a := numbers[L]
   left_value := a
 
-  move l, right_index
+  l := right_index
   a := numbers[L]
   right_value := a
 
-  move l, left_index
+  l := left_index
   a := right_value
   numbers[L] := a
 
-  move l, right_index
+  l := right_index
   a := left_value
   numbers[L] := a
 end
@@ -39,7 +39,7 @@ func reverse_range(left_index: byte, right_index: byte)
   end
 
   a := left_index
-  move b, right_index
+  b := right_index
   cp b
   if NC
     ret

--- a/examples/course/unit5/array_sum_recursive.zax
+++ b/examples/course/unit5/array_sum_recursive.zax
@@ -22,7 +22,7 @@ func sum_from(index_value: byte): HL
     ret
   end
 
-  move l, index_value
+  l := index_value
   a := numbers[L]
   current_value := a
 

--- a/examples/course/unit6/rpn_calculator.zax
+++ b/examples/course/unit6/rpn_calculator.zax
@@ -74,13 +74,13 @@ export func rpn_demo(): HL
       ret
     end
 
-    move l, token_index
+    l := token_index
     a := token_kinds[L]
     current_kind := a
 
     select A
       case KindNumber
-        move l, token_index
+        l := token_index
         hl := token_values[L]
         word_stack.push_word value_stack, stack_depth, hl
         stack_depth := a

--- a/examples/course/unit7/bst.zax
+++ b/examples/course/unit7/bst.zax
@@ -61,7 +61,7 @@ func bst_contains(node_ptr: addr, target_value: byte): HL
   end
 
   a := <TreeNode>node_ptr.value
-  move b, target_value
+  b := target_value
   cp b
   if Z
     ld hl, 1

--- a/examples/course/unit8/eight_queens.zax
+++ b/examples/course/unit8/eight_queens.zax
@@ -50,38 +50,38 @@ func place_row(row_index: byte)
     end
 
     a := row_index
-    move b, col_index
+    b := col_index
     add a, b
     sum_index := a
 
     a := row_index
     add a, DiagBias
-    move b, col_index
+    b := col_index
     sub b
     diff_index := a
 
-    move l, col_index
+    l := col_index
     a := col_used[L]
     or a
     if Z
-      move l, sum_index
+      l := sum_index
       a := diag_sum_used[L]
       or a
       if Z
-        move l, diff_index
+        l := diff_index
         a := diag_diff_used[L]
         or a
         if Z
-          move l, row_index
+          l := row_index
           a := col_index
           queen_cols[L] := a
 
-          move l, col_index
+          l := col_index
           ld a, 1
           col_used[L] := a
-          move l, sum_index
+          l := sum_index
           diag_sum_used[L] := a
-          move l, diff_index
+          l := diff_index
           diag_diff_used[L] := a
 
           a := row_index
@@ -94,12 +94,12 @@ func place_row(row_index: byte)
             ret
           end
 
-          move l, col_index
+          l := col_index
           ld a, 0
           col_used[L] := a
-          move l, sum_index
+          l := sum_index
           diag_sum_used[L] := a
-          move l, diff_index
+          l := diff_index
           diag_diff_used[L] := a
         end
       end

--- a/examples/language-tour/01_args_locals_basics.zax
+++ b/examples/language-tour/01_args_locals_basics.zax
@@ -9,7 +9,7 @@ func bump_byte(input_byte: byte): HL
     temp_word: word = 0
   end
 
-  move l, input_byte
+  l := input_byte
   ld h, 0
   inc l
   temp_word := hl

--- a/examples/language-tour/11_records_and_fields.zax
+++ b/examples/language-tour/11_records_and_fields.zax
@@ -15,8 +15,8 @@ func write_pair(lo_value: byte, hi_value: byte)
 end
 
 func read_pair_word(): HL
-  move l, pair_buf.lo
-  move h, pair_buf.hi
+  l := pair_buf.lo
+  h := pair_buf.hi
 end
 
 export func main()

--- a/examples/language-tour/31_scalar_byte_frame.zax
+++ b/examples/language-tour/31_scalar_byte_frame.zax
@@ -4,8 +4,8 @@ end
 
 section code boot at $0100
   export func touch_scalar_byte_frame(arg_b: byte): HL
-    move b, arg_b
-    move arg_b, b
+    b := arg_b
+    arg_b := b
     ld h, 0
     ld l, b
   end

--- a/examples/language-tour/35_byte_glob_reg8.zax
+++ b/examples/language-tour/35_byte_glob_reg8.zax
@@ -4,8 +4,8 @@ end
 
 section code boot at $0100
   export func byte_glob_reg(idx: word): HL
-    move b, glob_bytes[idx]
-    move glob_bytes[idx], b
+    b := glob_bytes[idx]
+    glob_bytes[idx] := b
     ld h, 0
     ld l, b
   end

--- a/examples/language-tour/38_byte_fvar_reg8.zax
+++ b/examples/language-tour/38_byte_fvar_reg8.zax
@@ -4,8 +4,8 @@ end
 
 section code boot at $0100
   export func byte_fvar_reg(arr: byte[], idx: word): HL
-    move b, arr[idx]
-    move arr[idx], b
+    b := arr[idx]
+    arr[idx] := b
     ld h, 0
     ld l, b
   end

--- a/test/fixtures/corpus/intermediate_indexing.zax
+++ b/test/fixtures/corpus/intermediate_indexing.zax
@@ -7,11 +7,11 @@ end
 
 section code main at $0000
   export func main()
-    move a, arr[idx]
-    move a, arr[idxw]
-    move a, arr[hl]
-    move a, arr[(hl)]
-    move a, grid[idx][0]
+    a := arr[idx]
+    a := arr[idxw]
+    a := arr[hl]
+    a := arr[(hl)]
+    a := grid[idx][0]
     ret
   end
 end

--- a/test/fixtures/pr260_value_semantics_scalar_index.zax
+++ b/test/fixtures/pr260_value_semantics_scalar_index.zax
@@ -5,8 +5,8 @@ section data vars at $1000
 end
 
 export func main()
-  move a, arr[idxb]
-  move arr[idxb], a
-  move a, arr[idxw]
-  move arr[idxw], a
+  a := arr[idxb]
+  arr[idxb] := a
+  a := arr[idxw]
+  arr[idxw] := a
 end

--- a/test/fixtures/pr264_runtime_atom_budget_valid.zax
+++ b/test/fixtures/pr264_runtime_atom_budget_valid.zax
@@ -6,11 +6,11 @@ section data vars at $1000
 end
 
 export func main()
-  move a, arr[idx]
-  move a, arr[idxw]
-  move a, arr[HL]
-  move a, arr[(HL)]
-  move a, grid[idx << 3]
+  a := arr[idx]
+  a := arr[idxw]
+  a := arr[HL]
+  a := arr[(HL)]
+  a := grid[idx << 3]
 
   select grid[idx << 3]
   case 0

--- a/test/fixtures/pr272_runtime_affine_invalid.zax
+++ b/test/fixtures/pr272_runtime_affine_invalid.zax
@@ -4,8 +4,8 @@ section data vars at $1000
 end
 
 export func main()
-  move a, arr[idx * 3]
-  move a, arr[idx >> 1]
-  move a, arr[idx / 2]
-  move a, arr + (idx / 2)
+  a := arr[idx * 3]
+  a := arr[idx >> 1]
+  a := arr[idx / 2]
+  a := arr + (idx / 2)
 end

--- a/test/fixtures/pr272_runtime_affine_valid.zax
+++ b/test/fixtures/pr272_runtime_affine_valid.zax
@@ -5,12 +5,12 @@ section data vars at $1000
 end
 
 export func main()
-  move a, arr[idx + 1]
-  move a, arr[1 + idx]
-  move a, arr[idxw + 2]
-  move a, arr[idx << 1]
-  move a, arr[(idx * 2) + 3]
-  move a, arr[idx + 4]
-  move a, arr[(idxw << 1) + 6]
+  a := arr[idx + 1]
+  a := arr[1 + idx]
+  a := arr[idxw + 2]
+  a := arr[idx << 1]
+  a := arr[(idx * 2) + 3]
+  a := arr[idx + 4]
+  a := arr[(idxw << 1) + 6]
   ret
 end

--- a/test/fixtures/pr274_type_padding_explicit_ok.zax
+++ b/test/fixtures/pr274_type_padding_explicit_ok.zax
@@ -12,6 +12,6 @@ section data vars at $1000
 end
 
 export func main()
-  move a, one.x
+  a := one.x
   ret
 end

--- a/test/fixtures/pr274_type_padding_warning.zax
+++ b/test/fixtures/pr274_type_padding_warning.zax
@@ -10,6 +10,6 @@ section data vars at $1000
 end
 
 export func main()
-  move a, one.x
+  a := one.x
   ret
 end

--- a/test/fixtures/pr276_typed_call_preservation_matrix.zax
+++ b/test/fixtures/pr276_typed_call_preservation_matrix.zax
@@ -12,7 +12,7 @@ section code boot at $0000
     getb 7
     ld a, l
     getw 9
-    move out, hl
+    out := hl
     ret
   end
 end

--- a/test/fixtures/pr277_index_redundant_paren_warning.zax
+++ b/test/fixtures/pr277_index_redundant_paren_warning.zax
@@ -4,9 +4,9 @@ end
 
 section code boot at $0000
   export func main()
-    move a, arr[(3 + 5)]
-    move a, arr[(HL)]
-    move a, arr[(IX+1)]
+    a := arr[(3 + 5)]
+    a := arr[(HL)]
+    a := arr[(IX+1)]
     ret
   end
 end

--- a/test/fixtures/pr278_nested_runtime_store_matrix.zax
+++ b/test/fixtures/pr278_nested_runtime_store_matrix.zax
@@ -9,15 +9,15 @@ end
 section code boot at $0000
   export func main()
     ld a, 1
-    move grid[idx], a
-    move arr[idx + 1], a
+    grid[idx] := a
+    arr[idx + 1] := a
 
-    move a, grid[idx]
+    a := grid[idx]
     ld hl, $1234
-    move mat[idx], hl
-    move hl, mat[idx]
+    mat[idx] := hl
+    hl := mat[idx]
 
-    move a, arr[idxw + 2]
+    a := arr[idxw + 2]
     ret
   end
 end

--- a/test/fixtures/pr283_local_arg_global_access_matrix.zax
+++ b/test/fixtures/pr283_local_arg_global_access_matrix.zax
@@ -13,12 +13,12 @@ section code boot at $0000
       localw: word
       localb: byte
     end
-    move hl, arg0
-    move localw, hl
-    move hl, localw
-    move gword, hl
-    move a, localb
-    move gbyte, a
+    hl := arg0
+    localw := hl
+    hl := localw
+    gword := hl
+    a := localb
+    gbyte := a
     touch gword
     ret
   end

--- a/test/fixtures/pr285_alias_init_globals_locals_positive.zax
+++ b/test/fixtures/pr285_alias_init_globals_locals_positive.zax
@@ -8,8 +8,8 @@ export func main()
     tmp: word = 1
     local_ref = base
   end
-  move hl, local_ref
-  move base, hl
-  move hl, base
+  hl := local_ref
+  base := hl
+  hl := base
   ret
 end

--- a/test/fixtures/pr289_place_expression_contexts_positive.zax
+++ b/test/fixtures/pr289_place_expression_contexts_positive.zax
@@ -10,19 +10,19 @@ section data vars at $1000
 end
 
 op readAddr(addr: ea)
-  move a, addr
+  a := addr
 end
 
 export func main()
-  move a, p.lo
-  move p.lo, a
-  move a, arr[idx]
-  move arr[idx], a
+  a := p.lo
+  p.lo := a
+  a := arr[idx]
+  arr[idx] := a
 
-  move a, p.lo
-  move p.lo, a
-  move a, arr[idx]
-  move arr[idx], a
+  a := p.lo
+  p.lo := a
+  a := arr[idx]
+  arr[idx] := a
 
   readAddr p.lo
   readAddr arr[idx]

--- a/test/fixtures/pr292_local_scalar_init_and_alias_positive.zax
+++ b/test/fixtures/pr292_local_scalar_init_and_alias_positive.zax
@@ -7,7 +7,7 @@ export func main()
     tmp: word = $1234
     local_ref = base
   end
-  move hl, tmp
-  move local_ref, hl
+  hl := tmp
+  local_ref := hl
   ret
 end

--- a/test/fixtures/pr330_frame_access_positive.zax
+++ b/test/fixtures/pr330_frame_access_positive.zax
@@ -2,6 +2,6 @@ func store_only(a: word)
   var
     dst: word = 0
   end
-  move dst, a
+  dst := a
   ret
 end

--- a/test/fixtures/pr364_call_with_arg_and_local.zax
+++ b/test/fixtures/pr364_call_with_arg_and_local.zax
@@ -4,10 +4,10 @@ func inc_one(input_word: word): HL
     unused_word: word = $33
   end
 
-  move de, input_word
+  de := input_word
   inc de
-  move temp_word, de
-  move de, temp_word
+  temp_word := de
+  de := temp_word
   ex de, hl
 end
 
@@ -17,5 +17,5 @@ export func main()
   end
 
   inc_one $44
-  move result_word, hl
+  result_word := hl
 end

--- a/test/fixtures/pr365_args_locals_basics.zax
+++ b/test/fixtures/pr365_args_locals_basics.zax
@@ -1,6 +1,6 @@
 func add_words(left_word: word, right_word: word): HL
-  move hl, left_word
-  move de, right_word
+  hl := left_word
+  de := right_word
   add hl, de
 end
 
@@ -9,11 +9,11 @@ func bump_byte(input_byte: byte): HL
     temp_word: word = 0
   end
 
-  move l, input_byte
+  l := input_byte
   ld h, 0
   inc l
-  move temp_word, hl
-  move hl, temp_word
+  temp_word := hl
+  hl := temp_word
 end
 
 export func main()
@@ -22,7 +22,7 @@ export func main()
   end
 
   add_words 10, 20
-  move result_word, hl
+  result_word := hl
 
   bump_byte 7
 end

--- a/test/fixtures/pr405_byte_global_non_a_symbols.zax
+++ b/test/fixtures/pr405_byte_global_non_a_symbols.zax
@@ -3,8 +3,8 @@ section data vars at $1000
 end
 
 export func main(): AF, BC, DE, HL
-  move b, glob_b
-  move h, glob_b
-  move glob_b, b
-  move glob_b, h
+  b := glob_b
+  h := glob_b
+  glob_b := b
+  glob_b := h
 end

--- a/test/fixtures/pr405_byte_global_scalar_symbols.zax
+++ b/test/fixtures/pr405_byte_global_scalar_symbols.zax
@@ -3,6 +3,6 @@ section data vars at $1000
 end
 
 export func main(): AF, BC, DE, HL
-  move a, glob_b
-  move glob_b, a
+  a := glob_b
+  glob_b := a
 end

--- a/test/fixtures/pr405_byte_indexed_templates.zax
+++ b/test/fixtures/pr405_byte_indexed_templates.zax
@@ -4,7 +4,7 @@ end
 
 export func main(): AF, BC, DE, HL
   ld c, $01
-  move a, arr_b[c]
+  a := arr_b[c]
   ld h, $22
-  move arr_b[c], h
+  arr_b[c] := h
 end

--- a/test/fixtures/pr405_byte_scalar_fast_paths.zax
+++ b/test/fixtures/pr405_byte_scalar_fast_paths.zax
@@ -3,8 +3,8 @@ export func main()
     slot: byte = 0
   end
 
-  move h, slot
-  move l, slot
-  move slot, h
-  move slot, l
+  h := slot
+  l := slot
+  slot := h
+  slot := l
 end

--- a/test/fixtures/pr406_word_frame_scalar_accessors.zax
+++ b/test/fixtures/pr406_word_frame_scalar_accessors.zax
@@ -4,9 +4,9 @@ section code main at $0100
       local_w: word = $1234
     end
 
-    move bc, local_w
-    move de, local_w
-    move local_w, bc
-    move local_w, de
+    bc := local_w
+    de := local_w
+    local_w := bc
+    local_w := de
   end
 end

--- a/test/fixtures/pr406_word_global_scalar_accessors.zax
+++ b/test/fixtures/pr406_word_global_scalar_accessors.zax
@@ -4,9 +4,9 @@ end
 
 section code main at $0100
   export func main(): AF, BC, DE, HL
-    move bc, glob_w
-    move de, glob_w
-    move glob_w, bc
-    move glob_w, de
+    bc := glob_w
+    de := glob_w
+    glob_w := bc
+    glob_w := de
   end
 end

--- a/test/fixtures/pr406_word_hl_fallback_store.zax
+++ b/test/fixtures/pr406_word_hl_fallback_store.zax
@@ -5,5 +5,5 @@ end
 
 export func main(): AF, BC, DE, HL
   ld hl, $1234
-  move arr_w[idx_word + 1], hl
+  arr_w[idx_word + 1] := hl
 end

--- a/test/fixtures/pr406_word_index_bc.zax
+++ b/test/fixtures/pr406_word_index_bc.zax
@@ -4,5 +4,5 @@ end
 
 export func main()
   ld hl, $0001        ; runtime index
-  move bc, arr_w[hl]  ; load word into BC via runtime index
+  bc := arr_w[hl]  ; load word into BC via runtime index
 end

--- a/test/fixtures/pr406_word_index_bc_store.zax
+++ b/test/fixtures/pr406_word_index_bc_store.zax
@@ -4,6 +4,6 @@ end
 
 export func main()
   ld hl, $0001
-  move bc, arr_w[hl]
-  move arr_w[hl], bc
+  bc := arr_w[hl]
+  arr_w[hl] := bc
 end

--- a/test/fixtures/pr406_word_mem_to_mem_mixed_reverse.zax
+++ b/test/fixtures/pr406_word_mem_to_mem_mixed_reverse.zax
@@ -5,6 +5,6 @@ end
 
 export func main(): AF, BC, DE, HL
   ld hl, $0001
-  move de, arr_w[hl]
-  move dst_w, de
+  de := arr_w[hl]
+  dst_w := de
 end

--- a/test/fixtures/pr406_word_mem_to_mem_partial_fast_path.zax
+++ b/test/fixtures/pr406_word_mem_to_mem_partial_fast_path.zax
@@ -5,6 +5,6 @@ end
 
 export func main(): AF, BC, DE, HL
   ld hl, $0001
-  move de, src_w
-  move arr_w[hl], de
+  de := src_w
+  arr_w[hl] := de
 end

--- a/test/fixtures/pr406_word_mem_to_mem_scalar.zax
+++ b/test/fixtures/pr406_word_mem_to_mem_scalar.zax
@@ -8,10 +8,10 @@ export func main(): AF, BC, DE, HL
     local_w: word = $1234
   end
 
-  move de, glob_src
-  move glob_dst, de
-  move de, glob_src
-  move local_w, de
-  move de, local_w
-  move glob_dst, de
+  de := glob_src
+  glob_dst := de
+  de := glob_src
+  local_w := de
+  de := local_w
+  glob_dst := de
 end

--- a/test/fixtures/pr407_word_load_store.zax
+++ b/test/fixtures/pr407_word_load_store.zax
@@ -6,7 +6,7 @@ end
 section code boot at $0100
   export func main()
     ld hl, $0001      ; index
-    move hl, arr_w[hl]  ; load word via runtime index
-    move tmp, hl        ; store word to global
+    hl := arr_w[hl]  ; load word via runtime index
+    tmp := hl        ; store word to global
   end
 end

--- a/test/fixtures/pr407_word_regression.zax
+++ b/test/fixtures/pr407_word_regression.zax
@@ -10,15 +10,15 @@ export func main()
   end
 
   ; reg8 index load/store
-  move hl, gw[idx8]
-  move gw[idx8], hl
+  hl := gw[idx8]
+  gw[idx8] := hl
 
   ; reg16 index load/store (HL as index)
-  move hl, idxw
-  move de, gw[hl]
-  move gw[hl], de
+  hl := idxw
+  de := gw[hl]
+  gw[hl] := de
 
   ; store tmp via reg8 index
-  move hl, tmp
-  move gw[idx8], hl
+  hl := tmp
+  gw[idx8] := hl
 end

--- a/test/fixtures/pr412_runtime_index_byte_matrix.zax
+++ b/test/fixtures/pr412_runtime_index_byte_matrix.zax
@@ -4,7 +4,7 @@ end
 
 export func main(): AF, BC, DE, HL
   ld a, $03
-  move b, arr_b[a]
+  b := arr_b[a]
   ld hl, $0002
-  move c, arr_b[hl]
+  c := arr_b[hl]
 end

--- a/test/fixtures/pr544_program_lowering.zax
+++ b/test/fixtures/pr544_program_lowering.zax
@@ -8,7 +8,7 @@ end
 
 section code boot at $0100
   func helper(): HL
-    move a, arr[K - 2]
+    a := arr[K - 2]
     ld l, a
     ld h, 0
   end

--- a/test/fixtures/pr603_determinism_single_module.zax
+++ b/test/fixtures/pr603_determinism_single_module.zax
@@ -4,7 +4,7 @@ end
 
 section code boot at $0000
   export func main()
-    move a, arr[0]
+    a := arr[0]
     ret
   end
 end

--- a/test/fixtures/pr770_typed_reinterpretation_positive.zax
+++ b/test/fixtures/pr770_typed_reinterpretation_positive.zax
@@ -10,24 +10,24 @@ type Header
 end
 
 func touch_pair(p: Pair)
-  move a, p.y
+  a := p.y
   inc a
-  move p.y, a
+  p.y := a
 end
 
 op bump(slot: ea)
-  move a, slot
+  a := slot
   inc a
-  move slot, a
+  slot := a
 end
 
 export func main(ptr: addr)
-  move hl, ptr
-  move a, <Header>hl.flags
+  hl := ptr
+  a := <Header>hl.flags
 
-  move de, ptr
+  de := ptr
   ld a, 1
-  move <Header>de.flags, a
+  <Header>de.flags := a
 
   bump <Header>hl.flags
   touch_pair <Header>ptr.pair

--- a/test/fixtures/pr820_exact_nested_indexing.zax
+++ b/test/fixtures/pr820_exact_nested_indexing.zax
@@ -14,7 +14,7 @@ section data vars at $8000
 end
 
 func read_right_lo(row_index: word)
-  move hl, row_index
-  move a, rows[HL].right.lo
+  hl := row_index
+  a := rows[HL].right.lo
   ret
 end

--- a/test/fixtures/pr849_local_init_consts_positive.zax
+++ b/test/fixtures/pr849_local_init_consts_positive.zax
@@ -6,6 +6,6 @@ export func main()
     high_index: word = LastIndex
     mask_value: byte = 1 << Shift
   end
-  move hl, high_index
+  hl := high_index
   ret
 end


### PR DESCRIPTION
## Summary
- migrate remaining live course and language-tour examples from `move` to `:=`
- update README and reference text to remove stale transitional `move` guidance
- convert supported test fixtures to `:=` so coverage follows the preferred surface

## Notes
- one `move` fixture remains intentionally: `test/fixtures/pr406_word_ix_fallback_load.zax`
- that file still uses `move ix, ...` because `:=` does not support `IX` in the current assignment surface

## Verification
- `npm run typecheck`
- `npx vitest run test/pr260_value_semantics_scalar_index.test.ts test/pr264_runtime_atom_budget_matrix.test.ts test/pr272_runtime_affine_index_offset.test.ts test/pr274_type_padding_warning.test.ts test/pr277_index_redundant_paren_warning.test.ts test/pr278_nested_runtime_store_matrix.test.ts test/pr283_hidden_lowering_risk_matrix.test.ts test/pr285_alias_init_parser_semantics_matrix.test.ts test/pr289_place_expression_contexts.test.ts test/pr292_local_var_initializer_enforcement.test.ts test/pr330_frames_epilogue_and_access.test.ts test/pr364_call_with_arg_and_local_regression.test.ts test/pr365_args_locals_basics_regression.test.ts test/pr405_byte_global_non_a_symbols.test.ts test/pr405_byte_global_scalar_symbols.test.ts test/pr405_byte_indexed_templates.test.ts test/pr405_byte_scalar_fast_paths.test.ts test/pr406_word_scalar_accessors.test.ts test/pr406_word_hl_fallback_store.test.ts test/pr406_word_memmove_regression.test.ts test/pr407_word_regression.test.ts test/pr412_runtime_index_matrix.test.ts test/pr544_program_lowering_integration.test.ts test/pr770_typed_reinterpretation_integration.test.ts test/pr820_exact_size_cleanup.test.ts test/pr849_local_init_consts.test.ts test/pr869_assignment_reg8_integration.test.ts`
