### PR TITLE
docs(learning): rewrite Part 1 chapters with full technical depth

### DIFF
--- a/learning/part1/01-the-computer.md
+++ b/learning/part1/01-the-computer.md
@@ -2,97 +2,182 @@
 
 # Chapter 1 — The Computer
 
-To program at the level of machine code you need a clear picture of what the machine actually is. This chapter builds that picture from the ground up. No code yet — just the mental model that everything else depends on.
+Before writing a single line of assembly, you need to know what you are programming. This chapter describes the Z80 computer — its memory, its registers, and the cycle by which it executes instructions. Everything in the rest of the book depends on this picture being clear.
+
+---
+
+## Bits and Bytes
+
+The memory of any computer stores only two values: 0 and 1. Each individual 0 or 1 is called a **bit** (from *binary digit*). The Z80 cannot access individual bits directly, however. It always handles memory in groups of eight bits at a time. A group of eight bits is a **byte**.
+
+The eight bits in a byte are numbered from position 7 down to position 0. The numbering reflects each bit's contribution to the byte's total value: bit 7 represents 2<sup>7</sup> = 128, bit 6 represents 2<sup>6</sup> = 64, and so on down to bit 0, which represents 2<sup>0</sup> = 1. To find the numeric value of a byte, multiply each bit by its positional value and add up the results.
+
+Here is the byte `0b01110101` worked out in full (the `0b` prefix means the number is written in binary):
+
+| Bit position | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
+|---|---|---|---|---|---|---|---|---|
+| Positional value | 128 | 64 | 32 | 16 | 8 | 4 | 2 | 1 |
+| Digit | 0 | 1 | 1 | 1 | 0 | 1 | 0 | 1 |
+| Contribution | 0 | 64 | 32 | 16 | 0 | 4 | 0 | 1 |
+
+Total: 64 + 32 + 16 + 4 + 1 = **117**.
+
+A byte can hold any value from 0 (`0b00000000`) to 255 (`0b11111111`). This is the smallest unit of data the Z80 can directly read, write, or operate on.
+
+### Words
+
+Two consecutive bytes form a **word**, a 16-bit value. A word can hold values from 0 to 2<sup>16</sup> − 1 = 65,535. The Z80 handles both bytes and words; many of its registers are 16 bits wide and its memory addressing uses 16-bit values throughout. (Other CPUs have 32-bit or 64-bit words, but the Z80 only works with these two sizes.)
+
+When a word is stored in memory, it occupies two consecutive bytes. Which byte comes first matters, and this is discussed below under *Endianness*.
+
+---
+
+## Hexadecimal
+
+Writing out eight bits every time you mean a byte value is tedious and error-prone. Instead, Z80 programmers almost universally use **hexadecimal** — base 16 — and so will you. Hexadecimal numbers are prefixed with `$` throughout this book.
+
+Hexadecimal uses sixteen digits: `0`–`9` for values 0–9, then `A`–`F` for values 10–15. The key property that makes hexadecimal useful in this context is that exactly four bits correspond to exactly one hexadecimal digit. Converting between hex and binary requires no arithmetic — just split the bits into groups of four and substitute each group directly.
+
+Taking the example from above, `0b01110101`:
+
+```
+  0111   0101
+   7      5
+  $75
+```
+
+So `0b01110101 = $75`. Confirm in the other direction: `$75 = 7 × 16 + 5 = 112 + 5 = 117`. ✓
+
+The same holds for 16-bit words: `$FFFF` is `0b1111111111111111`, and a four-digit hex number always represents exactly sixteen bits. Addresses in the Z80 are always four hex digits, running from `$0000` to `$FFFF`.
+
+You will see hex constantly in Z80 work. Every opcode, every address, every constant value is typically written this way. It is worth spending a few minutes converting numbers in both directions until it feels natural.
 
 ---
 
 ## Memory
 
-Memory is the computer's storage. Think of it as a very long row of numbered boxes. Each box holds one number between 0 and 255. The number that identifies a box is its **address**. The number stored inside the box is a **byte**.
+The Z80 can address 65,536 bytes of memory, at addresses `$0000` through `$FFFF`. Think of it as a flat array: 65,536 numbered slots, each holding one byte. The number that identifies a slot is its **address**. To read or write any byte, you name its address.
 
-On the Z80, there are 65,536 boxes — addresses 0 through 65,535. We normally write addresses in hexadecimal, so the range runs from `$0000` to `$FFFF`. That is 64 kilobytes, and it is the entire extent of memory that the Z80 can see.
+Two types of memory occupy different parts of this address space:
+
+**ROM** (read-only memory) holds content that cannot be changed during normal operation and retains its contents when power is removed. On the Z80, ROM almost always occupies the lowest addresses, starting at `$0000`. The program that runs at power-on must live in ROM, because the CPU always begins executing from address `$0000`.
+
+**RAM** (random-access memory) holds content that can be freely read and written. RAM loses its contents when power is removed. RAM normally occupies the upper portion of the address space.
+
+The exact layout depends on the hardware. A small Z80 system might look like this:
 
 ```
-Address  Contents
-$0000      $3E
-$0001      $05
-$0002      $47
-$0003      $3E
-  ...      ...
-$FFFF      $00
+$0000–$3FFF   ROM   (16 KB — startup code, fixed routines)
+$4000–$7FFF   —     (unmapped or memory-mapped I/O)
+$8000–$FFFF   RAM   (32 KB — your programs and data)
 ```
 
-Every byte the computer uses — instructions, numbers, text, anything at all — lives somewhere in this address space. There is no other storage visible to the CPU.
+Other systems use completely different layouts. The important thing is that on any Z80 system, ROM begins at `$0000`.
 
-Two kinds of memory occupy different parts of this space:
+### Endianness
 
-**ROM** (read-only memory) holds content that does not change. ROM keeps its contents when the power goes off. On the Z80, ROM almost always occupies the bottom of the address space, starting at `$0000`.
+When a 16-bit word is stored in memory, its two bytes must go into two consecutive addresses. The Z80 is **little-endian**: the low byte of the word is stored at the lower address, and the high byte at the higher address.
 
-**RAM** (random-access memory) holds content that can be read and written freely. RAM loses its contents when power goes off. RAM normally occupies the upper portion of the address space.
+For example, storing the word `$1A2B` at address `$8000`:
 
-The exact split between ROM and RAM depends on the hardware the Z80 is installed in. A typical arrangement might have ROM from `$0000` to `$3FFF` and RAM from `$4000` to `$FFFF`, but other layouts are common.
+```
+Address   Contents
+$8000       $2B    ← low byte first
+$8001       $1A    ← high byte second
+```
+
+Read it back: the byte at `$8000` is `$2B` (low), the byte at `$8001` is `$1A` (high), so the word is `$1A2B`. This is not something you can change — every Z80 instruction that handles 16-bit values follows this rule. You will encounter it whenever you store addresses or multi-byte values in memory, so remember it.
 
 ---
 
-## The CPU
+## The CPU and Its Registers
 
-The CPU (central processing unit) is the chip that does the work. It reads bytes from memory, interprets them as instructions, and carries them out.
+The CPU (central processing unit) is the chip that does the work. It reads bytes from memory, interprets them as instructions, and carries them out one after another. To carry out those instructions, the CPU needs a small amount of very fast internal storage. That storage is called the **registers**.
 
-Inside the CPU are **registers** — named storage locations that the CPU uses while working. Registers are not part of memory. They are built into the CPU chip, faster to access than RAM, and there are only a handful of them.
+Registers are not part of RAM. They are built into the CPU itself, much faster to access than any external memory, and there are only a small number of them. Almost every instruction you write uses at least one register.
 
-The Z80 registers you will use most often:
+Here is the complete Z80 register set:
 
-| Register | Width  | Purpose |
-|----------|--------|---------|
-| A        | 8 bits | The **accumulator**. Most arithmetic and logic operations happen here. |
-| B, C     | 8 bits | General purpose. B is often used as a loop counter. |
-| D, E     | 8 bits | General purpose. Often holds a memory address as the pair DE. |
-| H, L     | 8 bits | General purpose. HL is the primary address register — most memory access goes through it. |
-| SP       | 16 bits | **Stack pointer.** Tracks the top of the call stack. |
-| PC       | 16 bits | **Program counter.** Always contains the address of the next instruction to execute. |
+| Register | Width | Role |
+|----------|-------|------|
+| A | 8 bits | **Accumulator.** Most arithmetic and logic operations happen here. If an instruction produces a result, it usually ends up in A. |
+| F | 8 bits | **Flags.** Individual bits record the outcome of the last operation (zero result, carry, overflow, etc.). Cannot be used directly in most instructions. |
+| B | 8 bits | General purpose. Frequently used as a loop counter. |
+| C | 8 bits | General purpose. Also used as a port number with the `in`/`out` instructions. |
+| D | 8 bits | General purpose. |
+| E | 8 bits | General purpose. |
+| H | 8 bits | General purpose. High byte of HL. |
+| L | 8 bits | General purpose. Low byte of HL. |
+| BC | 16 bits | B and C treated as a pair. Useful for 16-bit counts and addresses. |
+| DE | 16 bits | D and E treated as a pair. Commonly used as a destination address when copying data. |
+| HL | 16 bits | H and L treated as a pair. The primary address register — most indirect memory access goes through HL. |
+| IX | 16 bits | Index register. Used for indexed memory access (address + offset). Splits into IXH and IXL. |
+| IY | 16 bits | Index register. Same role as IX, a second independent index. Splits into IYH and IYL. |
+| SP | 16 bits | **Stack pointer.** Points to the most recently pushed value on the hardware stack. |
+| PC | 16 bits | **Program counter.** Always contains the address of the next instruction to execute. Cannot be read or written directly. |
+| I | 8 bits | Interrupt vector register. Used with interrupt mode 2. |
+| R | 8 bits | Refresh register. Incremented automatically as each instruction is fetched. Only the low seven bits cycle; the top bit stays zero. Rarely useful to the programmer. |
 
-B and C together form the 16-bit pair **BC**; D and E form **DE**; H and L form **HL**. The pairs behave as single 16-bit values when you need a full memory address.
+When B and C are used as the pair BC, B holds the high byte and C holds the low byte — the same pattern as DE (D high, E low) and HL (H high, L low). IX and IY follow the same rule with their halves. So for example if HL = `$1A2B`, then H = `$1A` and L = `$2B`.
+
+### Shadow Registers
+
+There is a second, hidden copy of A, F, B, C, D, E, H, and L — denoted A′, F′, B′, C′, D′, E′, H′, and L′. These are the **shadow registers**. You cannot use them directly in instructions. Two dedicated exchange instructions swap the main registers with their shadow counterparts:
+
+- `EX AF, AF′` swaps A and F with A′ and F′.
+- `EXX` swaps BC, DE, and HL with BC′, DE′, and HL′ simultaneously.
+
+One `EXX` moves six registers in a single instruction — much faster than six individual saves to memory. This makes the shadow registers useful for very tight interrupt handlers or innermost loops where you need to save and restore a full register state instantly.
+
+---
+
+## The Flags Register in Detail
+
+The flags register F contains eight bits, each of which records something about the result of the last operation that affected it. You will use these flags constantly — every conditional branch in the Z80 tests one of them.
+
+| Bit | Symbol | Name | Meaning |
+|-----|--------|------|---------|
+| 7 | S | Sign | Set if the result, interpreted as a signed number, is negative (i.e. bit 7 of the result is 1). |
+| 6 | Z | Zero | Set if the result is zero. |
+| 5 | — | | Undefined. |
+| 4 | H | Half carry | Set if there was a carry from bit 3 to bit 4. Used for BCD arithmetic. You will almost certainly never need this. |
+| 3 | — | | Undefined. |
+| 2 | P/V | Parity / Overflow | Used for two different purposes depending on the instruction: parity (set if the number of 1-bits in the result is even) or overflow (set if the result exceeded the signed range). Which meaning applies is determined by the instruction. |
+| 1 | N | Subtract | Set if the last operation was a subtraction. Used internally for BCD correction. |
+| 0 | C | Carry | Set if the last operation produced a carry out of bit 7, or a borrow in the case of subtraction. |
+
+Not every instruction updates every flag. Some instructions update all flags; some update only Z and C; some leave all flags unchanged. You will learn which flags each instruction affects as you encounter them in Part 2.
 
 ---
 
 ## The Fetch-Execute Cycle
 
-The CPU does one thing, over and over, as fast as its clock allows: it reads the byte at the address stored in PC, interprets it as an instruction, executes it, and updates PC to point past that instruction. This is called the **fetch-execute cycle**.
+The CPU does one thing, over and over: read the byte at address PC, interpret it as an instruction, carry it out, and advance PC to the next instruction. This is the **fetch-execute cycle**.
 
-Concretely:
-
-1. Read the byte at address PC. That byte is an instruction code.
-2. Carry out what the instruction says.
-3. Advance PC past the instruction. (Some instructions are one byte; some are two or three.)
-4. Go back to step 1.
-
-The CPU never stops to wonder what to do next. It just keeps fetching and executing.
-
-When the Z80 is powered on, PC starts at `$0000`. Execution therefore begins at the very first byte in memory — which is why ROM, containing your startup code, lives at address `$0000`.
+The Z80 starts with PC at `$0000`. The first byte fetched is therefore the byte at the lowest address in ROM — which is why ROM must occupy `$0000`. Some instructions are one byte long, some are two, three, or four. After executing an instruction, PC advances by exactly as many bytes as that instruction occupied, unless the instruction itself changes PC — jumps and calls do exactly that.
 
 ---
 
 ## Input and Output
 
-Memory handles storage, but a computer also communicates with the outside world: keyboards, displays, serial ports, storage devices. The Z80 connects to external hardware through **I/O ports**.
+Memory covers data and programs, but the Z80 also communicates with the outside world through **I/O ports** — a separate 256-address space, numbered 0 to 255, entirely independent of the `$0000`–`$FFFF` memory space. Each port typically connects to a hardware peripheral: a keyboard, a display, a serial line, or a timer. The instructions `IN` and `OUT` read from and write to ports.
 
-The Z80 has 256 I/O ports, numbered 0 to 255. Each port connects to a hardware device. You read from and write to ports using dedicated instructions (`in` and `out`). Ports are completely separate from memory — they do not occupy any addresses in the `$0000`–`$FFFF` range.
-
-Which devices connect to which ports depends entirely on the hardware the Z80 is installed in. We will come back to I/O in a later chapter, once you have the rest of the picture.
+Which device sits at which port number depends on the hardware. We will cover I/O in detail in Part 2, Chapter 7, once you have the instruction set under your belt.
 
 ---
 
 ## Summary
 
-- Memory is a flat array of 65,536 bytes, addressed `$0000` to `$FFFF`
-- Each byte holds a value 0–255; addresses identify which byte you mean
-- ROM holds fixed content and normally starts at `$0000`; RAM holds changeable content
-- The CPU has a small set of named registers for working data — A, B, C, D, E, H, L, SP, PC
-- PC contains the address of the next instruction; it starts at `$0000`
-- The CPU fetches, executes, and advances PC — endlessly, automatically
-- I/O ports connect to external hardware and are separate from the memory address space
-
-The next chapter shows what a program looks like when it is sitting in memory.
+- Memory is 65,536 bytes at addresses `$0000`–`$FFFF`; each byte holds 0–255
+- A byte is 8 bits; a word is 16 bits (two bytes)
+- The `0b` prefix marks binary numbers; the `$` prefix marks hexadecimal numbers
+- Four bits = one hex digit; conversion between binary and hex is direct and requires no arithmetic
+- The Z80 is little-endian: the low byte of a word is stored at the lower address
+- ROM occupies `$0000` (the startup address); RAM occupies the upper address space
+- The CPU has 20+ named registers; the main working registers are A, BC, DE, HL, IX, IY, SP, and PC
+- The flags register F records results of operations; its bits (S, Z, H, P/V, N, C) control conditional branches
+- PC always holds the address of the next instruction; the CPU fetches and executes endlessly
+- I/O ports form a separate 256-address space for hardware peripherals
 
 ---
 

--- a/learning/part1/02-machine-code.md
+++ b/learning/part1/02-machine-code.md
@@ -2,100 +2,110 @@
 
 # Chapter 2 — Machine Code
 
-## A Program Is Bytes
-
-A program is a sequence of bytes sitting in memory. That is all it is.
-
-The CPU does not know whether a byte is an instruction or a number — that distinction is entirely in how the byte is used. When PC points to an address, the CPU reads the byte there and treats it as an instruction. If that instruction says to read a value from another address, the byte at that address is treated as data.
-
-Instructions and data are both just bytes. The difference is whether the CPU is currently fetching an instruction or reading data.
+A program is a sequence of bytes in memory. The CPU fetches one byte, executes the corresponding operation, advances PC, and fetches the next. This chapter shows what that looks like concretely — actual opcodes, an actual hex program decoded instruction by instruction, and the reason assembly was invented.
 
 ---
 
-## A Real Program in Hex
+## Opcodes
 
-Here is a complete Z80 program written as raw hexadecimal bytes:
+The byte (or bytes) that represent an instruction are called its **opcode**. Each opcode is a fixed numeric code that the Z80's hardware decodes into an operation. Some instructions are one byte; others include one or more additional bytes carrying a constant value, a memory address, or an offset.
 
-```
-3E 05 47 3E 03 80 32 00 80 76
-```
+A few examples from the Z80 instruction set:
 
-Ten bytes. This is a real program that a real Z80 will execute. Let us decode it.
+| Byte sequence | Instruction | What it does |
+|---------------|-------------|--------------|
+| `$3E n` | `LD A, n` | Load the constant value `n` into A |
+| `$06 n` | `LD B, n` | Load the constant value `n` into B |
+| `$47` | `LD B, A` | Copy A into B |
+| `$80` | `ADD A, B` | Add B to A; result goes into A |
+| `$32 lo hi` | `LD (nn), A` | Store A at the 16-bit address `nn` |
+| `$3A lo hi` | `LD A, (nn)` | Load A from the 16-bit address `nn` |
+| `$76` | `HALT` | Stop the CPU |
 
----
-
-## Decoding by Hand
-
-The CPU starts at the first byte, `$3E`. On the Z80, `$3E` is the opcode for the instruction "load the next byte into register A." The next byte, `$05`, is the value to load. After these two bytes, A contains 5 and PC has moved forward by 2.
-
-```
-$0000: 3E    ; load next byte into A
-$0001: 05    ;   the value: 5
-```
-
-Next byte is `$47`. This is the opcode for "copy A into B." No extra byte needed — the instruction is one byte. B now contains 5. PC moves forward by 1.
-
-```
-$0002: 47    ; copy A into B
-```
-
-Next is `$3E` again — another "load next byte into A," this time with value `$03`. A now contains 3. B still holds 5.
-
-```
-$0003: 3E    ; load next byte into A
-$0004: 03    ;   the value: 3
-```
-
-Next byte is `$80`. This is "add B to A, result in A." A was 3, B is 5, so A becomes 8.
-
-```
-$0005: 80    ; add B to A
-```
-
-Next three bytes: `$32 $00 $80`. This is "store A at the address given by the next two bytes." On the Z80, 16-bit addresses are stored low byte first, so `$00 $80` means address `$8000`. The value 8 is written to memory location `$8000`.
-
-```
-$0006: 32    ; store A at address (follows)
-$0007: 00    ;   address low byte
-$0008: 80    ;   address high byte
-```
-
-Final byte: `$76`. This is HALT — the CPU stops.
-
-```
-$0009: 76    ; halt
-```
+Address operands always follow the Z80's little-endian convention: low byte first, high byte second. The address `$8000` appears in the instruction stream as `$00 $80`.
 
 ---
 
-## What the Program Did
+## A Complete Hex Program
 
-Starting at address `$0000`, the CPU executed those ten bytes and left the value 8 at memory address `$8000`. You can verify this by inspecting memory after the halt: address `$8000` contains `$08`.
+Here is a complete Z80 program written entirely as bytes, placed in memory starting at address `$0000`. It loads the values 5 and 3 into registers, adds them, and stores the result at address `$8000`.
 
-The program computed 5 + 3 and stored the result. That took ten bytes and required knowing that `$3E` means "load immediate into A", that `$80` means "add B to A", that `$32` means "store A at address", and that 16-bit addresses are stored low byte first.
+```
+$0000:  3E 05        ; LD A, 5         — load 5 into A
+$0002:  47           ; LD B, A         — copy A into B; B now holds 5, A holds 5
+$0003:  3E 03        ; LD A, 3         — load 3 into A; B still holds 5
+$0005:  80           ; ADD A, B        — A = A + B = 3 + 5 = 8
+$0006:  32 00 80     ; LD ($8000), A   — store A at address $8000
+$0009:  76           ; HALT
+```
+
+Ten bytes, starting at `$0000`, ending at `$0009`.
+
+### Stepping Through It
+
+The CPU starts with PC = `$0000`.
+
+**PC = `$0000`:** The byte there is `$3E`. The Z80 recognises this as a two-byte instruction: "load the next byte into A." It reads the following byte, `$05`, and loads 5 into A. PC advances to `$0002`.
+
+**PC = `$0002`:** The byte is `$47`: "copy A into B." One byte, no operand. B becomes 5; A remains 5. PC advances to `$0003`.
+
+**PC = `$0003`:** `$3E $03` — load 3 into A. B is unchanged and still holds 5. A is now 3. PC advances to `$0005`.
+
+**PC = `$0005`:** `$80` — add B to A. The Z80 adds the contents of B (5) to the contents of A (3) and puts the result (8) into A. The flags register is updated: Zero is clear (8 ≠ 0), Carry is clear (8 < 256), Sign is clear (bit 7 of 8 is 0). PC advances to `$0006`.
+
+**PC = `$0006`:** `$32 $00 $80` — store A at a 16-bit address. The opcode `$32` is followed by two address bytes: `$00` (low) and `$80` (high), giving address `$8000`. The value 8 is written to memory location `$8000`. PC advances to `$0009`.
+
+**PC = `$0009`:** `$76` — HALT. The CPU stops. Address `$8000` now contains `$08`.
 
 ---
 
-## The Problem
+## Variables
 
-Writing programs this way is possible. It is also painful in ways that compound as programs grow.
+In the program above, the result was written to the fixed address `$8000`. But `$8000` is embedded as raw bytes in the instruction at `$0006`. If you later decide the result should live at `$8100` instead, you must find that instruction and change bytes `$07` and `$08` by hand. If you have fifty instructions referencing the same address, you change fifty places.
 
-Every multi-byte instruction embeds a raw address or value. If you move your data to a different memory location, you update every instruction that references it — and you do it by hand, across the byte sequence, with no help. If you insert an instruction in the middle of the program, any address calculated from a position after that insertion is now wrong.
+This is the core problem with raw machine code: there is no concept of a name. Everything is a position number. The programmer must manually track what every address means and keep every reference consistent.
 
-A typo produces no error message. If you write `$83` instead of `$80`, you get "add E to A" instead of "add B to A." The program runs, produces a wrong answer, and offers no clue why.
+Assembly solves this with **labels**. A label is a name that the assembler associates with a particular address at assembly time. Everywhere you write the label, the assembler substitutes the correct address automatically. If the variable moves, you update the label's definition and every reference updates with it.
 
-Labels, meaningful names, and structure do not exist at this level. Everything is a position, an offset, or a raw value.
+In a traditional Z80 assembler the label definition looks like this:
 
-Nobody writes real programs as raw hex bytes. The next chapter shows the tool that solves this.
+```
+Result:          ; the assembler records "Result" as the current address
+  .byte 0        ; allocate one byte at this address
+```
+
+From this point on, writing `LD ($Result), A` in the code is equivalent to writing `LD ($8000), A` — but the programmer never has to know or write `$8000`. The assembler handles it.
+
+Labels also name positions within the code — the targets of jumps and branches. Instead of writing `JP $0034`, you write `JP loop_top`, and the assembler works out the address of `loop_top` itself.
+
+This is the single most important difference between machine code and assembly. Machine code is just bytes. Assembly adds names for addresses.
+
+---
+
+## Why Raw Machine Code Is Impractical
+
+The program above was ten bytes. Real programs are thousands. Writing them as raw hex creates compounding problems:
+
+**No names.** Every address is a number. `$8000` might be your result, or it might be a display buffer, or it might be the start of a lookup table. Nothing in the code tells you which.
+
+**Fragility.** Insert one instruction in the middle of the program and every address calculated from that point shifts. You update them all by hand, and one missed update produces a silent wrong result — not an error message.
+
+**Unreadability.** You cannot skim `3E 05 47 3E 03 80 32 00 80 76` and understand what the program does. You have to decode each byte from memory.
+
+**No structure.** Machine code has no subroutines, no loops, no conditionals — just bytes and addresses. Everything that programs need beyond raw arithmetic must be built by hand from jumps to raw addresses.
+
+An assembler does not change the fact that the CPU sees bytes. It changes what you, the programmer, have to write and maintain.
 
 ---
 
 ## Summary
 
-- A program is a sequence of bytes in memory; the CPU fetches and executes them in order
-- Each opcode byte has a specific meaning defined by the Z80; some opcodes are followed by additional bytes (values, addresses)
-- 16-bit addresses in instructions are stored low byte first, then high byte
-- Writing programs as raw hex is exact but fragile — a single wrong byte silently produces wrong behaviour with no indication of where the problem is
+- Every Z80 instruction has a specific numeric opcode; the CPU reads this byte and carries out the corresponding operation
+- Multi-byte instructions include operand bytes after the opcode: constants, addresses, or offsets
+- Address operands are always little-endian: low byte first
+- The CPU steps through instructions one at a time by following PC; PC advances by the length of each instruction
+- Raw machine code has no names, no structure, and breaks silently whenever you move things around
+- Labels — names for addresses — are the fundamental thing assembly adds over raw machine code
 
 ---
 

--- a/learning/part1/03-the-assembler.md
+++ b/learning/part1/03-the-assembler.md
@@ -2,38 +2,182 @@
 
 # Chapter 3 — The Assembler
 
-## Mnemonics
+An assembler reads a text source file and produces a binary — the byte sequence that goes into memory. The programmer writes instructions using mnemonics (human-readable names for opcodes) and labels (names for addresses), and the assembler handles the translation to bytes, the calculation of label addresses, and the resolution of every reference.
 
-The fundamental problem with raw machine code is not that the CPU is hard to understand — the fetch-execute cycle is straightforward. The problem is that hex bytes give you nothing to hold onto: no names, no structure, no indication of intent.
-
-An assembler solves this by letting you write instructions using **mnemonics** — human-readable names that correspond one-to-one with opcodes. Instead of writing `$3E $05`, you write:
-
-```
-ld a, 5
-```
-
-`ld` stands for "load." `a` names the destination register. `5` is the value. The assembler reads this text and produces the same bytes `$3E $05` that the CPU expects.
-
-Here is the program from Chapter 2, written as Z80 assembly mnemonics:
-
-```
-ld a, 5        ; load 5 into A
-ld b, a        ; copy A into B
-ld a, 3        ; load 3 into A
-add a, b       ; A = A + B
-ld ($8000), a  ; store result at address $8000
-halt           ; stop
-```
-
-Six readable lines instead of ten opaque bytes. The assembler translates them back into exactly the same byte sequence: `3E 05 47 3E 03 80 32 00 80 76`.
+This chapter covers the most important single instruction in the Z80 (`LD`), introduces the hardware stack, and shows what a complete ZAX program looks like from source to output.
 
 ---
 
-## A ZAX Program
+## The LD Instruction
 
-ZAX is an assembler for the Z80. It understands all the standard Z80 mnemonics, and adds a structured layer on top: named variables, typed storage, and control flow written in a readable form. But underneath, ZAX still produces raw machine code — the same bytes the CPU reads.
+`LD` is the Z80's load instruction. It copies a value from a source location to a destination location: a register, a memory address, or an immediate constant. Its general form is:
 
-Here is the same program written in ZAX:
+```
+ld destination, source
+```
+
+`LD` by itself does not affect the flags register. It is a pure copy — source is unchanged, destination receives the value, nothing else happens.
+
+Not every combination of source and destination is legal. The Z80's hardware supports specific pairings, and asking for an unsupported one is an assembler error. The rules are worth knowing in full, because `LD` is the most frequently used instruction in any Z80 program.
+
+### 8-bit register to register
+
+Any of the registers A, B, C, D, E, H, L can be copied to any other. The only restriction concerns the undivided halves of IX and IY (IXH, IXL, IYH, IYL): you can freely mix within one pair (`LD IXH, IXL` is valid), but you cannot mix between HL's bytes and IX's or IY's bytes in the same instruction.
+
+```zax
+ld a, b     ; A = B
+ld d, h     ; D = H
+ld l, c     ; L = C
+ld a, a     ; legal, pointless
+```
+
+### Immediate constant into register
+
+Any 8-bit register takes an immediate byte constant (0–255). Any 16-bit register pair or index register takes a 16-bit constant.
+
+```zax
+ld a, 42        ; A = 42
+ld b, $FF       ; B = 255
+ld hl, $8000    ; HL = $8000
+ld ix, $4000    ; IX = $4000
+```
+
+### Memory access through HL
+
+HL is the primary indirect address register. `(HL)` means "the byte at the address currently in HL."
+
+```zax
+ld a, (hl)     ; A = byte at address HL
+ld (hl), a     ; byte at address HL = A
+ld b, (hl)     ; B = byte at address HL
+ld (hl), 19    ; byte at address HL = 19  (immediate constant also valid here)
+```
+
+Any of A, B, C, D, E, H, L can appear on either side when the other side is `(HL)`.
+
+### Indexed memory access through IX and IY
+
+IX and IY support **displaced** (indexed) addressing: `(IX+n)` means "the byte at address IX + n", where n is a signed 8-bit offset from −128 to +127.
+
+```zax
+ld a, (ix+0)    ; A = byte at address IX
+ld b, (ix+7)    ; B = byte at address IX+7
+ld (iy-2), a    ; byte at address IY-2 = A
+ld (ix+1), $3F  ; byte at address IX+1 = $3F
+```
+
+This is the mechanism behind struct field access and array element access in ZAX — you set IX or IY to point to the start of a structure, then access fields at known offsets.
+
+### Memory access through BC or DE
+
+Only the accumulator A can be used with `(BC)` or `(DE)`:
+
+```zax
+ld a, (bc)     ; A = byte at address BC
+ld (de), a     ; byte at address DE = A
+```
+
+Neither `LD B, (BC)` nor `LD (DE), H` is legal.
+
+### Direct memory address
+
+A can be loaded from or stored to a fixed 16-bit address. 16-bit register pairs can also be loaded from or stored to memory, transferring both bytes in one instruction (little-endian, as always).
+
+```zax
+ld a, ($8000)      ; A = byte at $8000
+ld ($8001), a      ; byte at $8001 = A
+ld hl, ($8002)     ; HL = word at $8002–$8003 (little-endian)
+ld ($8004), bc     ; word at $8004–$8005 = BC (low byte first)
+```
+
+Note that `LD (nn), r` where `r` is a 16-bit pair works for BC, DE, HL, SP, IX, and IY. All are stored little-endian.
+
+### Two memory locations cannot be combined
+
+There is no single instruction that copies one memory address directly to another. You must go through a register:
+
+```zax
+; No such instruction: ld ($8001), ($8000)
+
+; Do this instead:
+ld a, ($8000)
+ld ($8001), a
+```
+
+### Summary of LD forms
+
+| Form | Example | Notes |
+|------|---------|-------|
+| reg8 ← reg8 | `ld a, b` | Any 8-bit register to any other (with IX/IY half-register restriction) |
+| reg8 ← n | `ld b, $FF` | Immediate 8-bit constant |
+| reg16 ← nn | `ld hl, $8000` | Immediate 16-bit constant |
+| reg8 ← (HL) | `ld c, (hl)` | Read byte at address HL |
+| (HL) ← reg8 | `ld (hl), d` | Write byte to address HL |
+| (HL) ← n | `ld (hl), 0` | Write immediate to address HL |
+| reg8 ← (IX+n) | `ld a, (ix+3)` | Read byte at IX + offset (n: −128 to +127) |
+| (IX+n) ← reg8 | `ld (ix+3), a` | Write byte to IX + offset |
+| A ← (BC) | `ld a, (bc)` | Read byte at address BC; A only |
+| (DE) ← A | `ld (de), a` | Write A to address DE; A only |
+| A ← (nn) | `ld a, ($8000)` | Read byte from fixed address |
+| (nn) ← A | `ld ($8001), a` | Write A to fixed address |
+| reg16 ← (nn) | `ld hl, ($8002)` | Read 16-bit word from memory |
+| (nn) ← reg16 | `ld ($8004), hl` | Write 16-bit word to memory |
+| SP ← reg16 | `ld sp, hl` | SP = HL (or IX or IY) |
+
+---
+
+## The Stack
+
+The **stack** is a region of RAM used for temporary storage of register values. It is managed through the stack pointer SP, which always points to the most recently stored item. The Z80 provides two instructions for using it: `PUSH` and `POP`.
+
+Both instructions work with 16-bit register pairs: AF, BC, DE, HL, IX, or IY.
+
+### PUSH
+
+`PUSH HL` does two things in sequence:
+1. SP is decremented by 2.
+2. The value of HL is written to memory at address SP — L at SP, H at SP+1 (little-endian).
+
+### POP
+
+`POP HL` does the inverse:
+1. The word at address SP is read: the byte at SP goes into L, the byte at SP+1 goes into H.
+2. SP is incremented by 2.
+
+### The stack is last-in, first-out
+
+Values come off the stack in the reverse order they went on. If you push BC and then push DE, popping gives you DE first and BC second.
+
+```zax
+push bc       ; save BC
+push de       ; save DE
+; ... do something that wrecks BC and DE ...
+pop de        ; restore DE (came off first — was pushed last)
+pop bc        ; restore BC (came off second — was pushed first)
+```
+
+This is the standard pattern for preserving registers across a block of code that would otherwise destroy them. You will see it constantly.
+
+### A useful trick
+
+There is no direct instruction to copy AF to another register pair or to access F directly. You can work around this using the stack: push AF, then pop into the target pair (where the byte that was F ends up in the low register).
+
+```zax
+push af
+pop hl        ; H = A, L = F
+```
+
+### The stack is ordinary RAM
+
+The stack is not a separate structure — it is the same RAM as your program and data. SP starts pointing somewhere in RAM (you set it up at the start of your program, or it is set for you), and push/pop move SP up and down within that area. There is nothing magical about it and nothing enforced — if you push more than you pop, SP drifts downward and will eventually collide with something you care about. It is your responsibility to keep pushes and pops balanced.
+
+---
+
+## A First ZAX Program
+
+ZAX wraps Z80 instructions in a structured outer form. A ZAX source file is organised into **sections** — declarations that tell the assembler where in the address space to place the code and data.
+
+Here is the addition program in complete ZAX:
 
 ```zax
 section data state at $8000
@@ -51,53 +195,51 @@ section code app at $0100
 end
 ```
 
-A few things to notice.
+### What each part means
 
-`section data state at $8000` tells ZAX that the variables declared below live starting at address `$8000`. ZAX calculates the exact address of `result` — you name it, ZAX tracks where it lives.
+`section data state at $8000` — declares a data section. The variables defined below will be placed in memory starting at address `$8000`. The assembler tracks the exact address of each variable for you.
 
-`section code app at $0100` tells ZAX that the code below starts at address `$0100`. (This is the convention used by CP/M, a common Z80 operating environment, which reserves the bottom of RAM for its own use.)
+`var result: byte` — declares one byte of named storage. The name `result` behaves as a label: everywhere you write `result` in the code, the assembler substitutes the actual address. If you add more variables before it or change the section's start address, every reference updates automatically.
 
-`var result: byte` names a one-byte storage location. Writing `result` in the code is clearer than writing `$8000`, and it stays correct even if you reorganise your data layout.
+`section code app at $0100` — declares a code section starting at address `$0100`. The `$0100` origin is a CP/M convention: the CP/M operating system occupies the bottom of RAM and loads application programs at `$0100`.
 
-`result := a` is ZAX syntax for "store A into the variable `result`." ZAX translates this into the store instruction `ld ($8000), a` — the same opcode as before.
+`export func main(): void` — declares the program's entry point. ZAX generates the function header automatically. The function's closing `end` emits a `ret` instruction, so you do not write one yourself.
 
-`export func main(): void` declares the program's entry point. ZAX automatically adds the housekeeping that a well-formed function needs: a header, a final `ret` instruction, and correct structure for the linker.
+`result := a` — ZAX's typed assignment operator. This specific form means "store the value of A into the byte variable `result`." The assembler translates it to `LD ($8000), A`.
 
----
+### The output
 
-## What ZAX Produces
+Running ZAX on this source produces a binary file. The bytes inside the function body are identical to the ones decoded in Chapter 2 — the same opcodes, now starting at `$0100` instead of `$0000`. The store to `$8000` is unchanged.
 
-When you run ZAX on that source file, it produces a binary — a sequence of bytes ready to be loaded into memory. The store to address `$8000` is still there; the result is still 8.
-
-The bytes are different from Chapter 2 only because the code now starts at `$0100` instead of `$0000`, and ZAX adds a small function header. The arithmetic is identical: 5 + 3, stored at `$8000`.
-
-ZAX does not change what the program does. It changes how you express it.
+ZAX does not change what the program does. It changes how you write and maintain it.
 
 ---
 
-## Why ZAX Goes Further
+## Beyond Mnemonics: What ZAX Adds
 
-Most assemblers stop at mnemonics — they translate names to bytes and track label addresses. ZAX adds things that become valuable as programs grow:
+Most assemblers stop at mnemonics and labels. ZAX goes further with features that become important as programs grow:
 
-**Named variables.** `result` instead of `$8000`. You add a variable and ZAX places it; you do not adjust addresses by hand when your layout changes.
+**Typed variables.** `var result: byte` not only names the storage location — it records what size it is. ZAX uses that information to generate the correct load and store instructions for `:=` assignments. This catches mismatches at assembly time rather than silently generating wrong code.
 
-**Typed storage.** `result := a` knows that `result` is a byte and generates the right store instruction. `:=` is ZAX's assignment operator; it handles the load or store sequence for you.
+**Typed function parameters.** Functions can declare what values they receive and what value they return. The assembler generates the correct load and store sequences at call sites.
 
-**Structured control flow.** `if`, `while`, `break`, and `func` generate correct conditional jumps and call sequences. You write the structure; ZAX counts the bytes and calculates the offsets.
+**Structured control flow.** `if`, `while`, `break`, and `continue` generate correct conditional jumps and loop structures, including the offsets that raw Z80 assembly requires you to calculate manually. You write the structure; the assembler produces the bytes.
 
-All of these features produce machine code. The CPU still sees bytes. ZAX just handles the bookkeeping that would otherwise be your problem.
+**`op` — inline expansion.** An `op` block is like a function, but its body is copied inline at every call site instead of being called with `CALL`/`RET`. This gives you the reuse of a named block without the overhead of a subroutine call.
+
+All of these still produce machine code. The CPU sees bytes. ZAX just handles the bookkeeping.
 
 ---
 
-## What Comes Next
+## Summary
 
-You now have the mental model:
-
-- A computer is a CPU, memory, and I/O ports (Chapter 1)
-- A program is bytes in memory; the CPU fetches and executes them (Chapter 2)
-- An assembler translates readable source into those bytes; ZAX adds structure on top of that (this chapter)
-
-Part 2 of this book teaches Z80 programming with ZAX in detail — the full instruction set, addressing modes, the stack, subroutines, and ZAX's typed features. Every chapter in Part 2 builds on the picture you have just established.
+- An assembler translates mnemonics and labels to bytes; label addresses are calculated and substituted automatically
+- `LD` copies a value from source to destination; it does not affect flags
+- Not all combinations of source and destination are legal — the key groupings are: register-to-register, immediate constant, indirect through HL, indexed through IX/IY, indirect through BC or DE (A only), and direct memory address
+- Two memory locations cannot both appear in a single `LD`; use a register as an intermediate
+- The stack is a region of RAM managed through SP; `PUSH` decrements SP by 2 and stores; `POP` loads and increments SP by 2
+- Pushes and pops must be balanced; the stack is ordinary RAM with no automatic protection
+- A ZAX program wraps instructions in `section` and `func` blocks; it adds typed variables, structured control flow, and typed function interfaces on top of standard Z80 assembly
 
 ---
 

--- a/learning/part2/01-numbers-and-registers.md
+++ b/learning/part2/01-numbers-and-registers.md
@@ -15,13 +15,13 @@ Prerequisites: Chapter 00 (bytes, addresses, the module shell).
 
 Every byte in the Z80 holds an eight-bit binary value. Each bit is either 0 or 1.
 The bits are numbered 7 (most significant, leftmost) down to 0 (least
-significant, rightmost). The binary value `%10000001` has bits 7 and 0 set and
+significant, rightmost). The binary value `0b10000001` has bits 7 and 0 set and
 all others clear; its decimal value is 128 + 1 = 129.
 
 Binary notation is precise but long. Hexadecimal (base 16) is shorter. One hex
 digit represents exactly four bits: `0`–`9` for values 0–9, `A`–`F` for
 values 10–15. Two hex digits describe a full byte. The binary byte
-`%10000001` written in hex is `$81` (8×16 + 1 = 129). ZAX uses the `$` prefix
+`0b10000001` written in hex is `$81` (8×16 + 1 = 129). ZAX uses the `$` prefix
 for hex literals throughout.
 
 The table below shows the correspondence for the sixteen possible four-bit
@@ -66,8 +66,8 @@ pattern `$80` is -128.
 
 Two's complement is the standard encoding for negative integers on the Z80.
 To compute the two's complement of a positive value, invert all bits and add
-one. The two's complement of `$01` (binary `%00000001`) is `%11111110 + 1 =
-%11111111 = $FF`, which is -1.
+one. The two's complement of `$01` (binary `0b00000001`) is `0b11111110 + 1 =
+0b11111111 = $FF`, which is -1.
 
 The CPU arithmetic instructions do not distinguish: `add a, b` performs the same
 bitwise addition regardless of whether you intend the values as signed or


### PR DESCRIPTION
## Summary

Substantial rewrite of all three Part 1 chapters. Previous versions were too brief and assumed too much. These versions build every concept from scratch with actual precision.

**Chapter 1 — The Computer**
- Binary arithmetic: full positional-value table showing how `0b01110101 = 117`
- Hexadecimal: step-by-step conversion `0b01110101 → $75 → 7×16+5 = 117`, explains why four bits = one hex digit
- Endianness: defined with a concrete memory layout diagram
- All Z80 registers in a complete table with roles (including IX, IY, SP, PC, I, R)
- Shadow registers and `EX AF`/`EXX` explained
- Flags register: full bit-by-bit table (S, Z, H, P/V, N, C) with meanings

**Chapter 2 — Machine Code**
- Opcode table showing byte sequences for core instructions
- The 5+3 program walked through with PC tracking at each step
- Labels introduced as the defining difference between machine code and assembly
- Four specific reasons raw hex is impractical at scale

**Chapter 3 — The Assembler**
- `LD` instruction covered completely: all legal groupings, summary table, two-memory restriction stated explicitly
- Stack: precise semantics ("SP decremented by 2, then HL written to (SP)"), LIFO pattern, save/restore example, AF-via-stack trick
- ZAX `section`/`func`/`var` structure annotated line by line

**Binary prefix**: changed from `%` to `0b` throughout (`0b01110101`, `0b11111111`, etc.). ZAX accepts both; `0b` follows C conventions and is less ambiguous in prose. Part 2 ch1 updated to match.

## Test plan
- [ ] Read all three chapters end-to-end for accuracy
- [ ] Verify binary/hex examples cross-check correctly
- [ ] Verify opcode bytes in Chapter 2 table against Z80 manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)