### PR TITLE
ERGONOMICS-906: sweep course succ/pred updates

### DIFF
--- a/examples/course/unit1/binary_search.zax
+++ b/examples/course/unit1/binary_search.zax
@@ -53,15 +53,13 @@ func binary_search(target_value: byte): HL
       ret
     end
     if C
-      hl := mid_index
-      dec hl
-      high_index := hl
+      high_index := mid_index
+      pred high_index
     end
     if NC
       if NZ
-        hl := mid_index
-        inc hl
-        low_index := hl
+        low_index := mid_index
+        succ low_index
       end
     end
 

--- a/examples/course/unit1/bubble_sort.zax
+++ b/examples/course/unit1/bubble_sort.zax
@@ -55,9 +55,8 @@ func bubble_pass(last_index: byte)
     a := values[L]
     left_value := a
 
-    a := inner_index
-    inc a
-    next_index := a
+    next_index := inner_index
+    succ next_index
 
     l := next_index
     a := values[L]
@@ -72,9 +71,7 @@ func bubble_pass(last_index: byte)
       end
     end
 
-    a := inner_index
-    inc a
-    inner_index := a
+    succ inner_index
 
     ld a, 1
     or a
@@ -100,9 +97,7 @@ export func bubble_sort()
 
     bubble_pass pass_last
 
-    a := pass_last
-    dec a
-    pass_last := a
+    pred pass_last
 
     ld a, 1
     or a

--- a/examples/course/unit1/insertion_sort.zax
+++ b/examples/course/unit1/insertion_sort.zax
@@ -24,9 +24,8 @@ func insert_hole(scan_index: byte, hold_value: byte)
     ret
   end
 
-  a := scan_index
-  dec a
-  prior_index := a
+  prior_index := scan_index
+  pred prior_index
 
   l := prior_index
   a := values[L]
@@ -76,9 +75,7 @@ export func insertion_sort()
 
     insert_hole outer_index, hold_value
 
-    a := outer_index
-    inc a
-    outer_index := a
+    succ outer_index
 
     ld a, 1
     or a

--- a/examples/course/unit1/linear_search.zax
+++ b/examples/course/unit1/linear_search.zax
@@ -39,9 +39,7 @@ func linear_search(target_value: byte): HL
       ret
     end
 
-    a := scan_index
-    inc a
-    scan_index := a
+    succ scan_index
 
     ld a, 1
     or a

--- a/examples/course/unit1/prime_sieve.zax
+++ b/examples/course/unit1/prime_sieve.zax
@@ -29,9 +29,7 @@ export func prime_sieve()
     a := is_prime[L]
     or a
     if Z
-      a := factor_index
-      inc a
-      factor_index := a
+      succ factor_index
       ld a, 1
       or a
     end
@@ -66,9 +64,7 @@ export func prime_sieve()
         end
       end
 
-      a := factor_index
-      inc a
-      factor_index := a
+      succ factor_index
 
       ld a, 1
       or a

--- a/examples/course/unit1/selection_sort.zax
+++ b/examples/course/unit1/selection_sort.zax
@@ -84,9 +84,7 @@ func find_min_index(start_index: byte, last_index: byte): HL
       best_value := a
     end
 
-    a := current_index
-    inc a
-    current_index := a
+    succ current_index
 
     ld a, 1
     or a
@@ -126,9 +124,7 @@ export func selection_sort()
       swap_values outer_index, min_index
     end
 
-    a := outer_index
-    inc a
-    outer_index := a
+    succ outer_index
 
     ld a, 1
     or a

--- a/examples/course/unit2/atoi.zax
+++ b/examples/course/unit2/atoi.zax
@@ -51,9 +51,7 @@ export func atoi_demo(): HL
     add hl, de
     result_value := hl
 
-    hl := scan_ptr
-    inc hl
-    scan_ptr := hl
+    succ scan_ptr
 
     ld a, 1
     or a

--- a/examples/course/unit2/itoa.zax
+++ b/examples/course/unit2/itoa.zax
@@ -30,9 +30,7 @@ func div_u16(dividend: word, divisor: word): HL
     end
 
     remainder_value := hl
-    hl := quotient_value
-    inc hl
-    quotient_value := hl
+    succ quotient_value
 
     ld a, 1
     or a
@@ -105,9 +103,7 @@ export func itoa_demo()
       a := digit_value
       reverse_digits[L] := a
 
-      a := write_index
-      inc a
-      write_index := a
+      succ write_index
 
       hl := quotient_value
       remaining_value := hl
@@ -129,9 +125,7 @@ export func itoa_demo()
       ret
     end
 
-    a := write_index
-    dec a
-    write_index := a
+    pred write_index
 
     l := write_index
     a := reverse_digits[L]
@@ -141,9 +135,7 @@ export func itoa_demo()
     a := digit_value
     output_text[L] := a
 
-    a := read_index
-    inc a
-    read_index := a
+    succ read_index
 
     ld a, 1
     or a

--- a/examples/course/unit3/bit_reverse.zax
+++ b/examples/course/unit3/bit_reverse.zax
@@ -39,9 +39,7 @@ export func bit_reverse_demo(): HL
     srl a
     source_value := a
 
-    a := bit_count
-    dec a
-    bit_count := a
+    pred bit_count
 
     ld a, 1
     or a

--- a/examples/course/unit3/getbits.zax
+++ b/examples/course/unit3/getbits.zax
@@ -26,9 +26,7 @@ export func getbits_demo(): HL
       srl a
       working_value := a
 
-      a := offset_value
-      dec a
-      offset_value := a
+      pred offset_value
 
       ld a, 1
       or a
@@ -64,9 +62,7 @@ export func getbits_demo(): HL
     add a, a
     bit_mask := a
 
-    a := width_value
-    dec a
-    width_value := a
+    pred width_value
 
     ld a, 1
     or a

--- a/examples/course/unit3/popcount.zax
+++ b/examples/course/unit3/popcount.zax
@@ -24,9 +24,7 @@ export func popcount_demo(): HL
     a := working_value
     and 1
     if NZ
-      a := count_value
-      inc a
-      count_value := a
+      succ count_value
     end
 
     a := working_value

--- a/examples/course/unit5/array_reverse_recursive.zax
+++ b/examples/course/unit5/array_reverse_recursive.zax
@@ -47,13 +47,11 @@ func reverse_range(left_index: byte, right_index: byte)
 
   swap_values left_index, right_index
 
-  a := left_index
-  inc a
-  next_left := a
+  next_left := left_index
+  succ next_left
 
-  a := right_index
-  dec a
-  next_right := a
+  next_right := right_index
+  pred next_right
 
   reverse_range next_left, next_right
 end

--- a/examples/course/unit5/array_sum_recursive.zax
+++ b/examples/course/unit5/array_sum_recursive.zax
@@ -26,9 +26,8 @@ func sum_from(index_value: byte): HL
   a := numbers[L]
   current_value := a
 
-  a := index_value
-  inc a
-  next_index := a
+  next_index := index_value
+  succ next_index
 
   sum_from next_index
 

--- a/examples/course/unit5/hanoi.zax
+++ b/examples/course/unit5/hanoi.zax
@@ -17,9 +17,8 @@ func hanoi_count(disks_count: byte, source_peg: byte, spare_peg: byte, target_pe
     ret
   end
 
-  a := disks_count
-  dec a
-  reduced_count := a
+  reduced_count := disks_count
+  pred reduced_count
 
   hanoi_count reduced_count, source_peg, target_peg, spare_peg
   left_count := hl

--- a/examples/course/unit8/eight_queens.zax
+++ b/examples/course/unit8/eight_queens.zax
@@ -105,9 +105,7 @@ func place_row(row_index: byte)
       end
     end
 
-    a := col_index
-    inc a
-    col_index := a
+    succ col_index
 
     ld a, 1
     or a


### PR DESCRIPTION
## Summary
- replace obvious register shuttle increment/decrement patterns in course examples with `succ` / `pred`
- keep scope to course examples only
- leave language-tour, corpus, and parser/lowering untouched

## Verification
- `npm run typecheck`
- `for f in examples/course/unit1/binary_search.zax examples/course/unit1/bubble_sort.zax examples/course/unit1/insertion_sort.zax examples/course/unit1/linear_search.zax examples/course/unit1/prime_sieve.zax examples/course/unit1/selection_sort.zax examples/course/unit2/atoi.zax examples/course/unit2/itoa.zax examples/course/unit3/bit_reverse.zax examples/course/unit3/getbits.zax examples/course/unit3/popcount.zax examples/course/unit5/array_reverse_recursive.zax examples/course/unit5/array_sum_recursive.zax examples/course/unit5/hanoi.zax examples/course/unit8/eight_queens.zax; do npm run zax -- "$f"; done`