### PR TITLE
docs: align source overview and ratchet emit cap

### DIFF
--- a/docs/reference/source-overview.md
+++ b/docs/reference/source-overview.md
@@ -25,7 +25,8 @@ in-memory artifacts through injected format writers.
 ```
 src/
   cli.ts                  CLI entry point (argument parsing, file I/O, format wiring)
-  compile.ts              Top-level compile orchestrator (import resolution + pipeline)
+  compile.ts              Top-level compile orchestrator (phase sequencing + artifact emission)
+  moduleLoader.ts         Import/include expansion, module graph walk, topo ordering, source capture
   pipeline.ts             Type contracts only: CompilerOptions, CompileResult, PipelineDeps
 
   addressing/
@@ -69,7 +70,7 @@ src/
   lowering/
     emit.ts               Program emission orchestrator: callable/section scan, item emission, fixups
     emitContextBuilder.ts Shared wiring for function/program lowering contexts used by emit.ts
-    ldLowering.ts         LD instruction lowering helpers (~800 lines; ctx: any — see QR-2)
+    ldLowering.ts         Typed LD lowering facade: form selection + encoding composition
     programLowering.ts    Program item dispatch: pre-scan, DataBlock/VarBlock, finalization
     functionLowering.ts   FuncDecl coordinator: frame setup, prologue, epilogue, body
     functionCallLowering.ts  Typed-call argument dispatch (byte/word/ea/mem variants)
@@ -121,8 +122,9 @@ CLI / test harness
   ▼
 compile(entryFile, options, deps)           [compile.ts]
   │
-  ├─ loadProgram()
+  ├─ loadProgram()                          [moduleLoader.ts]
   │    ├─ readFile + parseModuleFile()      [frontend/parser.ts]
+  │    ├─ expand includes + capture source comments
   │    ├─ resolve imports (BFS + topo sort)
   │    └─ cycle detection, ID collision check
   │

--- a/scripts/source-file-size-allowlist.json
+++ b/scripts/source-file-size-allowlist.json
@@ -1,7 +1,7 @@
 {
   "hardCap": {
     "src/frontend/parser.ts": 1181,
-    "src/lowering/emit.ts": 1227,
+    "src/lowering/emit.ts": 1180,
     "src/lowering/functionLowering.ts": 1262
   }
 }


### PR DESCRIPTION
## Summary
- document `moduleLoader.ts` in the source overview and point the pipeline map at the extracted loader seam
- update the `ldLowering.ts` description to reflect the current typed facade
- ratchet `src/lowering/emit.ts` in the source-size allowlist from 1227 down to its current 1180-line ceiling

## Verification
- `npx prettier -c docs/reference/source-overview.md`
- `npm run check:source-file-sizes:enforce`
- `npx vitest run test/pr472_source_file_size_guard.test.ts`