### PR TITLE
docs: record move retirement policy

### DIFF
--- a/docs/design/assignment-syntax-vs-move.md
+++ b/docs/design/assignment-syntax-vs-move.md
@@ -203,6 +203,25 @@ Landed on `main`.
 Deprecate `move` in docs, decide the compatibility-test policy, and consider a
 warning or removal path only after that policy is explicit.
 
+## Retirement policy
+
+The retirement path should now be:
+
+1. keep `:=` as the only recommended user-facing surface
+2. classify remaining `move` uses into:
+   - explicit compatibility tests
+   - historical/design references
+   - stale ordinary coverage
+3. convert all stale ordinary coverage to `:=`
+4. keep only a narrow compatibility subset proving that legacy `move` still
+   aliases the same lowering behavior during the grace period
+5. after that, choose between:
+   - a deprecation warning phase
+   - direct parser/lowering removal
+
+The important rule is that no new active examples, docs, or ordinary coverage
+should be written with `move`.
+
 ## Deferred forms
 
 The following may be acceptable later, but are not required in the next slice:

--- a/docs/work/current-stream.md
+++ b/docs/work/current-stream.md
@@ -20,9 +20,11 @@ direction.
 
 1. Decide the `move` retirement path now that the full active assignment surface
    is covered by `:=`.
-2. Resolve the remaining compatibility/historical `move` cases consistently
-   with that retirement policy.
-3. Continue parser/grammar convergence work.
+2. Reduce remaining `move` usage to a minimal explicit compatibility subset.
+3. Decide whether the next step after that subset is:
+   - a deprecation warning phase
+   - or direct parser/lowering removal.
+4. Continue parser/grammar convergence work.
 
 ### Deferred until re-planned
 


### PR DESCRIPTION
## Summary
- record the explicit `move` retirement policy now that `:=` covers the active assignment surface
- set the immediate priority to reducing `move` to a minimal compatibility subset
- stage the follow-up split between compatibility cleanup and final deprecation/removal

## Related
- informs #880
- informs #881
