### PR TITLE
fix(intro): ZAX func ret handling — remove redundant trailing ret, clarify prose

### DIFF
--- a/docs/intro/06-stack-and-subroutines.md
+++ b/docs/intro/06-stack-and-subroutines.md
@@ -97,7 +97,6 @@ Example documentation pattern:
 func add_bytes(): AF
   ld a, b
   add a, c
-  ret
 end
 ```
 
@@ -118,18 +117,30 @@ which registers to save and restore around the function frame:
 - **`func name(): HL`** — HL holds the result; AF, BC, and DE are saved and
   restored; HL is live on return.
 
-The Phase A idiom for a subroutine that returns a byte result in A is:
+### ZAX `func` blocks emit `ret` automatically
+
+A ZAX `func` block does **not** require a final `ret`. When control reaches
+`end`, the compiler emits the frame epilogue and `ret` automatically. Only use
+`ret` inside a `func` for **early exits** — places in the function body where
+you want to return before reaching `end`.
 
 ```zax
 func my_sub(): AF
   ; ... compute result in A ...
-  ret          ; A reaches the caller intact
+  ; No explicit ret needed: ZAX emits ret at end.
 end
 ```
 
+This is different from raw labeled subroutines (Phase A code reached by `call
+label` but not wrapped in a ZAX `func`). Raw subroutines are plain Z80 — the
+assembler does not insert any epilogue — so they **do** require an explicit
+`ret`. Chapter 07 shows several Phase A subroutines that must keep their `ret`.
+In Phase B (Chapters 08–10), you write ZAX `func` blocks exclusively, and the
+compiler handles the return for you.
+
 Declaring `: void` when the function leaves a meaningful value in A is a bug:
-the compiler's `pop AF` will overwrite A before returning, and the caller sees
-stale flag values rather than the computed result.
+the compiler's `pop AF` in the epilogue will overwrite A before returning, and
+the caller sees stale flag values rather than the computed result.
 
 ---
 
@@ -149,15 +160,14 @@ internally. The pattern:
 func example(): void
   push bc          ; save caller's BC on entry
   ; ... use BC for internal work ...
-  pop bc           ; restore caller's BC before ret
-  ret
+  pop bc           ; restore caller's BC before returning
 end
 ```
 
 The critical rule: every `push` in a subroutine must have exactly one matching
-`pop` before `ret`. If a subroutine pushes twice and pops once, the stack has
-an extra word on it when `ret` runs. `ret` will then read that extra word as the
-return address and jump to garbage.
+`pop` before the function returns. If a subroutine pushes twice and pops once,
+the stack has an extra word on it when `ret` runs. `ret` will then read that
+extra word as the return address and jump to garbage.
 
 Stack depth discipline: count your pushes and pops. They must be balanced.
 
@@ -174,14 +184,17 @@ This is useful for early-exit patterns:
 ```zax
 func check_nonzero(): void
   or a          ; test A for zero
-  ret z         ; return early if A is zero
+  ret z         ; early exit: return immediately if A is zero
   ; ... rest of the function runs only when A != 0 ...
-  ret
+  ; No explicit ret needed at the end: ZAX emits it automatically.
 end
 ```
 
+`ret z` here is an **early exit** — it returns before `end` is reached.
+ZAX still emits the epilogue and final `ret` at `end` for the normal path.
+
 When using `ret cc`, the stack must be balanced at the conditional return point
-just as it must be at the final `ret`. If the function pushed a register before
+just as it must be at the final return. If the function pushed a register before
 the test, it must pop before `ret z` as well.
 
 ---
@@ -246,10 +259,9 @@ func max_word(): HL
   pop de
   jr c, max_is_de
   add hl, de
-  ret
+  ret                ; early exit: HL holds the original HL (the larger value)
 max_is_de:
-  ex de, hl
-  ret
+  ex de, hl          ; HL < DE: put DE (the larger value) into HL
 end
 ```
 
@@ -307,12 +319,16 @@ paths.
   16-bit word, BC and DE for secondary values. Document which registers carry
   inputs and which carry outputs.
 - `push rr` saves a register pair; `pop rr` restores it. Every push must have
-  a matching pop before `ret`.
+  a matching pop before the function returns.
 - Unbalanced push/pop causes `ret` to jump to garbage, because the wrong bytes
   are at the top of the stack when `ret` reads the return address.
 - `ret cc` returns conditionally; the stack must be balanced at that point too.
 - Subroutines can call other subroutines. Each call pushes a return address;
   each ret pops one. The stack depth grows with each nested call.
+- A ZAX `func` block emits the epilogue and `ret` automatically at `end`. A
+  trailing `ret` is not needed. Use `ret` inside a `func` only for early exits.
+  Raw labeled subroutines (Phase A code reached by `call label` outside a ZAX
+  `func`) are plain Z80 and do require an explicit `ret`.
 
 ## What Comes Next
 

--- a/docs/intro/07-a-phase-a-program.md
+++ b/docs/intro/07-a-phase-a-program.md
@@ -71,8 +71,6 @@ export func main(): void
   ld c, 64
   call count_above
   ld (above_64), a
-
-  ret
 end
 ```
 
@@ -102,7 +100,6 @@ find_max_loop:
 find_max_no_update:
   inc hl
   djnz find_max_loop
-  ret
 end
 ```
 
@@ -137,7 +134,6 @@ count_above_skip:
   inc hl
   djnz count_above_loop
   ld a, d
-  ret
 end
 ```
 

--- a/docs/intro/08-typed-storage-and-assignment.md
+++ b/docs/intro/08-typed-storage-and-assignment.md
@@ -44,7 +44,6 @@ func example(): void
     total: word = 0
   end
   ; instructions follow
-  ret
 end
 ```
 
@@ -160,7 +159,6 @@ find_max_loop:
 find_max_no_update:
   inc hl
   djnz find_max_loop
-  ret
 end
 ```
 
@@ -184,7 +182,6 @@ find_max_no_update:
   inc hl
   djnz find_max_loop
   a := running_max               ; load result for caller
-  ret
 end
 ```
 
@@ -211,7 +208,6 @@ count_above_skip:
   inc hl
   djnz count_above_loop
   ld a, d
-  ret
 end
 ```
 
@@ -237,7 +233,6 @@ count_above_skip:
   inc hl
   djnz count_above_loop
   a := cnt
-  ret
 end
 ```
 

--- a/docs/intro/09-structured-control-flow.md
+++ b/docs/intro/09-structured-control-flow.md
@@ -226,7 +226,6 @@ find_max_loop:
 find_max_no_update:
   inc hl
   djnz find_max_loop
-  ret
 end
 ```
 
@@ -255,7 +254,6 @@ func find_max_cf(): AF
     or a
   end
   a := running_max
-  ret
 end
 ```
 
@@ -300,7 +298,6 @@ count_above_skip:
   inc hl
   djnz count_above_loop
   ld a, d
-  ret
 end
 ```
 
@@ -332,7 +329,6 @@ func count_above_cf(): AF
     or a
   end
   a := cnt
-  ret
 end
 ```
 

--- a/docs/intro/10-functions-arguments-and-op.md
+++ b/docs/intro/10-functions-arguments-and-op.md
@@ -103,6 +103,12 @@ ret
 For a void function that preserves BC, DE, HL, and AF, the epilogue also emits
 the register restore sequence before the final `ret`.
 
+**A ZAX `func` does not need a final `ret`.** The compiler emits the epilogue
+and `ret` automatically when it reaches `end`. Use `ret` inside a `func` only
+for early exits — places in the body where you want to return before `end` is
+reached. Conditional returns (`ret cc`) are also early exits and remain valid
+wherever they are needed.
+
 That is six instructions of overhead — three prologue, three epilogue — plus
 the register save/restore pushes. A raw `call` and `ret` are two instructions
 total with no frame at all.
@@ -303,6 +309,10 @@ Each generation removes one source of bookkeeping:
 - Chapter 08 → Chapter 09: label scaffolding replaced by `if`/`while`.
 - Chapter 09 → Chapter 10: register-passing conventions replaced by typed parameters.
 
+Across all Phase B chapters, the compiler also handles frame setup, frame
+teardown, register preservation, and the final `ret` at `end`. A ZAX `func`
+never needs a trailing `ret` — that bookkeeping is automatic.
+
 The Z80 machine model has not changed. Registers, flags, the stack, and indexed
 addressing are all still present in Chapter 10's programs. What has changed is
 how much of the bookkeeping the compiler manages.
@@ -319,6 +329,9 @@ how much of the bookkeeping the compiler manages.
 - The function frame costs a three-instruction prologue and a three-instruction
   epilogue plus register saves/restores. A frameless function (no params, no
   locals) has none of this overhead.
+- The compiler emits the epilogue and `ret` automatically at `end`. A ZAX
+  `func` does not need a trailing `ret`. Use `ret` only for early exits inside
+  the function body.
 - The return clause controls which registers carry results and which the compiler
   saves/restores. Declaring `: void` when the function leaves a result in A
   causes the epilogue to overwrite it before the caller sees it.

--- a/examples/intro/00_first_program.zax
+++ b/examples/intro/00_first_program.zax
@@ -9,5 +9,5 @@ end
 export func main(): void
   ld a, StoredValue              ; A = $42
   ld (result), a                 ; write A to the byte named 'result'
-  ret
+  ; No explicit ret needed: ZAX emits the epilogue and ret automatically at end.
 end

--- a/examples/intro/01_register_moves.zax
+++ b/examples/intro/01_register_moves.zax
@@ -18,6 +18,4 @@ export func main(): void
   ; Copy HL to DE using register-to-register moves
   ld d, h                        ; D = H = $12
   ld e, l                        ; E = L = $34
-
-  ret
 end

--- a/examples/intro/02_constants_and_labels.zax
+++ b/examples/intro/02_constants_and_labels.zax
@@ -24,6 +24,4 @@ export func main(): void
   ld scratch, hl                 ; scratch = $1234  (bare name: write typed word)
 
   ld hl, scratch                 ; HL = $1234  (bare name: read typed word)
-
-  ret
 end

--- a/examples/intro/03_flag_tests_and_jumps.zax
+++ b/examples/intro/03_flag_tests_and_jumps.zax
@@ -37,6 +37,4 @@ loop_top:
   ld (counter), a                ; counter++
   dec b                          ; B--; sets Z when B reaches 0
   jp nz, loop_top                ; repeat while B != 0
-
-  ret
 end

--- a/examples/intro/04_djnz_loops.zax
+++ b/examples/intro/04_djnz_loops.zax
@@ -58,6 +58,4 @@ flag_loop:
   djnz flag_loop                 ; else continue while table bytes remain
 flag_done:
   ld (flagval), a                ; flagval = sum at the point the loop exited
-
-  ret
 end

--- a/examples/intro/05_data_tables.zax
+++ b/examples/intro/05_data_tables.zax
@@ -63,6 +63,4 @@ no_new_max:
   ld (rec1_id), a                ; rec1_id = $02
   ld a, (ix+2)                   ; A = lo field  (offset 2)
   ld (rec1_lo), a                ; rec1_lo = $B0
-
-  ret
 end

--- a/examples/intro/06_subroutines.zax
+++ b/examples/intro/06_subroutines.zax
@@ -21,8 +21,6 @@ export func main(): void
   ld de, $00C8                   ; second candidate: 200
   call max_word                  ; HL = max($0050, $00C8) = $00C8
   ld (result_max), hl            ; result_max = 200
-
-  ret
 end
 
 ; add_bytes: add B and C, return result in A.
@@ -32,7 +30,6 @@ end
 func add_bytes(): AF
   ld a, b                        ; A = B
   add a, c                       ; A = B + C  (flags set by add)
-  ret
 end
 
 ; max_word: return the larger of two 16-bit values.
@@ -51,5 +48,5 @@ func max_word(): HL
   ret                            ; HL = original HL (the larger value)
 max_is_de:
   ex de, hl                      ; HL < DE: put DE (the larger value) into HL
-  ret                            ; HL = original DE (the larger value)
+  ; No explicit ret needed: ZAX emits the epilogue and ret automatically at end.
 end

--- a/examples/intro/07_phase_a_capstone.zax
+++ b/examples/intro/07_phase_a_capstone.zax
@@ -30,8 +30,6 @@ export func main(): void
   ld c, 64                       ; threshold
   call count_above               ; A = 3  (91, 67, 88 are all > 64)
   ld (above_64), a               ; store the count
-
-  ret
 end
 
 ; find_max: scan a byte table and return the largest value.
@@ -48,7 +46,6 @@ find_max_loop:
 find_max_no_update:
   inc hl                         ; advance to next entry
   djnz find_max_loop             ; B--; loop while B != 0
-  ret                            ; A = maximum value
 end
 
 ; count_above: count table entries strictly greater than a threshold byte.
@@ -78,5 +75,4 @@ count_above_skip:
   inc hl
   djnz count_above_loop
   ld a, d                        ; A = final count
-  ret
 end

--- a/examples/intro/08_typed_storage.zax
+++ b/examples/intro/08_typed_storage.zax
@@ -30,8 +30,6 @@ export func main(): void
   ld c, 64
   call count_above_b
   ld (above_64), a
-
-  ret
 end
 
 ; find_max_b: scan a byte table and return the maximum value.
@@ -57,7 +55,6 @@ find_max_no_update:
   djnz find_max_loop
 
   a := running_max             ; load result into A for the caller
-  ret
 end
 
 ; count_above_b: count table entries strictly greater than a threshold.
@@ -84,5 +81,4 @@ count_above_skip:
   djnz count_above_loop
 
   a := cnt                     ; load final count into A for the caller
-  ret
 end

--- a/examples/intro/09_structured_control.zax
+++ b/examples/intro/09_structured_control.zax
@@ -29,8 +29,6 @@ export func main(): void
   ld c, 64
   call count_above_cf
   ld (above_64), a
-
-  ret
 end
 
 ; find_max_cf: scan a byte table and return the maximum byte value.
@@ -64,7 +62,6 @@ func find_max_cf(): AF
   end
 
   a := running_max
-  ret
 end
 
 ; count_above_cf: count table entries strictly greater than a threshold.
@@ -98,5 +95,4 @@ func count_above_cf(): AF
   end
 
   a := cnt
-  ret
 end

--- a/examples/intro/10_functions_and_op.zax
+++ b/examples/intro/10_functions_and_op.zax
@@ -42,8 +42,6 @@ export func main(): void
   count_above_f values, TableLen, 64
   ld a, l                          ; byte result is in L (H = 0)
   ld (cnt_val), a
-
-  ret
 end
 
 ; find_max_f: return the maximum byte in a table.


### PR DESCRIPTION
## Summary

- Removes redundant trailing `ret` from all ZAX `func` blocks across `examples/intro/00` through `10` — the compiler emits the epilogue and `ret` automatically at `end`; only early exits need explicit `ret`
- Preserves all early-exit `ret` and conditional `ret cc` statements (e.g. the mid-body `ret` in `max_word` after `add hl, de`)
- Adds a dedicated "ZAX `func` blocks emit `ret` automatically" section to Chapter 06 explaining the distinction between raw labeled subroutines (need explicit `ret`) and ZAX `func` blocks (compiler handles it), with a preview of Phase B
- Updates Chapter 10 to state clearly that a ZAX `func` does not need a trailing `ret`, adds the automatic return to the "what ZAX handles for you" list and the "What This Chapter Teaches" bullets
- Updates all code snippets in Chapters 07, 08, 09, and 10 to match the corrected example files (no trailing `ret` in `func` bodies)

## Test plan

- [x] `npm run typecheck` — passes with no errors
- [x] All 11 intro example files reviewed; only bare trailing `ret`s removed; early exits and raw subroutine `ret`s untouched
- [x] Chapter 06 new section cross-references Phase A vs Phase B distinction correctly
- [x] Doc code snippets match corrected `.zax` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)