### PR TITLE
docs(ch1-4): apply three-pass prose critique fixes

### DIFF
--- a/learning/part1/01-the-computer.md
+++ b/learning/part1/01-the-computer.md
@@ -4,7 +4,7 @@
 
 Every computer, at the lowest level, runs **machine code** — raw numeric instructions built into the CPU's hardware. High-level languages like C or Python hide the machine entirely; a compiler or interpreter handles the translation down to those numbers. Assembly does not hide the machine. Each line you write corresponds directly to one CPU instruction, and the assembler's job is mostly mechanical: turn your readable text into the exact bytes the CPU expects.
 
-Assembly requires you to think like the computer. You get full control — every register, every memory access, every branch is yours to specify. Nothing happens unless you ask for it. But you also carry the full burden: you must understand what the CPU can do, how it stores data, and how it steps through a program byte by byte. There is no safety net of type checking, garbage collection, or automatic memory management.
+Assembly requires you to think like the computer. You get full control — every register, every memory access, every branch is yours to specify. But you also carry the full burden: you must understand what the CPU can do, how it stores data, and how it steps through a program byte by byte. There is no safety net of type checking, garbage collection, or automatic memory management.
 
 ZAX is an assembler for the Z80 that adds some structure on top — named variables, typed storage, and control flow keywords like `if` and `while` — but the underlying model is the same. Every ZAX program compiles down to Z80 machine code, and understanding that machine code is what this book teaches.
 
@@ -64,11 +64,7 @@ You will see hex constantly in Z80 work. Every opcode, every address, every cons
 
 The Z80 has a 16-bit address bus, which means it can address 2<sup>16</sup> = 65,536 bytes of memory, at addresses `$0000` through `$FFFF`. Think of it as a flat array: 65,536 numbered slots, each holding one byte. The number that identifies a slot is its **address**. To read or write any byte, you name its address.
 
-The CPU itself does not know or care what kind of memory chip sits behind any given address. It simply puts an address on the bus and reads or writes a byte. The hardware designer decides which addresses connect to which chips. Two kinds of memory chip are common:
-
-**ROM** (read-only memory) contains pre-programmed data that cannot be changed during normal operation. ROM retains its contents when power is removed. It is used for code and data that must survive power cycles — bootloaders, fixed routines, lookup tables.
-
-**RAM** (random-access memory) can be freely read and written, but loses its contents when power is removed. RAM is where your running program stores variables, the stack, and any data it creates or modifies.
+The CPU itself does not know or care what kind of memory chip sits behind any given address. It simply puts an address on the bus and reads or writes a byte. The hardware designer decides which addresses connect to which chips. Two kinds are common. ROM (read-only memory) holds data that cannot change during normal operation and retains its contents when power is removed — bootloaders, fixed routines, and lookup tables live here. RAM (random-access memory) can be freely read and written, but loses its contents when power goes; variables, the stack, and any data your program creates or modifies go in RAM.
 
 A system's **memory map** describes which address ranges connect to which chips. There is no single standard layout — it varies from system to system. A typical small Z80 board might look like this:
 
@@ -94,7 +90,7 @@ $8000       $2B    ← low byte first
 $8001       $1A    ← high byte second
 ```
 
-Read it back: the byte at `$8000` is `$2B` (low), the byte at `$8001` is `$1A` (high), so the word is `$1A2B`. This is not something you can change — every Z80 instruction that handles 16-bit values follows this rule. You will encounter it whenever you store addresses or multi-byte values in memory, so remember it.
+Read it back: the byte at `$8000` is `$2B` (low), the byte at `$8001` is `$1A` (high), so the word is `$1A2B`. This is not something you can change — every Z80 instruction that handles 16-bit values follows this rule. You will encounter it whenever you store addresses or multi-byte values in memory.
 
 ---
 
@@ -124,7 +120,7 @@ Here is the complete Z80 register set:
 | SP | 16 bits | **Stack pointer.** Points to the most recently pushed value on the hardware stack. |
 | PC | 16 bits | **Program counter.** Always contains the address of the next instruction to execute. Cannot be read or written directly. |
 | I | 8 bits | Interrupt vector register. Used with interrupt mode 2. |
-| R | 8 bits | Refresh register. Incremented automatically as each instruction is fetched. Only the low seven bits cycle; the top bit stays zero. Rarely useful to the programmer. |
+| R | 8 bits | Refresh register. Incremented automatically as each instruction is fetched. Only the low seven bits cycle; the top bit stays zero. Rarely something you will use directly. |
 
 When B and C are used as the pair BC, B holds the high byte and C holds the low byte — the same pattern as DE (D high, E low) and HL (H high, L low). IX and IY follow the same rule with their halves. So for example if HL = `$1A2B`, then H = `$1A` and L = `$2B`.
 
@@ -147,7 +143,7 @@ The flags register F contains eight bits, each of which records something about 
 | 1 | N | Subtract | Set if the last operation was a subtraction. Used internally for BCD correction. |
 | 0 | C | Carry | Set if the last operation produced a carry out of bit 7, or a borrow in the case of subtraction. |
 
-Not every instruction updates every flag. Some instructions update all flags; some update only Z and C; some leave all flags unchanged. You will learn which flags each instruction affects as you encounter them in later chapters.
+Not every instruction updates every flag. Some instructions update all flags; some update only Z and C; some leave all flags unchanged.
 
 ---
 

--- a/learning/part1/02-machine-code.md
+++ b/learning/part1/02-machine-code.md
@@ -65,7 +65,7 @@ From the CPU's point of view, a variable is just a byte (or several bytes) of me
 
 In the program above, the result was written to the fixed address `$8000`. But `$8000` is embedded as raw bytes in the instruction at `$0006`. If you later decide the result should live at `$8100` instead, you must find that instruction and change bytes `$07` and `$08` by hand. If you have fifty instructions referencing the same address, you change fifty places.
 
-This is the core problem with raw machine code: there is no concept of a name. Everything is a position number. The programmer must manually track what every address means and keep every reference consistent.
+This is the core problem with raw machine code: there is no concept of a name. Everything is a position number. You must manually track what every address means and keep every reference consistent.
 
 Assembly solves this with **labels**. A label is a name that the assembler associates with a particular address at assembly time. Everywhere you write the label, the assembler substitutes the correct address automatically. If the variable moves, you update the label's definition and every reference updates with it.
 
@@ -76,7 +76,7 @@ Result:          ; the assembler records "Result" as the current address
   DB 0           ; allocate one byte at this address, initial value 0
 ```
 
-(`DB` stands for "define byte." `DW` defines a 16-bit word.) From this point on, writing `LD (Result), A` in the code is equivalent to writing `LD ($8000), A` — but the programmer never has to know or write `$8000`. The assembler handles it.
+(`DB` stands for "define byte." `DW` defines a 16-bit word.) From this point on, writing `LD (Result), A` in the code is equivalent to writing `LD ($8000), A` — but you never have to know or write `$8000`. The assembler handles it.
 
 Labels also name positions within the code — the targets of jumps and branches. Instead of writing `JP $0034`, you write `JP loop_top`, and the assembler works out the address of `loop_top` itself.
 
@@ -86,15 +86,7 @@ Machine code is just bytes. Assembly adds names for addresses.
 
 ## Why Raw Machine Code Is Impractical
 
-The program above was ten bytes. Real programs are thousands. Writing them as raw hex creates compounding problems:
-
-**No names.** Every address is a number. `$8000` might be your result, or it might be a display buffer, or it might be the start of a lookup table. Nothing in the code tells you which.
-
-**Fragility.** Insert one instruction in the middle of the program and every address calculated from that point shifts. You update them all by hand, and one missed update produces a silent wrong result — not an error message.
-
-**Unreadability.** You cannot skim `3E 05 47 3E 03 80 32 00 80 76` and understand what the program does. You have to decode each byte from memory.
-
-**No structure.** Machine code has no subroutines, no loops, no conditionals — just bytes and addresses. Everything that programs need beyond raw arithmetic must be built by hand from jumps to raw addresses.
+The program above was ten bytes. Real programs are thousands, and raw hex does not scale. Every address is a bare number — `$8000` could be your result variable, a display buffer, or a lookup table, and nothing in the code says which. Insert one instruction anywhere and every downstream address shifts; miss a single update and you get a silent wrong result with no error to point to. Reading the code directly is no help: `3E 05 47 3E 03 80 32 00 80 76` means nothing until you decode each byte by hand. And there are no structural building blocks — no subroutines, no loops, no conditionals, just bytes and jump targets calculated by hand.
 
 The CPU still sees bytes — the assembler changes what you write and maintain.
 

--- a/learning/part1/03-assembly-language.md
+++ b/learning/part1/03-assembly-language.md
@@ -140,8 +140,7 @@ ld ix, $4000    ; IX = $4000
 ### Memory access through HL
 
 HL is the primary indirect address register. `(HL)` means "the byte at the
-address currently in HL." This is what makes HL so important: once an address
-is in HL, you can read or write the byte there directly.
+address currently in HL." Once an address is in HL, you can read or write the byte there directly.
 
 ```zax
 ld a, (hl)     ; A = byte at address HL
@@ -153,8 +152,7 @@ ld (hl), 19    ; byte at address HL = 19
 Any of A, B, C, D, E, H, L can appear on either side when the other side is
 `(HL)`. BC and DE also have indirect forms, but only with A — `ld a, (bc)` and
 `ld (de), a` — and nothing else. The standard pattern is: load an address into
-HL, read or write with `(HL)`, increment HL, repeat. You will see this
-pattern constantly.
+HL, read or write with `(HL)`, increment HL, repeat.
 
 ### Indexed memory access through IX and IY
 
@@ -211,7 +209,7 @@ This catches everyone at first. The CPU can talk to memory or to its own registe
 
 | Form | Example | Notes |
 |------|---------|-------|
-| reg8 ← reg8 | `ld a, b` | Any 8-bit register to any other (IX/IY restriction below) |
+| reg8 ← reg8 | `ld a, b` | Any 8-bit register to any other |
 | reg8 ← n | `ld b, $FF` | Immediate 8-bit constant |
 | reg16 ← nn | `ld hl, $8000` | Immediate 16-bit constant |
 | reg8 ← (HL) | `ld c, (hl)` | Read byte at address HL |
@@ -314,7 +312,7 @@ thing from Chapter 3, make it that.
 
 `EX DE, HL` swaps DE and HL in a single instruction. Afterward, DE holds what HL had and HL holds what DE had.
 
-This is a true bidirectional swap, not a copy. Copying HL into DE without caring about DE's old value takes two instructions:
+Copying HL into DE without caring about DE's old value takes two instructions:
 
 ```zax
 ld d, h

--- a/learning/part1/04-flags-comparisons-jumps.md
+++ b/learning/part1/04-flags-comparisons-jumps.md
@@ -13,9 +13,8 @@ and `or a` set them, and how `jp` uses them to direct execution.
 
 The Z80 flag register F holds eight bits, each of which records one piece of
 information about the last instruction that affected flags. Programs cannot read
-or write F directly with `ld`. Instead, arithmetic instructions set the flags
-as a side effect, and conditional jump instructions test the flags to decide
-whether to jump.
+or write F directly with `ld`. Arithmetic instructions set the flags as a side
+effect, and conditional jump instructions test them to decide whether to branch.
 
 The four flags you will use most often are:
 
@@ -52,8 +51,7 @@ cp 5      ; A - 5 = -2; Z flag is clear, C flag is set (borrow)
 After `cp 5` with A = 3: Z is clear (result is not zero), C is set (A was less
 than 5 — unsigned borrow is treated as carry).
 
-The rule: after `cp n`, Z is set if A equals n, and C is set if A is less than
-n (unsigned).
+After `cp n`, Z is set if A equals n, and C is set if A is less than n (unsigned).
 
 ---
 
@@ -139,9 +137,8 @@ but saves one byte of code.
 `jr nz, label` is the conditional relative jump form: jump to `label` if Z is
 clear.
 
-`jr` is commonly used for short backward jumps in loops. For any jump that could
-exceed the 128-byte backward range, use `jp` instead. The assembler will report
-an error if a `jr` target is out of range.
+For any jump that could exceed the 128-byte backward range, use `jp` instead.
+The assembler will report an error if a `jr` target is out of range.
 
 The practical differences:
 
@@ -278,9 +275,9 @@ branches back while B is non-zero.
 
 After the loop, `counter` holds 5. B holds 0. The loop ran exactly five times.
 
-Notice that `dec b` sets the Z flag: this is how `jp nz` knows when to stop.
-The flag is not set by `ld`; it is set by the instruction that changes the
-counter. Always identify which instruction sets the flag you are about to test.
+`dec b` sets the Z flag — not the preceding `ld (counter), a`, which never
+touches flags. `jp nz` reads whatever `dec b` left. Always identify which
+instruction sets the flag before the branch that reads it.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Blocker**: Ch3 LD summary table had dangling "(IX/IY restriction below)" note referencing a deleted section — removed
- **Significant (Rule 18)**: Rewrote Ch1 ROM/RAM bold-term paragraphs and Ch2 "Why Raw Machine Code Is Impractical" bold-term list into flowing prose
- **Significant (Rule 10)**: Rewrote Ch4 "Notice that `dec b`..." paragraph as a direct statement
- **Polish (×10)**: Removed hollow phrases, third-person distance, discourse connectors, classification openers, deferral sentences across all four chapters

## Test plan
- [ ] Read Ch1 Memory section — ROM/RAM paragraph flows as prose, no bold-term blocks
- [ ] Read Ch2 "Why Raw Machine Code Is Impractical" — single flowing paragraph, no bold items
- [ ] Read Ch3 LD summary table — first row has no dangling parenthetical
- [ ] Read Ch4 Section C walkthrough — "dec b" paragraph is a direct statement, no "Notice that"

🤖 Generated with [Claude Code](https://claude.com/claude-code)