### PR TITLE
Fix perimeter math error and tighten four prose issues

### DIFF
--- a/learning/part1/01-the-computer.md
+++ b/learning/part1/01-the-computer.md
@@ -4,7 +4,7 @@
 
 Every computer, at the lowest level, runs **machine code** — raw numeric instructions built into the CPU's hardware. High-level languages like C or Python hide the machine entirely; a compiler or interpreter handles the translation down to those numbers. Assembly does not hide the machine. Each line you write corresponds directly to one CPU instruction, and the assembler's job is mostly mechanical: turn your readable text into the exact bytes the CPU expects.
 
-This directness is both the appeal and the difficulty. You get full control — every register, every memory access, every branch is yours to specify. Nothing happens unless you ask for it. But you also carry the full burden: you must understand what the CPU can do, how it stores data, and how it steps through a program byte by byte. There is no safety net of type checking, garbage collection, or automatic memory management. This is what makes assembly harder to learn than other languages: you have to think like the computer rather than in the abstractions that high-level languages provide.
+Assembly requires you to think like the computer. You get full control — every register, every memory access, every branch is yours to specify. Nothing happens unless you ask for it. But you also carry the full burden: you must understand what the CPU can do, how it stores data, and how it steps through a program byte by byte. There is no safety net of type checking, garbage collection, or automatic memory management.
 
 ZAX is an assembler for the Z80 that adds some structure on top — named variables, typed storage, and control flow keywords like `if` and `while` — but the underlying model is the same. Every ZAX program compiles down to Z80 machine code, and understanding that machine code is what this book teaches.
 
@@ -102,7 +102,7 @@ Read it back: the byte at `$8000` is `$2B` (low), the byte at `$8001` is `$1A` (
 
 The CPU (central processing unit) is the chip that does the work. It reads bytes from memory, interprets them as instructions, and carries them out one after another. To carry out those instructions, the CPU needs a small amount of very fast internal storage. That storage is called the **registers**.
 
-Registers are not part of RAM. They are built into the CPU itself, much faster to access than any external memory. The Z80 has only 26 bytes of register storage in total — a tiny amount compared to the 64K of addressable memory. It is not useful to think of them as a single block; each register has its own name and its own special roles. Almost every instruction you write uses at least one register, and almost every calculation must pass through them — there are very few Z80 operations that work directly on memory without involving a register.
+Registers are not part of RAM. They are built into the CPU itself, much faster to access than any external memory. The Z80 has only 26 bytes of register storage in total — a tiny amount compared to the 64K of addressable memory. Each register has its own name and its own special roles. Almost every instruction you write uses at least one register, and almost every calculation must pass through them — there are very few Z80 operations that work directly on memory without involving a register.
 
 Here is the complete Z80 register set:
 

--- a/learning/part1/03-the-assembler.md
+++ b/learning/part1/03-the-assembler.md
@@ -156,7 +156,7 @@ add a, a            ; A = (Height + Width + Width) * 2    ← WRONG
 ld (Perim), a       ; stores the wrong value
 ```
 
-The final `ADD A, A` does not double the original width — it doubles the running total in A, which by that point is already Height + 2 × Width. The result is `2 × (Height + 2 × Width)`, which is Height × 2 too large.
+The final `ADD A, A` does not double the original width — it doubles the running total in A, which by that point is already Height + 2 × Width. The result is `2 × (Height + 2 × Width)`, which is 2 × Width too large.
 
 The mistake is natural if you think of `ADD` as an algebraic operator. It is not. It is an instruction that replaces the contents of A with a new value, and every subsequent instruction sees the new value, not the original. This kind of ordering bug is common in assembly, easy to miss, and produces no error message — just a wrong answer.
 

--- a/learning/part1/06-flags-comparisons-jumps.md
+++ b/learning/part1/06-flags-comparisons-jumps.md
@@ -193,8 +193,8 @@ bits — the only difference is how you interpret bit 7. Comparing against `$80`
 is the dividing line between the two halves: 0–127 (non-negative) and 128–255
 (negative when read as signed).
 
-Note that `neg` applied to -128 produces 128, which overflows back to -128 in
-a signed byte. The absolute value of -128 does not fit in 8 bits.
+Note that `neg` applied to -128 gives -128 — the mathematical result (+128)
+does not fit in a signed byte, so the bit pattern (`$80`) is unchanged.
 
 ---
 

--- a/learning/part1/07-counting-loops-and-djnz.md
+++ b/learning/part1/07-counting-loops-and-djnz.md
@@ -6,8 +6,7 @@ There are no loops in assembly. There are no subroutines, no if-statements, no
 structured blocks of any kind. The language is nothing but individual
 instructions, one after another. Every structure that exists in high-level
 languages — loops, conditionals, function calls — you build yourself out of
-jumps and labels. This might sound limiting, but it gives you complete freedom
-of creation: the CPU does exactly what you tell it, nothing more.
+jumps and labels. The CPU does exactly what you write, nothing more.
 
 This chapter introduces `djnz`, the Z80's single-instruction counted loop
 primitive. After reading it you will be able to write a DJNZ counted loop, a


### PR DESCRIPTION
## Summary

All five issues from the second review are still relevant and are fixed here:

1. **Ch03 — factual error**: The perimeter bug explanation said "Height × 2 too large" but the correct difference is 2 × Width (since 2(H+2W) − 2(H+W) = 2W)
2. **Ch01 — redundant sentence**: Moved "think like the computer" to the paragraph opening as framing; removed the trailing restatement that said in vague terms what the preceding sentences already said concretely
3. **Ch01 — defensive phrasing**: Removed "It is not useful to think of them as a single block" — the reader hasn't had this misconception yet
4. **Ch07 — empty rhetoric**: Cut "This might sound limiting, but it gives you complete freedom of creation:" — the useful claim is "The CPU does exactly what you write, nothing more"
5. **Ch06 — ambiguous neg/-128**: Changed from "produces 128, which overflows back to -128" (sounds like two values) to "the mathematical result (+128) does not fit in a signed byte, so the bit pattern is unchanged"

## Test plan

- [ ] No source changes — `npm test` unaffected
- [ ] Verify the perimeter arithmetic: 2(H + 2W) = 2H + 4W; correct = 2H + 2W; error = 2W ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)