### PR TITLE
ci: enforce source file size guard policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,10 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Source file size guard
+        if: runner.os == 'Linux'
+        run: npm run check:source-file-sizes:enforce
+
       - name: Windows npm CLI smoke
         if: runner.os == 'Windows'
         shell: bash

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "format": "prettier -w .",
     "format:check": "prettier -c .",
     "check:source-file-sizes": "node scripts/check-source-file-sizes.mjs",
+    "check:source-file-sizes:enforce": "node scripts/check-source-file-sizes.mjs --enforce-hard-cap",
     "zax": "npm run build && node dist/src/cli.js",
     "regen:language-tour": "bash scripts/regenerate-language-tour.sh",
     "regen:codegen-corpus": "node scripts/regenerate-codegen-corpus.mjs",

--- a/scripts/check-source-file-sizes.mjs
+++ b/scripts/check-source-file-sizes.mjs
@@ -3,31 +3,74 @@
 import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 
-const ROOT = new URL('../src/', import.meta.url);
 const SOFT_LIMIT = 750;
 const HARD_LIMIT = 1000;
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_ROOT = path.resolve(SCRIPT_DIR, '../src');
+const DEFAULT_ALLOWLIST_FILE = path.resolve(SCRIPT_DIR, 'source-file-size-allowlist.json');
 
-async function collectTsFiles(dirUrl) {
-  const entries = await readdir(dirUrl, { withFileTypes: true });
+// Policy:
+// - files over the soft limit are always reported
+// - files over the hard cap must either be absent or pinned in the allowlist
+// - allowlisted files may not grow past their recorded ceiling
+
+function normalizePathForOutput(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+function parseArgs(argv) {
+  let enforceHardCap = false;
+  let rootDir = DEFAULT_ROOT;
+  let allowlistFile = DEFAULT_ALLOWLIST_FILE;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--enforce-hard-cap') {
+      enforceHardCap = true;
+      continue;
+    }
+    if (arg === '--root') {
+      const next = argv[i + 1];
+      if (!next) throw new Error('--root requires a path argument');
+      rootDir = path.resolve(process.cwd(), next);
+      i += 1;
+      continue;
+    }
+    if (arg === '--allowlist-file') {
+      const next = argv[i + 1];
+      if (!next) throw new Error('--allowlist-file requires a path argument');
+      allowlistFile = path.resolve(process.cwd(), next);
+      i += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return { enforceHardCap, rootDir, allowlistFile };
+}
+
+async function collectTsFiles(dirPath) {
+  const entries = await readdir(dirPath, { withFileTypes: true });
   const files = [];
 
   for (const entry of entries) {
-    const childUrl = new URL(`${entry.name}${entry.isDirectory() ? '/' : ''}`, dirUrl);
+    const childPath = path.join(dirPath, entry.name);
     if (entry.isDirectory()) {
-      files.push(...(await collectTsFiles(childUrl)));
+      files.push(...(await collectTsFiles(childPath)));
       continue;
     }
     if (entry.isFile() && entry.name.endsWith('.ts')) {
-      files.push(childUrl);
+      files.push(childPath);
     }
   }
 
   return files;
 }
 
-async function countLines(fileUrl) {
-  const text = await readFile(fileUrl, 'utf8');
+async function countLines(filePath) {
+  const text = await readFile(filePath, 'utf8');
   if (text.length === 0) return 0;
   let lines = 1;
   for (const ch of text) {
@@ -37,41 +80,83 @@ async function countLines(fileUrl) {
   return lines;
 }
 
-function toWorkspaceRelative(fileUrl) {
-  const fsPath = fileUrl.pathname;
-  const cwd = process.cwd();
-  const rel = path.relative(cwd, fsPath);
-  return rel || path.basename(fsPath);
+function toRootRelative(filePath, rootDir) {
+  const baseDir = path.dirname(rootDir);
+  const rel = path.relative(baseDir, filePath);
+  return normalizePathForOutput(rel || path.basename(filePath));
+}
+
+async function loadAllowlist(allowlistFile) {
+  const raw = await readFile(allowlistFile, 'utf8');
+  const parsed = JSON.parse(raw);
+  const hardCap = parsed?.hardCap;
+  if (hardCap === null || typeof hardCap !== 'object' || Array.isArray(hardCap)) {
+    throw new Error(`Invalid hardCap map in ${allowlistFile}`);
+  }
+
+  const out = new Map();
+  for (const [key, value] of Object.entries(hardCap)) {
+    if (typeof value !== 'number' || !Number.isInteger(value) || value < HARD_LIMIT) {
+      throw new Error(`Invalid hard-cap ceiling for ${key} in ${allowlistFile}`);
+    }
+    out.set(normalizePathForOutput(key), value);
+  }
+  return out;
 }
 
 async function main() {
-  const enforceHardCap = process.argv.includes('--enforce-hard-cap');
-  const files = await collectTsFiles(ROOT);
+  const { enforceHardCap, rootDir, allowlistFile } = parseArgs(process.argv.slice(2));
+  const files = await collectTsFiles(rootDir);
+  const hardCapAllowlist = await loadAllowlist(allowlistFile);
   const rows = [];
 
-  for (const fileUrl of files) {
+  for (const filePath of files) {
     rows.push({
-      path: toWorkspaceRelative(fileUrl),
-      lines: await countLines(fileUrl),
+      path: toRootRelative(filePath, rootDir),
+      lines: await countLines(filePath),
     });
   }
 
   rows.sort((a, b) => b.lines - a.lines || a.path.localeCompare(b.path));
 
-  const hardBreaches = rows.filter((row) => row.lines > HARD_LIMIT);
+  const allowedHardBreaches = [];
+  const hardViolations = [];
+  for (const row of rows.filter((candidate) => candidate.lines > HARD_LIMIT)) {
+    const ceiling = hardCapAllowlist.get(row.path);
+    if (ceiling === undefined) {
+      hardViolations.push({ ...row, kind: 'unallowlisted' });
+      continue;
+    }
+    if (row.lines > ceiling) {
+      hardViolations.push({ ...row, kind: 'grew', ceiling });
+      continue;
+    }
+    allowedHardBreaches.push({ ...row, ceiling });
+  }
   const softBreaches = rows.filter((row) => row.lines > SOFT_LIMIT && row.lines <= HARD_LIMIT);
 
-  if (hardBreaches.length === 0 && softBreaches.length === 0) {
+  if (allowedHardBreaches.length === 0 && hardViolations.length === 0 && softBreaches.length === 0) {
     console.log(`source-file-size-guard: ok (soft ${SOFT_LIMIT}, hard ${HARD_LIMIT})`);
     process.exit(0);
   }
 
   console.log(`source-file-size-guard: soft>${SOFT_LIMIT}, hard>${HARD_LIMIT}`);
 
-  if (hardBreaches.length > 0) {
-    console.log('hard-cap breaches:');
-    for (const row of hardBreaches) {
-      console.log(`- ${row.path}: ${row.lines}`);
+  if (allowedHardBreaches.length > 0) {
+    console.log('hard-cap breaches (allowlisted ceilings):');
+    for (const row of allowedHardBreaches) {
+      console.log(`- ${row.path}: ${row.lines} (ceiling ${row.ceiling})`);
+    }
+  }
+
+  if (hardViolations.length > 0) {
+    console.log('hard-cap violations:');
+    for (const row of hardViolations) {
+      if (row.kind === 'unallowlisted') {
+        console.log(`- ${row.path}: ${row.lines} (not allowlisted)`);
+        continue;
+      }
+      console.log(`- ${row.path}: ${row.lines} (ceiling ${row.ceiling})`);
     }
   }
 
@@ -82,7 +167,7 @@ async function main() {
     }
   }
 
-  process.exit(enforceHardCap && hardBreaches.length > 0 ? 1 : 0);
+  process.exit(enforceHardCap && hardViolations.length > 0 ? 1 : 0);
 }
 
 await main();

--- a/scripts/source-file-size-allowlist.json
+++ b/scripts/source-file-size-allowlist.json
@@ -1,0 +1,7 @@
+{
+  "hardCap": {
+    "src/frontend/parser.ts": 1181,
+    "src/lowering/emit.ts": 1227,
+    "src/lowering/functionLowering.ts": 1262
+  }
+}

--- a/test/pr472_source_file_size_guard.test.ts
+++ b/test/pr472_source_file_size_guard.test.ts
@@ -1,8 +1,10 @@
 import { readFile } from 'node:fs/promises';
 import { readdir } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
 import { describe, expect, it } from 'vitest';
 
 const execFileAsync = promisify(execFile);
@@ -19,20 +21,6 @@ function normalizeGuardOutput(text: string): string {
   return text.replaceAll('\\', '/');
 }
 
-async function collectTsFiles(root: string): Promise<string[]> {
-  const entries = await readdir(root, { withFileTypes: true });
-  const out: string[] = [];
-  for (const entry of entries) {
-    const full = join(root, entry.name);
-    if (entry.isDirectory()) {
-      out.push(...(await collectTsFiles(full)));
-      continue;
-    }
-    if (entry.isFile() && entry.name.endsWith('.ts')) out.push(full);
-  }
-  return out;
-}
-
 describe('PR472: source file size guard', () => {
   it('reports current oversized files deterministically in warn-only mode', async () => {
     const { stdout } = await execFileAsync('node', ['scripts/check-source-file-sizes.mjs'], {
@@ -44,9 +32,15 @@ describe('PR472: source file size guard', () => {
     const normalizedStdout = normalizeGuardOutput(stdout);
 
     expect(normalizedStdout).toContain('source-file-size-guard: soft>750, hard>1000');
-    expect(normalizedStdout).toContain(`src/lowering/emit.ts: ${emitLines}`);
+    expect(normalizedStdout).toContain(`src/lowering/emit.ts: ${emitLines} (ceiling ${emitLines})`);
     if (parserLines > 750) {
-      expect(normalizedStdout).toContain(`src/frontend/parser.ts: ${parserLines}`);
+      if (parserLines > 1000) {
+        expect(normalizedStdout).toContain(
+          `src/frontend/parser.ts: ${parserLines} (ceiling ${parserLines})`,
+        );
+      } else {
+        expect(normalizedStdout).toContain(`src/frontend/parser.ts: ${parserLines}`);
+      }
     } else {
       expect(normalizedStdout).not.toContain(`src/frontend/parser.ts: ${parserLines}`);
     }
@@ -57,20 +51,47 @@ describe('PR472: source file size guard', () => {
     }
   });
 
-  it('enforce mode only fails when a hard-cap breach remains', async () => {
-    const sourceFiles = await collectTsFiles('src');
-    const hasHardCapBreach = (
-      await Promise.all(sourceFiles.map((file) => currentLineCount(file)))
-    ).some((count) => count > 1000);
+  it('enforce mode passes in the current tree because hard-cap breaches are allowlisted', async () => {
+    await expect(
+      execFileAsync('node', ['scripts/check-source-file-sizes.mjs', '--enforce-hard-cap'], {
+        cwd: process.cwd(),
+      }),
+    ).resolves.toMatchObject({ stderr: '' });
+  });
 
-    const run = execFileAsync('node', ['scripts/check-source-file-sizes.mjs', '--enforce-hard-cap'], {
-      cwd: process.cwd(),
-    });
+  it('enforce mode fails when an allowlisted hard-cap file grows past its ceiling', async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), 'zax-size-guard-'));
+    const fixtureRoot = join(tempRoot, 'workspace');
+    const fixtureSrc = join(fixtureRoot, 'src');
+    const oversizedFile = join(fixtureSrc, 'oversized.ts');
+    const allowlistFile = join(fixtureRoot, 'allowlist.json');
+    const scriptPath = resolve(process.cwd(), 'scripts/check-source-file-sizes.mjs');
+    const oversizedText = `${Array.from({ length: 1002 }, () => 'export const x = 1;').join('\n')}\n`;
 
-    if (hasHardCapBreach) {
-      await expect(run).rejects.toMatchObject({ code: 1 });
-    } else {
-      await expect(run).resolves.toMatchObject({ stderr: '' });
+    await mkdir(fixtureSrc, { recursive: true });
+    await writeFile(oversizedFile, oversizedText);
+    await writeFile(
+      allowlistFile,
+      JSON.stringify({ hardCap: { 'src/oversized.ts': 1001 } }, null, 2),
+    );
+
+    try {
+      await expect(
+        execFileAsync(
+          'node',
+          [
+            scriptPath,
+            '--root',
+            fixtureSrc,
+            '--allowlist-file',
+            allowlistFile,
+            '--enforce-hard-cap',
+          ],
+          { cwd: fixtureRoot },
+        ),
+      ).rejects.toMatchObject({ code: 1 });
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary
- enforce the source file size guard in CI on Linux runs
- add a hard-cap allowlist with ceilings for the current oversized files
- extend the guard tests to cover allowlisted pass and ceiling-regression failure cases

## Testing
- npm run check:source-file-sizes
- npm run check:source-file-sizes:enforce
- npm run typecheck
- npx vitest run test/pr472_source_file_size_guard.test.ts

Closes #1029
