### PR TITLE
fix(examples): correct unit header comments (units 2–9)

### DIFF
--- a/examples/course/unit2/binary_search.zax
+++ b/examples/course/unit2/binary_search.zax
@@ -1,7 +1,7 @@
 ; binary_search.zax
 ;
 ; Source/problem: binary search over a sorted byte array.
-; Unit 1 example: divide-and-conquer search on sorted storage.
+; Unit 2 example: divide-and-conquer search on sorted storage.
 
 const LastIndex = 7
 

--- a/examples/course/unit2/bubble_sort.zax
+++ b/examples/course/unit2/bubble_sort.zax
@@ -1,7 +1,7 @@
 ; bubble_sort.zax
 ;
 ; Source/problem: bubble sort over a small byte array.
-; Unit 1 example: repeated adjacent swaps through shrinking passes.
+; Unit 2 example: repeated adjacent swaps through shrinking passes.
 
 const ItemCount = 8
 const LastIndex = 7

--- a/examples/course/unit2/insertion_sort.zax
+++ b/examples/course/unit2/insertion_sort.zax
@@ -1,7 +1,7 @@
 ; insertion_sort.zax
 ;
 ; Source/problem: insertion sort over a small byte array.
-; Unit 1 example: sorted insertion into a growing prefix.
+; Unit 2 example: sorted insertion into a growing prefix.
 
 const ItemCount = 8
 

--- a/examples/course/unit2/linear_search.zax
+++ b/examples/course/unit2/linear_search.zax
@@ -1,7 +1,7 @@
 ; linear_search.zax
 ;
 ; Source/problem: linear search over a byte array.
-; Unit 1 example: scan until a matching element is found.
+; Unit 2 example: scan until a matching element is found.
 
 const ItemCount = 8
 

--- a/examples/course/unit2/prime_sieve.zax
+++ b/examples/course/unit2/prime_sieve.zax
@@ -1,7 +1,7 @@
 ; prime_sieve.zax
 ;
 ; Source/problem: sieve of Eratosthenes over a small flag array.
-; Unit 1 example: repeated marking of composite multiples.
+; Unit 2 example: repeated marking of composite multiples.
 
 const Limit = 16
 const StopFactor = 5

--- a/examples/course/unit2/selection_sort.zax
+++ b/examples/course/unit2/selection_sort.zax
@@ -1,7 +1,7 @@
 ; selection_sort.zax
 ;
 ; Source/problem: selection sort over a small byte array.
-; Unit 1 example: select the minimum remaining element each pass.
+; Unit 2 example: select the minimum remaining element each pass.
 
 const ItemCount = 8
 const LastIndex = 7

--- a/examples/course/unit4/bit_reverse.zax
+++ b/examples/course/unit4/bit_reverse.zax
@@ -1,7 +1,7 @@
 ; bit_reverse.zax
 ;
 ; Source/problem: reverse the bit order of one byte.
-; Unit 3 example: a local op for the append-low-bit idiom.
+; Unit 4 example: a local op for the append-low-bit idiom.
 
 op append_low_bit(reversed_reg: A, source_reg: B)
   add a, a

--- a/examples/course/unit4/getbits.zax
+++ b/examples/course/unit4/getbits.zax
@@ -1,7 +1,7 @@
 ; getbits.zax
 ;
 ; Source/problem: extract a bit-field from one byte.
-; Unit 3 example: shift down, then rebuild the requested width.
+; Unit 4 example: shift down, then rebuild the requested width.
 
 export func getbits_demo(): HL
   var

--- a/examples/course/unit4/parity.zax
+++ b/examples/course/unit4/parity.zax
@@ -1,7 +1,7 @@
 ; parity.zax
 ;
 ; Source/problem: compute odd parity for one byte.
-; Unit 3 example: toggle a parity bit while shifting through the source.
+; Unit 4 example: toggle a parity bit while shifting through the source.
 
 export func parity_demo(): HL
   var

--- a/examples/course/unit4/popcount.zax
+++ b/examples/course/unit4/popcount.zax
@@ -1,7 +1,7 @@
 ; popcount.zax
 ;
 ; Source/problem: count the set bits in one byte.
-; Unit 3 example: bit tests plus repeated right shifts.
+; Unit 4 example: bit tests plus repeated right shifts.
 
 export func popcount_demo(): HL
   var

--- a/examples/course/unit5/ring_buffer.zax
+++ b/examples/course/unit5/ring_buffer.zax
@@ -1,7 +1,7 @@
 ; ring_buffer.zax
 ;
 ; Source/problem: fixed-capacity ring buffer over exact-size records.
-; Unit 4 example: record layout plus non-power-of-two indexed access.
+; Unit 5 example: record layout plus non-power-of-two indexed access.
 
 const Capacity = 5
 

--- a/examples/course/unit6/array_reverse_recursive.zax
+++ b/examples/course/unit6/array_reverse_recursive.zax
@@ -1,7 +1,7 @@
 ; array_reverse_recursive.zax
 ;
 ; Source/problem: recursive in-place array reversal.
-; Unit 5 example: recurse toward the middle while swapping endpoints.
+; Unit 6 example: recurse toward the middle while swapping endpoints.
 
 const LastIndex = 5
 

--- a/examples/course/unit6/array_sum_recursive.zax
+++ b/examples/course/unit6/array_sum_recursive.zax
@@ -1,7 +1,7 @@
 ; array_sum_recursive.zax
 ;
 ; Source/problem: recursive sum of a byte array.
-; Unit 5 example: recurse on the tail and add the current element on unwind.
+; Unit 6 example: recurse on the tail and add the current element on unwind.
 
 const ItemCount = 6
 

--- a/examples/course/unit6/hanoi.zax
+++ b/examples/course/unit6/hanoi.zax
@@ -1,7 +1,7 @@
 ; hanoi.zax
 ;
 ; Source/problem: Tower of Hanoi move counting.
-; Unit 5 example: direct recursive decomposition with local frame state.
+; Unit 6 example: direct recursive decomposition with local frame state.
 
 func hanoi_count(disks_count: byte, source_peg: byte, spare_peg: byte, target_peg: byte): HL
   var

--- a/examples/course/unit7/rpn_calculator.zax
+++ b/examples/course/unit7/rpn_calculator.zax
@@ -1,7 +1,7 @@
 ; rpn_calculator.zax
 ;
 ; Source/problem: evaluate a small reverse-polish expression with a software stack.
-; Unit 6 example: explicit push/pop discipline over typed stack storage.
+; Unit 7 example: explicit push/pop discipline over typed stack storage.
 
 import "word_stack.zax"
 

--- a/examples/course/unit8/bst.zax
+++ b/examples/course/unit8/bst.zax
@@ -1,7 +1,7 @@
 ; bst.zax
 ;
 ; Source/problem: search a binary search tree using addr-linked records.
-; Unit 7 example: recursive traversal using direct typed reinterpretation from
+; Unit 8 example: recursive traversal using direct typed reinterpretation from
 ; an addr parameter.
 
 type TreeNode

--- a/examples/course/unit8/linked_list.zax
+++ b/examples/course/unit8/linked_list.zax
@@ -1,7 +1,7 @@
 ; linked_list.zax
 ;
 ; Source/problem: traverse and sum a singly-linked list.
-; Unit 7 example: addr-linked traversal using direct typed reinterpretation from
+; Unit 8 example: addr-linked traversal using direct typed reinterpretation from
 ; an addr local.
 
 type ListNode

--- a/examples/course/unit9/eight_queens.zax
+++ b/examples/course/unit9/eight_queens.zax
@@ -1,7 +1,7 @@
 ; eight_queens.zax
 ;
 ; Source/problem: first-solution search for the eight queens puzzle.
-; Unit 8 example: recursive backtracking with an explicit found flag to simulate named exit.
+; Unit 9 example: recursive backtracking with an explicit found flag to simulate named exit.
 
 const BoardSize = 8
 const LastRow = 7


### PR DESCRIPTION
## Summary

- All `.zax` example files in `examples/course/unit2/` through `examples/course/unit9/` had off-by-one unit numbers in their header comments (e.g., a file in `unit2/` said "Unit 1 example").
- Fixed 18 files across 7 units: every file's header now states the correct unit number matching its directory.
- `unit3/` files (7 files) were already correct and required no changes.
- `unit7/word_stack.zax` uses "Support module:" rather than a "Unit N example:" line, so it was left unchanged.

## Files changed

| File | Old | New |
|------|-----|-----|
| unit2/binary_search.zax | Unit 1 | Unit 2 |
| unit2/bubble_sort.zax | Unit 1 | Unit 2 |
| unit2/insertion_sort.zax | Unit 1 | Unit 2 |
| unit2/linear_search.zax | Unit 1 | Unit 2 |
| unit2/prime_sieve.zax | Unit 1 | Unit 2 |
| unit2/selection_sort.zax | Unit 1 | Unit 2 |
| unit4/bit_reverse.zax | Unit 3 | Unit 4 |
| unit4/getbits.zax | Unit 3 | Unit 4 |
| unit4/parity.zax | Unit 3 | Unit 4 |
| unit4/popcount.zax | Unit 3 | Unit 4 |
| unit5/ring_buffer.zax | Unit 4 | Unit 5 |
| unit6/array_reverse_recursive.zax | Unit 5 | Unit 6 |
| unit6/array_sum_recursive.zax | Unit 5 | Unit 6 |
| unit6/hanoi.zax | Unit 5 | Unit 6 |
| unit7/rpn_calculator.zax | Unit 6 | Unit 7 |
| unit8/bst.zax | Unit 7 | Unit 8 |
| unit8/linked_list.zax | Unit 7 | Unit 8 |
| unit9/eight_queens.zax | Unit 8 | Unit 9 |

## Test plan

- [x] `npm run typecheck` passes with no errors or warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)