### PR TITLE
Auto-rebuild BOOK.md on chapter changes

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -1,0 +1,28 @@
+name: Build BOOK.md
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'learning/part1/*.md'
+      - 'learning/part2/*.md'
+      - 'scripts/build-book.sh'
+
+jobs:
+  build-book:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build BOOK.md
+        run: bash scripts/build-book.sh
+
+      - name: Commit if changed
+        run: |
+          git diff --quiet learning/BOOK.md && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add learning/BOOK.md
+          git commit -m "Regenerate BOOK.md [skip ci]"
+          git push


### PR DESCRIPTION
## Summary

- Adds a GitHub Action that automatically regenerates `learning/BOOK.md` whenever chapter files or the build script change on `main`
- Only triggers on pushes to `main` that touch `learning/part1/*.md`, `learning/part2/*.md`, or `scripts/build-book.sh`
- If BOOK.md is already up to date, the job exits cleanly with no commit
- Uses `[skip ci]` in the auto-commit message to prevent infinite workflow loops

## How it works

1. Push to main changes a chapter file
2. Workflow runs `bash scripts/build-book.sh`
3. If `learning/BOOK.md` differs from what's in the repo, commits and pushes the update
4. BOOK.md is always current on GitHub — no manual rebuild needed

## Test plan
- [ ] Merge this PR, then merge any chapter change — verify BOOK.md commit appears automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)