### PR TITLE
docs(ch4): expand prose, fix ordering, remove abstract list

### DIFF
--- a/learning/part1/04-flags-comparisons-jumps.md
+++ b/learning/part1/04-flags-comparisons-jumps.md
@@ -3,80 +3,99 @@
 # Chapter 4 — Flags, Comparisons, and Jumps
 
 Every program makes decisions. The Z80 makes them by recording the outcome of
-each operation in the flags register, then testing those flags with a
-conditional jump. This chapter introduces both: what the flags record, how `cp`,
-`or a`, and the logical operations set them, and how `jp` uses them to direct
-execution.
+each operation in the flags register, then testing those flags to decide where
+execution goes next. This chapter introduces both: what the flags record, how `cp` and the logical
+operations set them, and how `jp` uses them.
 
 ---
 
-## The flag register
+## The flags register
 
-The Z80 flag register F holds eight bits, each of which records one piece of
-information about the last instruction that affected flags. Programs cannot read
-or write F directly with `ld`. Arithmetic instructions set the flags as a side
-effect, and conditional jump instructions test them to decide whether to branch.
+F holds eight bits. Each bit is called a flag and records one thing about the
+result of the last instruction that changed flags. You cannot set them
+explicitly with `ld` or any other direct assignment. Instructions like `sub`,
+`cp`, `and`, `or`, `xor`, `inc`, and `dec` update them as a side effect. The
+flags just change — you observe them afterward.
 
-The four flags you will use most often are:
+One thing to get straight from the start: not every instruction affects every
+flag, and some instructions affect no flags at all. `ld` never touches the
+flags. `inc` and `dec` update most flags but leave C unchanged. This matters
+constantly in practice — when a `jp` instruction tests a flag, you need to know
+which earlier instruction set it and whether anything in between might have
+changed it. An `ld` between your comparison and your `jp` leaves the flags
+exactly as they were; a `dec` between them replaces them. Tracking this is one
+of the things that takes time to do automatically when reading Z80 code.
+
+The four flags you will use most:
 
 | Flag | Name | Set when |
 |------|------|----------|
 | Z | Zero | Result is zero |
-| C | Carry | Arithmetic produced a carry out of bit 7 (unsigned overflow) |
-| S | Sign | Bit 7 of the result is 1 (result is negative in signed interpretation) |
+| C | Carry | Arithmetic produced a carry out of bit 7, or a borrow in subtraction |
+| S | Sign | Bit 7 of the result is 1 |
 | P/V | Parity/Overflow | Result parity is even; or signed overflow occurred |
 
-The Z and C flags appear in almost every conditional branch. S and P/V appear
-in more specialized cases. For the full flags reference and all condition codes,
-see [Appendix 2](../appendices/02-registers-flags-and-conditions.md).
+**Z** is the one you will reach for constantly. After `sub` or `cp`, Z is set
+when the two values were equal. After `dec`, Z is set when a register reaches
+zero. After `and`, Z is set when none of the tested bits were present.
+
+**C** records unsigned overflow. After addition, C is set when the result
+exceeded 255 — the carry out of bit 7. After `sub` or `cp`, C is set when A
+was less than the subtracted value: the subtraction had to borrow. Addition and
+subtraction share the same flag for these two distinct purposes, which is why
+learning to read C in context takes a little time.
+
+**S** mirrors bit 7 of the result. In signed arithmetic bit 7 is the sign bit,
+so S tells you whether the result was negative. When you are working with
+unsigned values you can usually ignore S.
+
+**P/V** has two unrelated meanings depending on which instruction set it. After
+`add` and `sub` it is the overflow flag: set when a signed operation produced a
+result outside −128 to +127. After logical instructions and rotates it reports
+parity: set when the result has an even number of 1 bits. The instruction
+reference will tell you which meaning applies.
+
+For the full flags reference and all condition codes, see
+[Appendix 2](../appendices/02-registers-flags-and-conditions.md).
 
 ---
 
-## `cp`: compare without storing
+## `sub` and `cp`: subtraction and comparison
 
-`cp n` subtracts the value `n` from A and sets the flags based on the result,
-but does **not** store the result back in A. After `cp n`, A is unchanged and
-the flags reflect `A - n`.
+`sub n` subtracts `n` from A, writes the result back into A, and updates the
+flags to reflect what happened.
 
 ```zax
-ld a, 5
-cp 5      ; A - 5 = 0; Z flag is set, C flag is clear
+ld a, 8
+sub 3     ; A = 5; Z is clear (result non-zero), C is clear (no borrow)
 ```
-
-After `cp 5` with A = 5: Z is set (result is zero), C is clear (no borrow).
 
 ```zax
 ld a, 3
-cp 5      ; A - 5 = -2; Z flag is clear, C flag is set (borrow)
+sub 5     ; A = $FE (−2); Z is clear, C is set (borrow — A was less than 5)
 ```
 
-After `cp 5` with A = 3: Z is clear (result is not zero), C is set (A was less
-than 5 — unsigned borrow is treated as carry).
+C is set when the subtraction needed to borrow — equivalently, when A was less
+than the value subtracted (treating both as unsigned). Z is set when the result
+is zero.
 
-After `cp n`, Z is set if A equals n, and C is set if A is less than n (unsigned).
-
-`sub n` does the same subtraction and sets the same flags, but writes the result
-back into A. Use `cp` when you only want the flags; use `sub` when you need the
-computed value.
-
----
-
-## `or a`: test whether A is zero
-
-`or a` performs the bitwise OR of A with itself. The result is always equal to
-A, so A is unchanged. The flags are updated: Z is set if A is zero, C is
-cleared.
+`cp n` does exactly the same subtraction and sets the same flags, but discards
+the result. A is unchanged after `cp n`.
 
 ```zax
-ld a, 0
-or a       ; Z is set because A is zero
-
-ld a, $FF
-or a       ; Z is clear because A is non-zero
+ld a, 5
+cp 5      ; subtracts 5; Z is set (result is zero); A stays 5
 ```
 
-`or a` reflects whether A is currently zero — one byte, no comparison value.
-(`cp 0` would do the same job in two bytes.)
+```zax
+ld a, 3
+cp 5      ; subtracts 5; C is set (borrow); A stays 3
+```
+
+After `cp n`: Z is set if A equals n, C is set if A is less than n (unsigned).
+
+Use `sub` when you need the computed difference. Use `cp` when you only need to
+know the relationship — equal, less than, greater than — without changing A.
 
 ---
 
@@ -91,7 +110,7 @@ byte:
 
 ```zax
 ld a, $F3          ; A = %11110011
-and $0F            ; A = %00000011 — upper nibble cleared, lower kept
+and $0F            ; A = %00000011 — upper four bits cleared, lower four kept
 ```
 
 `or n` sets bits where the mask has 1 and leaves others unchanged:
@@ -101,11 +120,25 @@ ld a, $03
 or $80             ; A = %10000011 — bit 7 now set
 ```
 
+`or a` is a useful special case: A ORed with itself always equals A, so the
+value does not change. Only the flags are updated — Z is set if A is zero, C is
+cleared. One instruction tells you whether A is currently zero, with no
+comparison value needed. (`cp 0` gives the same flags in two bytes instead of
+one.)
+
+```zax
+ld a, 0
+or a       ; Z is set because A is zero
+
+ld a, $FF
+or a       ; Z is clear because A is non-zero
+```
+
 `xor n` toggles bits where the mask has 1:
 
 ```zax
 ld a, $FF
-xor $0F            ; A = %11110000 — lower nibble flipped
+xor $0F            ; A = %11110000 — lower four bits flipped
 ```
 
 The most-used form is `xor a`. A XOR'd against itself is always zero — every
@@ -118,48 +151,62 @@ in both A and the carry, reach for `xor a`.
 xor a              ; A = 0; Z is set; C is clear
 ```
 
-Testing whether a specific bit is set uses `and` with a single-bit mask. The
-result is zero only if that bit was 0 in A:
-
-```zax
-ld a, (status)
-and $04            ; keep only bit 2; Z is set if bit 2 was clear
-jp z, bit_clear    ; branch if that bit was not set
-```
-
 All three instructions accept a register, an immediate byte, `(HL)`, or an
 index register form. The quick reference for arithmetic and logical instruction
 forms is in [Appendix 3](../appendices/03-addressing-prefixes-and-instruction-forms.md).
 
 ---
 
-## Unconditional jump: `jp nn`
+## `jp`: moving execution to a new address
 
-`jp $8010` changes the program counter to `$8010`. The CPU's next fetch comes
-from that address. Execution continues from there, not from the instruction
-following the `jp`.
+From Chapter 1 you know that the CPU always executes the instruction at the
+address in PC, then advances PC to the next instruction. `jp` breaks that
+sequence: instead of advancing PC by the instruction's length, it puts a new
+address into PC. The CPU's next fetch comes from that address. Whatever was
+written after the `jp` in the source does not run.
 
-`jp` can target a label:
+```zax
+jp $8010      ; PC becomes $8010; next instruction comes from $8010
+```
+
+This is not a subroutine call. Nothing is saved and no return address is
+recorded. After a `jp` the CPU has no memory of where it came from. Execution
+simply continues from the new address.
+
+You will almost always target a label rather than a raw address:
 
 ```zax
 jp done
-...
+; code written here is never reached
 done:
-  ret
+  ...
 ```
 
-The assembler resolves the label `done` to its address and encodes that address
-into the `jp` instruction. The jump always happens — the flags are not consulted.
+The assembler works out the address of `done` and encodes it into the
+instruction bytes. The jump always happens — the flags play no role.
+
+On its own, an unconditional `jp` is mostly useful for two things: skipping
+over a block of code (which becomes the else-half of a conditional structure),
+or jumping back to an earlier address to repeat something. Its real power comes
+when it works together with the flags.
 
 ---
 
-## Conditional jump: `jp cc, label`
+## Conditional `jp`: testing the flags
 
-`jp z, target` jumps to `target` only if the Z flag is currently set. If Z is
-clear, execution falls through to the next instruction.
+A conditional `jp` works exactly like an unconditional one, with one addition:
+before changing PC, it checks a flag. If the flag condition is met, PC changes
+and execution continues from the target address. If it is not met, the
+instruction does nothing and execution continues with the instruction that
+immediately follows — it falls through.
 
-`jp nz, target` jumps if Z is clear (n = "not"). The condition codes for the
-four main flags are:
+`jp z, target` checks Z. If Z is set, the jump happens. If Z is clear,
+execution falls through to the next instruction.
+
+`jp nz, target` is the inverse: it jumps when Z is clear and falls through when
+Z is set. The `n` prefix means "not": `nz` is "not zero", `nc` is "not carry".
+
+The condition codes you will use most:
 
 | Code | Meaning |
 |------|---------|
@@ -168,55 +215,70 @@ four main flags are:
 | `c` | Jump if C is set |
 | `nc` | Jump if C is clear |
 
-These four handle most branch conditions. `jp` also supports `m` (S set), `p`
-(S clear), `pe` (P/V set), and `po` (P/V clear) for signed arithmetic and
-parity tests. The full list is in
+`jp` also supports `m` (S set), `p` (S clear), `pe` (P/V set), and `po` (P/V
+clear) for signed arithmetic and parity tests. The full list is in
 [Appendix 2](../appendices/02-registers-flags-and-conditions.md).
 
-A conditional branch is the raw Z80 equivalent of an if-statement. There is no
-structured keyword; you set the flags with `cp`, `or a`, or a logical
-instruction, then use a conditional `jp` to skip over the "then" block:
+This gives you the raw material for an if-statement. You set a flag with `cp`
+or a logical instruction, then use a conditional `jp` to skip over the block
+you do not want to execute:
 
 ```zax
-; if A == 5: do something
 cp 5
-jp nz, skip    ; if A != 5, skip the block
-; ... the "then" body ...
+jp nz, skip    ; A != 5: jump to skip
+; ... this body runs only when A == 5 ...
 skip:
 ```
 
-If A equals 5, Z is set, `jp nz` does not branch, and the then-body executes.
-If A is anything else, Z is clear, `jp nz` branches to `skip`, and the
-then-body is skipped.
+`cp 5` subtracts 5 from A and sets Z if the result was zero — that is, if A
+was 5. `jp nz` then jumps if Z is clear, which means A was not 5. If A was 5,
+Z is set, `jp nz` falls through, and the body runs. If A was anything else, Z
+is clear, `jp nz` jumps to `skip`, and the body is skipped.
+
+Getting the direction right is the part that trips everyone up at first. The
+condition on `jp` is the condition that causes the jump — not the condition
+that runs the body. `jp nz, skip` means "jump away if not-equal." The body
+that follows is the equal case. It helps to read it as: "if this is NOT what
+I want, get out."
+
+`and` with a single-bit mask lets you test one specific bit of A and act on the
+result:
+
+```zax
+ld a, (status)
+and $04            ; keep only bit 2; Z is set if bit 2 was 0
+jp z, bit_clear    ; bit 2 was 0 — go to bit_clear
+```
+
+`and $04` clears every bit except bit 2. If bit 2 was already 0 in A, the
+result is 0, Z is set, and `jp z` jumps. If bit 2 was 1, the result is
+non-zero, Z is clear, and execution falls through.
 
 ---
 
 ## Short relative jump: `jr`
 
-`jr` is a shorter form of `jp`. Where `jp` encodes a full 16-bit target
-address, `jr` encodes a signed 8-bit displacement from the current instruction.
-This limits its range to approximately 127 bytes forward or 128 bytes backward,
-but saves one byte of code.
+`jp` encodes a full 16-bit target address in its three instruction bytes.
+`jr` encodes only a signed 8-bit displacement — the distance from the current
+instruction to the target, not the target's actual address. This limits its
+reach to roughly 127 bytes forward or 128 bytes backward from the `jr`
+instruction itself, but the instruction is one byte shorter.
 
-`jr nz, label` is the conditional relative jump form: jump to `label` if Z is
-clear.
+`jr nz, label` jumps to `label` if Z is clear. The conditional forms support
+`z`, `nz`, `c`, and `nc` only — fewer conditions than `jp`.
 
-For any jump that could exceed the 128-byte backward range, use `jp` instead.
-The assembler will report an error if a `jr` target is out of range.
-
-The practical differences:
-
-| | `jp` (absolute) | `jr` (relative) |
+| | `jp` | `jr` |
 |---|---|---|
 | Address encoding | Full 16-bit address | Signed 8-bit displacement |
 | Instruction size | 3 bytes | 2 bytes |
 | Reach | Anywhere in 64K | ≈ 128 bytes backward / 127 forward |
-| Available conditions | z, nz, c, nc, pe, po, m, p | z, nz, c, nc only |
+| Conditions available | z, nz, c, nc, m, p, pe, po | z, nz, c, nc only |
 
-Use `jr` when the target is close and you want compact code. Use `jp` when the
-target may be far away, or when you need the `pe`, `po`, `m`, or `p` conditions
-that `jr` does not support. Branch range limits for `jr` and the related `djnz`
-instruction (Chapter 5) are summarised in
+For short loops and nearby tests, `jr` saves a byte per jump and the range is
+rarely a problem. For anything that might be far away, or when you need a
+condition that `jr` does not support, `jp` is the safe choice. The assembler
+will tell you if a `jr` target is out of range. Jump range limits for `jr` and
+the related `djnz` instruction (Chapter 5) are in
 [Appendix 2](../appendices/02-registers-flags-and-conditions.md).
 
 ---
@@ -248,28 +310,6 @@ is the dividing line between the two halves: 0–127 (non-negative) and 128–25
 
 `neg` applied to −128 gives −128 — the mathematical result (+128) does not fit
 in a signed byte, so the bit pattern (`$80`) is unchanged.
-
----
-
-## Label-based control flow structure
-
-Every conditional block in raw Z80 has the same skeleton:
-
-1. Set the flags (using `cp`, `or a`, `and`, `xor`, arithmetic, or another instruction).
-2. Conditionally jump over the block you want to skip.
-3. Write the block.
-4. Place an exit label after the block.
-
-A simple loop has a similar skeleton:
-
-1. Initialize a counter or pointer before the loop.
-2. Place a label at the loop top.
-3. Write the loop body.
-4. Update the counter or pointer.
-5. Test the exit condition.
-6. Conditionally jump back to the loop-top label.
-
-The example file below runs both back to back — trace each one and watch which instruction sets the flag before the branch reads it.
 
 ---
 
@@ -328,41 +368,42 @@ through `ld a, 1 / ld (found), a`, then `jp done_compare` skips the else-block
 and lands at `done_compare:`.
 
 If A had held any value other than 5, Z would have been clear, `jp nz` would
-have branched to `not_equal:`, and `found` would have been set to 0.
+have jumped to `not_equal:`, and `found` would have been set to 0.
 
-**Section B — zero test with `or a`.** `ld a, 0` loads zero. `or a` sets Z because
-A is zero. `jp z, was_zero` branches because Z is set. The instruction
-`ld a, $AA` executes as the "zero was detected" branch; this marks the register
-so you can verify in a debugger or simulator that this path ran. `jp skip_zero`
-then skips past the end of the zero-branch.
+**Section B — zero test with `or a`.** `ld a, 0` loads zero. `or a` sets Z
+because A is zero. `jp z, was_zero` sees Z set and jumps to `was_zero:`.
+`ld a, $AA` runs — this marks A so you can confirm in a debugger that this
+path was taken. `jp skip_zero` then skips past the end of the block.
 
-This pair — `jp z, was_zero` / `jp skip_zero` — is the raw conditional branch
-pattern defined in "Label-based control flow structure" above: set a flag, use a
-conditional jump to enter or skip a consequence block, and place an exit label
-after it. The only difference from the `cp`-based Section A is that `or a` sets
-the flag here instead of `cp`.
+The structure is the same as Section A: set a flag, use a conditional `jp` to
+enter or skip a consequence block, place an exit label after it. The only
+difference is that `or a` sets the flag here instead of `cp`.
 
-**Section C — counted loop with `dec` / `jp nz`.** `ld b, Limit` initializes B to
-5. At `loop_top:`, the body reads `counter` from RAM, increments it, and stores
+**Section C — counted loop with `dec` / `jp nz`.** `ld b, Limit` loads 5 into
+B. At `loop_top:`, the body reads `counter` from RAM, increments it, and stores
 it back. `dec b` decrements B and sets Z when B reaches zero. `jp nz, loop_top`
-branches back while B is non-zero.
+jumps back to `loop_top:` while B is non-zero.
 
-After the loop, `counter` holds 5. B holds 0. The loop ran exactly five times.
+After five iterations, `counter` holds 5 and B holds 0.
 
-`dec b` sets the Z flag — not the preceding `ld (counter), a`, which never
-touches flags. `jp nz` reads whatever `dec b` left. Always identify which
-instruction sets the flag before the branch that reads it.
+Pay attention to which instruction sets Z here. `dec b` sets it — not
+`ld (counter), a`, which never touches flags at all. `jp nz` reads whatever
+`dec b` left. An `ld` between a comparison and a `jp` leaves the flags
+unchanged; a `dec` replaces them entirely. Getting this wrong is one of the
+most common sources of silent bugs in Z80 programs.
 
-**Section D — logical operations.** `and $0F` masks A to its low nibble: bits
-7–4 are cleared, bits 3–0 are kept. `$F3 & $0F = $03`. Z is clear.
+**Section D — logical operations.** A is loaded with `$F3` (`%11110011`), then
+`and $0F` clears bits 7–4 and keeps bits 3–0. Result: `$03`. Z is clear.
 
-`or $80` sets bit 7 of A regardless of its previous value. `$03 | $80 = $83`.
+`ld a, $03` reloads A — this resets A to a known value before the next
+demonstration. `or $80` sets bit 7 of A regardless of what was already there.
+`$03 | $80 = $83`. Z is clear.
+
+`ld a, $FF` reloads A again. `xor $0F` flips bits 3–0. `$FF ^ $0F = $F0`.
 Z is clear.
 
-`xor $0F` flips the low nibble of A. `$FF ^ $0F = $F0`. Z is clear.
-
-`xor a` computes A XOR A. Every bit cancels. A is zeroed, Z is set, C is
-cleared — in one instruction.
+`xor a` computes A XOR A. Every bit cancels out — any bit XOR'd with itself is
+always 0. A is zeroed, Z is set, C is cleared, in one instruction.
 
 ---
 
@@ -371,10 +412,11 @@ cleared — in one instruction.
 - The Z, C, S, and P/V flags record the outcome of the last instruction that
   affected them. Most `ld` instructions do not affect flags; arithmetic,
   comparison, and logical instructions do.
-- `cp n` subtracts n from A and sets flags without changing A. Z is set if
-  A = n; C is set if A < n (unsigned).
-- `sub n` subtracts n from A and sets the same flags, but stores the result
-  in A. Use `cp` for testing; use `sub` for computing.
+- `sub n` subtracts n from A, stores the result in A, and updates flags. Z is
+  set if the result is zero; C is set if A was less than n (unsigned borrow).
+- `cp n` does the same subtraction and sets the same flags, but discards the
+  result — A is unchanged. Use it when you only need the relationship, not the
+  difference.
 - `or a` sets Z if A is zero, without changing A. Use it to test A for zero
   without a comparison value.
 - `and n` keeps bits where the mask has 1 (clears others); `or n` sets bits
@@ -382,17 +424,17 @@ cleared — in one instruction.
   clear C and update Z.
 - `xor a` zeroes A, sets Z, and clears C in one instruction. Prefer it over
   `ld a, 0` when you need a known flag state.
-- `jp label` jumps unconditionally to the address of `label`.
+- `jp label` puts the address of `label` into PC; execution continues from
+  there. The jump always happens — the flags are not consulted.
 - `jp nz, label` jumps if Z is clear; `jp z, label` jumps if Z is set; `jp c`
   and `jp nc` test C. The full condition-code list is in Appendix 2.
-- `jr` is a shorter, range-limited relative jump. Use it for nearby branches;
-  use `jp` when the target might be more than 127 bytes away.
-- A conditional block in raw Z80 uses a flag-setting instruction, a conditional
-  `jp` to skip the block, the block body, and an exit label.
-- A counted loop uses a register as the counter, a loop-top label, the loop
-  body, a decrement, and `jp nz` back to the loop-top label.
-- Always identify which instruction sets the flag before the branch that reads
-  it.
+- The condition on `jp cc` is what triggers the jump, not what runs the body.
+  `jp nz, skip` jumps away when not-equal; what follows is the equal case.
+- `jr` is a 2-byte relative jump, limited to roughly ±128 bytes and four
+  conditions. Use it when the target is close; use `jp` otherwise.
+- When a `jp` tests a flag, trace back to find which instruction set it.
+  An `ld` between a comparison and a `jp` leaves the flags unchanged; `dec`
+  and `inc` replace them. Getting this wrong produces silent wrong results.
 
 ---
 

--- a/learning/part1/examples/03_flag_tests_and_jumps.zax
+++ b/learning/part1/examples/03_flag_tests_and_jumps.zax
@@ -40,13 +40,13 @@ loop_top:
 
   ; --- Part 4: logical operations (and, or, xor) ---
   ld a, $F3                      ; A = %11110011
-  and $0F                        ; A = %00000011; upper nibble cleared; Z clear, C clear
+  and $0F                        ; A = %00000011; upper four bits cleared; Z clear, C clear
 
   ld a, $03                      ; A = %00000011
   or $80                         ; A = %10000011; bit 7 set; Z clear
 
   ld a, $FF                      ; A = %11111111
-  xor $0F                        ; A = %11110000; lower nibble flipped; Z clear
+  xor $0F                        ; A = %11110000; lower four bits flipped; Z clear
 
   xor a                          ; A = 0; Z is set; C is clear
 end


### PR DESCRIPTION
## Summary

- Significantly expands the flags register, unconditional `jp`, and conditional `jp` sections following a richer, more explanatory writing style
- Fixes multiple ordering issues where terms were used before being introduced (`or a` before `or`, `jump`/`branch` before `jp` sections, `nibble` never defined, `sub` introduced after `cp`)
- Removes the abstract "Label-based control flow structure" numbered list (patterns already demonstrated concretely)
- Cleans up several prose issues: classification openers, forward references, imperative instructions, "substituted" jargon

## Test plan

- [ ] Read chapter end-to-end and verify no term is used before it is introduced
- [ ] Verify example file assembles correctly
- [ ] Check all `jp`/`jr` examples are syntactically valid ZAX

🤖 Generated with [Claude Code](https://claude.com/claude-code)