### PR TITLE
docs: tighten function-local alias rules

### DIFF
--- a/docs/reference/ZAX-quick-guide.md
+++ b/docs/reference/ZAX-quick-guide.md
@@ -154,11 +154,11 @@ Module storage is declared inside named `data` sections. Three declaration forms
 section data vars at $8000
   count:     word              ; storage declaration — allocates, zero-initialized
   base:      addr = $C000      ; typed value initializer — allocates and initializes
-  alias_ptr  = count           ; alias initializer — no storage; new name for an existing symbol
+  alias_ptr  = count           ; alias initializer — no storage; new name for direct module-scope storage
 end
 ```
 
-The **typed alias form** `name: Type = rhs` is always a compile error in both named `data` sections and function-local `var` blocks. Use `name: Type = valueExpr` for value initialization, or `name = rhs` for aliasing.
+The **typed alias form** `name: Type = rhs` is always a compile error in both named `data` sections and function-local `var` blocks. Use `name: Type = valueExpr` for value initialization, or `name = rhs` for aliasing. In function-local `var`, that alias form is intentionally narrow: the right-hand side must be a direct module-scope storage name.
 
 Composite storage can be zero-initialized using scalar zero:
 
@@ -889,11 +889,11 @@ Three declaration forms are valid inside a `var` block:
 | ------------------------ | ------------------------------------------------------------- |
 | `name: Type`             | allocates a scalar frame slot, zero-initialized               |
 | `name: Type = valueExpr` | allocates a scalar frame slot, initialized to `valueExpr`     |
-| `name = rhs`             | alias — no frame slot; binds a new name to an existing symbol |
+| `name = GlobalStorageName` | alias — no frame slot; binds a local name to direct module-scope storage |
 
 The **typed alias form** `name: Type = rhs` is always a compile error.
 
-Only scalar types (`byte`, `word`, `addr`, `ptr`, or aliases resolving to those) may have frame slots. Non-scalar locals (arrays, records) are allowed only as alias declarations — they name an existing address but allocate no storage:
+Only scalar types (`byte`, `word`, `addr`, `ptr`, or aliases resolving to those) may have frame slots. Non-scalar locals (arrays, records) are allowed only as alias declarations to direct module-scope storage — they name an existing address but allocate no storage:
 
 ```zax
 section data vars at $8000
@@ -904,7 +904,7 @@ func process(): void
   var
     count:   word = 0        ; valid: scalar slot, initialized
     offset:  byte            ; valid: scalar slot, zero-initialized
-    tbl    = table           ; valid: alias — 'tbl' is another name for 'table'
+    tbl    = table           ; valid: alias to direct module-scope storage
     bad:     byte[4] = table ; COMPILE ERROR: typed alias form
   end
   ; tbl and table are the same address
@@ -912,6 +912,23 @@ end
 ```
 
 Scalar initializers are lowered in declaration order at function entry. For zero or constant word-sized init, the preferred lowering is `LD HL, imm16` / `PUSH HL`, which allocates and initializes the slot in one sequence.
+
+Rejected local alias forms:
+
+```zax
+func bad(buf: byte[16])
+  var
+    a = buf        ; COMPILE ERROR: parameter target not allowed
+  end
+end
+
+func also_bad(): void
+  var
+    count: word = 0
+    c = count      ; COMPILE ERROR: local target not allowed
+  end
+end
+```
 
 ### 6.3 The Typed Call Boundary
 
@@ -992,6 +1009,17 @@ Compatibility at call sites:
 - `T[N]` → `T[]` is allowed (narrowing to flexible view)
 - `T[]` → `T[N]` is rejected unless the compiler can prove the length is exactly `N`
 - Element-type mismatch is always rejected
+- Forwarding a non-scalar parameter is legal and does not require a local alias
+
+```zax
+func stage2(t: byte[16])
+  a := t[hl]
+end
+
+func stage1(t: byte[16])
+  stage2 t
+end
+```
 
 ```zax
 section data vars at $8000
@@ -1059,7 +1087,7 @@ ld d, (ix+tmp+1)
 
 Arguments resolve to positive IX displacements; locals resolve to negative displacements. This is separate from typed/value semantics in `:=` — bare names there still mean typed values/paths, not frame offsets.
 
-Only scalar locals/args with real frame slots participate in this raw IX-offset form. Non-scalar parameters are still passed in one 16-bit frame slot as storage references, but their names are not valid raw IX-offset symbols. Alias-only locals also do not participate.
+Only scalar locals/args with real frame slots participate in this raw IX-offset form. Non-scalar parameters are still passed in one 16-bit frame slot as storage references, but their names are not valid raw IX-offset symbols. Legal alias-only locals denote module-scope storage, not frame slots, so in raw code they behave like their module-scope target rather than as IX-offset symbols.
 
 #### Epilogue (compiler-generated)
 

--- a/docs/spec/zax-grammar.ebnf.md
+++ b/docs/spec/zax-grammar.ebnf.md
@@ -129,7 +129,7 @@ local_var_block = "var" , newline , local_decl , { newline , local_decl } , newl
 
 local_decl      = identifier , ":" , type_expr                              (* local scalar decl *)
                 | identifier , ":" , type_expr , "=" , value_init_expr      (* local scalar value-init *)
-                | identifier , "=" , rhs_alias_expr ;                        (* local alias-init *)
+                | identifier , "=" , rhs_alias_expr ;                        (* local alias-init to direct module-scope storage *)
 
 op_decl         = "op" , identifier , [ "(" , [ op_param_list ] , ")" ] ,
                   newline , instr_stream , "end" ;
@@ -247,7 +247,9 @@ These are semantic constraints enforced beyond pure grammar:
 - `import` remains module-scope only. It is not valid inside a named section.
 - Variable declarations inside a `code` named section are a compile error.
 - Local non-scalar value-init declarations are invalid.
-- Local non-scalar declarations are alias-only (`name = rhs`).
+- Local non-scalar declarations are alias-only (`name = GlobalStorageName`).
+- In function-local `var`, the alias RHS must be a direct module-scope storage name.
+- Function-local aliases may not target parameters, locals, aliases, field paths, indexed paths, constants, or labels.
 - `@path` is not a general expression operator. In v1 it is accepted only on the source side of `rr := @path` (with transitional `move rr, @path` still supported).
 - Raw data directives (`db`/`dw`/`ds`) and `raw_label` are only valid inside `section data` blocks.
 - A `raw_label` must be followed by a raw directive; it cannot stand alone.
@@ -257,7 +259,8 @@ These are semantic constraints enforced beyond pure grammar:
 - Raw instruction name resolution is semantic, not purely syntactic:
   - module-scope storage names behave as raw labels in raw Z80 instruction operands
   - scalar function args/locals may act as symbolic IX-relative slot offsets in raw instruction operands/immediates
-  - non-scalar parameters and alias-only locals do not participate in that raw IX-offset form
+  - non-scalar parameters do not participate in that raw IX-offset form
+  - legal function-local aliases denote module-scope storage in raw instruction contexts; they do not denote frame slots
 
 ## 9. Maintenance Rule
 

--- a/docs/spec/zax-spec.md
+++ b/docs/spec/zax-spec.md
@@ -932,13 +932,22 @@ Function-local `var` declaration forms (v0.2):
 
 - scalar storage declaration: `name: Type`
 - scalar value initializer: `name: Type = valueExpr`
-- alias initializer: `name = rhs`
+- alias initializer: `name = GlobalStorageName`
 
 Function-local `var` invalid forms and rules:
 
 - typed alias is invalid: `name: Type = rhs`
 - non-scalar local storage declaration without alias init is invalid in this scope
-- non-scalar locals are allowed only via alias form (`name = rhs`) and allocate no frame slot
+- non-scalar locals are allowed only via alias form and allocate no frame slot
+- in a function-local alias declaration, the right-hand side must be a **direct module-scope storage name**
+- therefore a function-local alias may target a module-scope scalar or aggregate storage symbol, but it may not target:
+  - a parameter
+  - a local
+  - another alias
+  - a field path
+  - an indexed path
+  - a constant
+  - a label
 
 Examples (normative classification):
 
@@ -950,7 +959,7 @@ end
 func sample(): void
   var
     a: word = 0             ; valid scalar value-init
-    b = table               ; valid alias-init
+    b = table               ; valid alias-init to direct module-scope storage
     bad: byte[4] = table    ; invalid typed alias form
   end
 end
@@ -1011,6 +1020,7 @@ Non-scalar argument contract (v0.2):
   - passing `T[N]` to `T[]` is allowed.
   - passing `T[]` to `T[N]` is rejected unless compiler can prove length is exactly `N`.
   - element-type mismatch is rejected.
+- Forwarding a non-scalar parameter to another non-scalar parameter is legal; it forwards the same storage reference and does not require a local alias.
 - This is a type/semantic rule; stack width remains one 16-bit slot for non-scalar args.
 
 ### 8.3 Calling Functions From Instruction Streams
@@ -1084,7 +1094,7 @@ Operand identifier resolution (v0.1):
   - each argument is one 16-bit slot
   - local scalar storage declarations allocate one 16-bit slot each
 - Local storage allocation in this scope remains scalar-slot based (`byte`, `word`, `addr`, `ptr`, or aliases resolving to those scalar types).
-- Non-scalar locals are permitted only as alias declarations (`name = rhs`) and do not allocate frame slots.
+- Non-scalar locals are permitted only as alias declarations to direct module-scope storage (`name = GlobalStorageName`) and do not allocate frame slots.
 
 Frame shape:
 
@@ -1102,6 +1112,7 @@ Raw instruction name resolution in framed functions:
 - Only scalar locals/args with real frame slots participate in this raw IX-offset form.
 - Non-scalar parameters are still passed in one 16-bit frame slot as storage references, but their names are not valid raw IX-offset symbols.
 - Alias-only locals do not allocate frame slots and are not valid raw IX-offset symbols.
+- Legal function-local aliases still denote module-scope storage in raw instruction contexts; e.g. `alias = table` permits `ld hl, alias` and `ld a, (alias)`.
 - Examples:
   - `ld hl, count` loads the address of module-scope `count`
   - `ld hl, (count)` loads the stored word at module-scope `count`


### PR DESCRIPTION
Tightens the documented function-local alias model before implementation.\n\n- restricts local alias RHS to direct module-scope storage names\n- preserves non-scalar parameter forwarding as a legal storage-reference call pattern\n- clarifies raw behavior of legal aliases in raw instruction contexts\n- updates the grammar companion's semantic notes to match\n