### PR TITLE
docs: defer for and prioritize ergonomics sweep

### DIFF
--- a/docs/design/ergonomics-proposals.md
+++ b/docs/design/ergonomics-proposals.md
@@ -342,7 +342,7 @@ This is conceptually closer to a counted `while` than to `repeat ... until`: ini
 
 ### Status
 
-Design is settled. Implement after proposals 1 and 2.
+Design is settled but deferred. It is not part of the current implementation priority.
 
 ---
 
@@ -366,6 +366,6 @@ Allowing arithmetic on the RHS requires hidden temporary selection, sequencing r
 |----------------------------------|----------------------|
 | Scalar path-to-path `:=`         | Yes — implement next |
 | `succ` / `pred` on typed paths   | Yes — implement      |
-| Pascal-style counted `for`       | Yes — Pascal-style, implement after proposals 1 and 2 |
+| Pascal-style counted `for`       | Deferred — design settled, not active work |
 | General RHS arithmetic           | No, for now          |
 | C-style `for`                    | No                   |

--- a/docs/work/current-stream.md
+++ b/docs/work/current-stream.md
@@ -2,30 +2,34 @@
 
 ## Current language direction
 
-The rolled-back `addr` / ops-first addressing stream is not the active language
-direction.
+The active ergonomics stream has landed its core language work:
+- `:=` is the assignment surface on `main`
+- scalar path-to-path `:=` is implemented on `main`
+- `succ` / `pred` on typed scalar paths are implemented on `main`
+
+The old `move` surface is removed. The rolled-back `addr` / ops-first addressing
+stream is not the active language direction.
 
 ### Current implementation state
 
-- Typed storage transfers now prefer `:=`; `move` remains supported as a transitional surface.
+- Typed storage transfers use `:=` on `main`.
+- Scalar path-to-path `:=` is implemented on `main`.
+- `succ` / `pred` typed-path lowering is implemented on `main`.
 - Grouped and ranged `select case` values are implemented.
-- Parser/grammar convergence work is active again.
-- Typed reinterpretation syntax `<Type>base.tail` is now implemented on
-  `main`, with parser and lowering landed.
+- Parser/grammar convergence work remains active.
+- Typed reinterpretation syntax `<Type>base.tail` is implemented on `main`.
 - Raw data directives and raw-label semantics are implemented on `main`.
-- `@path` address-of storage paths are implemented on `main` under
-  `rr := @path`.
+- `@path` address-of storage paths are implemented on `main`.
 
 ### Immediate priority
 
-1. Remove `move` directly from parser/lowering/docs now that the active
-   assignment surface is fully covered by `:=`.
-2. Delete the remaining compatibility-only `move` subset as part of that
-   removal.
+1. Sweep obvious load/store shuttle patterns to scalar path-to-path `:=` in live examples/docs/tests.
+2. Sweep obvious scalar update patterns to `succ` / `pred` in live examples/docs/tests.
 3. Continue parser/grammar convergence work.
 
 ### Deferred until re-planned
 
+- Pascal-style counted `for`
 - any reintroduction of `addr` as a source-language feature
 - broad addressing-surface redesign
-- further addressing-surface redesign beyond the current `move`/typed-path split
+- further addressing-surface redesign beyond the current typed-path model


### PR DESCRIPTION
Updates the active work record after landing scalar path-to-path `:=` and `succ` / `pred`.

Changes:
- marks Pascal-style `for` as designed but deferred
- removes it from immediate priorities
- makes the ergonomics cleanup sweep the active next step
- refreshes `current-stream.md` to match current `main` state