### PR TITLE
ci(build-book): add contents: write permission for bot push

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -12,6 +12,8 @@ jobs:
   build-book:
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

The `build-book` workflow was failing with a 403 on the `git push` step.
`github-actions[bot]` needs `contents: write` to push the regenerated
BOOK.md back to main. Adds the permission at the job level.

All recent chapter merges (#1002, #1003, #1004) produced a stale BOOK.md
as a result. Once this lands, the next push to a chapter file will trigger
a clean regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)