### PR TITLE
fix(course): while NZ entry flags, README summaries, recursion taxonomy

### DIFF
--- a/docs/course/06-recursion.md
+++ b/docs/course/06-recursion.md
@@ -210,8 +210,8 @@ See `examples/course/unit6/array_reverse_recursive.zax`.
 ## Examples in This Unit
 
 - `examples/course/unit6/hanoi.zax` — Towers of Hanoi move count, double recursion
-- `examples/course/unit6/array_sum_recursive.zax` — array sum by tail recursion
-  and accumulation on unwind
+- `examples/course/unit6/array_sum_recursive.zax` — array sum by linear recursion
+  with accumulation on unwind
 - `examples/course/unit6/array_reverse_recursive.zax` — in-place reversal by
   structural recursion on a shrinking index range
 

--- a/docs/course/07-composition.md
+++ b/docs/course/07-composition.md
@@ -132,10 +132,7 @@ end
 
 `word_stack.zax` loads the depth count into L with `ld l, a` — L is the index token for the `arr[L]` path expression — while DE carries the word value via `de := value_word`. `stack_slots[L] := de` then stores it cleanly. This is the established ZAX idiom for word-array access with an 8-bit index: index in L, value in DE.
 
-This is a real design choice, not an accident of the implementation. When writing
-operations over word arrays, DE holds the value and L holds the index, and HL is
-the working address register. `word_stack.zax` is short enough to read in its
-entirety — the full source is in `examples/course/unit7/word_stack.zax`.
+This is a real design choice, not an accident of the implementation. The programmer writes `ld l, a` to set the index, `de := value_word` to hold the value, and `stack_slots[L] := de` to store it — that is all that appears in the source. `word_stack.zax` is short enough to read in its entirety — the full source is in `examples/course/unit7/word_stack.zax`.
 
 ---
 

--- a/docs/course/09-gaps-and-futures.md
+++ b/docs/course/09-gaps-and-futures.md
@@ -147,10 +147,14 @@ is implemented and available on the current surface. The course examples use it.
   examples. Same classification: library candidate once the pattern is measured
   across enough examples.
 
+**Language gaps, not library gaps**:
+
 - Local named-constant initialization: `var` block initializers cannot currently
   reference named constants by name. This is a real readability gap, grounded
-  specifically in `binary_search.zax` and `bubble_sort.zax`. It is a focused
-  language issue, not yet opened at the time of writing.
+  specifically in `binary_search.zax` and `bubble_sort.zax`. It requires a
+  language change — the compiler must resolve constant names at `var`-block init
+  time — and is not addressable by a library or idiom. Not yet opened at the
+  time of writing.
 
 **Style observations**:
 

--- a/docs/course/README.md
+++ b/docs/course/README.md
@@ -67,10 +67,10 @@ it) shows the generated assembly for each source file.
 | `00-introduction.md` | Introduction | What ZAX is, why it exists, the structured assembler philosophy. No code. |
 | `01-foundations.md` | Foundations | Variables, `:=` assignment, functions, `while`/`if`, `succ`/`pred`. Arithmetic and number-theory algorithms. |
 | `02-arrays-and-loops.md` | Arrays and Loops | Array indexing with register operands, `break` and `continue`, the register-as-index convention. Sorting and searching. |
-| `03-strings.md` | Strings | Pointer-based traversal, null-terminated scanning, `repeat`/`until`, local `op`. String algorithms. |
+| `03-strings.md` | Strings | Null-terminated strings, byte-by-byte traversal, `while NZ` sentinel loops with early `break`. String algorithms. |
 | `04-bit-patterns.md` | Bit Patterns | Z80 shift and logic idioms, counter-driven loops, local `op` for recurring register patterns. Bit manipulation. |
 | `05-records.md` | Records | Typed aggregate state, field access, `sizeof`/`offsetof`, non-power-of-two strides. Ring buffer. |
-| `06-recursion.md` | Recursion | Recursive functions, IX frame per call, preserving return values across multiple calls. Hanoi, recursive sort and sum. |
+| `06-recursion.md` | Recursion | Recursive functions, IX frame per call, preserving return values across multiple calls. Hanoi, recursive reverse and sum. |
 | `07-composition.md` | Composition | `import`, module-qualified calls, `select`/`case` dispatch, software-stack discipline. RPN calculator. |
 | `08-pointer-structures.md` | Pointer Structures | Typed reinterpretation (`<Type>local.field`), null-sentinel traversal, static pointer wiring. Linked list and BST. |
 | `09-gaps-and-futures.md` | Gaps and Futures | Control-flow pressure, recorded language gaps, design status. Eight queens capstone. |

--- a/examples/course/unit1/exp_squaring.zax
+++ b/examples/course/unit1/exp_squaring.zax
@@ -11,6 +11,8 @@ func mul_u16(lhs: word, rhs: word): HL
 
   count := rhs
 
+  ld a, 1
+  or a
   while NZ
     hl := count
     ld a, h
@@ -44,6 +46,8 @@ func exp_squaring(base: word, exponent: word): HL
   factor := base
   remaining := exponent
 
+  ld a, 1
+  or a
   while NZ
     hl := remaining
     ld a, h

--- a/examples/course/unit1/fibonacci.zax
+++ b/examples/course/unit1/fibonacci.zax
@@ -11,6 +11,8 @@ func fib(target_count: word): HL
     next_value: word = 0
   end
 
+  ld a, 1
+  or a
   while NZ
     hl := index_value
     de := target_count

--- a/examples/course/unit1/gcd_iterative.zax
+++ b/examples/course/unit1/gcd_iterative.zax
@@ -14,6 +14,8 @@ func gcd_iterative(left_input: word, right_input: word): HL
   hl := right_input
   right := hl
 
+  ld a, 1
+  or a
   while NZ
     hl := right
     ld a, h

--- a/examples/course/unit1/power.zax
+++ b/examples/course/unit1/power.zax
@@ -11,6 +11,8 @@ func mul_u16(lhs: word, rhs: word): HL
 
   count := rhs
 
+  ld a, 1
+  or a
   while NZ
     hl := count
     ld a, h
@@ -42,6 +44,8 @@ func power(base: word, exponent: word): HL
 
   remaining := exponent
 
+  ld a, 1
+  or a
   while NZ
     hl := remaining
     ld a, h


### PR DESCRIPTION
## Summary

- **Fix 1 (Blocker)**: Added `ld a, 1` / `or a` entry flag setup immediately before every `while NZ` in `power.zax` (2 loops), `gcd_iterative.zax` (1 loop), `fibonacci.zax` (1 loop), and `exp_squaring.zax` (2 loops). Without this, stale Z=1 on entry causes `while NZ` to skip the loop body entirely.

- **Fix 2 (Significant)**: Corrected the Chapter 03 summary line in `docs/course/README.md` — it incorrectly advertised `repeat/until`; Chapter 03 actually uses `while NZ` sentinel loops with early `break`. Summary now reads: null-terminated strings, byte-by-byte traversal, `while NZ` sentinel loops with early `break`.

- **Fix 3a (Significant)**: Corrected the Chapter 06 summary line in `docs/course/README.md` — changed "recursive sort and sum" to "recursive reverse and sum" to match the actual examples (`array_sum_recursive.zax` and `array_reverse_recursive.zax`).

- **Fix 3b (Significant)**: Removed the "tail recursion" label from `array_sum_recursive.zax` in the Examples section of `docs/course/06-recursion.md`. Accumulation on unwind is the opposite of tail recursion; the entry now says "linear recursion with accumulation on unwind."

- **Fix 4 (Significant)**: Resolved the inconsistent classification of named-constant initialization in `docs/course/09-gaps-and-futures.md`. It was listed under "Library gaps, not language gaps" but then called "a focused language issue" in the same bullet. Since resolving this requires the compiler to recognise constant names at `var`-block init time (a language change, not a library fix), the bullet is now under its own "Language gaps, not library gaps" heading with consistent language-issue framing.

- **Fix 5 (Polish)**: Rewrote the implementation-internal sentence in `docs/course/07-composition.md` (~line 133) that said "HL is the working address register." The revised text stays at the observable source-level idiom: what the programmer writes (`ld l, a`, `de := value_word`, `stack_slots[L] := de`) without describing hidden compiler machinery.

## Test plan

- [x] `npm run typecheck` passes with no errors
- [x] All `while NZ` entry sites in unit1 examples now have `ld a, 1` / `or a` immediately before the loop keyword
- [x] README chapter summaries match the actual chapter content
- [x] No "tail recursion" label remains on an accumulate-on-unwind example
- [x] Named-constant initialization is classified consistently as a language gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)