### PR TITLE
docs(intro): Volume 1 editorial pass

### DIFF
--- a/docs/intro/07-a-phase-a-program.md
+++ b/docs/intro/07-a-phase-a-program.md
@@ -50,21 +50,10 @@ program will process. The vars section at `$8020` holds the two result bytes.
 
 ## The return clause and register survival
 
-In ZAX, the return clause on a `func` declaration controls which registers the
-compiler saves and restores. A `func name(): void` declaration causes ZAX to
-save AF, BC, DE, and HL on entry and restore them before `ret`. That means any
-value placed in A inside the function is wiped out by `pop AF` before the caller
-sees it.
-
-Subroutines that return a result in a register must declare that register in the
-return clause:
-
-- `func name(): AF` — A holds the result; AF is not saved/restored, so the
-  value in A survives to the caller.
-- `func name(): HL` — HL holds the result; HL is live on return.
-
-This is the Phase A idiom for register-passing subroutines. Both `find_max` and
-`count_above` return their result in A, so both are declared `func ...: AF`.
+Chapter 06 established that the return clause on a `func` declaration controls
+which registers the compiler saves and restores. Both `find_max` and
+`count_above` return their result in A, so both are declared `func ...: AF` —
+which tells ZAX not to save and restore AF, leaving A intact for the caller.
 
 ---
 

--- a/docs/intro/08-typed-storage-and-assignment.md
+++ b/docs/intro/08-typed-storage-and-assignment.md
@@ -107,21 +107,11 @@ compiler-managed. You do not write it; you write `hl := count`.
 
 ## Bare-name access vs address dereference
 
-In Phase A, a named storage location like `count` could appear in two ways:
-
-```zax
-ld a, count      ; bare name: load the value stored at count
-ld a, (count)    ; parentheses: dereference — same result for a byte scalar
-```
-
-Both produce the same machine code for a simple byte scalar because the address
-is fixed and the instruction encodes it directly. Chapter 02 established the
-rule: the bare form means "the typed value at this location" and `(name)` means
-"memory at this address."
-
-With typed locals, the bare form is the only form used for `:=`. Typed locals
-live at IX-relative offsets, not at fixed absolute addresses; the dereference
-form `(count)` would mean "memory at the address value stored in the count slot,"
+Chapter 02 established the bare-name rule: the bare form means "the typed value
+at this location" and `(name)` means "memory at this address." With typed
+locals, the bare form is the only form used for `:=`. Typed locals live at
+IX-relative offsets, not at fixed absolute addresses; the dereference form
+`(count)` would mean "memory at the address value stored in the count slot,"
 which is not the same thing. Use bare names with `:=` for all reads and writes
 of typed locals.
 

--- a/docs/intro/09-structured-control-flow.md
+++ b/docs/intro/09-structured-control-flow.md
@@ -142,7 +142,7 @@ a loop over B counts is to copy B into A and `or a`:
 ```zax
 ld b, 10
 ld a, b           ; copy B into A
-or a              ; A | A = A, sets Z if A is zero, sets NZ if A is non-zero
+or a              ; sets Z if A is zero, NZ if non-zero (see Chapter 03)
 while NZ
   dec b
   ld a, b
@@ -150,11 +150,9 @@ while NZ
 end
 ```
 
-Chapter 04 covered the `or a` idiom for flag-establishment in loop-entry guards
-(`or a / jr z, skip_loop`). The same reasoning applies here: `or a` ORs A with
-itself, producing the same value in A, but setting the Z flag based on whether A
-is zero. Use `ld a, b / or a` to convert a register value into a flag state
-before `while`.
+The `or a` idiom for flag-establishment was introduced in Chapter 03 and applied
+to loop-entry guards in Chapter 04. The same reasoning applies here. Use
+`ld a, b / or a` to convert a register value into a flag state before `while`.
 
 The back edge of a `while` loop also tests the condition. Every `continue` or
 fall-through to the `end` line re-runs the condition test. That means the loop

--- a/docs/intro/10-functions-arguments-and-op.md
+++ b/docs/intro/10-functions-arguments-and-op.md
@@ -278,8 +278,9 @@ caller holds. Decrementing `len` each iteration is valid; the caller's value is
 already on the stack and this function's frame slot is a copy.
 
 The `op load_and_or` appears at both the loop entry and the back edge. This is
-intentional: the while condition is re-tested at the back edge using the same
-flag state, so the same setup must be correct at both points.
+intentional: the while condition is re-tested at the back edge (as established
+in Chapter 09) using the same flag state, so the same setup must be correct at
+both points.
 
 Notice that the call passes `B`, not `len`. This is required: `op` parameters
 typed `reg8` accept only physical register names at the call site. The frame

--- a/docs/intro/README.md
+++ b/docs/intro/README.md
@@ -1,78 +1,67 @@
 # Learn Z80 Programming in ZAX
 
-Status: planned Volume 1 course
+Status: complete Volume 1 course
 Audience: hobbyist / retro learner first, determined absolute beginner second
 
-This directory is the planned entry point for the beginner-first ZAX course.
+This directory is the entry point for the beginner-first ZAX course.
 It is the first volume of the two-volume teaching path:
 
 - Volume 1: learn Z80 programming in ZAX from the machine model upward
 - Volume 2: continue with larger practical programs in `docs/course/`
 
-This volume is not written yet. The current planning brief is:
-
-- `docs/work/z80-intro-course-plan.md`
-
 The mandatory editorial standard for all prose in this volume is:
 
 - `docs/work/course-writing-standard.md`
 
-## What this volume will cover
+## How to compile and run the examples
 
-The planned arc is deliberately split in two:
+The examples require the ZAX compiler. To compile a single file:
 
-- Phase A: raw-first Z80 in ZAX
-- Phase B: structured ZAX as justified relief
+```
+npm run zax -- examples/intro/00_first_program.zax
+```
 
-That means early chapters stay close to ordinary Z80 programming:
+`npm run zax` builds the compiler from source and passes arguments to the CLI.
+Run `npm run build` once to pre-build, then invoke `node dist/src/cli.js`
+directly for subsequent runs.
 
-- registers
-- flags
-- raw jumps and labels
-- `djnz`
-- `db` / `dw`
-- `call` / `ret`
+## Phase A and Phase B
 
-Only later chapters introduce the higher-level ZAX surface:
+The volume is split into two phases.
 
-- typed storage and `:=`
-- `if` / `while`
-- `succ` / `pred`
-- `break` / `continue`
-- arguments, locals, and `op`
+**Phase A** (Chapters 00–07) stays close to ordinary Z80 programming. The
+reader writes raw instructions, manages registers by hand, invents loop labels,
+and calls subroutines with register-passing conventions documented only in
+comments. Chapter 07 is the Phase A capstone: a complete program that uses
+every Phase A construct and names the points where the raw approach creates
+overhead.
 
-## Planned chapter map
+**Phase B** (Chapters 08–10) introduces the higher-level ZAX surface as
+justified relief from that overhead. Each Phase B construct is introduced by
+showing exactly which Phase A cost it removes. The machine model does not
+change; the compiler takes on more of the bookkeeping.
 
-- `00` — What a Computer Is Doing
-- `01` — Numbers and the Z80 Register Set
-- `02` — Loading, Storing, and Simple Constants
-- `03` — Flags, Comparisons, and Jumps
-- `04` — Counting Loops and `djnz`
-- `05` — Data Tables and Indexed Access
-- `06` — Stack and Subroutines
-- `07` — A Phase A Program
-- `08` — Typed Storage and Assignment
-- `09` — Structured Control Flow
-- `10` — Subroutines, Arguments, and `op`
+## Chapter table
 
-## Before drafting begins
+| Chapter | File | Phase | What it covers |
+|---------|------|-------|----------------|
+| 00 | `00-what-a-computer-is-doing.md` | A | Bytes, addresses, machine code, the ZAX module shell |
+| 01 | `01-numbers-and-registers.md` | A | Binary and hex, the Z80 register set, register pairs |
+| 02 | `02-loading-storing-constants.md` | A | `ld` addressing modes, labels, `const`, named storage |
+| 03 | `03-flags-comparisons-jumps.md` | A | Flag register, `cp`, `or a`, conditional and unconditional jumps |
+| 04 | `04-counting-loops-and-djnz.md` | A | `djnz`, sentinel loops, flag-exit loops, zero-count edge case |
+| 05 | `05-data-tables-and-indexed-access.md` | A | Byte/word tables, HL sequential access, IX+d displaced access |
+| 06 | `06-stack-and-subroutines.md` | A | `call`/`ret`, the hardware stack, `push`/`pop`, register conventions |
+| 07 | `07-a-phase-a-program.md` | A | Phase A capstone; names Phase A costs that Phase B will address |
+| 08 | `08-typed-storage-and-assignment.md` | B | Typed locals, `:=` assignment, `succ`/`pred` |
+| 09 | `09-structured-control-flow.md` | B | `if`/`else`, `while`, `break`, `continue` |
+| 10 | `10-functions-arguments-and-op.md` | B | Typed parameters, typed return values, `op` |
 
-The following have now been settled or confirmed for the first tranche:
-
-- Phase A uses a generic / abstract Z80 target rather than a machine-specific
-  ROM environment
-- raw user-defined labels work cleanly with:
-  - `jp`
-  - `jr`
-  - `djnz`
-  - `call`
-
-Still open for later review:
-
-- whether a text-level `include` feature is needed for early example sharing
+Example files live under `examples/intro/` and are numbered to match their
+chapter: `00_first_program.zax` through `10_functions_and_op.zax`.
 
 ## Relationship to Volume 2
 
-After this volume, the reader should be ready to start here:
+After completing Chapter 10, the reader is ready to start Volume 2:
 
 - `docs/course/README.md`


### PR DESCRIPTION
## Summary

- Full editorial pass across all 11 files in `docs/intro/`
- No language changes, no new content, no redesign of chapter structure

## Files changed and what was done

### `docs/intro/README.md`
- Updated status from "planned" to "complete" and removed "not written yet" placeholder text
- Replaced unordered "Planned chapter map" with a structured table listing all chapters 00–10 with their Phase A/B label and a brief summary of what each covers
- Added a "Phase A and Phase B" section explaining what each phase means, which chapter range each covers, and how Phase B relates to Phase A
- Added compile/run instructions (adapted from the existing `docs/course/README.md` pattern)
- Removed now-stale "Before drafting begins" and planning-brief material
- Verified the Volume 2 link points to `docs/course/README.md`

### `docs/intro/07-a-phase-a-program.md`
- Trimmed the "The return clause and register survival" section: replaced a full re-explanation of the `: void` / `: AF` / `: HL` return clause (which duplicated Chapter 06) with a single cross-reference sentence pointing to Chapter 06, followed by the one sentence of new application content for this chapter

### `docs/intro/08-typed-storage-and-assignment.md`
- Trimmed the "Bare-name access vs address dereference" section: removed the two-code-block re-explanation of the bare-name vs parentheses rule (already established in full in Chapter 02), replaced with a single attribution sentence ("Chapter 02 established the bare-name rule") followed by the new point specific to Chapter 08 (typed locals at IX-relative offsets)

### `docs/intro/09-structured-control-flow.md`
- Trimmed the "Establishing flags before `while`" section: the inline comment on `or a` that re-stated the `A | A = A` mechanics was replaced with a `(see Chapter 03)` pointer; the two-sentence re-explanation of the `or a` idiom that followed was replaced with a one-sentence cross-reference to Chapter 03 (introduction) and Chapter 04 (loop-entry guard application)

### `docs/intro/10-functions-arguments-and-op.md`
- Added a cross-reference to Chapter 09 in the `op` example walkthrough where "back edge" is used in context, since the concept was established in Chapter 09 and a reader might not have the term fresh

## Example path verification

All `.zax` files referenced in chapters 00–10 were verified against `examples/intro/`. All 11 files exist:

- `00_first_program.zax` — exists
- `01_register_moves.zax` — exists
- `02_constants_and_labels.zax` — exists
- `03_flag_tests_and_jumps.zax` — exists
- `04_djnz_loops.zax` — exists
- `05_data_tables.zax` — exists
- `06_subroutines.zax` — exists
- `07_phase_a_capstone.zax` — exists
- `08_typed_storage.zax` — exists
- `09_structured_control.zax` — exists
- `10_functions_and_op.zax` — exists

No missing example paths found.

## Typecheck result

`npm run typecheck` passed with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)