### PR TITLE
docs(course): Phase 4 editorial pass

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,13 @@ Recently completed design records now live under:
 - `work/` is for operational WIP and deferred items.
 - `archive/` is not active guidance.
 
+### `docs/course/`
+
+A guided course teaching ZAX through classic algorithms. Start at
+`docs/course/README.md`. Each chapter is paired with compilable example files
+under `examples/course/`. The intended reader knows Z80 assembly and is new to
+ZAX.
+
 ## Current priority
 
 Keep the reviewer-facing core as small as possible. The primary review path should be:

--- a/docs/course/01-foundations.md
+++ b/docs/course/01-foundations.md
@@ -381,6 +381,15 @@ See `examples/course/unit1/digits.zax`.
 
 ---
 
+## What comes next
+
+Chapter 02 extends the foundation with arrays and the full loop-control surface:
+`break` and `continue`. The algorithms there sort and search small byte arrays,
+which requires indexed storage, multi-pass loops, and early exits — three things
+that build directly on the typed storage and control flow introduced here.
+
+---
+
 ## Exercises
 
 1. In `gcd_iterative.zax`, both the iterative and recursive forms use the

--- a/docs/course/02-arrays-and-loops.md
+++ b/docs/course/02-arrays-and-loops.md
@@ -476,6 +476,16 @@ See `examples/course/unit2/prime_sieve.zax`.
 
 ---
 
+## What comes next
+
+Chapter 03 moves from indexed arrays to pointer-walked memory. The string
+algorithms there advance HL and DE directly rather than loading an index into L
+— a different traversal discipline built on the same `while NZ` loop structure
+used here. `break` reappears in the scan-to-terminator pattern; `continue` does
+not, because string traversal rarely needs to skip iterations rather than exit.
+
+---
+
 ## Exercises
 
 1. In `prime_sieve.zax`, the `continue` before the inner loop requires

--- a/docs/course/03-strings.md
+++ b/docs/course/03-strings.md
@@ -265,6 +265,16 @@ See `examples/course/unit3/itoa.zax`.
 
 ---
 
+## What comes next
+
+Chapter 04 returns to tight, register-level work: bit manipulation using Z80
+shift and logic instructions. The loop structures are the same `while NZ` idiom
+from Chapter 01 — counter-driven rather than sentinel-driven — and the local
+`op` pattern introduced in this chapter's `strcpy.zax` reappears in
+`bit_reverse.zax`.
+
+---
+
 ## Exercises
 
 1. `strlen.zax` increments `count_value` by loading into DE, incrementing DE, and

--- a/docs/course/04-bit-patterns.md
+++ b/docs/course/04-bit-patterns.md
@@ -249,6 +249,16 @@ idiom, and unit 4 shows it at its most concentrated.
 
 ---
 
+## What comes next
+
+Chapter 05 introduces typed aggregate state: records and arrays of records.
+The byte and word scalars that have carried algorithm state throughout the
+course are grouped into named types with automatic offset computation. The
+ring buffer example applies the same modular-index discipline used in the
+counter-driven loops here, now over a struct array rather than a scalar.
+
+---
+
 ## Exercises
 
 1. `popcount.zax` exits the loop when `working_value` reaches zero. This is

--- a/docs/course/05-records.md
+++ b/docs/course/05-records.md
@@ -223,6 +223,16 @@ the mechanics.
 
 ---
 
+## What comes next
+
+Chapter 06 takes up recursion. Recursive functions in ZAX use the same `func`
+and `var` block syntax as everything else — no special forms — but the call
+stack becomes the active data structure. Reading the Towers of Hanoi and
+recursive array examples requires tracking the IX frame stack mentally, which
+is the natural next step after the structured record layout in this chapter.
+
+---
+
 ## Exercises
 
 1. `ring_buffer.zax` stores both a `value` and a `stamp` in each `Entry`. If you

--- a/docs/course/06-recursion.md
+++ b/docs/course/06-recursion.md
@@ -217,6 +217,16 @@ See `examples/course/unit6/array_reverse_recursive.zax`.
 
 ---
 
+## What comes next
+
+Chapter 07 shows how a larger program is assembled from multiple source files.
+The RPN calculator imports a support module and dispatches on token kind using
+`select`. The pattern of storing intermediate results into typed locals before
+the next call — visible in `hanoi.zax` here — reappears throughout the
+calculator's operator arms.
+
+---
+
 ## Exercises
 
 1. `hanoi_count` stores both recursive results in `word` locals before combining

--- a/docs/course/07-composition.md
+++ b/docs/course/07-composition.md
@@ -184,6 +184,15 @@ the right operand is saved, the left operand is popped, the operation is applied
 
 ---
 
+## What comes next
+
+Chapter 08 works with pointer fields and typed reinterpretation. The linked
+list and binary search tree examples require following stored addresses rather
+than advancing an index — a structurally different traversal from the software
+stack here, but using the same typed-path and null-sentinel discipline.
+
+---
+
 ## Exercises
 
 1. The `KindMultiply` case calls the helper `mul_u16`. `mul_u16` uses a

--- a/docs/course/08-pointer-structures.md
+++ b/docs/course/08-pointer-structures.md
@@ -257,6 +257,16 @@ grounded in the evidence from `linked_list.zax` and `bst.zax`.
 
 ---
 
+## What comes next
+
+Chapter 09 closes the course with the eight-queens problem — a backtracking
+search that puts maximum pressure on the loop-escape surface. It also functions
+as a design review: after nine chapters of examples, the chapter maps which
+language gaps remain, which have been addressed, and what the current design
+work is targeting.
+
+---
+
 ## Exercises
 
 1. `list_sum` initialises `total_value` to zero and accumulates into it.

--- a/docs/course/09-gaps-and-futures.md
+++ b/docs/course/09-gaps-and-futures.md
@@ -41,7 +41,8 @@ back to the root call.
 
 ## `break` and `continue` in Practice
 
-The column loop in `place_row` uses both `break` and `continue`:
+The column loop in `place_row` uses both `break` and `continue` (introduced in
+Chapter 02, `prime_sieve.zax`):
 
 ```zax
     l := col_index
@@ -192,6 +193,24 @@ The eight-queens example is a good place to end. It is a real program. It
 compiles, it runs, it finds a solution. The flag variable is there; so is the
 clean use of `break` and `continue`. The gap and the progress both show up in
 the same source file. That is an accurate picture of where ZAX is.
+
+---
+
+## What This Unit Teaches About ZAX
+
+- `break` and `continue` are implemented and available on the current surface.
+  The eight-queens column loop shows both in a single algorithm: `continue`
+  skips failed constraint checks cleanly; `break` exits on a found solution.
+- An explicit flag variable is still the necessary mechanism for propagating a
+  found result across recursive frames. ZAX has no named exit from nested
+  structures; this is a recorded gap, not a design oversight.
+- Pointer-typing ergonomics (the `<Type>local.field` repetition from Chapter 08)
+  and software-stack verbosity (the `pop_word`/`stack_depth` bouncing from
+  Chapter 07) are both grounded, open design issues. See `docs/design/` for
+  current work.
+- The `.asm` output is deterministic and inspectable throughout. The compiler
+  adds no hidden passes or runtime system. That design position is deliberate
+  and unchanged.
 
 ---
 

--- a/docs/course/README.md
+++ b/docs/course/README.md
@@ -12,6 +12,21 @@ where it still asks something of the programmer.
 
 ---
 
+## Where to Start
+
+**New to Z80?** This course assumes Z80 knowledge. Read a Z80 primer first,
+then return to Chapter 00.
+
+**Know Z80 but new to ZAX?** Start at Chapter 00 for the design rationale,
+then Chapter 01 for the first working code. If you want to dive straight into
+code, Chapter 01 is self-contained.
+
+**Already familiar with ZAX basics?** Jump to whichever chapter covers the
+pattern you are working with. Each chapter's "What This Unit Teaches" section
+gives a quick summary of what it covers.
+
+---
+
 ## How to Read This Course
 
 Each chapter is paired with example files under `examples/course/`. Read the
@@ -25,20 +40,40 @@ that needs them.
 
 ---
 
+## How to Compile and Run the Examples
+
+The examples require the ZAX compiler. To compile a single file:
+
+```
+npm run zax -- examples/course/unit1/power.zax
+```
+
+`npm run zax` builds the compiler from source and passes arguments to the CLI.
+Run `npm run build` once to pre-build, then invoke `node dist/src/cli.js`
+directly for subsequent runs. The compiler emits a flat binary, an optional
+Intel HEX file, a symbol listing, and a debug map — run it with `--help` to
+see output options.
+
+There is no test harness for the course examples; they are intended to be read,
+compiled, and inspected. The `.asm` output (if your build is configured to emit
+it) shows the generated assembly for each source file.
+
+---
+
 ## Chapter List
 
-| File | Chapter | Coverage |
-|------|---------|----------|
-| `00-introduction.md` | Introduction | What ZAX is and why it exists; the structured assembler philosophy; course overview. No code yet. |
-| `01-foundations.md` | Foundations | Variables, types, `:=` assignment, functions, basic control flow. Arithmetic and number-theory algorithms from unit 1. |
-| `02-arrays-and-loops.md` | Arrays and Loops | Array declaration and indexing, `while`/`repeat`, `break` and `continue`, the register-as-index convention. Sorting and searching algorithms from unit 2. |
-| `03-strings.md` | Strings | Pointer-based traversal, null-terminated scanning, `repeat`/`until`. String algorithms from unit 3. |
-| `04-bit-patterns.md` | Bit Patterns | Shift idioms, `op` with immediate matchers. Bit-manipulation algorithms from unit 4. |
-| `05-records.md` | Records | Typed aggregate state, field access, `sizeof`/`offsetof`. Ring buffer from unit 5. |
-| `06-recursion.md` | Recursion | Recursive functions, IX frame discipline, argument passing. Tower of Hanoi and recursive array operations from unit 6. |
-| `07-composition.md` | Composition | How a larger program assembles from helper routines, typed storage, and a support module. RPN calculator from unit 7. |
-| `08-pointer-structures.md` | Pointer Structures | Pointer fields, typed reinterpretation, traversal patterns, fixed-pool allocation. Linked list and BST from unit 8. |
-| `09-gaps-and-futures.md` | Gaps and Futures | Control-flow pressure, language limits, and what comes next. Eight queens from unit 9. |
+| File | Chapter | What it covers |
+|------|---------|----------------|
+| `00-introduction.md` | Introduction | What ZAX is, why it exists, the structured assembler philosophy. No code. |
+| `01-foundations.md` | Foundations | Variables, `:=` assignment, functions, `while`/`if`, `succ`/`pred`. Arithmetic and number-theory algorithms. |
+| `02-arrays-and-loops.md` | Arrays and Loops | Array indexing with register operands, `break` and `continue`, the register-as-index convention. Sorting and searching. |
+| `03-strings.md` | Strings | Pointer-based traversal, null-terminated scanning, `repeat`/`until`, local `op`. String algorithms. |
+| `04-bit-patterns.md` | Bit Patterns | Z80 shift and logic idioms, counter-driven loops, local `op` for recurring register patterns. Bit manipulation. |
+| `05-records.md` | Records | Typed aggregate state, field access, `sizeof`/`offsetof`, non-power-of-two strides. Ring buffer. |
+| `06-recursion.md` | Recursion | Recursive functions, IX frame per call, preserving return values across multiple calls. Hanoi, recursive sort and sum. |
+| `07-composition.md` | Composition | `import`, module-qualified calls, `select`/`case` dispatch, software-stack discipline. RPN calculator. |
+| `08-pointer-structures.md` | Pointer Structures | Typed reinterpretation (`<Type>local.field`), null-sentinel traversal, static pointer wiring. Linked list and BST. |
+| `09-gaps-and-futures.md` | Gaps and Futures | Control-flow pressure, recorded language gaps, design status. Eight queens capstone. |
 
 ---
 


### PR DESCRIPTION
## Summary

- **Consistency pass**: Added a "What comes next" forward-pointer paragraph to chapters 01–08, so every chapter closes with navigation to the next. Added the missing "What This Unit Teaches About ZAX" section to chapter 09 (matching the pattern in chapters 01–08).
- **Repetition control**: Added a back-reference in chapter 09's `break`/`continue` section pointing to its introduction in chapter 02. Verified that all other repeat-idiom sites (Ch04 `while NZ`, Ch08 `or l` null-sentinel) already use references rather than re-derivation; no further trimming was necessary.
- **README and navigation**: Rewrote `docs/course/README.md` — added a "Where to Start" navigation section with reader-entry guidance, added a "How to Compile and Run the Examples" note using `npm run zax`, refreshed the chapter table to use cleaner one-line descriptions. Added a `docs/course/` discovery entry to `docs/README.md`.
- **Example path verification**: All 33 `.zax` files referenced in the course prose were checked against `examples/course/`. No broken paths found.

## Changed files

| File | Change |
|------|--------|
| `docs/course/README.md` | Navigation hints, compile note, refreshed chapter table |
| `docs/README.md` | Added `docs/course/` discovery entry |
| `docs/course/01-foundations.md` | Added "What comes next" |
| `docs/course/02-arrays-and-loops.md` | Added "What comes next" |
| `docs/course/03-strings.md` | Added "What comes next" |
| `docs/course/04-bit-patterns.md` | Added "What comes next" |
| `docs/course/05-records.md` | Added "What comes next" |
| `docs/course/06-recursion.md` | Added "What comes next" |
| `docs/course/07-composition.md` | Added "What comes next" |
| `docs/course/08-pointer-structures.md` | Added "What comes next" |
| `docs/course/09-gaps-and-futures.md` | Added "What This Unit Teaches"; added Ch02 back-reference |

## Broken example paths

None. All 33 .zax files referenced in the course are present in examples/course/.

## Remaining editorial concerns

- No occurrences of `for` as active syntax were found in the course docs.
- Ch07 line 133 has a slightly run-on sentence in the word_stack explanation; minor, not a correctness issue.
- No language surface changes, no .zax file changes, no content redesign.

Generated with [Claude Code](https://claude.com/claude-code)