### PR TITLE
SUCCPRED-899: add succ/pred parser and acceptance support

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -16,6 +16,7 @@ import { collectNonBankedSectionKeys } from './sectionKeys.js';
 import { canonicalModuleId } from './moduleIdentity.js';
 import { validateAssignmentAcceptance } from './semantics/assignmentAcceptance.js';
 import { buildEnv } from './semantics/env.js';
+import { validateSuccPredAcceptance } from './semantics/succPredAcceptance.js';
 
 function hasErrors(diagnostics: Diagnostic[]): boolean {
   return diagnostics.some((d) => d.severity === 'error');
@@ -365,6 +366,10 @@ export const compile: CompileFn = async (
   }
 
   validateAssignmentAcceptance(program, env, diagnostics);
+  if (hasErrors(diagnostics)) {
+    return { diagnostics, artifacts: [] };
+  }
+  validateSuccPredAcceptance(program, env, diagnostics);
   if (hasErrors(diagnostics)) {
     return { diagnostics, artifacts: [] };
   }

--- a/src/frontend/parseOperands.ts
+++ b/src/frontend/parseOperands.ts
@@ -383,6 +383,10 @@ export function parseAsmInstruction(
   const headLower = head.toLowerCase();
   const rest = firstSpace === -1 ? '' : trimmed.slice(firstSpace).trim();
 
+  if (headLower === 'succ' || headLower === 'pred') {
+    return parseSuccPredInstruction(filePath, headLower, rest, instrSpan, diagnostics);
+  }
+
   if (headLower === 'move') {
     diag(diagnostics, filePath, `"move" has been removed; use ":=".`, {
       line: instrSpan.start.line,
@@ -472,6 +476,69 @@ function parseAssignmentInstruction(
     column: instrSpan.start.column,
   });
   return undefined;
+}
+
+function parseSuccPredInstruction(
+  filePath: string,
+  head: 'succ' | 'pred',
+  operandText: string,
+  instrSpan: SourceSpan,
+  diagnostics: Diagnostic[],
+): AsmInstructionNode | undefined {
+  const text = operandText.trim();
+  if (text.length === 0 || text.includes(',')) {
+    diag(diagnostics, filePath, `"${head}" expects exactly one typed path operand`, {
+      line: instrSpan.start.line,
+      column: instrSpan.start.column,
+    });
+    return undefined;
+  }
+
+  const canonicalRegister = canonicalRegisterToken(text);
+  if (ALL_REGISTER_NAMES.has(canonicalRegister)) {
+    diag(diagnostics, filePath, `"${head}" only accepts typed path operands in this slice`, {
+      line: instrSpan.start.line,
+      column: instrSpan.start.column,
+    });
+    return undefined;
+  }
+  if (text.startsWith('(') && text.endsWith(')')) {
+    diag(diagnostics, filePath, `"${head}" does not accept indirect memory operands`, {
+      line: instrSpan.start.line,
+      column: instrSpan.start.column,
+    });
+    return undefined;
+  }
+  if (text.startsWith('@')) {
+    diag(diagnostics, filePath, `"${head}" does not accept address-of operands`, {
+      line: instrSpan.start.line,
+      column: instrSpan.start.column,
+    });
+    return undefined;
+  }
+
+  const ea = parseEaExprFromText(filePath, text, instrSpan, diagnostics);
+  if (!ea) {
+    diag(diagnostics, filePath, `Invalid "${head}" operand "${text}"`, {
+      line: instrSpan.start.line,
+      column: instrSpan.start.column,
+    });
+    return undefined;
+  }
+  if (!isAssignmentStoragePath(ea)) {
+    diag(diagnostics, filePath, `"${head}" requires a typed storage path, not an affine address expression`, {
+      line: instrSpan.start.line,
+      column: instrSpan.start.column,
+    });
+    return undefined;
+  }
+
+  return {
+    kind: 'AsmInstruction',
+    span: instrSpan,
+    head,
+    operands: [{ kind: 'Ea', span: instrSpan, expr: ea }],
+  };
 }
 
 function parseAssignmentTarget(

--- a/src/semantics/succPredAcceptance.ts
+++ b/src/semantics/succPredAcceptance.ts
@@ -1,0 +1,199 @@
+import { DiagnosticIds } from '../diagnostics/types.js';
+import type { Diagnostic } from '../diagnostics/types.js';
+import type {
+  AsmInstructionNode,
+  EaExprNode,
+  FuncDeclNode,
+  OpDeclNode,
+  ProgramNode,
+  SourceSpan,
+  TypeExprNode,
+  VarDeclNode,
+} from '../frontend/ast.js';
+import { visitDeclTree } from './declVisitor.js';
+import type { CompileEnv } from './env.js';
+import { createTypeResolutionHelpers } from '../lowering/typeResolution.js';
+import { resolveVisibleType } from '../moduleVisibility.js';
+
+function diagAt(diagnostics: Diagnostic[], span: SourceSpan, message: string): void {
+  diagnostics.push({
+    id: DiagnosticIds.SemanticsError,
+    severity: 'error',
+    message,
+    file: span.file,
+    line: span.start.line,
+    column: span.start.column,
+  });
+}
+
+function collectModuleStorage(program: ProgramNode, env: CompileEnv) {
+  const storageTypes = new Map<string, TypeExprNode>();
+  const rawAddressSymbols = new Set<string>();
+  const moduleAliasTargets = new Map<string, EaExprNode>();
+
+  const resolveScalarKind = (typeExpr: TypeExprNode, seen: Set<string> = new Set()) => {
+    if (typeExpr.kind !== 'TypeName') return undefined;
+    const lower = typeExpr.name.toLowerCase();
+    if (lower === 'byte' || lower === 'word' || lower === 'addr') return lower;
+    if (lower === 'ptr') return 'addr';
+    if (seen.has(lower)) return undefined;
+    seen.add(lower);
+    const decl = resolveVisibleType(typeExpr.name, typeExpr.span.file, env);
+    if (!decl || decl.kind !== 'TypeDecl') return undefined;
+    return resolveScalarKind(decl.typeExpr, seen);
+  };
+
+  visitDeclTree(program.files.flatMap((file) => file.items), (item, ctx) => {
+    const namedSection = ctx.section;
+    switch (item.kind) {
+      case 'VarBlock':
+        if (item.scope !== 'module' || namedSection) return;
+        for (const decl of item.decls) {
+          const lower = decl.name.toLowerCase();
+          if (decl.form === 'typed') storageTypes.set(lower, decl.typeExpr);
+          else moduleAliasTargets.set(lower, decl.initializer.expr);
+        }
+        return;
+      case 'DataBlock':
+        for (const decl of item.decls) {
+          const lower = decl.name.toLowerCase();
+          storageTypes.set(lower, decl.typeExpr);
+          if (!resolveScalarKind(decl.typeExpr)) rawAddressSymbols.add(lower);
+        }
+        return;
+      case 'DataDecl': {
+        if (namedSection && namedSection.section !== 'data') return;
+        const lower = item.name.toLowerCase();
+        storageTypes.set(lower, item.typeExpr);
+        if (!resolveScalarKind(item.typeExpr)) rawAddressSymbols.add(lower);
+        return;
+      }
+      case 'BinDecl':
+      case 'HexDecl':
+      case 'RawDataDecl':
+        rawAddressSymbols.add(item.name.toLowerCase());
+        return;
+      default:
+        return;
+    }
+  });
+
+  return { storageTypes, rawAddressSymbols, moduleAliasTargets };
+}
+
+function collectFunctionLocals(decls: VarDeclNode[]) {
+  const stackSlotTypes = new Map<string, TypeExprNode>();
+  const localAliasTargets = new Map<string, EaExprNode>();
+  for (const decl of decls) {
+    const lower = decl.name.toLowerCase();
+    if (decl.form === 'typed') stackSlotTypes.set(lower, decl.typeExpr);
+    else localAliasTargets.set(lower, decl.initializer.expr);
+  }
+  return { stackSlotTypes, localAliasTargets };
+}
+
+function validateSuccPredInstruction(
+  item: AsmInstructionNode,
+  env: CompileEnv,
+  storageTypes: Map<string, TypeExprNode>,
+  rawAddressSymbols: Set<string>,
+  moduleAliasTargets: Map<string, EaExprNode>,
+  stackSlotTypes: Map<string, TypeExprNode>,
+  localAliasTargets: Map<string, EaExprNode>,
+  diagnostics: Diagnostic[],
+): void {
+  if ((item.head !== 'succ' && item.head !== 'pred') || item.operands.length !== 1) return;
+  const operand = item.operands[0];
+  if (operand?.kind !== 'Ea' || operand.explicitAddressOf) return;
+
+  const helpers = createTypeResolutionHelpers({
+    env,
+    storageTypes,
+    stackSlotTypes,
+    rawAddressSymbols,
+    moduleAliasTargets,
+    getLocalAliasTargets: () => localAliasTargets,
+  });
+
+  const typeExpr = helpers.resolveEaTypeExpr(operand.expr);
+  const scalar = helpers.resolveScalarTypeForLd(operand.expr);
+  if (!scalar) {
+    const detail = typeExpr ? helpers.typeDisplay(typeExpr) : 'unknown';
+    diagAt(diagnostics, item.span, `"${item.head}" requires scalar storage; got ${detail}.`);
+    return;
+  }
+  if (scalar !== 'byte' && scalar !== 'word') {
+    diagAt(diagnostics, item.span, `"${item.head}" only supports byte and word scalar paths in this slice.`);
+  }
+}
+
+function validateFunctionSuccPred(
+  item: FuncDeclNode,
+  env: CompileEnv,
+  storageTypes: Map<string, TypeExprNode>,
+  rawAddressSymbols: Set<string>,
+  moduleAliasTargets: Map<string, EaExprNode>,
+  diagnostics: Diagnostic[],
+): void {
+  const { stackSlotTypes, localAliasTargets } = collectFunctionLocals(item.locals.decls);
+  for (const param of item.params) {
+    stackSlotTypes.set(param.name.toLowerCase(), param.typeExpr);
+  }
+  for (const asmItem of item.asm.items) {
+    if (asmItem.kind !== 'AsmInstruction') continue;
+    validateSuccPredInstruction(
+      asmItem,
+      env,
+      storageTypes,
+      rawAddressSymbols,
+      moduleAliasTargets,
+      stackSlotTypes,
+      localAliasTargets,
+      diagnostics,
+    );
+  }
+}
+
+function validateOpSuccPred(item: OpDeclNode, diagnostics: Diagnostic[]): void {
+  for (const asmItem of item.body.items) {
+    if (
+      asmItem.kind === 'AsmInstruction' &&
+      (asmItem.head === 'succ' || asmItem.head === 'pred') &&
+      asmItem.operands.length === 1 &&
+      asmItem.operands[0]?.kind === 'Ea'
+    ) {
+      diagAt(
+        diagnostics,
+        asmItem.span,
+        `"${asmItem.head}" typed-path forms are not supported inside ops in this slice.`,
+      );
+    }
+  }
+}
+
+export function validateSuccPredAcceptance(
+  program: ProgramNode,
+  env: CompileEnv,
+  diagnostics: Diagnostic[],
+): void {
+  const { storageTypes, rawAddressSymbols, moduleAliasTargets } = collectModuleStorage(program, env);
+
+  for (const file of program.files) {
+    visitDeclTree(file.items, (item) => {
+      if (item.kind === 'FuncDecl') {
+        validateFunctionSuccPred(
+          item,
+          env,
+          storageTypes,
+          rawAddressSymbols,
+          moduleAliasTargets,
+          diagnostics,
+        );
+        return;
+      }
+      if (item.kind === 'OpDecl') {
+        validateOpSuccPred(item, diagnostics);
+      }
+    });
+  }
+}

--- a/test/pr899_succ_pred_acceptance.test.ts
+++ b/test/pr899_succ_pred_acceptance.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import type { ProgramNode } from '../src/frontend/ast.js';
+import { parseModuleFile } from '../src/frontend/parser.js';
+import { validateSuccPredAcceptance } from '../src/semantics/succPredAcceptance.js';
+import { buildEnv } from '../src/semantics/env.js';
+
+function parseProgram(modulePath: string, source: string): { program: ProgramNode; diagnostics: Diagnostic[] } {
+  const diagnostics: Diagnostic[] = [];
+  const moduleFile = parseModuleFile(modulePath, source, diagnostics);
+  const program: ProgramNode = {
+    kind: 'Program',
+    span: moduleFile.span,
+    entryFile: modulePath,
+    files: [moduleFile],
+  };
+  return { program, diagnostics };
+}
+
+describe('PR899 succ/pred acceptance', () => {
+  it('accepts scalar byte and word path operands', () => {
+    const { program, diagnostics } = parseProgram(
+      'pr899_succ_pred_positive.zax',
+      `
+type Rec
+  field: byte
+end
+
+section data globals at $8000
+  count: byte
+  used_slots: word
+  arr: byte[4]
+  rec: Rec
+end
+
+section code text at $0000
+func main()
+  succ count
+  pred used_slots
+  succ arr[1]
+  pred rec.field
+  ret
+end
+end
+      `,
+    );
+
+    const env = buildEnv(program, diagnostics);
+    validateSuccPredAcceptance(program, env, diagnostics);
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  it('rejects composite and address-typed operands', () => {
+    const { program, diagnostics } = parseProgram(
+      'pr899_succ_pred_negative.zax',
+      `
+type Rec
+  field: byte
+end
+
+section data globals at $8000
+  rec: Rec
+  ptr: ptr
+  raw_buf:
+    db 1, 2, 3
+end
+
+section code text at $0000
+func main()
+  succ rec
+  pred ptr
+  succ raw_buf
+  ret
+end
+end
+      `,
+    );
+
+    const env = buildEnv(program, diagnostics);
+    validateSuccPredAcceptance(program, env, diagnostics);
+
+    const messages = diagnostics.map((d) => d.message);
+    expect(messages).toContain('"succ" requires scalar storage; got Rec.');
+    expect(messages).toContain('"pred" only supports byte and word scalar paths in this slice.');
+    expect(messages).toContain('"succ" requires scalar storage; got unknown.');
+  });
+
+  it('rejects typed-path forms inside ops in this slice', () => {
+    const { program, diagnostics } = parseProgram(
+      'pr899_succ_pred_op_negative.zax',
+      `
+op bump(slot: ea)
+  succ slot
+end
+
+op drop(slot: ea)
+  pred slot
+end
+      `,
+    );
+
+    const env = buildEnv(program, diagnostics);
+    validateSuccPredAcceptance(program, env, diagnostics);
+
+    const messages = diagnostics.map((d) => d.message);
+    expect(messages).toContain('"succ" typed-path forms are not supported inside ops in this slice.');
+    expect(messages).toContain('"pred" typed-path forms are not supported inside ops in this slice.');
+  });
+});

--- a/test/pr899_succ_pred_parser.test.ts
+++ b/test/pr899_succ_pred_parser.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Diagnostic } from '../src/diagnostics/types.js';
+import { makeSourceFile, span } from '../src/frontend/source.js';
+import { parseAsmInstruction } from '../src/frontend/parseOperands.js';
+
+describe('PR899 succ/pred parser support', () => {
+  const file = makeSourceFile('pr899_succ_pred_parser.zax', '');
+  const zeroSpan = span(file, 0, 0);
+
+  function parse(
+    text: string,
+  ): { instr: ReturnType<typeof parseAsmInstruction>; diagnostics: Diagnostic[] } {
+    const diagnostics: Diagnostic[] = [];
+    const instr = parseAsmInstruction(file.path, text, zeroSpan, diagnostics);
+    return { instr, diagnostics };
+  }
+
+  it('parses typed-path forms', () => {
+    let parsed = parse('succ count');
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.instr).toMatchObject({
+      kind: 'AsmInstruction',
+      head: 'succ',
+      operands: [{ kind: 'Ea', expr: { kind: 'EaName', name: 'count' } }],
+    });
+
+    parsed = parse('pred rec.field');
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.instr).toMatchObject({
+      kind: 'AsmInstruction',
+      head: 'pred',
+      operands: [
+        {
+          kind: 'Ea',
+          expr: {
+            kind: 'EaField',
+            base: { kind: 'EaName', name: 'rec' },
+            field: 'field',
+          },
+        },
+      ],
+    });
+
+    parsed = parse('succ arr[idx]');
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.instr).toMatchObject({
+      kind: 'AsmInstruction',
+      head: 'succ',
+      operands: [
+        {
+          kind: 'Ea',
+          expr: {
+            kind: 'EaIndex',
+            base: { kind: 'EaName', name: 'arr' },
+          },
+        },
+      ],
+    });
+  });
+
+  it('rejects registers, indirect forms, address-of forms, and arity errors', () => {
+    for (const text of ['succ hl', 'pred (hl)', 'succ @path', 'pred left, right']) {
+      const parsed = parse(text);
+      expect(parsed.instr).toBeUndefined();
+      expect(parsed.diagnostics.length).toBeGreaterThan(0);
+      expect(parsed.diagnostics[0]?.message.toLowerCase()).toContain(text.startsWith('pred') ? 'pred' : 'succ');
+    }
+  });
+});


### PR DESCRIPTION
Implements GitHub issue #899.

Scope:
- parser support for `succ path` / `pred path`
- acceptance validation for scalar byte/word typed paths
- rejection of registers, indirect forms, address-of forms, and composite/raw path targets

Verification:
- `npm run typecheck`
- `npx vitest run test/pr899_succ_pred_parser.test.ts test/pr899_succ_pred_acceptance.test.ts test/pr862_assignment_parser.test.ts`