### PR TITLE
fix(course): complete while NZ entry setup and fix docs discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ zax [options] <entry.zax>
 | ------------------------------------------------ | ---------------------------------------------------------------- |
 | `docs/reference/ZAX-quick-guide.md`              | Practical quick-start — recommended first read after this README |
 | `docs/spec/zax-spec.md`                          | Normative language specification                                 |
-| `docs/design/zax-algorithms-course.md`           | Algorithm course — classic CS problems in ZAX                    |
+| `docs/course/README.md`                          | Algorithm course — classic CS problems in ZAX                    |
 | `docs/reference/testing-verification-guide.md`   | Testing and verification flow                                    |
 | `docs/reference/zax-dev-playbook.md`             | Contributor workflow and review hygiene                          |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,7 +74,7 @@ Recently completed design records now live under:
 ## Rules
 
 - Do not add new top-level files under `docs/` except `docs/README.md`.
-- Every new document must live under exactly one of: `spec`, `design`, `reference`, `work`, `archive`.
+- Every new document must live under exactly one of: `spec`, `design`, `reference`, `work`, `archive`, `course`.
 - `spec/` is authoritative.
 - `design/` is for active proposals, decisions, and near-term design sequencing.
 - `reference/` is for current supporting material.

--- a/docs/course/01-foundations.md
+++ b/docs/course/01-foundations.md
@@ -173,12 +173,11 @@ must also re-establish the flags before control reaches the back edge:
 at the entry setup and at the back edge whenever the loop condition must be
 guaranteed.
 
-Unit 1 examples use `ld a, 1` / `or a` at the back edge only; they are designed
-for non-zero arguments where the calling context provides appropriate entry
-conditions. Unit 3 and later examples always establish flags explicitly before
-the first `while` — both the initial setup and the back-edge re-establishment
-appear together. The entry-flag rule applies equally to both: if Z=1 on entry to
-a `while NZ` loop, the body never executes regardless of what is inside it.
+All unit 1 examples establish flags explicitly before entry with `ld a, 1` /
+`or a`, and the same idiom re-establishes NZ at the back edge of each iteration.
+This is the consistent rule: every `while NZ` has explicit entry flag setup.
+If Z=1 on entry to a `while NZ` loop, the body never executes regardless of
+what is inside it.
 
 ---
 
@@ -366,10 +365,10 @@ See `examples/course/unit1/digits.zax`.
   a typed call.
 - `while NZ` is the basic loop form. Entry flags always matter: a stale Z=1
   on entry skips the loop body entirely before any `ret` inside it can execute.
-  The safe, explicit idiom is `ld a, 1` / `or a` before the `while`; unit 3 and
-  later always use it. Unit 1 examples omit it because they rely on the calling
-  context having left appropriate entry flags — that is not the same as saying
-  entry flags are irrelevant.
+  All unit 1 examples establish flags explicitly before the `while` with
+  `ld a, 1` / `or a`, and the same idiom re-establishes NZ at the back edge.
+  This is the consistent rule throughout: every `while NZ` has explicit entry
+  flag setup.
 - `succ` and `pred` are the idiomatic scalar increment and decrement operators.
   They appear wherever a loop counter or accumulator needs stepping.
 - Recursive functions look and work like non-recursive ones. The compiler

--- a/examples/course/unit1/digits.zax
+++ b/examples/course/unit1/digits.zax
@@ -1,7 +1,7 @@
 ; digits.zax
 ;
 ; Source/problem: decimal digit counting by repeated division.
-; Unit 0 foundations example: count decimal digits by repeated division.
+; Unit 1 foundations example: count decimal digits by repeated division.
 
 func div_u16(dividend: word, divisor: word): HL
   var
@@ -11,6 +11,8 @@ func div_u16(dividend: word, divisor: word): HL
 
   remainder := dividend
 
+  ld a, 1
+  or a
   while NZ
     hl := remainder
     de := divisor
@@ -39,6 +41,8 @@ func decimal_digits(value: word): HL
 
   remaining := value
 
+  ld a, 1
+  or a
   while NZ
     hl := remaining
     ld de, 10

--- a/examples/course/unit1/exp_squaring.zax
+++ b/examples/course/unit1/exp_squaring.zax
@@ -1,7 +1,7 @@
 ; exp_squaring.zax
 ;
 ; Source/problem: binary exponentiation / exponentiation by squaring.
-; Unit 0 foundations example: exponentiation by squaring.
+; Unit 1 foundations example: exponentiation by squaring.
 
 func mul_u16(lhs: word, rhs: word): HL
   var

--- a/examples/course/unit1/fibonacci.zax
+++ b/examples/course/unit1/fibonacci.zax
@@ -1,7 +1,7 @@
 ; fibonacci.zax
 ;
 ; Source/problem: Fibonacci sequence, iterative local-state form.
-; Unit 0 foundations example: iterative Fibonacci with local state.
+; Unit 1 foundations example: iterative Fibonacci with local state.
 
 func fib(target_count: word): HL
   var

--- a/examples/course/unit1/gcd_iterative.zax
+++ b/examples/course/unit1/gcd_iterative.zax
@@ -1,7 +1,7 @@
 ; gcd_iterative.zax
 ;
 ; Source/problem: Euclid's algorithm, iterative subtraction form.
-; Unit 0 foundations example: Euclid's algorithm with iterative subtraction.
+; Unit 1 foundations example: Euclid's algorithm with iterative subtraction.
 
 func gcd_iterative(left_input: word, right_input: word): HL
   var

--- a/examples/course/unit1/gcd_recursive.zax
+++ b/examples/course/unit1/gcd_recursive.zax
@@ -1,7 +1,7 @@
 ; gcd_recursive.zax
 ;
 ; Source/problem: Euclid's algorithm, recursive subtraction form.
-; Unit 0 foundations example: recursive Euclid subtraction.
+; Unit 1 foundations example: recursive Euclid subtraction.
 
 func gcd_recursive(left_input: word, right_input: word): HL
   var

--- a/examples/course/unit1/power.zax
+++ b/examples/course/unit1/power.zax
@@ -1,7 +1,7 @@
 ; power.zax
 ;
 ; Source/problem: SICP-style repeated multiplication baseline for integer power.
-; Unit 0 foundations example: naive integer power by repeated multiplication.
+; Unit 1 foundations example: naive integer power by repeated multiplication.
 
 func mul_u16(lhs: word, rhs: word): HL
   var

--- a/examples/course/unit1/sqrt_newton.zax
+++ b/examples/course/unit1/sqrt_newton.zax
@@ -1,7 +1,7 @@
 ; sqrt_newton.zax
 ;
 ; Source/problem: Newton-Raphson integer square root.
-; Unit 0 foundations example: integer square root by Newton iteration.
+; Unit 1 foundations example: integer square root by Newton iteration.
 
 func div_u16(dividend: word, divisor: word): HL
   var
@@ -11,6 +11,8 @@ func div_u16(dividend: word, divisor: word): HL
 
   remainder := dividend
 
+  ld a, 1
+  or a
   while NZ
     hl := remainder
     de := divisor
@@ -49,6 +51,8 @@ func sqrt_newton(value: word): HL
 
   guess := hl
 
+  ld a, 1
+  or a
   while NZ
     hl := remaining_iters
     ld a, h

--- a/examples/course/unit3/atoi.zax
+++ b/examples/course/unit3/atoi.zax
@@ -1,7 +1,7 @@
 ; atoi.zax
 ;
 ; Source/problem: parse decimal digits into a word value.
-; Unit 2 example: pointer walking plus repeated scaling by 10.
+; Unit 3 example: pointer walking plus repeated scaling by 10.
 
 section data vars at $8000
   number_text: byte[6] = { '1', '2', '3', '4', 0, 0 }

--- a/examples/course/unit3/itoa.zax
+++ b/examples/course/unit3/itoa.zax
@@ -1,7 +1,7 @@
 ; itoa.zax
 ;
 ; Source/problem: convert a word value into decimal digits.
-; Unit 2 example: divide-by-10, reverse buffer, then forward copy.
+; Unit 3 example: divide-by-10, reverse buffer, then forward copy.
 
 section data vars at $8000
   reverse_digits: byte[6] = { 0, 0, 0, 0, 0, 0 }

--- a/examples/course/unit3/str_reverse.zax
+++ b/examples/course/unit3/str_reverse.zax
@@ -1,7 +1,7 @@
 ; str_reverse.zax
 ;
 ; Source/problem: reverse a zero-terminated string in place.
-; Unit 2 example: inward-moving left/right pointers.
+; Unit 3 example: inward-moving left/right pointers.
 
 section data vars at $8000
   text_value: byte[9] = { 'A', 'L', 'G', 'O', 'R', 'I', 'T', 'H', 0 }

--- a/examples/course/unit3/strcat.zax
+++ b/examples/course/unit3/strcat.zax
@@ -1,7 +1,7 @@
 ; strcat.zax
 ;
 ; Source/problem: append one zero-terminated string to another.
-; Unit 2 example: scan to the destination terminator, then copy the suffix.
+; Unit 3 example: scan to the destination terminator, then copy the suffix.
 
 section data vars at $8000
   prefix_text: byte[12] = { 'Z', '8', '0', '-', 0, 0, 0, 0, 0, 0, 0, 0 }

--- a/examples/course/unit3/strcmp.zax
+++ b/examples/course/unit3/strcmp.zax
@@ -1,7 +1,7 @@
 ; strcmp.zax
 ;
 ; Source/problem: lexicographic comparison of two zero-terminated strings.
-; Unit 2 example: dual-pointer scan with byte comparison.
+; Unit 3 example: dual-pointer scan with byte comparison.
 
 section data vars at $8000
   left_text: byte[6] = { 'A', 'L', 'P', 'H', 'A', 0 }

--- a/examples/course/unit3/strcpy.zax
+++ b/examples/course/unit3/strcpy.zax
@@ -1,7 +1,7 @@
 ; strcpy.zax
 ;
 ; Source/problem: copy a zero-terminated string byte by byte.
-; Unit 2 example: walk source and destination pointers together.
+; Unit 3 example: walk source and destination pointers together.
 
 op copy_and_advance(src_ptr: HL, dst_ptr: DE)
   ld a, (hl)

--- a/examples/course/unit3/strlen.zax
+++ b/examples/course/unit3/strlen.zax
@@ -1,7 +1,7 @@
 ; strlen.zax
 ;
 ; Source/problem: count bytes until a zero terminator.
-; Unit 2 example: the basic HL pointer-advance idiom.
+; Unit 3 example: the basic HL pointer-advance idiom.
 
 section data vars at $8000
   sample_text: byte[6] = { 'H', 'E', 'L', 'L', 'O', 0 }


### PR DESCRIPTION
## Fix 1a — Add entry flag setup to remaining unit 1 files

`digits.zax` and `sqrt_newton.zax` each had `while NZ` loops that entered without establishing entry flags. Added `ld a, 1` / `or a` immediately before every `while NZ` in both files (two insertions per file: one in the shared `div_u16` helper and one in the outer function).

## Fix 1b — Correct prose in `docs/course/01-foundations.md`

The summary passage around line 176 stated that unit 1 examples use `ld a, 1` / `or a` "at the back edge only" and that unit 3+ examples establish entry flags. This distinction is no longer accurate. Both passages (around line 176 and in the "What This Unit Teaches" section) were rewritten to state:
- All unit 1 examples establish flags before entry with `ld a, 1` / `or a`
- The same idiom re-establishes NZ at the back edge of each iteration
- This is the consistent rule: every `while NZ` has explicit entry flag setup

## Fix 2 — `docs/README.md` rules section

Added `course` to the list of valid top-level directories in the rules section so the rule no longer contradicts the existence of `docs/course/`.

## Fix 3 — Top-level `README.md` course link

Updated the documentation table to point to `docs/course/README.md` instead of `docs/design/zax-algorithms-course.md` as the algorithm course entry point.

## Fix 4 — Align example header comments with directory names

All unit1 files had headers saying "Unit 0" and all unit3 files had headers saying "Unit 2". Corrected all 14 files to match their actual directory:
- `examples/course/unit1/` (7 files): "Unit 0" → "Unit 1"
- `examples/course/unit3/` (7 files): "Unit 2" → "Unit 3"

🤖 Generated with [Claude Code](https://claude.com/claude-code)