### PR TITLE
asm80: broaden differential validation corpus

### DIFF
--- a/test/pr990_asm80_emitter_validation.test.ts
+++ b/test/pr990_asm80_emitter_validation.test.ts
@@ -71,8 +71,30 @@ describe('ASM80 emitter', () => {
     if (!asm80) return;
 
     const fixtures = [
+      // Raw asm basics / labels / constants
+      join(__dirname, 'fixtures', 'pr24_isa_core.zax'),
+      join(__dirname, 'fixtures', 'pr37_forward_label_call.zax'),
+      join(__dirname, 'fixtures', 'pr4_enum.zax'),
+      // Typed/global storage
+      join(__dirname, 'fixtures', 'pr405_byte_global_scalar_symbols.zax'),
+      join(__dirname, 'fixtures', 'pr406_word_global_scalar_accessors.zax'),
+      join(__dirname, 'fixtures', 'pr713_packed_top_level_arrays.zax'),
+      // Frame-related lowering
+      join(__dirname, 'fixtures', 'pr330_frame_access_positive.zax'),
+      join(__dirname, 'fixtures', 'pr406_word_frame_scalar_accessors.zax'),
+      join(__dirname, 'fixtures', 'pr952_raw_ix_slot_offsets_ok.zax'),
+      // Alias cases
+      join(__dirname, 'fixtures', 'pr980_local_alias_raw_scalar.zax'),
+      join(__dirname, 'fixtures', 'pr980_local_alias_raw_aggregate.zax'),
+      // Sections and placement
+      join(__dirname, 'fixtures', 'pr9_section_code_at.zax'),
+      join(__dirname, 'fixtures', 'pr585_named_section_order_root.zax'),
+      // Startup init
+      join(__dirname, 'fixtures', 'pr577_startup_init_main.zax'),
+      // Comments present (byte output unchanged)
+      join(__dirname, 'fixtures', 'pr991_comment_preservation.zax'),
+      // Raw data directives
       join(__dirname, 'fixtures', 'pr786_raw_data_lowering.zax'),
-      join(__dirname, 'fixtures', 'pr406_word_store_de.zax'),
     ];
 
     for (const entry of fixtures) {


### PR DESCRIPTION
Expand ASM80 differential validation to cover representative fixtures across raw asm, storage, frames, aliases, sections, startup init, and comments.