### PR TITLE
ASSIGN-896: lower scalar path-to-path assignments

### DIFF
--- a/src/lowering/asmInstructionLowering.ts
+++ b/src/lowering/asmInstructionLowering.ts
@@ -468,6 +468,14 @@ export function createAsmInstructionLoweringHelpers(ctx: Context) {
         return;
       }
       if (src.kind === 'Ea' && src.explicitAddressOf) {
+        if (dst.kind === 'Ea') {
+          if (ctx.lowerLdWithEa(asmItem)) {
+            ctx.syncToFlow();
+            return;
+          }
+          ctx.diagAt(ctx.diagnostics, asmItem.span, `":=" form is not supported.`);
+          return;
+        }
         if (dst.kind !== 'Reg' || !ctx.reg16.has(dst.name.toUpperCase())) {
           ctx.diagAt(
             ctx.diagnostics,

--- a/src/lowering/ldEncoding.ts
+++ b/src/lowering/ldEncoding.ts
@@ -125,6 +125,135 @@ export function createLdEncodingHelpers(ctx: LdEncodingContext) {
     const isAssignmentForm = inst.head.toLowerCase() === ':=';
     const halfIndexRegs = new Set(['IXH', 'IXL', 'IYH', 'IYL']);
     const isHalfIndexReg = (name: string): boolean => halfIndexRegs.has(name.toUpperCase());
+    const regPairForReg8 = (name: string): 'AF' | 'BC' | 'DE' | undefined => {
+      switch (name.toUpperCase()) {
+        case 'A':
+          return 'AF';
+        case 'B':
+        case 'C':
+          return 'BC';
+        case 'D':
+        case 'E':
+          return 'DE';
+        default:
+          return undefined;
+      }
+    };
+    const regOperand = (name: string): AsmOperandNode => ({ kind: 'Reg', span: inst.span, name });
+    const pushReg = (name: string): boolean => emitInstr('push', [regOperand(name)], inst.span);
+    const popReg = (name: string): boolean => emitInstr('pop', [regOperand(name)], inst.span);
+    const immExprUsesAnyRegister = (expr: ImmExprNode, names: ReadonlySet<string>): boolean => {
+      switch (expr.kind) {
+        case 'ImmLiteral':
+        case 'ImmSizeof':
+          return false;
+        case 'ImmName':
+          return names.has(expr.name.toUpperCase());
+        case 'ImmOffsetof':
+          return expr.path.steps.some((step) =>
+            step.kind === 'OffsetofIndex' ? immExprUsesAnyRegister(step.expr, names) : false,
+          );
+        case 'ImmUnary':
+          return immExprUsesAnyRegister(expr.expr, names);
+        case 'ImmBinary':
+          return (
+            immExprUsesAnyRegister(expr.left, names) || immExprUsesAnyRegister(expr.right, names)
+          );
+      }
+    };
+    const eaUsesAnyRegister = (ea: EaExprNode, names: ReadonlySet<string>): boolean => {
+      switch (ea.kind) {
+        case 'EaName':
+          return names.has(ea.name.toUpperCase());
+        case 'EaReinterpret':
+          return eaUsesAnyRegister(ea.base, names);
+        case 'EaField':
+          return eaUsesAnyRegister(ea.base, names);
+        case 'EaAdd':
+        case 'EaSub':
+          return eaUsesAnyRegister(ea.base, names) || immExprUsesAnyRegister(ea.offset, names);
+        case 'EaIndex':
+          switch (ea.index.kind) {
+            case 'IndexImm':
+              return (
+                eaUsesAnyRegister(ea.base, names) ||
+                immExprUsesAnyRegister(ea.index.value, names)
+              );
+            case 'IndexReg8':
+              return eaUsesAnyRegister(ea.base, names) || names.has(ea.index.reg.toUpperCase());
+            case 'IndexReg16':
+              return eaUsesAnyRegister(ea.base, names) || names.has(ea.index.reg.toUpperCase());
+            case 'IndexMemHL':
+              return eaUsesAnyRegister(ea.base, names) || names.has('HL');
+            case 'IndexMemIxIy':
+              return eaUsesAnyRegister(ea.base, names) || names.has(ea.index.base.toUpperCase());
+            case 'IndexEa':
+              return eaUsesAnyRegister(ea.base, names) || eaUsesAnyRegister(ea.index.expr, names);
+          }
+      }
+    };
+    const anyEaUsesAnyRegister = (
+      eas: ReadonlyArray<EaExprNode | undefined>,
+      names: ReadonlySet<string>,
+    ): boolean => eas.some((ea) => (ea ? eaUsesAnyRegister(ea, names) : false));
+    const pickHiddenByteReg = (...eas: Array<EaExprNode | undefined>): 'A' | 'B' | 'C' | 'D' | 'E' => {
+      for (const candidate of ['A', 'B', 'C', 'D', 'E'] as const) {
+        if (!anyEaUsesAnyRegister(eas, new Set([candidate]))) return candidate;
+      }
+      return 'A';
+    };
+    const pickHiddenWordPair = (...eas: Array<EaExprNode | undefined>): 'DE' | 'BC' | undefined => {
+      const usesDE = anyEaUsesAnyRegister(eas, new Set(['DE', 'D', 'E']));
+      const usesBC = anyEaUsesAnyRegister(eas, new Set(['BC', 'B', 'C']));
+      if (!usesDE) return 'DE';
+      if (!usesBC) return 'BC';
+      return undefined;
+    };
+    const makeSubForm = (
+      nextDst: AsmOperandNode,
+      nextSrc: AsmOperandNode,
+      overrides?: Partial<LdForm>,
+    ): LdForm => ({
+      ...form,
+      dst: nextDst,
+      src: nextSrc,
+      dstResolved: nextDst.kind === 'Mem' ? dstResolved : undefined,
+      srcResolved: nextSrc.kind === 'Mem' ? srcResolved : undefined,
+      dstScalarExact: nextDst.kind === 'Mem' ? dstScalarExact : undefined,
+      srcScalarExact: nextSrc.kind === 'Mem' ? srcScalarExact : undefined,
+      scalarMemToMem: undefined,
+      srcHasRegisterLikeEaBase: nextSrc.kind === 'Mem' ? form.srcHasRegisterLikeEaBase : false,
+      dstHasRegisterLikeEaBase: nextDst.kind === 'Mem' ? form.dstHasRegisterLikeEaBase : false,
+      srcIsIxIyDispMem: nextSrc.kind === 'Mem' ? form.srcIsIxIyDispMem : false,
+      dstIsIxIyDispMem: nextDst.kind === 'Mem' ? form.dstIsIxIyDispMem : false,
+      srcIsEaNameHL: nextSrc.kind === 'Mem' ? form.srcIsEaNameHL : false,
+      dstIsEaNameHL: nextDst.kind === 'Mem' ? form.dstIsEaNameHL : false,
+      srcIsEaNameBCorDE: nextSrc.kind === 'Mem' ? form.srcIsEaNameBCorDE : false,
+      dstIsEaNameBCorDE: nextDst.kind === 'Mem' ? form.dstIsEaNameBCorDE : false,
+      ...overrides,
+    });
+    const copyHlIntoPair = (pair: 'DE' | 'BC'): boolean => {
+      if (pair === 'DE') {
+        return emitInstr(
+          'ex',
+          [regOperand('DE'), regOperand('HL')],
+          inst.span,
+        );
+      }
+      return pushReg('HL') && popReg('BC');
+    };
+    const canDirectLoadByteToReg8 = (_regUp: string, resolved: EaResolution | undefined): boolean => {
+      if (resolved?.kind === 'abs') return true;
+      return resolved?.kind === 'stack' && resolved.ixDisp >= -0x80 && resolved.ixDisp <= 0x7f;
+    };
+    const canDirectStoreByteFromReg8 = (_regUp: string, resolved: EaResolution | undefined): boolean => {
+      if (resolved?.kind === 'abs') return true;
+      return resolved?.kind === 'stack' && resolved.ixDisp >= -0x80 && resolved.ixDisp <= 0x7f;
+    };
+    const canDirectLoadWordToPair = (resolved: EaResolution | undefined): boolean =>
+      resolved?.kind === 'abs' || resolved?.kind === 'stack';
+    const canDirectStoreWordFromPair = (resolved: EaResolution | undefined): boolean =>
+      resolved?.kind === 'abs' || resolved?.kind === 'stack';
 
     const ixDispMem = (disp: number): AsmOperandNode => ({
       kind: 'Mem',
@@ -137,17 +266,87 @@ export function createLdEncodingHelpers(ctx: LdEncodingContext) {
               span: inst.span,
               base: { kind: 'EaName', span: inst.span, name: 'IX' },
               offset: { kind: 'ImmLiteral', span: inst.span, value: Math.abs(disp) },
-            },
+      },
     });
+
+    const emitAssignmentMemTransfer = (): boolean => {
+      if (dst.kind !== 'Mem') return false;
+      if (src.kind === 'Ea' && src.explicitAddressOf) {
+        if (!isWordCompatibleScalarKind(dstScalarExact)) {
+          diagAt(diagnostics, inst.span, 'Address transfer requires a word/addr destination.');
+          return true;
+        }
+        const hiddenPair = pickHiddenWordPair(src.expr, dst.expr);
+        if (!hiddenPair) {
+          diagAt(diagnostics, inst.span, '":=" address transfer cannot preserve destination address registers cleanly.');
+          return true;
+        }
+        if (!pushReg(hiddenPair)) return false;
+        const preserveHl = !canDirectStoreWordFromPair(dstResolved);
+        if (preserveHl && !pushReg('HL')) return false;
+        if (!materializeEaAddressToHL(src.expr, inst.span)) return false;
+        if (!copyHlIntoPair(hiddenPair)) return false;
+        if (!emitLdForm(makeSubForm(dst, regOperand(hiddenPair)))) return false;
+        if (preserveHl && !popReg('HL')) return false;
+        if (!popReg(hiddenPair)) return false;
+        return true;
+      }
+      if (src.kind !== 'Mem') return false;
+      if (
+        (srcScalarExact === 'byte' && isWordCompatibleScalarKind(dstScalarExact)) ||
+        (dstScalarExact === 'byte' && isWordCompatibleScalarKind(srcScalarExact))
+      ) {
+        diagAt(diagnostics, inst.span, 'Word mem->mem transfer requires word-typed source and destination.');
+        return true;
+      }
+      if (scalarMemToMem === 'byte') {
+        const hiddenReg = pickHiddenByteReg(src.expr, dst.expr);
+        const preservePair = regPairForReg8(hiddenReg);
+        if (!preservePair) {
+          diagAt(diagnostics, inst.span, '":=" byte transfer could not choose a hidden transfer register.');
+          return true;
+        }
+        if (!pushReg(preservePair)) return false;
+        const preserveHl =
+          !canDirectLoadByteToReg8(hiddenReg, srcResolved) ||
+          !canDirectStoreByteFromReg8(hiddenReg, dstResolved);
+        if (preserveHl && !pushReg('HL')) return false;
+        if (!emitLdForm(makeSubForm(regOperand(hiddenReg), src))) return false;
+        if (!emitLdForm(makeSubForm(dst, regOperand(hiddenReg)))) return false;
+        if (preserveHl && !popReg('HL')) return false;
+        if (!popReg(preservePair)) return false;
+        return true;
+      }
+      if (!scalarMemToMem) return false;
+      const hiddenPair = pickHiddenWordPair(src.expr, dst.expr);
+      if (!hiddenPair) {
+        diagAt(diagnostics, inst.span, '":=" word transfer cannot preserve destination address registers cleanly.');
+        return true;
+      }
+      if (!pushReg(hiddenPair)) return false;
+      const preserveHl =
+        !canDirectLoadWordToPair(srcResolved) ||
+        !canDirectStoreWordFromPair(dstResolved);
+      if (preserveHl && !pushReg('HL')) return false;
+      if (!emitLdForm(makeSubForm(regOperand(hiddenPair), src))) return false;
+      if (!emitLdForm(makeSubForm(dst, regOperand(hiddenPair)))) return false;
+      if (preserveHl && !popReg('HL')) return false;
+      if (!popReg(hiddenPair)) return false;
+      return true;
+    };
 
     const emitByteMemLoadToReg8 = (regUp: string): boolean => {
       const d = reg8Code.get(regUp);
       const viaA = isHalfIndexReg(regUp);
       if ((d === undefined && !viaA) || src.kind !== 'Mem') return false;
 
-      if (srcResolved?.kind === 'abs' && srcResolved.addend === 0) {
+      if (srcResolved?.kind === 'abs') {
+        if (regUp === 'A') {
+          emitAbs16Fixup(0x3a, srcResolved.baseLower, srcResolved.addend, inst.span);
+          return true;
+        }
         if (!emitInstr('push', [{ kind: 'Reg', span: inst.span, name: 'AF' }], inst.span)) return false;
-        emitAbs16Fixup(0x3a, srcResolved.baseLower, 0, inst.span);
+        emitAbs16Fixup(0x3a, srcResolved.baseLower, srcResolved.addend, inst.span);
         if (!emitInstr('ld', [{ kind: 'Reg', span: inst.span, name: regUp }, { kind: 'Reg', span: inst.span, name: 'A' }], inst.span)) {
           return false;
         }
@@ -550,6 +749,10 @@ export function createLdEncodingHelpers(ctx: LdEncodingContext) {
         if (!materializeEaAddressToHL(dst.expr, inst.span)) return false;
         return emitStoreWordToHlAddress('DE', inst.span);
       }
+    }
+
+    if (isAssignmentForm && dst.kind === 'Mem' && (src.kind === 'Mem' || (src.kind === 'Ea' && src.explicitAddressOf))) {
+      return emitAssignmentMemTransfer();
     }
 
     if (dst.kind === 'Mem' && src.kind === 'Mem') {

--- a/src/lowering/ldFormSelection.ts
+++ b/src/lowering/ldFormSelection.ts
@@ -156,7 +156,7 @@ export function createLdFormSelectionHelpers(ctx: LdFormSelectionContext) {
       srcScalarExact: scalarKindOfResolution(srcResolved),
       scalarMemToMem:
         dst.kind === 'Mem' && src.kind === 'Mem'
-          ? resolveScalarTypeForEa(dst.expr) ?? resolveScalarTypeForEa(src.expr) ?? undefined
+          ? resolveScalarTypeForLd(dst.expr) ?? resolveScalarTypeForLd(src.expr) ?? undefined
           : undefined,
       srcHasRegisterLikeEaBase: src.kind === 'Mem' ? hasRegisterLikeEaBase(src.expr) : false,
       dstHasRegisterLikeEaBase: dst.kind === 'Mem' ? hasRegisterLikeEaBase(dst.expr) : false,

--- a/test/fixtures/pr312_11_records_and_fields.expected.asm
+++ b/test/fixtures/pr312_11_records_and_fields.expected.asm
@@ -35,59 +35,54 @@ push AF                        ; 012C: F5
 ld A, (pair_buf)               ; 012D: 3A 00 00
 ld L, A                        ; 0130: 6F
 pop AF                         ; 0131: F1
-push DE                        ; 0132: D5
-push HL                        ; 0133: E5
-ld de, pair_buf                ; 0134: 11 00 00
-ld HL, $0001                   ; 0137: 21 01 00
-add HL, DE                     ; 013A: 19
-ld E, (HL)                     ; 013B: 5E
-pop HL                         ; 013C: E1
-ld H, E                        ; 013D: 63
-pop DE                         ; 013E: D1
+push AF                        ; 0132: F5
+ld A, (pair_buf + 1)           ; 0133: 3A 00 00
+ld H, A                        ; 0136: 67
+pop AF                         ; 0137: F1
 __zax_epilogue_1:
-pop DE                         ; 013F: D1
-pop BC                         ; 0140: C1
-pop AF                         ; 0141: F1
-ld SP, IX                      ; 0142: DD F9
-pop IX                         ; 0144: DD E1
-ret                            ; 0146: C9
+pop DE                         ; 0138: D1
+pop BC                         ; 0139: C1
+pop AF                         ; 013A: F1
+ld SP, IX                      ; 013B: DD F9
+pop IX                         ; 013D: DD E1
+ret                            ; 013F: C9
 ; func main begin
 ; func read_pair_word end
 main:
-push IX                        ; 0147: DD E5
-ld IX, $0000                   ; 0149: DD 21 00 00
-add IX, SP                     ; 014D: DD 39
-push AF                        ; 014F: F5
-push BC                        ; 0150: C5
-push DE                        ; 0151: D5
-push HL                        ; 0152: E5
-ld HL, $0002                   ; 0153: 21 02 00
-push HL                        ; 0156: E5
-ld HL, $0001                   ; 0157: 21 01 00
-push HL                        ; 015A: E5
-call write_pair                ; 015B: CD 00 00
-inc SP                         ; 015E: 33
-inc SP                         ; 015F: 33
-inc SP                         ; 0160: 33
-inc SP                         ; 0161: 33
-ld A, (pair_buf)               ; 0162: 3A 00 00
-call read_pair_word            ; 0165: CD 00 00
+push IX                        ; 0140: DD E5
+ld IX, $0000                   ; 0142: DD 21 00 00
+add IX, SP                     ; 0146: DD 39
+push AF                        ; 0148: F5
+push BC                        ; 0149: C5
+push DE                        ; 014A: D5
+push HL                        ; 014B: E5
+ld HL, $0002                   ; 014C: 21 02 00
+push HL                        ; 014F: E5
+ld HL, $0001                   ; 0150: 21 01 00
+push HL                        ; 0153: E5
+call write_pair                ; 0154: CD 00 00
+inc SP                         ; 0157: 33
+inc SP                         ; 0158: 33
+inc SP                         ; 0159: 33
+inc SP                         ; 015A: 33
+ld A, (pair_buf)               ; 015B: 3A 00 00
+call read_pair_word            ; 015E: CD 00 00
 __zax_epilogue_2:
-pop HL                         ; 0168: E1
-pop DE                         ; 0169: D1
-pop BC                         ; 016A: C1
-pop AF                         ; 016B: F1
-ld SP, IX                      ; 016C: DD F9
-pop IX                         ; 016E: DD E1
-ret                            ; 0170: C9
+pop HL                         ; 0161: E1
+pop DE                         ; 0162: D1
+pop BC                         ; 0163: C1
+pop AF                         ; 0164: F1
+ld SP, IX                      ; 0165: DD F9
+pop IX                         ; 0167: DD E1
+ret                            ; 0169: C9
 ; func main end
 
 ; symbols:
 ; label write_pair = $0100
 ; label __zax_epilogue_0 = $0118
 ; label read_pair_word = $0121
-; label __zax_epilogue_1 = $013F
-; label main = $0147
-; label __zax_epilogue_2 = $0168
+; label __zax_epilogue_1 = $0138
+; label main = $0140
+; label __zax_epilogue_2 = $0161
 ; data pair_buf = $1000
 ; label __zax_startup = $1002

--- a/test/fixtures/pr896_assignment_ea_ea.zax
+++ b/test/fixtures/pr896_assignment_ea_ea.zax
@@ -1,0 +1,16 @@
+section data vars at $1000
+  arr1: byte[4] = [1, 2, 3, 4]
+  arr2: byte[4] = [0, 0, 0, 0]
+  idx: byte = 1
+  src_word: word = $1234
+  dst_word: word = 0
+  ptr_slot: ptr = 0
+end
+
+export func main()
+  arr2[0] := arr1[idx]
+  dst_word := src_word
+  ptr_slot := @arr1[1]
+  arr2[idx] := arr1[0]
+  ret
+end

--- a/test/fixtures/pr896_assignment_ea_ea_conflict.zax
+++ b/test/fixtures/pr896_assignment_ea_ea_conflict.zax
@@ -1,0 +1,12 @@
+section data vars at $1000
+  arr_w: word[4] = [0, 0, 0, 0]
+  src_word: word = $1234
+  dst_word: word = 0
+end
+
+export func main()
+  ld de, 1
+  arr_w[de] := src_word
+  dst_word := arr_w[de]
+  ret
+end

--- a/test/fixtures/pr896_assignment_ea_ea_direct_fastpath.zax
+++ b/test/fixtures/pr896_assignment_ea_ea_direct_fastpath.zax
@@ -1,0 +1,12 @@
+section data vars at $1000
+  arr1: byte[4] = [1, 2, 3, 4]
+  arr2: byte[4] = [0, 0, 0, 0]
+  src_word: word = $1234
+  dst_word: word = 0
+end
+
+export func main()
+  arr2[0] := arr1[1]
+  dst_word := src_word
+  ret
+end

--- a/test/pr896_assignment_ea_ea_integration.test.ts
+++ b/test/pr896_assignment_ea_ea_integration.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { AsmArtifact } from '../src/formats/types.js';
+
+describe('PR896 := scalar path-to-path lowering', () => {
+  it('lowers byte, word, and @path storage transfers end-to-end', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr896_assignment_ea_ea.zax');
+    const res = await compile(
+      entry,
+      { emitAsm: true, emitBin: false, emitHex: false, emitListing: false, emitD8m: false },
+      { formats: defaultFormatWriters },
+    );
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+
+    const asm = res.artifacts.find((a): a is AsmArtifact => a.kind === 'asm');
+    expect(asm).toBeDefined();
+    const text = asm!.text.toUpperCase();
+
+    expect(text).toContain('PUSH AF');
+    expect(text).toContain('POP AF');
+    expect(text).toContain('PUSH DE');
+    expect(text).toContain('POP DE');
+    expect(text).toContain('PUSH HL');
+    expect(text).toContain('POP HL');
+    expect(text).toContain('LD A, (HL)');
+    expect(text).toContain('LD (HL), A');
+    expect(text).toContain('LD DE, (SRC_WORD)');
+    expect(text).toContain('LD (DST_WORD), DE');
+  });
+
+  it('avoids preserving HL for direct scalar fast paths', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr896_assignment_ea_ea_direct_fastpath.zax');
+    const res = await compile(
+      entry,
+      { emitAsm: true, emitBin: false, emitHex: false, emitListing: false, emitD8m: false },
+      { formats: defaultFormatWriters },
+    );
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+
+    const asm = res.artifacts.find((a): a is AsmArtifact => a.kind === 'asm');
+    expect(asm).toBeDefined();
+    const text = asm!.text.toUpperCase();
+
+    expect(text.match(/PUSH HL/g) ?? []).toHaveLength(1);
+    expect(text.match(/POP HL/g) ?? []).toHaveLength(1);
+    expect(text).toContain('LD DE, (SRC_WORD)');
+    expect(text).toContain('LD (DST_WORD), DE');
+  });
+
+  it('promotes the hidden word transfer pair when either path needs DE', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr896_assignment_ea_ea_conflict.zax');
+    const res = await compile(
+      entry,
+      { emitAsm: true, emitBin: false, emitHex: false, emitListing: false, emitD8m: false },
+      { formats: defaultFormatWriters },
+    );
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+
+    const asm = res.artifacts.find((a): a is AsmArtifact => a.kind === 'asm');
+    expect(asm).toBeDefined();
+    const text = asm!.text.toUpperCase();
+
+    expect(text).toContain('PUSH BC');
+    expect(text).toContain('POP BC');
+    expect(text).toContain('LD BC, (SRC_WORD)');
+    expect(text).toContain('LD (DST_WORD), BC');
+  });
+});


### PR DESCRIPTION
Implements GitHub issue #896.

Scope:
- lower scalar path-to-path `:=`
- preserve programmer-visible registers around hidden transfer use
- support scalar byte/word/address transfers, indexed paths, conflict promotion, and accepted `@path` forms

Verification:
- `npm run typecheck`
- `npx vitest run test/pr896_assignment_ea_ea_integration.test.ts test/pr863_assignment_lowering.test.ts test/pr875_assignment_ixiy_integration.test.ts test/pr869_assignment_reg8_integration.test.ts test/pr895_assignment_acceptance.test.ts test/pr693_ld_form_selection.test.ts`