### PR TITLE
Fix naming consistency, CP/M framing, rhetoric, and entry pacing

### DIFF
--- a/learning/part1/03-the-assembler.md
+++ b/learning/part1/03-the-assembler.md
@@ -237,7 +237,7 @@ end
 
 `var result: byte` — declares one byte of named storage. The name `result` behaves as a label: everywhere you write `result` in the code, the assembler substitutes the actual address. If you add more variables before it or change the section's start address, every reference updates automatically.
 
-`section code app at $0100` — declares a code section starting at address `$0100`. The `$0100` origin is a CP/M convention: the CP/M operating system occupies the bottom of RAM and loads application programs at `$0100`.
+`section code app at $0100` — declares a code section starting at address `$0100`. The starting address depends on your target system's memory map. This example uses `$0100`, which is where the CP/M operating system loads application programs. A different board might use `$0000`, `$4000`, or any other address — you set it to match whatever hardware or loader you are targeting.
 
 `export func main(): void` — declares the program's entry point. ZAX generates the function header automatically. The function's closing `end` emits a `ret` instruction, so you do not write one yourself.
 

--- a/learning/part1/README.md
+++ b/learning/part1/README.md
@@ -27,14 +27,18 @@ Continue with [Part 2 — Algorithms and Data Structures in ZAX](../part2/README
 | 13 | [Structured Control Flow](13-structured-control-flow.md) | `if`/`while`/`break`/`continue`, `select`/`case`, structured programming in ZAX |
 | 14 | [Functions, Arguments, and Op](14-functions-arguments-and-op.md) | ZAX functions, typed parameters, `op` for inline expansion |
 
-Example files are under `examples/` in this directory.
+Example files are under `examples/` in this directory. The examples are numbered
+starting from `00` and correspond to chapters starting from Chapter 3:
+`00_first_program.zax` goes with Chapter 3, `01_register_moves.zax` with
+Chapter 4, and so on. Chapters 1 and 2 have no example files — they cover
+concepts that precede writing code.
 
 ---
 
 ## How to compile the examples
 
 ```sh
-npm run zax -- learning/part1/examples/00_first_program.zax
+npm run zax -- learning/part1/examples/01_register_moves.zax
 ```
 
 ---

--- a/learning/part2/00-introduction.md
+++ b/learning/part2/00-introduction.md
@@ -14,9 +14,8 @@ basics are already familiar.
 
 The chapters are built around practical programs. They cover arrays, strings,
 bit manipulation, records, recursion, composition, pointer structures, and a
-capstone search problem. The point is not to admire named algorithms as museum
-pieces. The point is to study real ZAX code that solves non-trivial problems
-and to learn how the language helps keep that code readable.
+capstone search problem. Each one works through real ZAX code that solves a
+non-trivial problem, and shows how the language helps keep that code readable.
 
 ## What ZAX Gives You Here
 

--- a/learning/part2/01-foundations.md
+++ b/learning/part2/01-foundations.md
@@ -11,13 +11,20 @@ keeps the working patterns visible before the language grows wider.
 
 ## Variables and Types
 
+In raw Z80 code, every intermediate value lives in a register or at a
+hand-chosen memory address. You track which register holds what, and if you run
+out of registers you spill to memory yourself. ZAX typed variables replace that
+manual tracking: you give a value a name and a type, and the compiler handles
+where it lives.
+
 ZAX has four scalar storage types: `byte` (8-bit unsigned), `word` (16-bit
 unsigned), `addr` (16-bit, signals a memory address), and `ptr` (16-bit,
-signals a pointer to something). In the Chapter 01 examples only `byte` and `word`
-appear — the others become relevant when dealing with arrays and records.
+signals a pointer to something). In these examples only `byte` and `word`
+appear — the others become relevant when you start working with arrays and
+records.
 
-Storage exists in two places: named `data` sections at module scope, and `var`
-blocks inside function bodies.
+You can declare storage in two places: named `data` sections at module scope,
+and `var` blocks inside function bodies.
 
 A `var` block declares function-local scalars with optional initializers:
 

--- a/learning/part2/README.md
+++ b/learning/part2/README.md
@@ -20,7 +20,8 @@ This part is for readers who already understand the Z80 basics — either from P
 | 8  | [Pointer Structures](08-pointer-structures.md) | Typed reinterpretation, unions, linked list, binary search tree. |
 | 9  | [Gaps and Futures](09-gaps-and-futures.md) | What ZAX can't yet do, known language gaps, eight queens capstone. |
 
-Chapter 1's examples are in `examples/unit1/`, Chapter 2's in `examples/unit2/`, and so on.
+Each chapter's examples are in a matching subdirectory: Chapter 1's examples
+are in `examples/unit1/`, Chapter 2's in `examples/unit2/`, and so on.
 
 ---
 
@@ -29,8 +30,6 @@ Chapter 1's examples are in `examples/unit1/`, Chapter 2's in `examples/unit2/`,
 ```sh
 npm run zax -- learning/part2/examples/unit1/fibonacci.zax
 ```
-
-Example files are under `examples/` in this directory, organised by unit.
 
 ---
 


### PR DESCRIPTION
## Summary

Addresses five findings from the rubric-based review:

1. **Naming consistency** (Part 1 README): Explain the example-to-chapter offset — examples start at `00` but chapters start at 1; Chapters 1–2 have no example files. Changed compile example from `00_first_program.zax` to `01_register_moves.zax`.
2. **Naming consistency** (Part 2 README): Clarify that `unit1/` maps to Chapter 1 etc. Remove redundant "organised by unit" line.
3. **CP/M framing** (Ch03): The first complete program used `$0100` and explained it as "a CP/M convention" with no caveat. Now explains the address is system-dependent, with `$0100` as one example.
4. **"Museum pieces"** (Part 2 intro): Removed the contrastive flourish. The paragraph now states directly what the chapters do.
5. **Problem before mechanism** (Part 2 Ch1): Added an opening paragraph to the Variables section explaining what raw register juggling costs, before listing the four types.

**Not addressed** (structural, needs separate discussion):
- Chapter 1 scope — the review notes it covers too many concepts for first contact. This would require splitting the chapter or deferring shadow registers / flags detail / I/O, which is a larger restructuring decision.

## Test plan

- [ ] No source changes — `npm test` unaffected
- [ ] Verify Part 1 README compile example path is valid
- [ ] Read Ch03 first-program section for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)