### PR TITLE
docs: choose direct move removal

### DIFF
--- a/docs/design/assignment-syntax-vs-move.md
+++ b/docs/design/assignment-syntax-vs-move.md
@@ -1,6 +1,6 @@
 # Assignment Syntax vs `move`
 
-Status: Stage 1-4 landed; retirement plan pending
+Status: Stage 1-4 landed; direct removal chosen
 
 ## Problem
 
@@ -200,8 +200,7 @@ Landed on `main`.
 
 ### Stage 5
 
-Deprecate `move` in docs, decide the compatibility-test policy, and consider a
-warning or removal path only after that policy is explicit.
+Remove `move` from parser/lowering/docs after compatibility cleanup.
 
 ## Retirement policy
 
@@ -214,13 +213,14 @@ The retirement path should now be:
    - stale ordinary coverage
 3. convert all stale ordinary coverage to `:=`
 4. keep only a narrow compatibility subset proving that legacy `move` still
-   aliases the same lowering behavior during the grace period
-5. after that, choose between:
-   - a deprecation warning phase
-   - direct parser/lowering removal
+   aliases the same lowering behavior during the cleanup phase
+5. then remove `move` directly from parser/lowering/docs
 
-The important rule is that no new active examples, docs, or ordinary coverage
-should be written with `move`.
+The important rules are:
+
+- no new active examples, docs, or ordinary coverage should be written with `move`
+- there will be no warning-only grace phase
+- the next step after compatibility cleanup is direct removal
 
 ## Deferred forms
 

--- a/docs/work/current-stream.md
+++ b/docs/work/current-stream.md
@@ -18,13 +18,11 @@ direction.
 
 ### Immediate priority
 
-1. Decide the `move` retirement path now that the full active assignment surface
-   is covered by `:=`.
-2. Reduce remaining `move` usage to a minimal explicit compatibility subset.
-3. Decide whether the next step after that subset is:
-   - a deprecation warning phase
-   - or direct parser/lowering removal.
-4. Continue parser/grammar convergence work.
+1. Remove `move` directly from parser/lowering/docs now that the active
+   assignment surface is fully covered by `:=`.
+2. Delete the remaining compatibility-only `move` subset as part of that
+   removal.
+3. Continue parser/grammar convergence work.
 
 ### Deferred until re-planned
 


### PR DESCRIPTION
## Summary
- record the final decision to remove `move` directly rather than adding a warning phase
- set the immediate priority to parser/lowering/docs removal
- make the remaining compatibility subset explicitly terminal rather than transitional

## Related
- informs #884
