### PR TITLE
docs(course): Phase 1 — introduction, foundations, arrays and loops

### DIFF
--- a/docs/course/00-introduction.md
+++ b/docs/course/00-introduction.md
@@ -1,0 +1,121 @@
+# Chapter 00 — Introduction
+
+## What ZAX Is
+
+ZAX is a structured assembler for the Z80 family. It compiles directly to
+machine code — no external linker, no object format, no runtime system. The
+output is a flat binary image alongside optional Intel HEX, a symbol listing,
+and a debug map.
+
+It is still assembly. You choose registers, manage flags, and decide what lives
+in ROM versus RAM. The Z80 instruction set is fully available, mnemonics and
+all. What ZAX adds is structure and names: typed storage declarations,
+functions with stack-frame discipline, structured control flow, and a system
+for defining inline macro-instructions (`op`) with compiler-level operand
+matching.
+
+That is the whole bargain. ZAX is not a systems language in the modern sense —
+there is no type inference, no allocation model, no garbage collector, no
+runtime exception system. It is not a macro assembler in the traditional sense
+either — there are no textual substitutions, no include-time tricks, no flat
+instruction streams hiding behind a label convention. It sits in a specific and
+defensible position: a structured assembler, one level above raw assembly, with
+the machine model fully visible throughout.
+
+## The Problem It Solves
+
+Z80 assembly is expressive. Every addressing mode, every flag condition, every
+clever register assignment is available to you directly. The problem is
+bookkeeping: which registers are live at this point? What is the offset of this
+field into that structure? Which label marks the entry to this inner loop? What
+does "count" mean in this context versus the `count` in the function three
+screens up?
+
+As a program grows, that bookkeeping noise accumulates. Comments explain what
+an `ld` instruction does rather than why the algorithm does it. Field offsets
+are hardcoded constants that silently break when a struct changes. Functions
+share conventions only by discipline, not by enforcement.
+
+ZAX handles the bookkeeping. Typed storage declarations give names to memory
+and let the compiler compute offsets. Functions declare their return registers
+and the compiler generates the preservation epilogue. Structured control flow
+replaces conditional jumps to ad-hoc labels. The `:=` assignment operator reads
+and writes typed storage paths — the compiler emits the IX-relative load/store
+sequence, not the programmer.
+
+You remain responsible for the algorithmic decisions: which register holds
+what, why this loop structure, what invariant this sequence maintains. That is
+the work that produces readable code. ZAX removes the mechanical layer so that
+work can show clearly.
+
+## Two Kinds of Transfer
+
+A central ZAX idiom is the distinction between `:=` and raw Z80 `ld`.
+
+`:=` is typed storage transfer. `count := hl` writes the value of HL into the
+typed local `count`. `hl := count` reads it back. The compiler emits the
+IX-relative load or store — typically a two-instruction EX/LD sequence because
+of the Z80's constraint that H and L cannot be used directly with IX-relative
+addressing. You write the intent; the compiler handles the mechanics.
+
+`ld` is the raw Z80 instruction. `ld hl, $FF00` loads an immediate into HL.
+`ld a, (hl)` dereferences HL. These are assembly mnemonics and they mean
+exactly what they say. They have no knowledge of typed storage symbols.
+
+The two forms coexist naturally in the same function body. Typed variable
+access uses `:=`; raw machine-level work uses Z80 mnemonics directly. You will
+see both in almost every example in this course.
+
+## Why Algorithms
+
+This course is organised around algorithms, not features. Each chapter
+introduces ZAX constructs in the context of a real problem. Features earn their
+place by being needed.
+
+The algorithm corpus is drawn from two foundational texts: Kernighan and
+Ritchie's _The C Programming Language_ and Niklaus Wirth's _Algorithms + Data
+Structures = Programs_. These are not arbitrary choices. These algorithms are
+short enough to hold in your head, varied enough to cover the key patterns of
+structured programming, and well-understood enough that you can judge whether a
+given ZAX expression is clean or awkward.
+
+The course is also a language design instrument. Where an algorithm resists
+clean ZAX expression, the friction is recorded honestly — in the prose and in
+the friction log that feeds the language roadmap. A reader who completes the
+course will understand both what ZAX can do cleanly and where the current
+surface still asks something extra of the programmer.
+
+## What You Will Build
+
+Working through the course, you will read and understand ZAX programs
+implementing:
+
+- arithmetic and number theory: power, GCD, Fibonacci, integer square root,
+  exponentiation by squaring, decimal digit decomposition
+- sorting and searching: insertion sort, bubble sort, selection sort, binary
+  search, linear search, the prime sieve of Eratosthenes
+- string operations: string length, copy, compare, concatenate, reverse,
+  integer-to-string and string-to-integer conversion
+- bit manipulation: population count, bit reversal, parity, field extraction
+- a ring buffer using exact-size record layout
+- recursive algorithms: Towers of Hanoi, recursive array sum and reverse
+- a complete RPN calculator assembled from helper routines
+- linked list and binary search tree traversal using typed pointer fields
+- the eight-queens problem as a capstone for control-flow structure
+
+None of these are toy programs. Each one is a real implementation that
+compiles and runs on Z80 hardware or a simulator. Together they constitute a
+body of non-trivial ZAX code that you can study, modify, and build from.
+
+## Assumptions
+
+You know the Z80 instruction set and register model. You understand flags,
+addressing modes, and the calling conventions of raw assembly. You have written
+non-trivial Z80 programs before.
+
+You do not need to know C, Pascal, or any high-level language. The algorithm
+descriptions in each chapter are self-contained. Familiarity with the K&R and
+Wirth texts is useful context but not required.
+
+The next chapter begins where ZAX code begins: variables, types, functions, and
+the first small programs.

--- a/docs/course/01-foundations.md
+++ b/docs/course/01-foundations.md
@@ -1,0 +1,400 @@
+# Chapter 01 — Foundations
+
+The unit 1 examples establish the basic voice of ZAX through arithmetic and
+number-theory algorithms. No arrays, no records, no pointer operations — just
+functions, typed locals, and structured control flow over integer computations.
+That constraint is deliberate: it lets you see the core idioms clearly before
+the surface gets wider.
+
+---
+
+## Variables and Types
+
+ZAX has four scalar storage types: `byte` (8-bit unsigned), `word` (16-bit
+unsigned), `addr` (16-bit, signals a memory address), and `ptr` (16-bit,
+signals a pointer to something). In the unit 1 examples only `byte` and `word`
+appear — the others become relevant when dealing with arrays and records.
+
+Storage exists in two places: named `data` sections at module scope, and `var`
+blocks inside function bodies.
+
+A `var` block declares function-local scalars with optional initializers:
+
+```zax
+func power(base: word, exponent: word): HL
+  var
+    result:    word = 1
+    remaining: word = 0
+  end
+  ...
+end
+```
+
+Each local occupies a 16-bit slot in the IX-anchored stack frame. The
+initializer value is emitted at function entry, before any instructions in the
+body run. The `var` block is terminated by its own `end`; a second `end` closes
+the function itself.
+
+The compiler allocates and initialises locals before the callee-save push
+sequence. Reading the `.asm` output for a framed function, you will see
+`LD HL, imm16` / `PUSH HL` pairs for each initialised local at the top of the
+prologue.
+
+---
+
+## The `:=` Assignment Operator
+
+`:=` is the typed storage transfer operator. It reads or writes typed storage
+paths: module symbols, function locals, record fields, array elements.
+
+```zax
+remaining := exponent    ; write argument value into local
+hl := result             ; read local into HL
+result := hl             ; write HL back into local
+```
+
+The left-hand side and the right-hand side are typed storage paths and
+registers. The compiler resolves the IX-relative addressing for frame slots and
+emits the required load or store instruction sequence.
+
+This is what distinguishes `:=` from `ld`. When you write `ld hl, $FF00` you
+are issuing a Z80 instruction directly. When you write `hl := remaining` you
+are asking the compiler to emit whatever instruction sequence is required to
+transfer the value of `remaining` into HL — which for a frame-local `word`
+means an EX DE,HL / LD-through-DE / EX DE,HL pattern, because H and L cannot
+be used directly with IX-relative addressing on the Z80.
+
+You write the intent; the compiler handles the lowering. Both forms appear in
+the same function body, and they sit next to each other naturally:
+
+```zax
+    hl := remaining     ; typed load: read frame local into HL
+    ld a, l
+    and 1               ; test the low bit of remaining
+    if NZ
+      mul_u16 result, factor
+      result := hl      ; typed store: write HL back to frame local
+    end
+```
+
+(From `examples/course/unit1/exp_squaring.zax`, lines 58–63.)
+
+The raw `ld a, l` and `and 1` test the low bit of a 16-bit value. That is
+pure Z80 work. The `:=` assignments on either side are typed storage transfers.
+Both are idiomatic ZAX.
+
+---
+
+## Functions
+
+Every computation in the unit 1 examples lives inside a `func`. The declaration
+names the function, lists its parameters with types, and declares the return
+register:
+
+```zax
+func gcd_iterative(left_input: word, right_input: word): HL
+```
+
+The return register declaration — `: HL` here — is load-bearing. It tells the
+compiler two things: HL is the value channel through which the result comes
+back, and the compiler should preserve AF, BC, and DE across the call. If
+you declare `: HL,DE`, the compiler preserves AF and BC; if you declare no
+return clause at all, the compiler preserves all four of AF, BC, DE, and HL.
+
+The caller receives the return value in HL and can rely on BC and DE having
+survived the call. That guarantee is mechanical and enforced — not a convention
+you maintain by hand.
+
+Parameters are passed on the stack, pushed right-to-left before the call,
+cleaned up by the caller after return. Inside the callee, parameter names are
+frame-bound: `left_input` reads the first argument from `IX+4`, `right_input`
+from `IX+6`, and so on. You write parameter names in expressions; the compiler
+emits the IX-relative addressing.
+
+A function call looks like this:
+
+```zax
+    mul_u16 result, factor
+    result := hl
+```
+
+The first line calls `mul_u16` with two arguments passed by value (each a
+`word` local, read from the frame and pushed). The result comes back in HL.
+The second line stores it into `result`.
+
+---
+
+## Basic Control Flow: `if` and `while`
+
+ZAX structured control flow works on the Z80 flag register, which is exactly
+what you would use for a conditional branch in raw assembly. The difference is
+that the compiler generates the hidden labels and conditional jumps — you write
+the condition code keyword, not a `jp` instruction.
+
+`if NZ`, `if Z`, `if C`, `if NC`, `if M`, `if P`, `if PE`, `if PO` — any Z80
+condition code is valid. The condition is tested at the `if` keyword using the
+current flag state. It is always the programmer's responsibility to establish
+the correct flags with a Z80 instruction immediately before the condition:
+
+```zax
+    hl := right
+    ld a, h
+    or l              ; set Z if HL is zero, clear Z otherwise
+    if Z
+      hl := left
+      ret
+    end
+```
+
+(From `examples/course/unit1/gcd_iterative.zax`, lines 18–23.)
+
+The `or l` instruction sets Z if HL is zero. The `if Z` block then handles the
+base case. This is the standard Z80 null-check pattern: OR H with L, or OR A
+with itself to test A, then branch on Z or NZ.
+
+`while <cc>` tests the condition on entry and at the back edge after each
+iteration. If the condition is false on entry, the body never runs. The body
+must re-establish the flags before control reaches the back edge:
+
+```zax
+    ld a, 1
+    or a              ; establish NZ to enter the loop
+    while NZ
+      ; ... loop body ...
+
+      ld a, 1
+      or a            ; re-establish NZ to continue
+    end
+```
+
+This is the recurring idiom for a loop that manages its own exit condition
+internally (via `ret` or a structured early exit). The `ld a, 1` / `or a`
+sequence before `while` establishes the entry condition; the same sequence at
+the bottom of each iteration re-establishes it. The actual exits happen via
+early `ret` statements inside the body.
+
+You will see this pattern in nearly every unit 1 function. It is verbose but
+transparent: the loop continues until the algorithm explicitly returns.
+
+---
+
+## `succ` and `pred`
+
+ZAX provides two built-in operations for incrementing and decrementing typed
+scalar paths: `succ` and `pred`. They operate on locals, module-scope
+variables, record fields, and array elements — any typed scalar storage path.
+
+```zax
+    succ index_value    ; increment the word local 'index_value' by 1
+    pred remaining      ; decrement the word local 'remaining' by 1
+```
+
+These are not function calls; they lower to an efficient read-increment-write
+(or read-decrement-write) sequence at the storage path in question. Using
+`succ` and `pred` instead of a manual HL-roundtrip sequence keeps the code
+concise and the intent visible.
+
+In the unit 1 examples, `succ` and `pred` are the standard way to advance or
+retreat a counter local. You will see them throughout the loops that drive
+counting and iteration.
+
+---
+
+## The Unit 1 Programs
+
+### Power: repeated multiplication
+
+`power.zax` builds integer power by repeated multiplication of `base`, using
+a helper function `mul_u16` to multiply two `word` values by repeated addition.
+Both functions share the same loop structure: a `while NZ` loop that counts
+down a `remaining` local, returning early when the count reaches zero.
+
+The `pred` built-in decrements `remaining` at the bottom of each iteration.
+This is the first example of a common unit 1 pattern: a counting loop with an
+explicit zero check at the top and a `pred` decrement at the bottom.
+
+See `examples/course/unit1/power.zax`.
+
+### GCD: iterative and recursive
+
+`gcd_iterative.zax` implements Euclid's algorithm by subtraction: at each step,
+replace the larger of two values with the difference. The loop continues until
+the two values are equal (difference is zero) or one of them reaches zero.
+
+The ZAX structure for this is a `while NZ` loop containing nested `if` blocks
+for the three cases (right is zero, values are equal, one is larger):
+
+```zax
+    hl := left
+    de := right
+    xor a
+    sbc hl, de          ; signed subtract: sets C if left < right, Z if equal
+    if Z
+      hl := left
+      ret
+    end
+    if NC
+      left := hl        ; left was larger: left := left - right
+    end
+    if C
+      ; right was larger: right := right - left
+      hl := right
+      de := left
+      xor a
+      sbc hl, de
+      right := hl
+    end
+```
+
+(From `examples/course/unit1/gcd_iterative.zax`, lines 26–43.)
+
+`xor a` clears the carry before `sbc hl, de`, so the subtraction result is
+exact (no borrow from a prior carry). After the subtraction, C is set if
+left < right, Z is set if left == right.
+
+`gcd_recursive.zax` expresses the same algorithm recursively. Each call reduces
+one or both operands and recurses. The compiler generates a fresh IX frame for
+each call, so the callee's locals are entirely independent of the caller's.
+Recursive `func` in ZAX is structurally identical to non-recursive `func` — the
+IX frame discipline handles the per-call local state automatically.
+
+See `examples/course/unit1/gcd_iterative.zax` and
+`examples/course/unit1/gcd_recursive.zax`.
+
+### Fibonacci: rolling state
+
+`fibonacci.zax` maintains two locals — `prev_value` and `curr_value` — that
+carry consecutive Fibonacci values across iterations. A third local
+`index_value` counts up to the target. At each step, the next value is computed
+from the sum of the current pair, then the pair advances one position:
+
+```zax
+    hl := prev_value
+    de := curr_value
+    add hl, de
+    next_value := hl
+
+    prev_value := curr_value
+    curr_value := next_value
+
+    succ index_value
+```
+
+(From `examples/course/unit1/fibonacci.zax`, lines 24–32.)
+
+The `add hl, de` computes the next Fibonacci number. The two `:=` assignments
+advance the rolling state. `succ index_value` steps the counter. The loop
+exits via an early `ret` when `index_value` reaches `target_count`.
+
+See `examples/course/unit1/fibonacci.zax`.
+
+### Integer square root: Newton iteration
+
+`sqrt_newton.zax` refines a guess iteratively. The initial guess is the input
+value itself (a very conservative but safe start). Each iteration computes
+`next = (guess + value/guess) / 2`, the standard Newton step for square root.
+The helper `div_u16` performs 16-bit unsigned division by repeated subtraction.
+
+The loop runs for a fixed number of iterations (`remaining_iters = 4`) rather
+than testing for convergence. This is a deliberate choice for an integer
+algorithm: four Newton steps are enough to converge for values in the range
+that fits in a `word`.
+
+See `examples/course/unit1/sqrt_newton.zax`.
+
+### Exponentiation by squaring
+
+`exp_squaring.zax` computes power more efficiently than repeated multiplication
+by halving the exponent at each step. If the current exponent bit is odd,
+multiply the running result by the current factor; then square the factor and
+halve the exponent:
+
+```zax
+    hl := remaining
+    ld a, l
+    and 1             ; test the low bit of the exponent
+    if NZ
+      mul_u16 result, factor
+      result := hl
+    end
+
+    mul_u16 factor, factor
+    factor := hl
+
+    hl := remaining
+    srl h
+    rr l              ; halve: logical right shift of 16-bit pair HL
+    remaining := hl
+```
+
+(From `examples/course/unit1/exp_squaring.zax`, lines 56–72.)
+
+The 16-bit right shift uses `srl h` / `rr l`: shift H right with zero fill,
+rotate L right through carry (which carries the bit from H). This is the
+standard Z80 idiom for a logical right shift of a 16-bit value held in a
+register pair.
+
+See `examples/course/unit1/exp_squaring.zax`.
+
+### Decimal digit decomposition
+
+`digits.zax` counts how many decimal digits a value has by dividing
+repeatedly by 10. The helper `div_u16` performs unsigned division; the outer
+function `decimal_digits` counts divisions until the remaining value is less
+than 10.
+
+A notable detail: the initial value of the count local is `1`, not `0`. A
+positive integer always has at least one decimal digit, so the count starts at
+one before the loop begins. The loop increments the count (`succ count`) each
+time division is needed. This is a small example of how initial-value choices
+in `var` declarations express algorithmic invariants.
+
+See `examples/course/unit1/digits.zax`.
+
+---
+
+## What This Unit Teaches About ZAX
+
+- `:=` is the interface between typed storage and the Z80 register file. It
+  appears constantly alongside raw Z80 mnemonics in the same function body.
+- Functions declare their return register. The compiler enforces the
+  complementary preservation set. Callers can rely on those registers surviving
+  a typed call.
+- `while NZ` with an explicit `ld a, 1` / `or a` idiom is the basic loop
+  form when the loop body manages its own termination via early `ret`.
+- `succ` and `pred` are the idiomatic scalar increment and decrement operators.
+  They appear wherever a loop counter or accumulator needs stepping.
+- Recursive functions look and work like non-recursive ones. The compiler
+  handles the per-call IX frame.
+
+---
+
+## Examples in This Unit
+
+- `examples/course/unit1/power.zax` — integer power by repeated multiplication
+- `examples/course/unit1/gcd_iterative.zax` — Euclid's algorithm, iterative
+- `examples/course/unit1/gcd_recursive.zax` — Euclid's algorithm, recursive
+- `examples/course/unit1/sqrt_newton.zax` — Newton-step integer square root
+- `examples/course/unit1/exp_squaring.zax` — exponentiation by squaring
+- `examples/course/unit1/fibonacci.zax` — iterative Fibonacci with rolling state
+- `examples/course/unit1/digits.zax` — decimal digit count by repeated division
+
+---
+
+## Exercises
+
+1. In `gcd_iterative.zax`, both the iterative and recursive forms use the
+   subtraction form of Euclid's algorithm rather than the modulo form. The
+   modulo form converges faster for inputs with a large ratio. Modify
+   `gcd_iterative.zax` to use `div_u16` for the remainder step. Does the
+   loop structure change meaningfully?
+
+2. `fibonacci.zax` uses four locals. Could it be rewritten using three, with
+   one less `word` slot? What is the tradeoff in readability?
+
+3. In `digits.zax`, the initial value of `count` is 1. Change it to 0 and
+   adjust the loop accordingly. Which version makes the invariant clearer?
+
+4. `sqrt_newton.zax` uses a fixed iteration count. Modify it to iterate until
+   `next_guess == guess` (convergence). What edge cases does the fixed count
+   avoid? What does an explicit convergence test expose?

--- a/docs/course/02-arrays-and-loops.md
+++ b/docs/course/02-arrays-and-loops.md
@@ -1,0 +1,501 @@
+# Chapter 02 — Arrays and Loops
+
+The unit 2 examples introduce arrays and the full loop surface: `while`,
+`break`, and `continue`. The algorithms in this unit — sorting and searching
+over small byte arrays — are chosen deliberately. They require indexed storage,
+they loop over it repeatedly, and they exit loops early under specific
+conditions. That last requirement is what makes `break` and `continue` earn
+their place in this chapter.
+
+---
+
+## Arrays
+
+An array in ZAX is declared with a type, a length, and an optional initializer:
+
+```zax
+section data vars at $8000
+  values: byte[8] = { 9, 4, 6, 2, 8, 1, 7, 3 }
+end
+```
+
+This declares a module-level `byte` array of eight elements, initialized to the
+given values. The storage lives in the named `data` section starting at `$8000`.
+
+`byte[8]` means exactly eight one-byte elements — `sizeof(byte[8]) = 8`.
+There is no padding. If you write `word[4]`, you get exactly eight bytes: four
+two-byte elements. The compiler tracks exact sizes and uses them to compute
+element strides for indexed access.
+
+Declaring an array as a function local is not directly supported for variable-
+length storage — function `var` blocks only hold scalars. Working arrays for
+unit 2 algorithms live in named `data` sections at module scope, which is the
+normal home for data that persists across function calls.
+
+---
+
+## Array Indexing
+
+To read or write an array element, you put a register inside the square
+brackets:
+
+```zax
+    l := scan_index       ; load the index into L (an 8-bit register)
+    a := values[L]        ; read the element at position L
+```
+
+The index register must be one of the valid Z80 register forms: an 8-bit
+register (`A`, `B`, `C`, `D`, `E`, `H`, `L`), a 16-bit pair (`HL`, `DE`,
+`BC`), or an indirect form like `(HL)`. Computed expressions are not valid
+inside `[...]` — you must compute the index into a register first.
+
+For a `byte[]` array with an 8-bit index, L is the natural choice. L is the
+low half of HL, which is the register pair the Z80 uses for most memory
+addressing. Loading the index into L and leaving H as zero gives you a valid
+16-bit address offset with minimal fuss.
+
+This is the register-as-index convention throughout the unit 2 examples: load
+the index into L (or occasionally B), perform the array access, then advance
+the index with `succ` or with an arithmetic instruction.
+
+### Writing Back
+
+The same syntax works for stores:
+
+```zax
+    l := left_index
+    a := right_value
+    values[L] := a        ; write A into values[L]
+```
+
+The place expression `values[L]` on the left side of `:=` is a store; the
+compiler emits the required address calculation and write instruction.
+
+### The `arr[HL]` vs `arr[(HL)]` Distinction
+
+One indexing detail is worth remembering: `values[HL]` uses HL directly as a
+16-bit index into the array. `values[(HL)]` reads a byte from memory at address
+HL and uses that byte as the index. These mean different things. The unit 2
+examples use the direct form: the index is a value held in a register, not
+a value pointed to by a register.
+
+---
+
+## Loops: `while` and `repeat`/`until`
+
+The unit 1 chapter introduced `while`. The unit 2 examples use it more
+extensively. The two loop forms are:
+
+- `while <cc> ... end`: checks the condition before each iteration. If the
+  condition is false on entry, the body never runs.
+- `repeat ... until <cc>`: runs the body at least once, then checks the
+  condition at the `until`. Continues looping as long as the condition is
+  false; stops when it is true.
+
+The `repeat`/`until` form is natural when the loop body must execute once
+before any test makes sense — a common pattern for null-terminated string
+scanning (Chapter 03). The unit 2 sorting and searching examples use `while`
+because the loop bounds are checked upfront.
+
+Both forms require the programmer to establish the correct flag state. `while`
+requires flags to be correct at the point of the `while` keyword and again at
+the back edge after each iteration. `until` requires flags to be correct at the
+`until` keyword, using whatever state the loop body left behind.
+
+---
+
+## `break` and `continue`
+
+`break` exits the enclosing loop immediately, transferring control to the
+statement after the loop's `end`. `continue` skips the remainder of the current
+loop iteration and jumps to the back-edge condition check.
+
+Both `break` and `continue` apply to the innermost enclosing loop — `while` or
+`repeat`/`until`. They are unconditional by themselves; if you want a
+conditional `break`, put the `break` inside an `if` block.
+
+### `break` in `prime_sieve.zax`
+
+The prime sieve uses `break` in two places: once to exit the outer factor loop
+when the factor exceeds the stop threshold, and once to exit the inner multiple-
+marking loop when the multiple exceeds the array limit.
+
+The outer loop:
+
+```zax
+  while NZ
+    a := factor_index
+    cp StopFactor
+    if NC
+      break               ; factor >= StopFactor: no more composites to mark
+    end
+
+    l := factor_index
+    a := is_prime[L]
+    or a
+    if Z
+      succ factor_index
+      ld a, 1
+      or a
+      continue            ; this factor is already composite: skip to next
+    end
+    ...
+```
+
+(From `examples/course/unit2/prime_sieve.zax`, lines 21–37.)
+
+The `break` fires when `factor_index >= StopFactor` (the `cp` instruction sets
+carry when A < StopFactor; `if NC` means carry is not set, so A >= StopFactor).
+At that point, every composite number up to the limit has been marked and the
+outer loop has nothing more to do. Without `break`, the loop would need an
+explicit boolean flag — a local set to 0 or 1 — and the condition test at the
+top of `while` would check that flag instead of the `ld a, 1` / `or a` idiom.
+With `break`, the exit condition is expressed exactly where it arises.
+
+### `continue` in `prime_sieve.zax`
+
+The `continue` in the outer loop skips the marking pass for a factor that has
+already been marked composite. If `is_prime[factor_index]` is zero (already
+composite), there is no point computing its multiples — they were already
+marked by a smaller factor. The `continue` advances `factor_index` with `succ`
+and re-enters the loop, re-establishing the `NZ` condition before jumping to
+the back edge:
+
+```zax
+    if Z
+      succ factor_index
+      ld a, 1
+      or a
+      continue            ; jump to the while NZ condition check
+    end
+```
+
+Note the `ld a, 1` / `or a` before `continue`. The back edge of the `while NZ`
+loop tests the flag state at that point. After `continue`, control returns to
+the condition test at the top of the `while`. The `or a` with A set to 1
+ensures the condition reads NZ (non-zero), so the loop continues rather than
+exits. If you omit this, the loop exits immediately on the `continue` because
+the `or a` from `is_prime[L]` left Z set.
+
+### `break` in the inner loop
+
+The inner loop marks multiples of the current factor composite. It also uses
+`break` to exit when the multiple index exceeds the sieve limit:
+
+```zax
+    while NZ
+      a := multiple_index
+      cp Limit
+      if NC
+        break             ; multiple_index >= Limit: done marking this factor
+      end
+
+      l := multiple_index
+      ld a, 0
+      is_prime[L] := a
+
+      a := multiple_index
+      b := factor_index
+      add a, b
+      multiple_index := a
+
+      ld a, 1
+      or a
+    end
+```
+
+(From `examples/course/unit2/prime_sieve.zax`, lines 43–63.)
+
+The structure is the same as the outer break: test the bound, `break` when
+exceeded. The loop body marks the current multiple composite, then advances
+`multiple_index` by `factor_index` (each multiple is one factor step further).
+The `ld a, 1` / `or a` re-establishes NZ for the next iteration.
+
+### `break` in `selection_sort.zax`
+
+The `find_min_index` helper in `selection_sort.zax` uses `break` to exit the
+scan loop once it has passed the last valid index:
+
+```zax
+  while NZ
+    a := current_index
+    b := last_index
+    cp b
+    if NC
+      if NZ
+        break             ; current_index > last_index: scan complete
+      end
+    end
+    ...
+    succ current_index
+    ld a, 1
+    or a
+  end
+```
+
+(From `examples/course/unit2/selection_sort.zax`, lines 53–82, condensed.)
+
+The condition `if NC` / `if NZ` tests for `current_index > last_index`: `cp b`
+sets NC when A >= B, and the nested `if NZ` excludes the equal case. When
+both conditions are true — the index has gone past the last valid position —
+the scan is complete and `break` exits the loop immediately.
+
+---
+
+## The Sorting Examples
+
+### Bubble sort
+
+Bubble sort repeatedly walks adjacent pairs through the array, swapping any
+pair that is out of order. Each pass pushes the largest unsorted element to its
+final position. The pass bound (`pass_last`) shrinks by one after each pass.
+
+The outer function `bubble_sort` drives the pass sequence; the inner function
+`bubble_pass` performs one pass. Each function has its own `while NZ` loop.
+`bubble_pass` exits early via `ret` when `inner_index` reaches `last_index`.
+
+```zax
+func bubble_pass(last_index: byte)
+  ...
+  while NZ
+    a := inner_index
+    b := last_index
+    cp b
+    if NC
+      ret               ; inner_index >= last_index: pass complete
+    end
+    ...
+    succ inner_index
+    ld a, 1
+    or a
+  end
+end
+```
+
+(From `examples/course/unit2/bubble_sort.zax`, lines 44–78, condensed.)
+
+The comparison and conditional swap use the same L-as-index pattern as the
+other sorting examples: load the index into L, read `values[L]`, compare,
+swap if out of order.
+
+See `examples/course/unit2/bubble_sort.zax`.
+
+### Insertion sort
+
+Insertion sort works by maintaining a sorted prefix of the array. For each new
+element (the `hold_value`), it finds the correct insertion position in the
+prefix and shifts elements right to make room.
+
+The unit 2 version implements this recursively through the helper
+`insert_hole`, which walks leftward through the prefix comparing adjacent
+elements. The recursion depth is bounded by the array length; for short arrays
+this is fine. The function exits early via `ret` in two cases: when the scan
+reaches index 0 (nowhere further left to shift), or when it finds an element
+that is already in the correct relative order.
+
+```zax
+func insert_hole(scan_index: byte, hold_value: byte)
+  ...
+  a := left_value
+  b := hold_value
+  cp b
+  if C                  ; left_value < hold_value: correct position found
+    l := scan_index
+    a := hold_value
+    values[L] := a
+    ret
+  end
+  ...
+  insert_hole prior_index, hold_value   ; recurse one step left
+end
+```
+
+(From `examples/course/unit2/insertion_sort.zax`, lines 34–54, condensed.)
+
+The comparison `cp b` sets C when `left_value < hold_value`, meaning the left
+element is already smaller than what we are inserting. The `if C` block writes
+the held value at the current position and returns. Otherwise, the left element
+shifts right and the recursion continues one step leftward.
+
+See `examples/course/unit2/insertion_sort.zax`.
+
+### Selection sort
+
+Selection sort finds the minimum element of the unsorted suffix on each pass
+and exchanges it with the element at the current outer index. The helper
+`find_min_index` scans from `start_index` to `last_index` tracking the index
+of the smallest value seen.
+
+The break example from `find_min_index` is shown in the `break` section above.
+After `find_min_index` returns the minimum index in HL (with the index in L),
+the outer loop swaps the minimum into position if it is not already there:
+
+```zax
+    find_min_index outer_index, LastIndex
+    ld a, l
+    min_index := a
+
+    a := min_index
+    b := outer_index
+    cp b
+    if NZ
+      swap_values outer_index, min_index
+    end
+
+    succ outer_index
+```
+
+(From `examples/course/unit2/selection_sort.zax`, lines 103–115.)
+
+The `if NZ` skips the swap when the minimum is already at `outer_index` (no
+work needed). This is a common ZAX idiom: compare, then conditionally call a
+helper inside an `if` block.
+
+See `examples/course/unit2/selection_sort.zax`.
+
+---
+
+## The Searching Examples
+
+### Linear search
+
+`linear_search.zax` scans `values` from index 0 upward, comparing each element
+against `target_value`. The loop exits via early `ret` in two cases: when the
+element matches (returning the index), or when the scan exhausts the array
+(returning `$FFFF` as a not-found sentinel).
+
+```zax
+    l := scan_index
+    a := values[L]
+    probe_value := a
+
+    a := target_value
+    b := probe_value
+    cp b
+    if Z
+      ld h, 0
+      a := scan_index
+      ld l, a
+      ret               ; found: return index in HL
+    end
+
+    succ scan_index
+```
+
+(From `examples/course/unit2/linear_search.zax`, lines 28–42.)
+
+When the match is found, the index needs to be in HL (the return register). The
+function loads 0 into H and `scan_index` into L, forming a 16-bit index value.
+`ld h, 0` is a raw Z80 instruction; `ld l, a` transfers A into L. The result is
+then in HL for the `ret`.
+
+See `examples/course/unit2/linear_search.zax`.
+
+### Binary search
+
+Binary search divides the sorted array in half repeatedly, narrowing the search
+range by comparing the target against the middle element.
+
+The midpoint calculation uses the standard Z80 idiom for a 16-bit arithmetic
+right shift: add `low_index` and `high_index` into HL, then shift right with
+`srl h` / `rr l`. This gives `(low + high) / 2` without overflow for values
+that fit in 16 bits:
+
+```zax
+    hl := low_index
+    de := high_index
+    add hl, de
+    srl h
+    rr l              ; HL = (low_index + high_index) / 2
+    mid_index := hl
+```
+
+(From `examples/course/unit2/binary_search.zax`, lines 37–42.)
+
+After computing the midpoint, the function reads `values[L]` (using L as the
+low byte of `mid_index`) and compares against `target_value`. If C is set
+(target is less than probe), the search continues in the left half by setting
+`high_index := mid_index - 1` via `pred`. If NC and NZ (target is greater than
+probe), it continues in the right half with `succ` on `low_index`. The loop
+exits when the search interval closes (`low_index > high_index`), returning
+`$FFFF` as not-found.
+
+`pred` and `succ` on `high_index` and `low_index` are the concise way to
+narrow the search bounds by one step in either direction.
+
+See `examples/course/unit2/binary_search.zax`.
+
+### Prime sieve
+
+The sieve of Eratosthenes marks all composite numbers in a flag array. It is
+the most algorithmically interesting unit 2 example because it has nested loops
+and uses both `break` and `continue` — the full loop-control surface.
+
+The outer loop iterates over candidate factors from 2 to `StopFactor`. For each
+prime factor, the inner loop marks all multiples of that factor as composite.
+`break` exits each loop when its bound is exceeded; `continue` skips the inner
+marking pass for factors already known to be composite.
+
+The complete structure is shown across the `break` and `continue` examples
+above. Reading `prime_sieve.zax` in full is the best way to see how the two
+constructs interact with the nested loop structure.
+
+See `examples/course/unit2/prime_sieve.zax`.
+
+---
+
+## What This Unit Teaches About ZAX
+
+- Arrays are declared with exact sizes. There is no hidden padding. A `byte[8]`
+  is eight bytes.
+- The index inside `[...]` must be a register. Load the index into a register
+  before the access. L is the natural choice for 8-bit indexing into `byte[]`
+  arrays.
+- `break` exits the current loop at the point where the exit condition is
+  known. It replaces an explicit flag variable that would otherwise track
+  whether the loop should continue. When you use `break`, re-establishing flags
+  before `continue` (or at the loop back edge) is your responsibility.
+- `continue` skips the remainder of the current iteration and jumps to the
+  condition test. It requires that flags be correct for the loop condition at
+  the point of the jump. Establishing those flags immediately before `continue`
+  is the pattern used in `prime_sieve.zax`.
+- `succ` and `pred` work on index locals just as they work on counter locals.
+  They appear wherever `low_index`, `high_index`, or `scan_index` needs
+  stepping by one.
+
+---
+
+## Examples in This Unit
+
+- `examples/course/unit2/bubble_sort.zax` — repeated adjacent-swap passes
+- `examples/course/unit2/insertion_sort.zax` — sorted insertion into a growing prefix
+- `examples/course/unit2/selection_sort.zax` — minimum-selection with `break`-terminated scan
+- `examples/course/unit2/linear_search.zax` — sequential scan with early return
+- `examples/course/unit2/binary_search.zax` — divide-and-conquer with `pred`/`succ` bound narrowing
+- `examples/course/unit2/prime_sieve.zax` — nested loops with `break` and `continue`
+
+---
+
+## Exercises
+
+1. In `prime_sieve.zax`, the `continue` before the inner loop requires
+   `ld a, 1` / `or a` to re-establish NZ before jumping to the condition test.
+   What would happen if those two instructions were removed? Try tracing the
+   flag state manually.
+
+2. `linear_search.zax` returns `$FFFF` as the not-found sentinel. The calling
+   convention uses HL as the return register. Modify `linear_search` to return
+   a `byte` result in L — `$FF` for not-found, 0-based index for found — and
+   update `main` accordingly. What changes in the return-register declaration?
+
+3. The bubble sort in `bubble_sort.zax` does not track whether any swaps
+   occurred during a pass. A classic optimization is to exit early if a pass
+   produces no swaps (the array is already sorted). Add a `swapped` local to
+   `bubble_pass` that tracks this, and modify `bubble_sort` to call a function
+   that returns whether any swaps happened. Does `break` make the outer loop
+   structure cleaner or not?
+
+4. `binary_search.zax` uses `word` locals for `low_index` and `high_index`
+   because the midpoint calculation uses 16-bit arithmetic. Could those locals
+   be `byte` instead, with the midpoint calculation adjusted? What would change
+   in the register usage and arithmetic?

--- a/docs/course/README.md
+++ b/docs/course/README.md
@@ -1,0 +1,58 @@
+# ZAX Algorithms Course
+
+This course teaches ZAX through classic short algorithms drawn from Kernighan
+and Ritchie's _The C Programming Language_ and Niklaus Wirth's _Algorithms +
+Data Structures = Programs_. It is not a language reference and not a Z80
+tutorial. It is a guided reading of real ZAX programs, organised around
+problems rather than features.
+
+The intended reader knows Z80 assembly. They are new to ZAX and want to
+understand what the structured assembler model offers, where it pays off, and
+where it still asks something of the programmer.
+
+---
+
+## How to Read This Course
+
+Each chapter is paired with example files under `examples/course/`. Read the
+chapter prose first, then open the source files it references. The prose
+explains the algorithm, the data model, and the ZAX idioms in play; the source
+files show how that all looks in a complete, compilable program.
+
+The chapters introduce syntax as it becomes necessary. They do not survey the
+language top-to-bottom. Features earn their introduction by appearing in code
+that needs them.
+
+---
+
+## Chapter List
+
+| File | Chapter | Coverage |
+|------|---------|----------|
+| `00-introduction.md` | Introduction | What ZAX is and why it exists; the structured assembler philosophy; course overview. No code yet. |
+| `01-foundations.md` | Foundations | Variables, types, `:=` assignment, functions, basic control flow. Arithmetic and number-theory algorithms from unit 1. |
+| `02-arrays-and-loops.md` | Arrays and Loops | Array declaration and indexing, `while`/`repeat`, `break` and `continue`, the register-as-index convention. Sorting and searching algorithms from unit 2. |
+| `03-strings.md` | Strings | Pointer-based traversal, null-terminated scanning, `repeat`/`until`. String algorithms from unit 3. |
+| `04-bit-patterns.md` | Bit Patterns | Shift idioms, `op` with immediate matchers. Bit-manipulation algorithms from unit 4. |
+| `05-records.md` | Records | Typed aggregate state, field access, `sizeof`/`offsetof`. Ring buffer from unit 5. |
+| `06-recursion.md` | Recursion | Recursive functions, IX frame discipline, argument passing. Tower of Hanoi and recursive array operations from unit 6. |
+| `07-composition.md` | Composition | How a larger program assembles from helper routines, typed storage, and a support module. RPN calculator from unit 7. |
+| `08-pointer-structures.md` | Pointer Structures | Pointer fields, typed reinterpretation, traversal patterns, fixed-pool allocation. Linked list and BST from unit 8. |
+| `09-gaps-and-futures.md` | Gaps and Futures | Control-flow pressure, language limits, and what comes next. Eight queens from unit 9. |
+
+---
+
+## Chapter and Unit Numbering
+
+Chapter numbers are offset from example unit numbers because chapter 00 is a
+course introduction with no corresponding example unit.
+
+- Chapter `00` — course introduction (no example unit)
+- Chapter `01` — draws on `examples/course/unit1/`
+- Chapter `02` — draws on `examples/course/unit2/`
+- Chapter `03` — draws on `examples/course/unit3/`
+- ...and so on through chapter `09` and `unit9/`
+
+This offset is consistent throughout. When a chapter says "see
+`examples/course/unit2/binary_search.zax`", the `unit2/` directory
+corresponds to chapter `02`.


### PR DESCRIPTION
## Files created

- **`docs/course/README.md`** — Course orientation: what the course is, how
  chapters relate to example units, chapter list with one-line descriptions,
  note on the chapter/unit numbering offset (chapter 00 is introduction, so
  chapter 01 maps to unit1, etc.)

- **`docs/course/00-introduction.md`** — What ZAX is and why it exists. The
  structured assembler philosophy. The `:=` vs raw `ld` distinction introduced
  conceptually. Brief overview of what the course builds. No code.

- **`docs/course/01-foundations.md`** — Covers all seven unit1 examples.
  Introduces `byte`/`word` types, the `var` block, the `:=` assignment
  operator, function declarations with return registers and the preservation
  contract, `while`/`if` control flow with flag-establishment discipline, and
  `succ`/`pred`. Each unit1 program is treated with an algorithm description,
  a representative excerpt, and explanation of the ZAX idioms in play.

- **`docs/course/02-arrays-and-loops.md`** — Covers all six unit2 examples.
  Introduces array declaration, the exact-size model, valid index forms, the
  L-as-index convention. Explicitly explains `break` and `continue` with
  excerpts from `prime_sieve.zax` (both constructs) and `selection_sort.zax`
  (`break`). All six unit2 programs are treated with prose and excerpts.

## Editorial uncertainties

- **`break`/`continue`/`succ`/`pred` are not yet documented in `zax-spec.md`
  or `ZAX-quick-guide.md`** — they appear in the course examples and are
  treated as current surface per the authoring plan, but a reader consulting
  the spec or quick guide will not find a formal reference entry. The course
  prose describes their behaviour from the examples. Consider adding spec/
  quick-guide coverage before or alongside Phase 2.

- **The `while NZ` idiom** (`ld a, 1` / `or a` at entry and loop bottom) is
  explained in both chapters. The prose names it as a pattern without
  apologising for the verbosity. It may warrant a dedicated named entry in the
  quick guide.

- **`succ`/`pred` are called "built-in operations"** because they are not
  `func` calls and not raw Z80 mnemonics. This wording may need alignment with
  whatever formal name the spec eventually assigns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)