### PR TITLE
cli: rename ASM80 artifact extension to .z80

### DIFF
--- a/docs/design/lowered-assembly-pipeline-plan.md
+++ b/docs/design/lowered-assembly-pipeline-plan.md
@@ -135,7 +135,7 @@ Notes:
 ### ASM80 emitter path (new)
 
 - Add `writeAsm80(...)` (new writer, or new path inside `formats/`) that consumes `LoweredAsmProgram`.
-- The output artifact should use a temporary distinct name (e.g., `.lasm` or `.asm80`) until the trace `.asm` can be retired.
+- The output artifact should use a distinct name (currently `.z80`) until the trace `.asm` can be retired.
 - Tests/harnesses should run ASM80 parsing/validation on this artifact only (no CLI invocation in v1).
 
 ## Migration sequence (smallest safe first patch)

--- a/docs/reference/ZAX-quick-guide.md
+++ b/docs/reference/ZAX-quick-guide.md
@@ -112,14 +112,14 @@ Common outputs:
 | `.lst`        | deterministic byte dump with symbol table         |
 | `.d8dbg.json` | D8 Debug Map for Debug80 and compatible tools     |
 | `.asm`        | lowered trace — exactly what the compiler emitted |
-| `.asm80`      | ASM80-compatible lowered source (assembler-valid) |
+| `.z80`        | ASM80-compatible lowered source (assembler-valid) |
 
 By default, ZAX derives all artifact paths from the primary output path. Use `-o <file>` to set the primary output; `-t hex` or `-t bin` to choose the primary type (default: `hex`). Suppress individual outputs with `--nolist`, `--nobin`, `--nohex`, `--nod8m`, `--noasm`. Emit ASM80 output explicitly with `--asm80`.
 
 Trace vs ASM80 output:
 
 - `.asm` is a compiler trace for inspection; it is not guaranteed assembler-valid.
-- `.asm80` is assembler-valid lowered output intended for ASM80.
+- `.z80` is assembler-valid lowered output intended for ASM80.
 
 Useful diagnostic options:
 

--- a/docs/spec/zax-spec.md
+++ b/docs/spec/zax-spec.md
@@ -1788,12 +1788,12 @@ ZAX uses a single “primary output path” to derive sibling artifacts.
     - Listing: `artifactBase + ".lst"`
     - Debug map (D8M v1): `artifactBase + ".d8dbg.json"`
     - Lowering trace source: `artifactBase + ".asm"`
-    - ASM80-compatible lowered source: `artifactBase + ".asm80"` (opt-in)
+    - ASM80-compatible lowered source: `artifactBase + ".z80"` (opt-in)
 
 Trace vs ASM80 note:
 
 - `.asm` is a compiler trace for inspection; it is not guaranteed assembler-valid.
-- `.asm80` is assembler-valid lowered output intended to assemble under ASM80.
+- `.z80` is assembler-valid lowered output intended to assemble under ASM80.
 
 Listing note:
 
@@ -1825,7 +1825,7 @@ Keep switches intentionally small:
 - `--nohex` Suppress `.hex`
 - `--nod8m` Suppress `.d8dbg.json`
 - `--noasm` Suppress `.asm` lowering trace output
-- `--asm80` Emit ASM80-compatible lowered source (`.asm80`)
+- `--asm80` Emit ASM80-compatible lowered source (`.z80`)
 - `-I, --include <dir>` Add import search path (repeatable)
 - `--case-style <mode>` Optional case-style linting for asm keywords/registers
   - supported: `off`, `upper`, `lower`, `consistent`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,7 @@ function usage(): string {
     '      --nohex           Suppress .hex',
     '      --nod8m           Suppress .d8dbg.json',
     '      --noasm           Suppress .asm lowering trace',
-    '      --asm80           Emit ASM80-compatible lowered source (.asm80)',
+    '      --asm80           Emit ASM80-compatible lowered source (.z80)',
     '      --case-style <m>  Case-style lint mode: off|upper|lower|consistent',
     '      --op-stack-policy <m> Op stack-policy mode: off|warn|error',
     '      --raw-typed-call-warn Emit warnings for raw call to typed callable targets',
@@ -248,7 +248,7 @@ async function writeArtifacts(
   const d8mPath = `${base}.d8dbg.json`;
   const lstPath = `${base}.lst`;
   const asmPath = `${base}.asm`;
-  const asm80Path = `${base}.asm80`;
+  const asm80Path = `${base}.z80`;
 
   const writes: Array<Promise<void>> = [];
   const ensureDir = async (p: string) => mkdir(dirname(p), { recursive: true });

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -606,7 +606,7 @@ export const compile: CompileFn = async (
       diagnostics.push({
         id: DiagnosticIds.Unknown,
         severity: 'warning',
-        message: 'emitAsm80=true but no asm80 writer is configured; skipping .asm80 artifact.',
+        message: 'emitAsm80=true but no asm80 writer is configured; skipping .z80 artifact.',
         file: program.entryFile,
       });
     }

--- a/src/formats/types.ts
+++ b/src/formats/types.ts
@@ -194,7 +194,7 @@ export interface AsmArtifact {
 }
 
 /**
- * In-memory ASM80 `.asm80` artifact.
+ * In-memory ASM80 `.z80` artifact.
  */
 export interface Asm80Artifact {
   kind: 'asm80';

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -31,7 +31,7 @@ export interface CompilerOptions {
   emitListing?: boolean;
   /** Emit lowering trace source (`.asm`). */
   emitAsm?: boolean;
-  /** Emit ASM80-compatible lowered source (`.asm80`). */
+  /** Emit ASM80-compatible lowered source (`.z80`). */
   emitAsm80?: boolean;
   /** Optional case-style lint mode for asm keywords/register tokens. */
   caseStyle?: CaseStyleMode;

--- a/test/cli_artifacts.test.ts
+++ b/test/cli_artifacts.test.ts
@@ -92,6 +92,22 @@ describe('cli artifacts', () => {
     await rm(work, { recursive: true, force: true });
   }, 20_000);
 
+  it('writes ASM80-compatible lowered source as .z80 when --asm80 is set', async () => {
+    const work = await mkdtemp(join(tmpdir(), 'zax-cli-z80-'));
+    const entry = join(work, 'main.zax');
+    await writeFile(entry, 'export func main()\n    nop\nend\n', 'utf8');
+
+    const outHex = join(work, 'out.hex');
+    const res = await runCli(['--asm80', '--nobin', '--nod8m', '--nolist', '--noasm', '-o', outHex, entry]);
+    expect(res.code).toBe(0);
+
+    expect(await exists(join(work, 'out.hex'))).toBe(true);
+    expect(await exists(join(work, 'out.z80'))).toBe(true);
+    expect(await exists(join(work, 'out.asm80'))).toBe(false);
+
+    await rm(work, { recursive: true, force: true });
+  }, 20_000);
+
   it('suppresses hex output for --type bin with --nohex', async () => {
     const work = await mkdtemp(join(tmpdir(), 'zax-cli-nohex-'));
     const entry = join(work, 'main.zax');


### PR DESCRIPTION
## What changed
- renamed the assembler-valid lowered-source artifact from `.asm80` to `.z80`
- updated CLI help, pipeline/type comments, and spec/reference docs
- added a CLI artifact test to verify `--asm80` writes `.z80` and no longer writes `.asm80`

## Verification
- `npm run typecheck`
- `npx vitest run test/cli_artifacts.test.ts test/cli_contract_matrix.test.ts test/pr991_asm80_comment_preservation.test.ts`

## Note
- `npx vitest run test/pr990_asm80_emitter_validation.test.ts` still fails in this local environment because the installed `asm80` rejects an existing fixture (`sub a, b`) unrelated to this extension rename.
