### PR TITLE
Replace := with ld (result), a in early Chapter 3 example

### DIFF
--- a/learning/BOOK.md
+++ b/learning/BOOK.md
@@ -662,7 +662,7 @@ section code app at $0100
     ld b, a
     ld a, 3
     add a, b
-    result := a
+    ld (result), a
   end
 end
 ```
@@ -677,7 +677,7 @@ end
 
 `export func main(): void` — declares the program's entry point. ZAX generates the function header automatically. The function's closing `end` emits a `ret` instruction, so you do not write one yourself.
 
-`result := a` — ZAX's typed assignment operator. This specific form means "store the value of A into the byte variable `result`." The assembler translates it to `LD ($8000), A`.
+`ld (result), a` — stores the value of A into the byte variable `result`. The parentheses around the name mean "the memory address of." The assembler substitutes the actual address, so this becomes `LD ($8000), A`.
 
 ### The output
 
@@ -691,7 +691,7 @@ ZAX does not change what the program does. It changes how you write and maintain
 
 Most assemblers stop at mnemonics and labels. ZAX goes further with features that become important as programs grow:
 
-**Typed variables.** `var result: byte` not only names the storage location — it records what size it is. ZAX uses that information to generate the correct load and store instructions for `:=` assignments. This catches mismatches at assembly time rather than silently generating wrong code.
+**Typed variables.** `var result: byte` not only names the storage location — it records what size it is. ZAX uses that information later to generate correct load and store sequences automatically. This catches mismatches at assembly time rather than silently generating wrong code.
 
 **Typed function parameters.** Functions can declare what values they receive and what value they return. The assembler generates the correct load and store sequences at call sites.
 

--- a/learning/part1/03-the-assembler.md
+++ b/learning/part1/03-the-assembler.md
@@ -226,7 +226,7 @@ section code app at $0100
     ld b, a
     ld a, 3
     add a, b
-    result := a
+    ld (result), a
   end
 end
 ```
@@ -241,7 +241,7 @@ end
 
 `export func main(): void` — declares the program's entry point. ZAX generates the function header automatically. The function's closing `end` emits a `ret` instruction, so you do not write one yourself.
 
-`result := a` — ZAX's typed assignment operator. This specific form means "store the value of A into the byte variable `result`." The assembler translates it to `LD ($8000), A`.
+`ld (result), a` — stores the value of A into the byte variable `result`. The parentheses around the name mean "the memory address of." The assembler substitutes the actual address, so this becomes `LD ($8000), A`.
 
 ### The output
 
@@ -255,7 +255,7 @@ ZAX does not change what the program does. It changes how you write and maintain
 
 Most assemblers stop at mnemonics and labels. ZAX goes further with features that become important as programs grow:
 
-**Typed variables.** `var result: byte` not only names the storage location — it records what size it is. ZAX uses that information to generate the correct load and store instructions for `:=` assignments. This catches mismatches at assembly time rather than silently generating wrong code.
+**Typed variables.** `var result: byte` not only names the storage location — it records what size it is. ZAX uses that information later to generate correct load and store sequences automatically. This catches mismatches at assembly time rather than silently generating wrong code.
 
 **Typed function parameters.** Functions can declare what values they receive and what value they return. The assembler generates the correct load and store sequences at call sites.
 


### PR DESCRIPTION
## Summary
- Replaces `result := a` with `ld (result), a` in Chapter 3's first ZAX program example
- Updates the explanation to describe standard Z80 parenthesised address syntax instead of the `:=` operator
- Adjusts the "Typed variables" paragraph to defer `:=` mention — it is properly introduced in Chapter 12
- Applies the same changes in BOOK.md

## Rationale
Early chapters should stay close to classic Z80 syntax. The `:=` assignment operator is a ZAX-specific feature that belongs in Chapter 12 (Typed Storage and Assignment), not in the reader's first encounter with a ZAX program.

## Test plan
- [ ] Verify Chapter 3 code example uses `ld (result), a`
- [ ] Verify BOOK.md Chapter 3 section matches
- [ ] Confirm `:=` is still properly introduced in Chapter 12

🤖 Generated with [Claude Code](https://claude.com/claude-code)