### PR TITLE
docs(learning): align example references and citations

### DIFF
--- a/learning/part1/09-a-phase-a-program.md
+++ b/learning/part1/09-a-phase-a-program.md
@@ -1,4 +1,4 @@
-[← I/O and Ports](08-io-and-ports.md) | [Part 1](README.md) | [Typed Storage and Assignment →](10-typed-storage-and-assignment.md)
+[← I/O and Ports](08-io-and-ports.md) | [Part 1](README.md) | [Functions and the IX Frame →](10-functions-and-the-ix-frame.md)
 
 # Chapter 9 — A Complete Program
 

--- a/learning/part1/10-functions-and-the-ix-frame.md
+++ b/learning/part1/10-functions-and-the-ix-frame.md
@@ -6,6 +6,8 @@ Chapter 7 showed that `call` is just a `push` of the return address followed by 
 
 This chapter introduces ZAX functions — the first feature in this book that is not raw Z80 assembly. A ZAX function declares its parameters and locals by name. The compiler builds a **stack frame** using IX as a base pointer, and you access every parameter and local through standard Z80 `ld` instructions with IX-relative offsets. No new syntax inside the function body. Just `ld a, (ix+name+0)` — the same displaced addressing you learned in Chapter 6.
 
+The companion example is `learning/part1/examples/09_typed_storage.zax`.
+
 ---
 
 ## Why register passing runs out

--- a/learning/part1/11-structured-control-flow.md
+++ b/learning/part1/11-structured-control-flow.md
@@ -280,6 +280,12 @@ The example file `learning/part1/examples/10_structured_control.zax` rewrites
 `find_max` and `count_above` from Chapter 9 using `while` and `if`. Here are
 the two versions side by side.
 
+The inline listings below are adapted from that example file. The shipped file
+already uses `:=` and `succ` in a few places where the final code is clearer,
+but the chapter keeps the raw IX-relative forms in the listings so you can
+focus on the control-flow rewrite before Chapter 12 introduces the assignment
+surface explicitly.
+
 **`find_max` — raw (Chapter 9):**
 
 ```zax
@@ -419,7 +425,9 @@ count it." The skip label is gone.
 The example file contains `main`, `find_max_cf`, and `count_above_cf`. It uses
 the same table and produces the same results as Chapter 9:
 maximum = 91, above-64 count = 3. The only difference is in how the subroutine
-bodies are written.
+bodies are written. The file is the final cleaned-up version, so you will see
+`:=` and `succ` where the chapter listings above kept the raw IX-relative frame
+access to isolate the control-flow changes.
 
 Read both files simultaneously. For each subroutine, compare:
 

--- a/learning/part1/12-typed-assignment.md
+++ b/learning/part1/12-typed-assignment.md
@@ -6,6 +6,8 @@ You have spent two chapters writing `ld a, (ix+running_max+0)` and `ld (ix+cnt+0
 
 Prerequisites: Chapters 3–11.
 
+The companion example is `learning/part1/examples/11_functions_and_op.zax`.
+
 ---
 
 ## `:=` as the assignment surface

--- a/learning/part2/01-foundations.md
+++ b/learning/part2/01-foundations.md
@@ -101,7 +101,7 @@ In practice, both `:=` and `ld` appear in the same function body:
     end
 ```
 
-(From `learning/part2/examples/unit1/exp_squaring.zax`, lines 60–66.)
+(Adapted from `learning/part2/examples/unit1/exp_squaring.zax`, lines 60–66.)
 
 The `ld a, l` and `and 1` are raw Z80 instructions — testing a specific bit
 of a specific register. The `:=` lines on either side are named transfers to
@@ -168,7 +168,7 @@ instruction immediately before the condition:
     end
 ```
 
-(From `learning/part2/examples/unit1/gcd_iterative.zax`, lines 20–26.)
+(Adapted from `learning/part2/examples/unit1/gcd_iterative.zax`, lines 20–26.)
 
 The `or l` instruction sets Z if HL is zero. The `if Z` block then handles the
 base case. This is the standard Z80 null-check pattern: OR H with L, or OR A
@@ -266,7 +266,7 @@ for the three cases (right is zero, values are equal, one is larger):
     end
 ```
 
-(From `learning/part2/examples/unit1/gcd_iterative.zax`, lines 28–45.)
+(Adapted from `learning/part2/examples/unit1/gcd_iterative.zax`, lines 28–45.)
 
 `xor a` clears the carry before `sbc hl, de`, so the subtraction result is
 exact (no borrow from a prior carry). After the subtraction, C is set if
@@ -348,7 +348,7 @@ halve the exponent:
     remaining := hl
 ```
 
-(From `learning/part2/examples/unit1/exp_squaring.zax`, lines 60–74.)
+(Adapted from `learning/part2/examples/unit1/exp_squaring.zax`, lines 60–74, condensed.)
 
 The 16-bit right shift uses `srl h` / `rr l`: shift H right with zero fill,
 rotate L right through carry (which carries the bit from H). This is the

--- a/learning/part2/02-arrays-and-loops.md
+++ b/learning/part2/02-arrays-and-loops.md
@@ -150,7 +150,7 @@ The outer loop:
     ...
 ```
 
-(From `learning/part2/examples/unit2/prime_sieve.zax`, lines 21–37.)
+(Adapted from `learning/part2/examples/unit2/prime_sieve.zax`, lines 21–37, condensed.)
 
 The `break` fires when `factor_index >= StopFactor` (the `cp` instruction sets
 carry when A < StopFactor; `if NC` means carry is not set, so A >= StopFactor).
@@ -390,7 +390,7 @@ element matches (returning the index), or when the scan exhausts the array
     succ scan_index
 ```
 
-(From `learning/part2/examples/unit2/linear_search.zax`, lines 28–42.)
+(Adapted from `learning/part2/examples/unit2/linear_search.zax`, lines 28–42.)
 
 When the match is found, the index needs to be in HL (the return register). The
 function loads 0 into H and `scan_index` into L, forming a 16-bit index value.
@@ -418,7 +418,7 @@ that fit in 16 bits:
     mid_index := hl
 ```
 
-(From `learning/part2/examples/unit2/binary_search.zax`, lines 37–42.)
+(Adapted from `learning/part2/examples/unit2/binary_search.zax`, lines 37–42.)
 
 After computing the midpoint, the function reads `values[L]` (using L as the
 low byte of `mid_index`) and compares against `target_value`. If C is set

--- a/learning/part2/03-strings.md
+++ b/learning/part2/03-strings.md
@@ -215,7 +215,7 @@ func times_ten(value_word: word): HL
 end
 ```
 
-(From `learning/part2/examples/unit3/atoi.zax`, lines 10–20.)
+(Adapted from `learning/part2/examples/unit3/atoi.zax`, lines 10–20.)
 
 The scan pointer advances through `succ scan_ptr` rather than `inc hl` because the
 pointer is kept in a typed local (`scan_ptr: word`) rather than held continuously

--- a/learning/part2/06-recursion.md
+++ b/learning/part2/06-recursion.md
@@ -70,7 +70,7 @@ and combines the results:
   add hl, de
 ```
 
-(From `learning/part2/examples/unit6/hanoi.zax`, lines 20–33.)
+(Adapted from `learning/part2/examples/unit6/hanoi.zax`, lines 20–33, condensed.)
 
 Both recursive calls return in HL. Each result is stored immediately into a local
 — `left_count := hl` and `right_count := hl` — before the next call overwrites


### PR DESCRIPTION
## Summary
- fix the Chapter 9 Part 1 navigation link
- add missing companion-example references in Chapters 10 and 12
- document that Chapter 11 inline listings are adapted from the shipped example file
- relabel Part 2 excerpt citations that are adapted or condensed rather than verbatim

## Why
These changes make the learning docs honest about example provenance and remove a misleading navigation link without changing any example code.
