### PR TITLE
docs(course): sweep remaining update shuttles to succ/pred

### DIFF
--- a/learning/part2/examples/unit3/strlen.zax
+++ b/learning/part2/examples/unit3/strlen.zax
@@ -26,9 +26,7 @@ export func strlen_demo(): HL
 
     inc hl
 
-    de := count_value
-    inc de
-    count_value := de
+    succ count_value
 
     ld a, 1
     or a


### PR DESCRIPTION
## Context
Bounded follow-up to **#903**: course-only ergonomics (**#906**). Only `learning/part2/examples/**/*.zax` was in scope.

## Change
- **`learning/part2/examples/unit3/strlen.zax`**: replace `de := count_value` / `inc de` / `count_value := de` with `succ count_value`.

## Inspected / intentionally unchanged
- **word_stack.zax**, **ring_buffer.zax**, **linked_list.zax**, **eight_queens.zax** — `inc`/`dec` tied to stack depth, pointers, or control flow, not a plain typed store-back shuttle.
- Other unit3 string examples (`strcpy`, `strcmp`, `strcat`, `str_reverse`) — `inc de` / `dec de` are raw pointer walks, not `:=` shuttles.

## Verification (local)
- `npm run typecheck` — pass
- `npm run zax -- learning/part2/examples/unit3/strlen.zax` — exits with existing **[ZAX300] Unresolved symbol "hl" in 16-bit fixup** (same failure on `main` before this edit; not introduced by `succ`)

Closes #906

Made with [Cursor](https://cursor.com)