### PR TITLE
Minor polish: soften universal claim, tighten status prose

### DIFF
--- a/learning/part1/04-numbers-and-registers.md
+++ b/learning/part1/04-numbers-and-registers.md
@@ -151,10 +151,9 @@ of general registers.
 Zilog's original Z80 documentation did not list IXH, IXL, IYH, or IYL as
 supported instructions. They were discovered by programmers who noticed that the
 prefix-byte encoding made them work, and they have been in common use since the
-early 1980s. Every Z80-compatible CPU executes them correctly, and modern
-assemblers — ZAX included — support them without qualification. You will
-sometimes see them called "undocumented instructions," but by now they are
-standard practice.
+early 1980s. Modern assemblers — ZAX included — support them without
+qualification. You will sometimes see them called "undocumented instructions,"
+but by now they are standard practice.
 
 There is a hardware constraint to be aware of. The Z80 encodes H, L, IXH, IXL,
 IYH, and IYL using the same bit positions in the instruction byte. The CPU

--- a/learning/part2/09-gaps-and-futures.md
+++ b/learning/part2/09-gaps-and-futures.md
@@ -81,11 +81,10 @@ because `break` exits only the innermost loop, not the entire recursive call
 chain — but the constraint-check skips use `continue` cleanly rather than
 nesting `if/else` blocks or duplicating the loop increment.
 
-The friction log entry for Chapter 09 marks this as the clearest language signal from
-the entire course: structured loop escape was the highest-priority language gap,
-and `break` and `continue` have since landed. The `eight_queens.zax` example was
-written after that landing; the `continue` in the constraint checks and the
-`break` after finding a solution are both using settled, implemented syntax.
+Structured loop escape — `break` and `continue` — was the highest-priority
+language gap identified during the course. Both are now implemented. The
+`eight_queens.zax` example uses `continue` in the constraint checks and `break`
+after finding a solution.
 
 ---
 


### PR DESCRIPTION
## Summary

Two optional polish items from the latest review pass:

- **Ch04**: Remove "Every Z80-compatible CPU executes them correctly" — the same fact-check-bait removed from Ch14 was still in Ch04. The surrounding sentences (common use since 1980s, standard practice, ZAX supports them) already establish reliability.
- **Part 2 Ch09**: Replace "clearest language signal from the entire course" / "settled, implemented syntax" with a direct three-sentence statement of what was implemented.

## Test plan

- [ ] No source changes — `npm test` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)