### PR TITLE
Tighten prose, fix label ambiguity, trim rhetoric

### DIFF
--- a/learning/part1/01-the-computer.md
+++ b/learning/part1/01-the-computer.md
@@ -70,7 +70,7 @@ The CPU itself does not know or care what kind of memory chip sits behind any gi
 
 **RAM** (random-access memory) can be freely read and written, but loses its contents when power is removed. RAM is where your running program stores variables, the stack, and any data it creates or modifies.
 
-A system's **memory map** describes which address ranges connect to which chips. There is no single standard layout — it varies from system to system. A small Z80 board might look like this:
+A system's **memory map** describes which address ranges connect to which chips. There is no single standard layout — it varies from system to system. A typical small Z80 board might look like this:
 
 ```
 $0000–$1FFF   ROM   (8 KB — startup code)
@@ -78,7 +78,7 @@ $2000–$7FFF   RAM   (24 KB — program and data)
 $8000–$FFFF   —     (unmapped, or more RAM, or memory-mapped I/O)
 ```
 
-Another system might have ROM at the top and RAM at the bottom, or multiple ROM chips at different address ranges, or bank-switched memory that maps different physical chips into the same address window depending on a control register. The Z80 imposes only one constraint: when it powers on or resets, the program counter starts at `$0000`, so whatever memory is mapped at that address must contain valid code. On many systems that means ROM at `$0000`, but on others, hardware logic copies code into RAM before the CPU starts, or a boot ROM runs briefly and then switches itself out of the address space. The point is that the memory map is a hardware decision, not a CPU rule.
+The Z80 imposes only one constraint: when it powers on or resets, the program counter starts at `$0000`, so whatever memory is mapped there must contain valid code. On the board above, that means ROM. Other boards arrange things differently — the memory map is always a hardware decision, not a CPU rule.
 
 What matters for you as a programmer is knowing the memory map of the specific system you are targeting. The assembler needs to know where to place your code and data so that the addresses in the output binary match the hardware layout.
 

--- a/learning/part1/06-flags-comparisons-jumps.md
+++ b/learning/part1/06-flags-comparisons-jumps.md
@@ -260,7 +260,7 @@ loop_top:
 end
 ```
 
-**Part 1 — equality test.** `ld a, Limit` loads 5 into A. `cp 5` subtracts 5
+**Section A — equality test.** `ld a, Limit` loads 5 into A. `cp 5` subtracts 5
 from A and sets Z. Because A equals 5, Z is set. `jp nz, not_equal` tests
 whether Z is clear: it is set, so the jump does not occur. Execution continues
 through `ld a, 1 / ld (found), a`, then `jp done_compare` skips the else-block
@@ -269,7 +269,7 @@ and lands at `done_compare:`.
 If A had held any value other than 5, Z would have been clear, `jp nz` would
 have branched to `not_equal:`, and `found` would have been set to 0.
 
-**Part 2 — zero test with `or a`.** `ld a, 0` loads zero. `or a` sets Z because
+**Section B — zero test with `or a`.** `ld a, 0` loads zero. `or a` sets Z because
 A is zero. `jp z, was_zero` branches because Z is set. The instruction
 `ld a, $AA` executes as the "zero was detected" branch; this marks the register
 so you can verify in a debugger or simulator that this path ran. `jp skip_zero`
@@ -278,10 +278,10 @@ then skips past the end of the zero-branch.
 This pair — `jp z, was_zero` / `jp skip_zero` — is the raw conditional branch
 pattern defined in "Label-based control flow structure" above: set a flag, use a
 conditional jump to enter or skip a consequence block, and place an exit label
-after it. The only difference from the `cp`-based Part 1 is that `or a` sets
+after it. The only difference from the `cp`-based Section A is that `or a` sets
 the flag here instead of `cp`.
 
-**Part 3 — counted loop with `dec` / `jp nz`.** `ld b, Limit` initializes B to
+**Section C — counted loop with `dec` / `jp nz`.** `ld b, Limit` initializes B to
 5. At `loop_top:`, the body reads `counter` from RAM, increments it, and stores
 it back. `dec b` decrements B and sets Z when B reaches zero. `jp nz, loop_top`
 branches back while B is non-zero.

--- a/learning/part1/07-counting-loops-and-djnz.md
+++ b/learning/part1/07-counting-loops-and-djnz.md
@@ -118,7 +118,7 @@ pre-test is needed.
 ## What the registers hold after a loop
 
 It is worth pausing to think about what state the CPU is in after a loop
-finishes. Consider the counted loop from Part 1 of the example below, which
+finishes. Consider the counted loop from Section A of the example below, which
 sums the five bytes `{ 3, 7, 2, 8, 5 }`:
 
 ```zax
@@ -235,7 +235,7 @@ all valid).
 
 The program runs three loop forms side by side over the same five-element table.
 
-**Part 1 — DJNZ counted loop.**
+**Section A — DJNZ counted loop.**
 
 ```zax
 ld hl, addends
@@ -253,7 +253,7 @@ sets B to 5. The body adds the current byte at HL to A and increments HL. DJNZ
 decrements B and loops back while B is non-zero. After 5 iterations B = 0, the
 loop exits, and `total` receives 25 ($19): the sum of 3 + 7 + 2 + 8 + 5.
 
-**Part 2 — sentinel loop (cp / jr z).**
+**Section B — sentinel loop (cp / jr z).**
 
 ```zax
 ld hl, addends
@@ -278,7 +278,7 @@ matched byte. DJNZ provides the overrun guard: if 8 were not present, the loop
 would exhaust all five entries and fall through to `ld a, $FF`. Because 8 is
 the fourth entry, `scanval` receives 8.
 
-**Part 3 — flag-exit loop.**
+**Section C — flag-exit loop.**
 
 ```zax
 ld hl, addends

--- a/learning/part1/08-data-tables-and-indexed-access.md
+++ b/learning/part1/08-data-tables-and-indexed-access.md
@@ -195,7 +195,7 @@ section data vars at $8020
 end
 ```
 
-**Part 1 — sequential HL loop, accumulating a sum.**
+**Section A — sequential HL loop, accumulating a sum.**
 
 ```zax
 ld hl, scores
@@ -212,7 +212,7 @@ HL walks the six score bytes. Each `add a, (hl)` adds the current byte to A.
 After six iterations, A = 10 + 20 + 30 + 40 + 50 + 60 = 210 (`$D2`), which is
 stored in `sum`.
 
-**Part 2 — sequential HL loop, finding the maximum.**
+**Section B — sequential HL loop, finding the maximum.**
 
 ```zax
 ld hl, scores
@@ -235,7 +235,7 @@ set if A is less than C. `jr nc` skips the update when A is already greater than
 or equal to C. `ld a, c` runs only when a new maximum is found. After six
 entries, `max_score` holds 60 (`$3C`).
 
-**Part 3 — IX+d access on a packed record table.**
+**Section C — IX+d access on a packed record table.**
 
 ```zax
 ld ix, records + RecSize    ; IX = base of record 1

--- a/learning/part1/14-functions-arguments-and-op.md
+++ b/learning/part1/14-functions-arguments-and-op.md
@@ -164,22 +164,10 @@ Chapter 9 established this rule; it applies to all three chapters.
 
 ## Undocumented opcodes: IXH, IXL, IYH, IYL
 
-The Z80's index registers IX and IY can each be split into 8-bit halves — IXH
-and IXL for IX, IYH and IYL for IY — just as HL splits into H and L. Zilog
-never listed these half-register instructions in the original Z80 data sheet,
-but programmers discovered them in the early 1980s by experimenting with the
-prefix-byte encoding. Every Z80-compatible CPU executes them correctly, and they
-have been in routine use for over forty years. The label "undocumented" is
-historical; in practice they are as reliable as any other Z80 instruction.
-
-ZAX supports all IXH/IXL/IYH/IYL instructions unconditionally — there is no
-flag to enable or disable them.
-
-The half-registers obey one hardware constraint described in Chapter 4: because
-the CPU uses a single prefix byte (`$DD` for IX, `$FD` for IY) to select which
-register family an instruction refers to, you cannot mix halves from different
-families in the same instruction. `ld ixh, ixl` is valid; `ld ixh, iyl` is not.
-Any combination with A, B, C, D, or E is fine:
+Chapter 4 introduced the half-index registers IXH, IXL, IYH, and IYL and the
+prefix-byte constraint that prevents mixing halves from different register
+families in one instruction. ZAX supports all half-index instructions
+unconditionally.
 
 ```zax
 ld ixh, a       ; store A in the high half of IX
@@ -188,11 +176,15 @@ ld ixl, b       ; store B in IXL
 add a, ixh      ; add IXH to A
 ```
 
-The halves are most useful when you need extra byte-sized scratch storage beyond
-A–L. Because the ZAX function frame uses IX as its base pointer, IXH and IXL
-are not available inside functions that have parameters or typed locals — the
-compiler owns IX for frame addressing in that context. Outside a frame (or in
-frameless functions), the halves are free to use.
+The practical constraint that matters in this chapter is the **frame conflict**.
+The ZAX function frame uses IX as its base pointer: every parameter and local is
+accessed as an offset from IX. Inside any function that has parameters or typed
+locals, the compiler owns IX, and IXH/IXL are unavailable. IYH and IYL remain
+free unless IY is also in use.
+
+In frameless functions — those with no parameters and no locals — IX is not
+claimed by the compiler, and all four halves are available as extra byte-sized
+scratch registers.
 
 ---
 
@@ -397,11 +389,9 @@ of the repetitive work the compiler does for you.
 
 ## Summary
 
-- IXH, IXL, IYH, and IYL are half-index-register instructions omitted from
-  Zilog's original documentation but universally supported by Z80 hardware. ZAX
-  enables them unconditionally. The only constraint is that halves from
-  different register families (HL, IX, IY) cannot appear in the same
-  instruction.
+- IXH, IXL, IYH, and IYL (Chapter 4) are supported unconditionally in ZAX.
+  Inside framed functions, IXH/IXL are unavailable because the compiler uses IX
+  for frame addressing. In frameless functions, all four halves are free.
 - ZAX pseudo-opcodes — `ld hl, de`, `ld de, bc`, and the other four pair-to-pair
   combinations — expand to two 8-bit moves. They add no run-time cost and make
   16-bit register transfers readable at a glance.

--- a/learning/part2/09-gaps-and-futures.md
+++ b/learning/part2/09-gaps-and-futures.md
@@ -98,9 +98,8 @@ a recursive call chain from inside a nested frame. In a language with named
 exits from nested structures, the termination would propagate structurally
 instead of through a shared flag.
 
-The evidence is now written code, not speculation. The issue is open and the
-gap is grounded, but no design has been finalised. Whether the right answer is
-a named exit label, a propagated break, or something else is genuinely open.
+No design has been finalised. Whether the right answer is a named exit label,
+a propagated break, or something else is an open question.
 
 ---
 
@@ -109,10 +108,10 @@ a named exit label, a propagated break, or something else is genuinely open.
 Working through the course examples surfaced the following gaps.
 
 **Already addressed**: Structured loop escape — `break` and `continue` — was
-the highest-priority signal from `eight_queens.zax` and the broader course. It
-is implemented and available on the current surface. The course examples use it.
+the highest-priority gap identified from `eight_queens.zax` and the broader
+course. It is now implemented. The course examples use it.
 
-**Real and grounded, design open**:
+**Design open**:
 
 - _Named exit from nested structures._ The `found_solution` flag in
   `eight_queens.zax` is a direct workaround for this. The gap is recorded;


### PR DESCRIPTION
## Summary

Addresses the three review comments from PR #964 plus one optional polish item:

- **Chapter 1**: Simplify memory map section — teach the default layout first, then a single sentence noting other boards differ. Removes the paragraph enumerating bank switching, boot-copy-to-RAM, and multiple ROM chips that overloaded the beginner model.
- **Chapter 14**: Collapse the IXH/IXL section from a repeated history lesson into a brief Chapter 4 callback. The new text focuses on the frame-availability tradeoff (IX owned by compiler inside framed functions) which is the actionable information at this point in the course.
- **Part 2 Chapter 9**: Trim meta-status rhetoric ("the evidence is now written code", "real and grounded, design open") — keep only the specific claim, workaround, and open question.
- **Chapters 6, 7, 8**: Rename walkthrough labels from "Part 1/2/3" to "Section A/B/C" to eliminate visual ambiguity with the book's Part 1/Part 2 structure.

## Test plan

- [ ] No source changes — `npm test` unaffected
- [ ] Spot-check renamed section labels render correctly on GitHub
- [ ] Read Chapter 1 memory section and Chapter 14 IXH section for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)