### PR TITLE
Move: trim ordinary compatibility usage

### DIFF
--- a/examples/codegen-corpus/intermediate_indexing.zax
+++ b/examples/codegen-corpus/intermediate_indexing.zax
@@ -7,10 +7,10 @@ end
 
 section code boot at $0000
   export func main()
-    move a, arr[idx]
-    move a, arr[idxw]
-    move a, arr[hl]
-    move a, arr[(hl)]
-    move a, grid[(idx << 3) + 0]
+    a := arr[idx]
+    a := arr[idxw]
+    a := arr[hl]
+    a := arr[(hl)]
+    a := grid[(idx << 3) + 0]
   end
 end

--- a/src/frontend/parseOperands.ts
+++ b/src/frontend/parseOperands.ts
@@ -407,7 +407,7 @@ export function parseAsmInstruction(
   }
 
   if (operands.some((op) => op.kind === 'Ea' && op.explicitAddressOf)) {
-    diag(diagnostics, filePath, `"@<path>" is only supported with "move" in this phase.`, {
+    diag(diagnostics, filePath, `"@<path>" is only supported with ":=" (legacy "move" also works) in this phase.`, {
       line: instrSpan.start.line,
       column: instrSpan.start.column,
     });

--- a/src/lowering/asmInstructionLowering.ts
+++ b/src/lowering/asmInstructionLowering.ts
@@ -526,7 +526,7 @@ export function createAsmInstructionLoweringHelpers(ctx: Context) {
       ctx.diagAt(
         ctx.diagnostics,
         asmItem.span,
-        `"ld" no longer accepts typed storage operands; use "move".`,
+        `"ld" no longer accepts typed storage operands; use ":=".`,
       );
       return;
     }

--- a/test/fixtures/pr406_word_ix_fallback_load.zax
+++ b/test/fixtures/pr406_word_ix_fallback_load.zax
@@ -4,5 +4,5 @@ section data vars at $2000
 end
 
 export func main(): AF, BC, DE, HL
-  move ix, arr_w[idx_word + 1]
+  ix := arr_w[idx_word + 1]
 end

--- a/test/pr287_address_of_operator.test.ts
+++ b/test/pr287_address_of_operator.test.ts
@@ -19,7 +19,7 @@ describe('PR287 explicit address-of operator (@place)', () => {
 
     const errors = res.diagnostics.filter((d) => d.severity === 'error');
     expect(errors.map((d) => d.message)).toContain(
-      '"@<path>" is only supported with "move" in this phase.',
+      '"@<path>" is only supported with ":=" (legacy "move" also works) in this phase.',
     );
   });
 

--- a/test/pr781_ld_typed_storage_migration_diag.test.ts
+++ b/test/pr781_ld_typed_storage_migration_diag.test.ts
@@ -75,7 +75,7 @@ describe('PR781 ld typed-storage migration diagnostics', () => {
     ctx.helper.lowerAsmInstructionDispatcher(ldItem);
 
     expect(ctx.diagnostics.length).toBeGreaterThan(0);
-    expect(ctx.diagnostics[0]?.message).toContain('move');
+    expect(ctx.diagnostics[0]?.message).toContain(':=');
     expect(ctx.ldCalled).toBe(false);
   });
 
@@ -94,7 +94,7 @@ describe('PR781 ld typed-storage migration diagnostics', () => {
     ctx.helper.lowerAsmInstructionDispatcher(ldItem);
 
     expect(ctx.diagnostics.length).toBeGreaterThan(0);
-    expect(ctx.diagnostics[0]?.message).toContain('move');
+    expect(ctx.diagnostics[0]?.message).toContain(':=');
     expect(ctx.ldCalled).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary\n- convert ordinary typed-transfer fixtures and corpus sources from move to :=\n- update stale diagnostics to point at := while preserving legacy move compatibility\n- keep focused move compatibility coverage for parser, lowering aliasing, and move rr, @path\n\n## Verification\n- npm run typecheck\n- npx vitest run test/pr303_codegen_corpus_expansion.test.ts test/pr406_word_ix_fallback_load.test.ts test/pr287_address_of_operator.test.ts test/pr781_ld_typed_storage_migration_diag.test.ts test/pr779_move_parser.test.ts test/pr780_move_lowering_integration.test.ts test/pr799_addr_expr_lowering.test.ts