### PR TITLE
Assign: lower IX/IY := forms

### DIFF
--- a/src/lowering/asmInstructionLowering.ts
+++ b/src/lowering/asmInstructionLowering.ts
@@ -80,7 +80,9 @@ export function createAsmInstructionLoweringHelpers(ctx: Context) {
       dstName === 'L' ||
       dstName === 'BC' ||
       dstName === 'DE' ||
-      dstName === 'HL'
+      dstName === 'HL' ||
+      dstName === 'IX' ||
+      dstName === 'IY'
     ) {
       return ctx.emitInstr('ld', [{ ...dst, name: dstName }, src], span);
     }
@@ -114,6 +116,7 @@ export function createAsmInstructionLoweringHelpers(ctx: Context) {
     if (dstName === srcName) return true;
     if (dstName === 'A' && srcName === 'A') return true;
     if (dstName === 'A') return false;
+    const wideRegs = new Set(['BC', 'DE', 'HL', 'IX', 'IY']);
     if (dstName === 'BC' || dstName === 'DE' || dstName === 'HL') {
       if (srcName === 'A') return emitZeroExtendReg8ToReg16(dstName, srcName, span);
       const asLd: AsmInstructionNode = {
@@ -126,6 +129,13 @@ export function createAsmInstructionLoweringHelpers(ctx: Context) {
         ],
       };
       return ctx.emitVirtualReg16Transfer(asLd);
+    }
+    if (dstName === 'IX' || dstName === 'IY') {
+      if (!wideRegs.has(srcName)) return false;
+      return (
+        ctx.emitInstr('push', [{ kind: 'Reg', span, name: srcName }], span) &&
+        ctx.emitInstr('pop', [{ kind: 'Reg', span, name: dstName }], span)
+      );
     }
     return false;
   };

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -233,7 +233,7 @@ export function emitProgram(
   const declaredBinNames = new Set<string>();
 
   const reg8 = new Set(['A', 'B', 'C', 'D', 'E', 'H', 'L']);
-  const reg16 = new Set(['BC', 'DE', 'HL']);
+  const reg16 = new Set(['BC', 'DE', 'HL', 'IX', 'IY']);
   const reg8Code = new Map([
     ['B', 0],
     ['C', 1],

--- a/test/fixtures/pr875_assignment_ixiy.zax
+++ b/test/fixtures/pr875_assignment_ixiy.zax
@@ -1,0 +1,15 @@
+section data vars at $8000
+  word_var: word
+  arr_w: word[4]
+end
+
+func sample()
+  ix := word_var
+  iy := @word_var
+  ix := arr_w[1]
+  ix := 0
+end
+
+export func main()
+  sample
+end

--- a/test/pr863_assignment_lowering.test.ts
+++ b/test/pr863_assignment_lowering.test.ts
@@ -66,7 +66,7 @@ function makeHelper(overrides: Partial<Parameters<typeof createAsmInstructionLow
       emittedInstrs.push(`virtual ${inst.operands.map((operand) => (operand.kind === 'Reg' ? operand.name : operand.kind)).join(',')}`);
       return true;
     },
-    reg16: new Set(['BC', 'DE', 'HL']),
+    reg16: new Set(['BC', 'DE', 'HL', 'IX', 'IY']),
     emitSyntheticEpilogue: false,
     epilogueLabel: '__zax_epilogue_0',
     emitJumpTo: () => {},
@@ -127,10 +127,20 @@ describe('PR863 := lowering', () => {
         { kind: 'Imm', span, expr: { kind: 'ImmLiteral', span, value: 1 } },
       ],
     });
+    helper.lowerAsmInstructionDispatcher({
+      kind: 'AsmInstruction',
+      span,
+      head: ':=',
+      operands: [
+        { kind: 'Reg', span, name: 'IX' },
+        { kind: 'Imm', span, expr: { kind: 'ImmLiteral', span, value: 0 } },
+      ],
+    });
 
     expect(diagnostics).toEqual([]);
     expect(emittedInstrs).toContain('ld HL,0');
     expect(emittedInstrs).toContain('ld A,1');
+    expect(emittedInstrs).toContain('ld IX,0');
   });
 
   it('lowers pair copy and byte-to-pair widening', () => {
@@ -163,6 +173,15 @@ describe('PR863 := lowering', () => {
         { kind: 'Reg', span, name: 'A' },
       ],
     });
+    helper.lowerAsmInstructionDispatcher({
+      kind: 'AsmInstruction',
+      span,
+      head: ':=',
+      operands: [
+        { kind: 'Reg', span, name: 'IY' },
+        { kind: 'Reg', span, name: 'HL' },
+      ],
+    });
 
     expect(diagnostics).toEqual([]);
     expect(emittedInstrs).toContain('virtual HL,DE');
@@ -170,6 +189,8 @@ describe('PR863 := lowering', () => {
     expect(emittedInstrs).toContain('ld L,A');
     expect(emittedInstrs).toContain('ld D,0');
     expect(emittedInstrs).toContain('ld E,A');
+    expect(emittedInstrs).toContain('push HL');
+    expect(emittedInstrs).toContain('pop IY');
   });
 
   it('lowers register address-of rhs via push/pop address materialization', () => {
@@ -181,7 +202,7 @@ describe('PR863 := lowering', () => {
       span,
       head: ':=',
       operands: [
-        { kind: 'Reg', span, name: 'HL' },
+        { kind: 'Reg', span, name: 'IY' },
         {
           kind: 'Ea',
           span,
@@ -193,7 +214,7 @@ describe('PR863 := lowering', () => {
 
     expect(diagnostics).toEqual([]);
     expect(harness.pushedEa).toMatchObject({ kind: 'EaName', name: 'x' });
-    expect(emittedInstrs).toContain('pop HL');
+    expect(emittedInstrs).toContain('pop IY');
   });
 
   it('diagnoses unsupported parsed register combinations', () => {

--- a/test/pr875_assignment_ixiy_integration.test.ts
+++ b/test/pr875_assignment_ixiy_integration.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { AsmArtifact } from '../src/formats/types.js';
+
+describe('PR875 := IX/IY integration', () => {
+  it('lowers accepted IX/IY assignment forms end-to-end', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr875_assignment_ixiy.zax');
+    const res = await compile(
+      entry,
+      { emitAsm: true, emitBin: false, emitHex: false, emitListing: false, emitD8m: false },
+      { formats: defaultFormatWriters },
+    );
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+
+    const asm = res.artifacts.find((a): a is AsmArtifact => a.kind === 'asm');
+    expect(asm).toBeDefined();
+    const text = asm!.text.toUpperCase();
+
+    expect(text).toContain('LD IX, (WORD_VAR)');
+    expect(text).toContain('LD HL, WORD_VAR');
+    expect(text).toContain('POP IY');
+    expect(text).toContain('LD IX, (ARR_W + 2)');
+    expect(text).toContain('LD IX, $0000');
+  });
+});


### PR DESCRIPTION
## Summary\n- extend := lowering to support IX/IY immediate and whole-register transfer forms\n- allow := address-of lowering to treat IX/IY as 16-bit register destinations\n- add focused unit and end-to-end coverage for IX/IY assignment forms\n\n## Verification\n- npm run typecheck\n- npx vitest run test/pr875_assignment_ixiy_integration.test.ts test/pr863_assignment_lowering.test.ts test/pr874_assignment_ixiy_parser.test.ts test/pr862_assignment_parser.test.ts test/pr799_addr_expr_lowering.test.ts