### PR TITLE
Assign: add half-index := parity

### DIFF
--- a/docs/spec/zax-grammar.ebnf.md
+++ b/docs/spec/zax-grammar.ebnf.md
@@ -158,7 +158,9 @@ instr_line      = z80_instruction
 assign_stmt     = assign_target , ":=" , assign_source ;
 assign_target   = assign_reg | ea_expr ;
 assign_source   = assign_reg | ea_expr | move_addr | imm_expr ;
-assign_reg      = "A" | "BC" | "DE" | "HL" ;   (* Stage 1 whole-register set only *)
+assign_reg      = "A" | "B" | "C" | "D" | "E" | "H" | "L"
+                | "IXH" | "IXL" | "IYH" | "IYL"
+                | "BC" | "DE" | "HL" | "IX" | "IY" ;
 
 move_stmt       = "move" , move_reg , "," , move_src
                 | "move" , move_path , "," , move_reg ;

--- a/src/frontend/parseOperands.ts
+++ b/src/frontend/parseOperands.ts
@@ -24,6 +24,10 @@ const ASSIGNMENT_REGISTER_NAMES = new Set<string>([
   'E',
   'H',
   'L',
+  'IXH',
+  'IXL',
+  'IYH',
+  'IYL',
   'BC',
   'DE',
   'HL',
@@ -492,7 +496,7 @@ function parseAssignmentInstruction(
 
   if (target.kind === 'Ea') {
     if (source.kind !== 'Reg') {
-      diag(diagnostics, filePath, `":=" storage targets require a whole-register source`, {
+      diag(diagnostics, filePath, `":=" storage targets require an assignment-register source`, {
         line: instrSpan.start.line,
         column: instrSpan.start.column,
       });
@@ -526,7 +530,7 @@ function parseAssignmentTarget(
     return { kind: 'Reg', span: operandSpan, name: canonicalRegister };
   }
   if (ALL_REGISTER_NAMES.has(canonicalRegister)) {
-    diag(diagnostics, filePath, `":=" only supports whole-register destinations in this slice`, {
+    diag(diagnostics, filePath, `":=" only supports assignment-register destinations in this slice`, {
       line: operandSpan.start.line,
       column: operandSpan.start.column,
     });
@@ -589,7 +593,7 @@ function parseAssignmentSource(
     return { kind: 'Reg', span: operandSpan, name: canonicalRegister };
   }
   if (ALL_REGISTER_NAMES.has(canonicalRegister)) {
-    diag(diagnostics, filePath, `":=" only supports whole-register sources in this slice`, {
+    diag(diagnostics, filePath, `":=" only supports assignment-register sources in this slice`, {
       line: operandSpan.start.line,
       column: operandSpan.start.column,
     });

--- a/src/lowering/asmInstructionLowering.ts
+++ b/src/lowering/asmInstructionLowering.ts
@@ -78,6 +78,10 @@ export function createAsmInstructionLoweringHelpers(ctx: Context) {
       dstName === 'E' ||
       dstName === 'H' ||
       dstName === 'L' ||
+      dstName === 'IXH' ||
+      dstName === 'IXL' ||
+      dstName === 'IYH' ||
+      dstName === 'IYL' ||
       dstName === 'BC' ||
       dstName === 'DE' ||
       dstName === 'HL' ||
@@ -113,9 +117,20 @@ export function createAsmInstructionLoweringHelpers(ctx: Context) {
   ): boolean => {
     const dstName = dst.name.toUpperCase();
     const srcName = src.name.toUpperCase();
+    const halfIndexRegs = new Set(['IXH', 'IXL', 'IYH', 'IYL']);
     if (dstName === srcName) return true;
     if (dstName === 'A' && srcName === 'A') return true;
     if (dstName === 'A') return false;
+    if (halfIndexRegs.has(dstName) || halfIndexRegs.has(srcName)) {
+      return ctx.emitInstr(
+        'ld',
+        [
+          { kind: 'Reg', span, name: dstName },
+          { kind: 'Reg', span, name: srcName },
+        ],
+        span,
+      );
+    }
     const wideRegs = new Set(['BC', 'DE', 'HL', 'IX', 'IY']);
     if (dstName === 'BC' || dstName === 'DE' || dstName === 'HL') {
       if (srcName === 'A') return emitZeroExtendReg8ToReg16(dstName, srcName, span);

--- a/src/lowering/ldEncoding.ts
+++ b/src/lowering/ldEncoding.ts
@@ -123,6 +123,8 @@ export function createLdEncodingHelpers(ctx: LdEncodingContext) {
   const emitLdForm = (form: LdForm): boolean => {
     const { inst, dst, src, dstResolved, srcResolved, dstScalarExact, srcScalarExact, scalarMemToMem } = form;
     const isAssignmentForm = inst.head.toLowerCase() === ':=';
+    const halfIndexRegs = new Set(['IXH', 'IXL', 'IYH', 'IYL']);
+    const isHalfIndexReg = (name: string): boolean => halfIndexRegs.has(name.toUpperCase());
 
     const ixDispMem = (disp: number): AsmOperandNode => ({
       kind: 'Mem',
@@ -140,27 +142,31 @@ export function createLdEncodingHelpers(ctx: LdEncodingContext) {
 
     const emitByteMemLoadToReg8 = (regUp: string): boolean => {
       const d = reg8Code.get(regUp);
-      if (d === undefined || src.kind !== 'Mem') return false;
+      const viaA = isHalfIndexReg(regUp);
+      if ((d === undefined && !viaA) || src.kind !== 'Mem') return false;
 
       if (srcResolved?.kind === 'abs' && srcResolved.addend === 0) {
         if (!emitInstr('push', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span)) return false;
         emitAbs16Fixup(0x3a, srcResolved.baseLower, 0, inst.span);
-        if (
-          !emitInstr(
-            'ld',
-            [
-              { kind: 'Reg', span: inst.span, name: regUp },
-              { kind: 'Reg', span: inst.span, name: 'A' },
-            ],
-            inst.span,
-          )
-        ) {
+        if (!emitInstr('ld', [{ kind: 'Reg', span: inst.span, name: regUp }, { kind: 'Reg', span: inst.span, name: 'A' }], inst.span)) {
           return false;
         }
         return emitInstr('pop', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span);
       }
 
       if (srcResolved?.kind === 'stack' && srcResolved.ixDisp >= -0x80 && srcResolved.ixDisp <= 0x7f) {
+        if (viaA) {
+          if (!emitInstr('push', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span)) return false;
+          emitRawCodeBytes(
+            Uint8Array.of(0xdd, 0x7e, srcResolved.ixDisp & 0xff),
+            inst.span.file,
+            `ld A, (ix${formatIxDisp(srcResolved.ixDisp)})`,
+          );
+          if (!emitInstr('ld', [{ kind: 'Reg', span: inst.span, name: regUp }, { kind: 'Reg', span: inst.span, name: 'A' }], inst.span)) {
+            return false;
+          }
+          return emitInstr('pop', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span);
+        }
         if (regUp === 'H' || regUp === 'L') {
           if (
             !emitInstr(
@@ -197,7 +203,7 @@ export function createLdEncodingHelpers(ctx: LdEncodingContext) {
         }
 
         emitRawCodeBytes(
-          Uint8Array.of(0xdd, 0x46 + (d << 3), srcResolved.ixDisp & 0xff),
+          Uint8Array.of(0xdd, 0x46 + (d! << 3), srcResolved.ixDisp & 0xff),
           inst.span.file,
           `ld ${regUp}, (ix${formatIxDisp(srcResolved.ixDisp)})`,
         );
@@ -207,14 +213,31 @@ export function createLdEncodingHelpers(ctx: LdEncodingContext) {
       const eaPipe = buildEaBytePipeline(src.expr, inst.span);
       if (eaPipe) {
         let templated: StepPipeline | null = null;
+        if (viaA) {
+          if (!emitInstr('push', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span)) return false;
+          if (!emitStepPipeline(TEMPLATE_L_ABC('A', eaPipe), inst.span)) return false;
+          if (!emitInstr('ld', [{ kind: 'Reg', span: inst.span, name: regUp }, { kind: 'Reg', span: inst.span, name: 'A' }], inst.span)) {
+            return false;
+          }
+          return emitInstr('pop', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span);
+        }
         if (regUp === 'A' || regUp === 'B' || regUp === 'C') templated = TEMPLATE_L_ABC(regUp, eaPipe);
         else if (regUp === 'H' || regUp === 'L') templated = TEMPLATE_L_HL(regUp as 'H' | 'L', eaPipe);
         else if (regUp === 'D' || regUp === 'E') templated = TEMPLATE_L_DE(regUp as 'D' | 'E', eaPipe);
         if (templated && emitStepPipeline(templated, inst.span)) return true;
       }
 
+      if (viaA) {
+        if (!emitInstr('push', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span)) return false;
+        if (!materializeEaAddressToHL(src.expr, inst.span)) return false;
+        emitRawCodeBytes(Uint8Array.of(0x7e), inst.span.file, 'ld A, (hl)');
+        if (!emitInstr('ld', [{ kind: 'Reg', span: inst.span, name: regUp }, { kind: 'Reg', span: inst.span, name: 'A' }], inst.span)) {
+          return false;
+        }
+        return emitInstr('pop', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span);
+      }
       if (!materializeEaAddressToHL(src.expr, inst.span)) return false;
-      emitRawCodeBytes(Uint8Array.of(0x46 + (d << 3)), inst.span.file, `ld ${regUp}, (hl)`);
+      emitRawCodeBytes(Uint8Array.of(0x46 + (d! << 3)), inst.span.file, `ld ${regUp}, (hl)`);
       return true;
     };
 
@@ -229,7 +252,7 @@ export function createLdEncodingHelpers(ctx: LdEncodingContext) {
       }
       const regUp = dst.name.toUpperCase();
       const d = reg8Code.get(regUp);
-      if (d !== undefined) {
+      if (d !== undefined || isHalfIndexReg(regUp)) {
         return emitByteMemLoadToReg8(regUp);
       }
 
@@ -352,21 +375,13 @@ export function createLdEncodingHelpers(ctx: LdEncodingContext) {
         emitAbs16Fixup(0x32, dstResolved.baseLower, dstResolved.addend, inst.span);
         return true;
       }
-      const s8 = reg8Code.get(src.name.toUpperCase());
-      if (s8 !== undefined) {
-        const regUp = src.name.toUpperCase();
+      const regUp = src.name.toUpperCase();
+      const s8 = reg8Code.get(regUp);
+      const viaA = isHalfIndexReg(regUp);
+      if (s8 !== undefined || viaA) {
         if (dstResolved?.kind === 'abs' && dstResolved.addend === 0) {
           if (!emitInstr('push', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span)) return false;
-          if (
-            !emitInstr(
-              'ld',
-              [
-                { kind: 'Reg', span: inst.span, name: 'A' },
-                { kind: 'Reg', span: inst.span, name: regUp },
-              ],
-              inst.span,
-            )
-          ) {
+          if (!emitInstr('ld', [{ kind: 'Reg', span: inst.span, name: 'A' }, { kind: 'Reg', span: inst.span, name: regUp }], inst.span)) {
             return false;
           }
           emitAbs16Fixup(0x32, dstResolved.baseLower, 0, inst.span);
@@ -374,6 +389,18 @@ export function createLdEncodingHelpers(ctx: LdEncodingContext) {
         }
 
         if (dstResolved?.kind === 'stack' && dstResolved.ixDisp >= -0x80 && dstResolved.ixDisp <= 0x7f) {
+          if (viaA) {
+            if (!emitInstr('push', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span)) return false;
+            if (!emitInstr('ld', [{ kind: 'Reg', span: inst.span, name: 'A' }, { kind: 'Reg', span: inst.span, name: regUp }], inst.span)) {
+              return false;
+            }
+            emitRawCodeBytes(
+              Uint8Array.of(0xdd, 0x77, dstResolved.ixDisp & 0xff),
+              inst.span.file,
+              `ld (ix${formatIxDisp(dstResolved.ixDisp)}), A`,
+            );
+            return emitInstr('pop', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span);
+          }
           if (regUp === 'H' || regUp === 'L') {
             if (
               !emitInstr(
@@ -409,7 +436,7 @@ export function createLdEncodingHelpers(ctx: LdEncodingContext) {
             );
           }
           emitRawCodeBytes(
-            Uint8Array.of(0xdd, 0x70 + s8, dstResolved.ixDisp & 0xff),
+            Uint8Array.of(0xdd, 0x70 + s8!, dstResolved.ixDisp & 0xff),
             inst.span.file,
             `ld (ix${formatIxDisp(dstResolved.ixDisp)}), ${regUp}`,
           );
@@ -418,18 +445,35 @@ export function createLdEncodingHelpers(ctx: LdEncodingContext) {
 
         const dstPipe = buildEaBytePipeline(dst.expr, inst.span);
         if (dstPipe) {
+          if (viaA) {
+            if (!emitInstr('push', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span)) return false;
+            if (!emitInstr('ld', [{ kind: 'Reg', span: inst.span, name: 'A' }, { kind: 'Reg', span: inst.span, name: regUp }], inst.span)) {
+              return false;
+            }
+            if (!emitStepPipeline(TEMPLATE_S_ANY('A', dstPipe), inst.span)) return false;
+            return emitInstr('pop', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span);
+          }
           if ((regUp === 'H' || regUp === 'L') && emitStepPipeline(TEMPLATE_S_HL(regUp as 'H' | 'L', dstPipe), inst.span)) {
             return true;
           }
           if (emitStepPipeline(TEMPLATE_S_ANY(regUp, dstPipe), inst.span)) return true;
         }
         const preserveA = regUp === 'A';
+        if (viaA) {
+          if (!emitInstr('push', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span)) return false;
+          if (!emitInstr('ld', [{ kind: 'Reg', span: inst.span, name: 'A' }, { kind: 'Reg', span: inst.span, name: regUp }], inst.span)) {
+            return false;
+          }
+          if (!materializeEaAddressToHL(dst.expr, inst.span)) return false;
+          emitRawCodeBytes(Uint8Array.of(0x77), inst.span.file, 'ld (hl), a');
+          return emitInstr('pop', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span);
+        }
         if (preserveA && !emitInstr('push', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span)) return false;
         if (!materializeEaAddressToHL(dst.expr, inst.span)) {
           if (preserveA) return emitInstr('pop', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span);
           return false;
         }
-        emitRawCodeBytes(Uint8Array.of(0x70 + s8), inst.span.file, `ld (hl), ${regUp}`);
+        emitRawCodeBytes(Uint8Array.of(0x70 + s8!), inst.span.file, `ld (hl), ${regUp}`);
         if (preserveA && !emitInstr('pop', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span)) return false;
         return true;
       }

--- a/test/fixtures/pr887_assignment_half_index.zax
+++ b/test/fixtures/pr887_assignment_half_index.zax
@@ -1,0 +1,14 @@
+section data vars at $2000
+  count: byte = 1
+  flags: byte = 0
+  idx: byte = 2
+  arr: byte[4] = { 4, 5, 6, 7 }
+end
+
+export func main(): AF, BC, DE, HL
+  ixh := count
+  ixl := arr[idx]
+  flags := ixh
+  iyh := 0
+  iyl := flags
+end

--- a/test/pr808_grammar_drift.test.ts
+++ b/test/pr808_grammar_drift.test.ts
@@ -14,6 +14,13 @@ function expectRegex(pattern: RegExp, label: string): void {
 }
 
 describe('PR808 grammar drift checks', () => {
+  it('documents assignment grammar with the active register set', () => {
+    expectLine('assign_stmt     = assign_target , ":=" , assign_source ;');
+    expectLine('assign_reg      = "A" | "B" | "C" | "D" | "E" | "H" | "L"');
+    expectLine('                | "IXH" | "IXL" | "IYH" | "IYL"');
+    expectLine('                | "BC" | "DE" | "HL" | "IX" | "IY" ;');
+  });
+
   it('documents move grammar with restricted register/source forms', () => {
     expectLine('move_stmt       = "move" , move_reg , "," , move_src');
     expectLine('                | "move" , move_path , "," , move_reg ;');

--- a/test/pr862_assignment_parser.test.ts
+++ b/test/pr862_assignment_parser.test.ts
@@ -110,8 +110,8 @@ describe('PR862 := assignment parser/AST support', () => {
     });
   });
 
-  it('rejects indirect, partial, and unsupported assignment forms', () => {
-    for (const text of ['(hl) := a', 'a := (hl)', 'ixh := a', 'iyl := a', 'x := y', 'x := @y']) {
+  it('rejects indirect and unsupported assignment forms', () => {
+    for (const text of ['(hl) := a', 'a := (hl)', 'x := y', 'x := @y']) {
       const parsed = parse(text);
       expect(parsed.instr).toBeUndefined();
       expect(parsed.diagnostics.length).toBeGreaterThan(0);

--- a/test/pr874_assignment_ixiy_parser.test.ts
+++ b/test/pr874_assignment_ixiy_parser.test.ts
@@ -26,8 +26,8 @@ describe('PR874 := IX/IY parser support', () => {
     }
   });
 
-  it('keeps raw indirect and half-index-register forms rejected', () => {
-    for (const text of ['a := (ix+4)', '(ix+4) := a', 'ixh := a', 'ixl := a', 'iyh := a', 'iyl := a']) {
+  it('keeps raw indirect forms rejected', () => {
+    for (const text of ['a := (ix+4)', '(ix+4) := a']) {
       const parsed = parse(text);
       expect(parsed.instr).toBeUndefined();
       expect(parsed.diagnostics.length).toBeGreaterThan(0);

--- a/test/pr887_assignment_half_index_integration.test.ts
+++ b/test/pr887_assignment_half_index_integration.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { AsmArtifact } from '../src/formats/types.js';
+
+describe('PR887 := half-index integration', () => {
+  it('lowers accepted half-index assignment forms end-to-end', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr887_assignment_half_index.zax');
+    const res = await compile(
+      entry,
+      { emitAsm: true, emitBin: false, emitHex: false, emitListing: false, emitD8m: false },
+      { formats: defaultFormatWriters },
+    );
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+
+    const asm = res.artifacts.find((a): a is AsmArtifact => a.kind === 'asm');
+    expect(asm).toBeDefined();
+    const text = asm!.text.toUpperCase();
+
+    expect(text).toContain('LD A, (COUNT)');
+    expect(text).toContain('LD IXH, A');
+    expect(text).toContain('LD HL, ARR');
+    expect(text).toContain('ADD HL, DE');
+    expect(text).toContain('LD A, (HL)');
+    expect(text).toContain('LD IXL, A');
+    expect(text).toContain('LD A, IXH');
+    expect(text).toContain('LD (FLAGS), A');
+    expect(text).toContain('LD IYH, $00');
+    expect(text).toContain('LD A, (FLAGS)');
+    expect(text).toContain('LD IYL, A');
+  });
+});

--- a/test/pr887_assignment_half_index_lowering.test.ts
+++ b/test/pr887_assignment_half_index_lowering.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { DiagnosticIds } from '../src/diagnostics/types.js';
+import type { AsmInstructionNode, AsmOperandNode, SourceSpan } from '../src/frontend/ast.js';
+import { createAsmInstructionLoweringHelpers } from '../src/lowering/asmInstructionLowering.js';
+
+const span: SourceSpan = {
+  file: 'fixture.zax',
+  start: { line: 1, column: 1, offset: 0 },
+  end: { line: 1, column: 1, offset: 0 },
+};
+
+describe('PR887 := half-index lowering', () => {
+  it('routes half-index typed storage transfers through shared ld lowering', () => {
+    const diagnostics: Diagnostic[] = [];
+    const lowered: AsmInstructionNode[] = [];
+
+    const helper = createAsmInstructionLoweringHelpers({
+      diagnostics,
+      diagAt: (_diags, _span, message) => {
+        diagnostics.push({
+          id: DiagnosticIds.EmitError,
+          severity: 'error',
+          message,
+          file: span.file,
+          line: span.start.line,
+          column: span.start.column,
+        });
+      },
+      emitInstr: () => true,
+      emitRawCodeBytes: () => {},
+      emitAbs16Fixup: () => {},
+      emitAbs16FixupPrefixed: () => {},
+      emitRel8Fixup: () => {},
+      conditionOpcodeFromName: () => undefined,
+      conditionNameFromOpcode: () => undefined,
+      callConditionOpcodeFromName: () => undefined,
+      jrConditionOpcodeFromName: () => undefined,
+      conditionOpcode: () => undefined,
+      symbolicTargetFromExpr: () => undefined,
+      evalImmExpr: () => undefined,
+      resolveScalarBinding: () => undefined,
+      diagIfRetStackImbalanced: () => {},
+      diagIfCallStackUnverifiable: () => {},
+      warnIfRawCallTargetsTypedCallable: () => {},
+      lowerLdWithEa: (inst) => {
+        lowered.push(inst);
+        return true;
+      },
+      pushEaAddress: () => false,
+      emitVirtualReg16Transfer: () => false,
+      reg16: new Set(['BC', 'DE', 'HL', 'IX', 'IY']),
+      emitSyntheticEpilogue: false,
+      epilogueLabel: '__zax_epilogue_0',
+      emitJumpTo: () => {},
+      emitJumpCondTo: () => {},
+      syncToFlow: () => {},
+      flowRef: { current: { reachable: true } },
+    });
+
+    for (const item of [
+      {
+        kind: 'AsmInstruction' as const,
+        span,
+        head: ':=',
+        operands: [
+          { kind: 'Reg', span, name: 'IXH' },
+          { kind: 'Ea', span, expr: { kind: 'EaName', span, name: 'count' } },
+        ] satisfies AsmOperandNode[],
+      },
+      {
+        kind: 'AsmInstruction' as const,
+        span,
+        head: ':=',
+        operands: [
+          { kind: 'Reg', span, name: 'IXL' },
+          {
+            kind: 'Ea',
+            span,
+            expr: {
+              kind: 'EaIndex',
+              span,
+              base: { kind: 'EaName', span, name: 'arr' },
+              index: { kind: 'IndexEa', span, expr: { kind: 'EaName', span, name: 'idx' } },
+            },
+          },
+        ] satisfies AsmOperandNode[],
+      },
+      {
+        kind: 'AsmInstruction' as const,
+        span,
+        head: ':=',
+        operands: [
+          { kind: 'Ea', span, expr: { kind: 'EaName', span, name: 'flags' } },
+          { kind: 'Reg', span, name: 'IYH' },
+        ] satisfies AsmOperandNode[],
+      },
+    ]) {
+      helper.lowerAsmInstructionDispatcher(item);
+    }
+
+    expect(diagnostics).toEqual([]);
+    expect(lowered).toHaveLength(3);
+    expect(lowered.map((inst) => inst.head)).toEqual([':=', ':=', ':=']);
+  });
+
+  it('lowers half-index immediate assignments through ld emission', () => {
+    const diagnostics: Diagnostic[] = [];
+    const emitted: string[] = [];
+
+    const helper = createAsmInstructionLoweringHelpers({
+      diagnostics,
+      diagAt: (_diags, _span, message) => {
+        diagnostics.push({
+          id: DiagnosticIds.EmitError,
+          severity: 'error',
+          message,
+          file: span.file,
+          line: span.start.line,
+          column: span.start.column,
+        });
+      },
+      emitInstr: (head, operands) => {
+        emitted.push(`${head} ${operands.map((operand) => (operand.kind === 'Reg' ? operand.name : operand.kind)).join(',')}`);
+        return true;
+      },
+      emitRawCodeBytes: () => {},
+      emitAbs16Fixup: () => {},
+      emitAbs16FixupPrefixed: () => {},
+      emitRel8Fixup: () => {},
+      conditionOpcodeFromName: () => undefined,
+      conditionNameFromOpcode: () => undefined,
+      callConditionOpcodeFromName: () => undefined,
+      jrConditionOpcodeFromName: () => undefined,
+      conditionOpcode: () => undefined,
+      symbolicTargetFromExpr: () => undefined,
+      evalImmExpr: () => undefined,
+      resolveScalarBinding: () => undefined,
+      diagIfRetStackImbalanced: () => {},
+      diagIfCallStackUnverifiable: () => {},
+      warnIfRawCallTargetsTypedCallable: () => {},
+      lowerLdWithEa: () => false,
+      pushEaAddress: () => false,
+      emitVirtualReg16Transfer: () => false,
+      reg16: new Set(['BC', 'DE', 'HL', 'IX', 'IY']),
+      emitSyntheticEpilogue: false,
+      epilogueLabel: '__zax_epilogue_0',
+      emitJumpTo: () => {},
+      emitJumpCondTo: () => {},
+      syncToFlow: () => {},
+      flowRef: { current: { reachable: true } },
+    });
+
+    for (const reg of ['IXH', 'IXL', 'IYH', 'IYL']) {
+      helper.lowerAsmInstructionDispatcher({
+        kind: 'AsmInstruction',
+        span,
+        head: ':=',
+        operands: [
+          { kind: 'Reg', span, name: reg },
+          { kind: 'Imm', span, expr: { kind: 'ImmLiteral', span, value: 0 } },
+        ] satisfies AsmOperandNode[],
+      });
+    }
+
+    expect(diagnostics).toEqual([]);
+    expect(emitted).toEqual(['ld IXH,Imm', 'ld IXL,Imm', 'ld IYH,Imm', 'ld IYL,Imm']);
+  });
+});

--- a/test/pr887_assignment_half_index_parser.test.ts
+++ b/test/pr887_assignment_half_index_parser.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { makeSourceFile, span } from '../src/frontend/source.js';
+import { parseAsmInstruction } from '../src/frontend/parseOperands.js';
+
+describe('PR887 := half-index parser support', () => {
+  const file = makeSourceFile('pr887_assignment_half_index_parser.zax', '');
+  const zeroSpan = span(file, 0, 0);
+
+  function parse(
+    text: string,
+  ): { instr: ReturnType<typeof parseAsmInstruction>; diagnostics: Diagnostic[] } {
+    const diagnostics: Diagnostic[] = [];
+    const instr = parseAsmInstruction(file.path, text, zeroSpan, diagnostics);
+    return { instr, diagnostics };
+  }
+
+  it('accepts typed byte transfer forms for IXH/IXL/IYH/IYL', () => {
+    for (const text of ['ixh := count', 'ixl := arr[idx]', 'flags := iyh', 'iyl := flag_byte']) {
+      const parsed = parse(text);
+      expect(parsed.diagnostics).toEqual([]);
+      expect(parsed.instr?.head).toBe(':=');
+    }
+  });
+
+  it('accepts byte immediates for half-index registers', () => {
+    for (const text of ['ixh := 0', 'ixl := 1', 'iyh := 2', 'iyl := 3']) {
+      const parsed = parse(text);
+      expect(parsed.diagnostics).toEqual([]);
+      expect(parsed.instr).toMatchObject({
+        kind: 'AsmInstruction',
+        head: ':=',
+        operands: [{ kind: 'Reg' }, { kind: 'Imm' }],
+      });
+    }
+  });
+
+  it('continues to reject raw indirect and non-assignment registers', () => {
+    for (const text of ['ixh := (hl)', '(ix+4) := iyl', 'i := count', 'r := count']) {
+      const parsed = parse(text);
+      expect(parsed.instr).toBeUndefined();
+      expect(parsed.diagnostics.length).toBeGreaterThan(0);
+      expect(parsed.diagnostics[0]?.message).toContain(':=');
+    }
+  });
+});


### PR DESCRIPTION
## Summary\n- extend := parser support to IXH/IXL/IYH/IYL and update active grammar to match\n- lower half-index typed byte transfers and immediates through the existing assignment path\n- add parser, lowering, integration, and grammar-drift coverage for half-index parity\n\n## Verification\n- npm run typecheck\n- npx vitest run test/pr887_assignment_half_index_parser.test.ts test/pr887_assignment_half_index_lowering.test.ts test/pr887_assignment_half_index_integration.test.ts test/pr862_assignment_parser.test.ts test/pr874_assignment_ixiy_parser.test.ts test/pr808_grammar_drift.test.ts test/pr869_assignment_reg8_lowering.test.ts test/pr875_assignment_ixiy_integration.test.ts\n- npx vitest run test/pr447_direct_index_high_low.test.ts test/pr477_encode_ld_family.test.ts