### PR TITLE
refactor(lowering): extract asm rewrite helpers

### DIFF
--- a/scripts/source-file-size-allowlist.json
+++ b/scripts/source-file-size-allowlist.json
@@ -2,6 +2,6 @@
   "hardCap": {
     "src/frontend/parser.ts": 1181,
     "src/lowering/emit.ts": 1180,
-    "src/lowering/functionLowering.ts": 1262
+    "src/lowering/functionLowering.ts": 1014
   }
 }

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1,5 +1,6 @@
-import { dirname, resolve } from 'node:path';
+import { dirname } from 'node:path';
 
+import { hasErrors, normalizePath } from './compileShared.js';
 import type { Diagnostic } from './diagnostics/types.js';
 import { DiagnosticIds } from './diagnostics/types.js';
 import type { CompileFn, CompilerOptions, CompileResult, PipelineDeps } from './pipeline.js';
@@ -14,10 +15,6 @@ import { loadProgram } from './moduleLoader.js';
 import { validateAssignmentAcceptance } from './semantics/assignmentAcceptance.js';
 import { buildEnv } from './semantics/env.js';
 import { validateSuccPredAcceptance } from './semantics/succPredAcceptance.js';
-
-function hasErrors(diagnostics: Diagnostic[]): boolean {
-  return diagnostics.some((d) => d.severity === 'error');
-}
 
 function withDefaults(
   options: CompilerOptions,
@@ -39,9 +36,6 @@ function withDefaults(
   return { emitBin, emitHex, emitD8m, emitListing, emitAsm80 };
 }
 
-function normalizePath(p: string): string {
-  return resolve(p);
-}
 
 function hasMainFunction(program: ProgramNode): boolean {
   const hasMainInItems = (items: Array<ModuleItemNode | SectionItemNode>): boolean => {

--- a/src/compileShared.ts
+++ b/src/compileShared.ts
@@ -1,0 +1,11 @@
+import { resolve } from 'node:path';
+
+import type { Diagnostic } from './diagnostics/types.js';
+
+export function hasErrors(diagnostics: Diagnostic[]): boolean {
+  return diagnostics.some((d) => d.severity === 'error');
+}
+
+export function normalizePath(p: string): string {
+  return resolve(p);
+}

--- a/src/lowering/functionAsmRewriting.ts
+++ b/src/lowering/functionAsmRewriting.ts
@@ -1,0 +1,320 @@
+import type { Diagnostic } from '../diagnostics/types.js';
+import type {
+  AsmOperandNode,
+  EaExprNode,
+  ImmExprNode,
+  SourceSpan,
+  TypeExprNode,
+} from '../frontend/ast.js';
+import type { CompileEnv } from '../semantics/env.js';
+import type { ScalarKind } from './typeResolution.js';
+
+type FrameOffsetMode = 'general' | 'ix_disp';
+
+export type FunctionAsmRewritingContext = {
+  diagnostics: Diagnostic[];
+  diagAt: (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
+  evalImmExpr: (
+    expr: ImmExprNode,
+    env: CompileEnv,
+    diagnostics: Diagnostic[],
+  ) => number | undefined;
+  env: CompileEnv;
+  stackSlotOffsets: Map<string, number>;
+  stackSlotTypes: Map<string, TypeExprNode>;
+  localAliasTargets: Map<string, EaExprNode>;
+  resolveScalarKind: (typeExpr: TypeExprNode) => ScalarKind | undefined;
+  symbolicTargetFromExpr: (
+    expr: ImmExprNode,
+  ) => { baseLower: string; addend: number } | undefined;
+  emitInstr: (head: string, operands: AsmOperandNode[], span: SourceSpan) => boolean;
+};
+
+export type FunctionAsmRewritingHelpers = {
+  resolveLocalAliasTargetName: (nameLower: string) => string | undefined;
+  evalImmExprForAsm: (expr: ImmExprNode) => number | undefined;
+  symbolicTargetFromExprForAsm: (
+    expr: ImmExprNode,
+  ) => { baseLower: string; addend: number } | undefined;
+  emitInstrForAsm: (head: string, operands: AsmOperandNode[], span: SourceSpan) => boolean;
+};
+
+export function createFunctionAsmRewritingHelpers(
+  ctx: FunctionAsmRewritingContext,
+): FunctionAsmRewritingHelpers {
+  const {
+    diagnostics,
+    diagAt,
+    evalImmExpr,
+    env,
+    stackSlotOffsets,
+    stackSlotTypes,
+    localAliasTargets,
+    resolveScalarKind,
+    symbolicTargetFromExpr,
+    emitInstr,
+  } = ctx;
+
+  const resolveLocalAliasTargetName = (nameLower: string): string | undefined => {
+    const target = localAliasTargets.get(nameLower);
+    return target && target.kind === 'EaName' ? target.name : undefined;
+  };
+
+  const rewriteImmExprForRawAliases = (
+    expr: ImmExprNode,
+  ): { expr: ImmExprNode; ok: boolean } => {
+    switch (expr.kind) {
+      case 'ImmLiteral':
+      case 'ImmSizeof':
+        return { expr, ok: true };
+      case 'ImmName': {
+        const aliasTarget = resolveLocalAliasTargetName(expr.name.toLowerCase());
+        if (aliasTarget) {
+          return { expr: { ...expr, name: aliasTarget }, ok: true };
+        }
+        return { expr, ok: true };
+      }
+      case 'ImmUnary': {
+        const inner = rewriteImmExprForRawAliases(expr.expr);
+        return { expr: { ...expr, expr: inner.expr }, ok: inner.ok };
+      }
+      case 'ImmBinary': {
+        const left = rewriteImmExprForRawAliases(expr.left);
+        const right = rewriteImmExprForRawAliases(expr.right);
+        return {
+          expr: { ...expr, left: left.expr, right: right.expr },
+          ok: left.ok && right.ok,
+        };
+      }
+      case 'ImmOffsetof': {
+        let ok = true;
+        const steps = expr.path.steps.map((step) => {
+          if (step.kind !== 'OffsetofIndex') return step;
+          const rewritten = rewriteImmExprForRawAliases(step.expr);
+          ok = ok && rewritten.ok;
+          return { ...step, expr: rewritten.expr };
+        });
+        return { expr: { ...expr, path: { ...expr.path, steps } }, ok };
+      }
+    }
+  };
+
+  const rewriteImmExprForFrameOffsets = (
+    expr: ImmExprNode,
+    mode: FrameOffsetMode,
+  ): { expr: ImmExprNode; ok: boolean } => {
+    switch (expr.kind) {
+      case 'ImmLiteral':
+      case 'ImmSizeof':
+        return { expr, ok: true };
+      case 'ImmName': {
+        const lower = expr.name.toLowerCase();
+        const slotOffset = stackSlotOffsets.get(lower);
+        if (slotOffset !== undefined) {
+          const typeExpr = stackSlotTypes.get(lower);
+          const scalarKind = typeExpr ? resolveScalarKind(typeExpr) : undefined;
+          if (!scalarKind) {
+            diagAt(
+              diagnostics,
+              expr.span,
+              `Non-scalar slot "${expr.name}" cannot be used as a raw IX offset.`,
+            );
+            return { expr, ok: false };
+          }
+          return { expr: { kind: 'ImmLiteral', span: expr.span, value: slotOffset }, ok: true };
+        }
+        if (localAliasTargets.has(lower) && mode === 'ix_disp') {
+          diagAt(
+            diagnostics,
+            expr.span,
+            `Alias "${expr.name}" has no frame slot; cannot be used as a raw IX offset.`,
+          );
+          return { expr, ok: false };
+        }
+        return { expr, ok: true };
+      }
+      case 'ImmUnary': {
+        const inner = rewriteImmExprForFrameOffsets(expr.expr, mode);
+        return { expr: { ...expr, expr: inner.expr }, ok: inner.ok };
+      }
+      case 'ImmBinary': {
+        const left = rewriteImmExprForFrameOffsets(expr.left, mode);
+        const right = rewriteImmExprForFrameOffsets(expr.right, mode);
+        return {
+          expr: { ...expr, left: left.expr, right: right.expr },
+          ok: left.ok && right.ok,
+        };
+      }
+      case 'ImmOffsetof': {
+        let ok = true;
+        const steps = expr.path.steps.map((step) => {
+          if (step.kind !== 'OffsetofIndex') return step;
+          const rewritten = rewriteImmExprForFrameOffsets(step.expr, mode);
+          ok = ok && rewritten.ok;
+          return { ...step, expr: rewritten.expr };
+        });
+        return { expr: { ...expr, path: { ...expr.path, steps } }, ok };
+      }
+    }
+  };
+
+  const rewriteEaExprForFrameOffsets = (
+    ea: EaExprNode,
+  ): { expr: EaExprNode; ok: boolean } => {
+    switch (ea.kind) {
+      case 'EaName':
+        return { expr: ea, ok: true };
+      case 'EaImm': {
+        const rewritten = rewriteImmExprForFrameOffsets(ea.expr, 'general');
+        return { expr: { ...ea, expr: rewritten.expr }, ok: rewritten.ok };
+      }
+      case 'EaReinterpret': {
+        const base = rewriteEaExprForFrameOffsets(ea.base);
+        return { expr: { ...ea, base: base.expr }, ok: base.ok };
+      }
+      case 'EaField': {
+        const base = rewriteEaExprForFrameOffsets(ea.base);
+        return { expr: { ...ea, base: base.expr }, ok: base.ok };
+      }
+      case 'EaAdd':
+      case 'EaSub': {
+        const base = rewriteEaExprForFrameOffsets(ea.base);
+        const nextMode: FrameOffsetMode =
+          base.expr.kind === 'EaName' &&
+          (base.expr.name.toUpperCase() === 'IX' || base.expr.name.toUpperCase() === 'IY')
+            ? 'ix_disp'
+            : 'general';
+        const offset = rewriteImmExprForFrameOffsets(ea.offset, nextMode);
+        return {
+          expr: { ...ea, base: base.expr, offset: offset.expr },
+          ok: base.ok && offset.ok,
+        };
+      }
+      case 'EaIndex': {
+        const base = rewriteEaExprForFrameOffsets(ea.base);
+        let ok = base.ok;
+        const index = (() => {
+          switch (ea.index.kind) {
+            case 'IndexImm': {
+              const value = rewriteImmExprForFrameOffsets(ea.index.value, 'general');
+              ok = ok && value.ok;
+              return { ...ea.index, value: value.expr };
+            }
+            case 'IndexMemIxIy': {
+              if (!ea.index.disp) return ea.index;
+              const disp = rewriteImmExprForFrameOffsets(ea.index.disp, 'general');
+              ok = ok && disp.ok;
+              return { ...ea.index, disp: disp.expr };
+            }
+            case 'IndexEa': {
+              const expr = rewriteEaExprForFrameOffsets(ea.index.expr);
+              ok = ok && expr.ok;
+              return { ...ea.index, expr: expr.expr };
+            }
+            default:
+              return ea.index;
+          }
+        })();
+        return { expr: { ...ea, base: base.expr, index }, ok };
+      }
+    }
+  };
+
+  const rewriteAsmOperandForFrameOffsets = (
+    op: AsmOperandNode,
+  ): { op: AsmOperandNode; ok: boolean } => {
+    switch (op.kind) {
+      case 'Reg':
+      case 'PortC':
+        return { op, ok: true };
+      case 'Imm':
+      case 'PortImm8': {
+        const rewritten = rewriteImmExprForFrameOffsets(op.expr, 'general');
+        return { op: { ...op, expr: rewritten.expr }, ok: rewritten.ok };
+      }
+      case 'Ea':
+      case 'Mem': {
+        const rewritten = rewriteEaExprForFrameOffsets(op.expr);
+        return { op: { ...op, expr: rewritten.expr }, ok: rewritten.ok };
+      }
+    }
+  };
+
+  const evalImmExprForAsm = (expr: ImmExprNode): number | undefined => {
+    const rewritten = rewriteImmExprForFrameOffsets(expr, 'general');
+    if (!rewritten.ok) return undefined;
+    return evalImmExpr(rewritten.expr, env, diagnostics);
+  };
+
+  const symbolicTargetFromExprForAsm = (
+    expr: ImmExprNode,
+  ): { baseLower: string; addend: number } | undefined => {
+    const rewritten = rewriteImmExprForRawAliases(expr);
+    if (!rewritten.ok) return undefined;
+    const symbolic = symbolicTargetFromExpr(rewritten.expr);
+    if (!symbolic) return undefined;
+    if (stackSlotOffsets.has(symbolic.baseLower)) return undefined;
+    return symbolic;
+  };
+
+  const emitInstrForAsm = (head: string, operands: AsmOperandNode[], span: SourceSpan): boolean => {
+    const immExprHasFrameSlotName = (expr: ImmExprNode): boolean => {
+      switch (expr.kind) {
+        case 'ImmName':
+          return stackSlotOffsets.has(expr.name.toLowerCase());
+        case 'ImmUnary':
+          return immExprHasFrameSlotName(expr.expr);
+        case 'ImmBinary':
+          return immExprHasFrameSlotName(expr.left) || immExprHasFrameSlotName(expr.right);
+        case 'ImmOffsetof':
+          return expr.path.steps.some(
+            (step) => step.kind === 'OffsetofIndex' && immExprHasFrameSlotName(step.expr),
+          );
+        default:
+          return false;
+      }
+    };
+
+    const checkFrameDispRange = (op: AsmOperandNode): boolean => {
+      if (op.kind !== 'Mem') return true;
+      const ea = op.expr;
+      const baseIsIxIy = (base: EaExprNode): boolean =>
+        base.kind === 'EaName' && (base.name.toUpperCase() === 'IX' || base.name.toUpperCase() === 'IY');
+      let dispExpr: ImmExprNode | undefined;
+      if ((ea.kind === 'EaAdd' || ea.kind === 'EaSub') && baseIsIxIy(ea.base)) {
+        dispExpr = ea.offset;
+      } else {
+        return true;
+      }
+      if (!immExprHasFrameSlotName(dispExpr)) return true;
+      const rewritten = rewriteImmExprForFrameOffsets(dispExpr, 'ix_disp');
+      if (!rewritten.ok) return false;
+      const value = evalImmExpr(rewritten.expr, env, diagnostics);
+      if (value === undefined) return false;
+      if (value < -128 || value > 127) {
+        diagAt(diagnostics, op.span, `IX/IY displacement out of range (-128..127): ${value}.`);
+        return false;
+      }
+      return true;
+    };
+
+    for (const op of operands) {
+      if (!checkFrameDispRange(op)) return false;
+    }
+
+    const rewritten: AsmOperandNode[] = [];
+    for (const op of operands) {
+      const next = rewriteAsmOperandForFrameOffsets(op);
+      if (!next.ok) return false;
+      rewritten.push(next.op);
+    }
+    return emitInstr(head, rewritten, span);
+  };
+
+  return {
+    resolveLocalAliasTargetName,
+    evalImmExprForAsm,
+    symbolicTargetFromExprForAsm,
+    emitInstrForAsm,
+  };
+}

--- a/src/lowering/functionLowering.ts
+++ b/src/lowering/functionLowering.ts
@@ -32,6 +32,7 @@ import {
   type FlowState,
   type OpExpansionFrame,
 } from './functionBodySetup.js';
+import { createFunctionAsmRewritingHelpers } from './functionAsmRewriting.js';
 import { createFunctionCallLoweringHelpers } from './functionCallLowering.js';
 
 // This module owns the per-function lowering coordinator. It assembles the
@@ -311,272 +312,23 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
     currentCodeSegmentTagRef.current = tag;
   };
   const emitInstr = emitInstrBase;
-
-  const resolveLocalAliasTargetName = (nameLower: string): string | undefined => {
-    const target = localAliasTargets.get(nameLower);
-    return target && target.kind === 'EaName' ? target.name : undefined;
-  };
-
-  const rewriteImmExprForRawAliases = (
-    expr: ImmExprNode,
-  ): { expr: ImmExprNode; ok: boolean } => {
-    switch (expr.kind) {
-      case 'ImmLiteral':
-      case 'ImmSizeof':
-        return { expr, ok: true };
-      case 'ImmName': {
-        const aliasTarget = resolveLocalAliasTargetName(expr.name.toLowerCase());
-        if (aliasTarget) {
-          return { expr: { ...expr, name: aliasTarget }, ok: true };
-        }
-        return { expr, ok: true };
-      }
-      case 'ImmUnary': {
-        const inner = rewriteImmExprForRawAliases(expr.expr);
-        return { expr: { ...expr, expr: inner.expr }, ok: inner.ok };
-      }
-      case 'ImmBinary': {
-        const left = rewriteImmExprForRawAliases(expr.left);
-        const right = rewriteImmExprForRawAliases(expr.right);
-        return {
-          expr: { ...expr, left: left.expr, right: right.expr },
-          ok: left.ok && right.ok,
-        };
-      }
-      case 'ImmOffsetof': {
-        let ok = true;
-        const steps = expr.path.steps.map((step) => {
-          if (step.kind !== 'OffsetofIndex') return step;
-          const rewritten = rewriteImmExprForRawAliases(step.expr);
-          ok = ok && rewritten.ok;
-          return { ...step, expr: rewritten.expr };
-        });
-        return { expr: { ...expr, path: { ...expr.path, steps } }, ok };
-      }
-    }
-  };
-
-  type FrameOffsetMode = 'general' | 'ix_disp';
-  const rewriteImmExprForFrameOffsets = (
-    expr: ImmExprNode,
-    mode: FrameOffsetMode,
-  ): { expr: ImmExprNode; ok: boolean } => {
-    switch (expr.kind) {
-      case 'ImmLiteral':
-      case 'ImmSizeof':
-        return { expr, ok: true };
-      case 'ImmName': {
-        const lower = expr.name.toLowerCase();
-        const slotOffset = stackSlotOffsets.get(lower);
-        if (slotOffset !== undefined) {
-          const typeExpr = stackSlotTypes.get(lower);
-          const scalarKind = typeExpr ? resolveScalarKind(typeExpr) : undefined;
-          if (!scalarKind) {
-            diagAt(
-              diagnostics,
-              expr.span,
-              `Non-scalar slot "${expr.name}" cannot be used as a raw IX offset.`,
-            );
-            return { expr, ok: false };
-          }
-          return { expr: { kind: 'ImmLiteral', span: expr.span, value: slotOffset }, ok: true };
-        }
-        if (localAliasTargets.has(lower) && mode === 'ix_disp') {
-          diagAt(
-            diagnostics,
-            expr.span,
-            `Alias "${expr.name}" has no frame slot; cannot be used as a raw IX offset.`,
-          );
-          return { expr, ok: false };
-        }
-        return { expr, ok: true };
-      }
-      case 'ImmUnary': {
-        const inner = rewriteImmExprForFrameOffsets(expr.expr, mode);
-        return { expr: { ...expr, expr: inner.expr }, ok: inner.ok };
-      }
-      case 'ImmBinary': {
-        const left = rewriteImmExprForFrameOffsets(expr.left, mode);
-        const right = rewriteImmExprForFrameOffsets(expr.right, mode);
-        return {
-          expr: { ...expr, left: left.expr, right: right.expr },
-          ok: left.ok && right.ok,
-        };
-      }
-      case 'ImmOffsetof': {
-        let ok = true;
-        const steps = expr.path.steps.map((step) => {
-          if (step.kind !== 'OffsetofIndex') return step;
-          const rewritten = rewriteImmExprForFrameOffsets(step.expr, mode);
-          ok = ok && rewritten.ok;
-          return { ...step, expr: rewritten.expr };
-        });
-        return { expr: { ...expr, path: { ...expr.path, steps } }, ok };
-      }
-    }
-  };
-
-  const rewriteEaExprForFrameOffsets = (
-    ea: EaExprNode,
-  ): { expr: EaExprNode; ok: boolean } => {
-    switch (ea.kind) {
-      case 'EaName':
-        return { expr: ea, ok: true };
-      case 'EaImm': {
-        const rewritten = rewriteImmExprForFrameOffsets(ea.expr, 'general');
-        return { expr: { ...ea, expr: rewritten.expr }, ok: rewritten.ok };
-      }
-      case 'EaReinterpret': {
-        const base = rewriteEaExprForFrameOffsets(ea.base);
-        return { expr: { ...ea, base: base.expr }, ok: base.ok };
-      }
-      case 'EaField': {
-        const base = rewriteEaExprForFrameOffsets(ea.base);
-        return { expr: { ...ea, base: base.expr }, ok: base.ok };
-      }
-      case 'EaAdd':
-      case 'EaSub': {
-        const base = rewriteEaExprForFrameOffsets(ea.base);
-        const mode: FrameOffsetMode =
-          base.expr.kind === 'EaName' &&
-          (base.expr.name.toUpperCase() === 'IX' || base.expr.name.toUpperCase() === 'IY')
-            ? 'ix_disp'
-            : 'general';
-        const offset = rewriteImmExprForFrameOffsets(ea.offset, mode);
-        return {
-          expr: { ...ea, base: base.expr, offset: offset.expr },
-          ok: base.ok && offset.ok,
-        };
-      }
-      case 'EaIndex': {
-        const base = rewriteEaExprForFrameOffsets(ea.base);
-        let ok = base.ok;
-        const index = (() => {
-          switch (ea.index.kind) {
-            case 'IndexImm': {
-              const value = rewriteImmExprForFrameOffsets(ea.index.value, 'general');
-              ok = ok && value.ok;
-              return { ...ea.index, value: value.expr };
-            }
-            case 'IndexMemIxIy': {
-              if (!ea.index.disp) return ea.index;
-              const disp = rewriteImmExprForFrameOffsets(ea.index.disp, 'general');
-              ok = ok && disp.ok;
-              return { ...ea.index, disp: disp.expr };
-            }
-            case 'IndexEa': {
-              const expr = rewriteEaExprForFrameOffsets(ea.index.expr);
-              ok = ok && expr.ok;
-              return { ...ea.index, expr: expr.expr };
-            }
-            default:
-              return ea.index;
-          }
-        })();
-        return { expr: { ...ea, base: base.expr, index }, ok };
-      }
-    }
-  };
-
-  const rewriteAsmOperandForFrameOffsets = (
-    op: AsmOperandNode,
-  ): { op: AsmOperandNode; ok: boolean } => {
-    switch (op.kind) {
-      case 'Reg':
-      case 'PortC':
-        return { op, ok: true };
-      case 'Imm':
-      case 'PortImm8': {
-        const rewritten = rewriteImmExprForFrameOffsets(op.expr, 'general');
-        return { op: { ...op, expr: rewritten.expr }, ok: rewritten.ok };
-      }
-      case 'Ea':
-      case 'Mem': {
-        const rewritten = rewriteEaExprForFrameOffsets(op.expr);
-        return { op: { ...op, expr: rewritten.expr }, ok: rewritten.ok };
-      }
-    }
-  };
-
-  const rewriteAsmInstructionForFrameOffsets = (
-    asmItem: AsmInstructionNode,
-  ): AsmInstructionNode | undefined => {
-    const rewritten: AsmOperandNode[] = [];
-    for (const op of asmItem.operands) {
-      const next = rewriteAsmOperandForFrameOffsets(op);
-      if (!next.ok) return undefined;
-      rewritten.push(next.op);
-    }
-    return { ...asmItem, operands: rewritten };
-  };
-
-  const evalImmExprForAsm = (expr: ImmExprNode): number | undefined => {
-    const rewritten = rewriteImmExprForFrameOffsets(expr, 'general');
-    if (!rewritten.ok) return undefined;
-    return evalImmExpr(rewritten.expr, env, diagnostics);
-  };
-
-  const symbolicTargetFromExprForAsm = (
-    expr: ImmExprNode,
-  ): { baseLower: string; addend: number } | undefined => {
-    const rewritten = rewriteImmExprForRawAliases(expr);
-    if (!rewritten.ok) return undefined;
-    const symbolic = symbolicTargetFromExpr(rewritten.expr);
-    if (!symbolic) return undefined;
-    if (stackSlotOffsets.has(symbolic.baseLower)) return undefined;
-    return symbolic;
-  };
-
-  const emitInstrForAsm = (head: string, operands: AsmOperandNode[], span: SourceSpan): boolean => {
-    const immExprHasFrameSlotName = (expr: ImmExprNode): boolean => {
-      switch (expr.kind) {
-        case 'ImmName':
-          return stackSlotOffsets.has(expr.name.toLowerCase());
-        case 'ImmUnary':
-          return immExprHasFrameSlotName(expr.expr);
-        case 'ImmBinary':
-          return immExprHasFrameSlotName(expr.left) || immExprHasFrameSlotName(expr.right);
-        case 'ImmOffsetof':
-          return expr.path.steps.some(
-            (step) => step.kind === 'OffsetofIndex' && immExprHasFrameSlotName(step.expr),
-          );
-        default:
-          return false;
-      }
-    };
-    const checkFrameDispRange = (op: AsmOperandNode): boolean => {
-      if (op.kind !== 'Mem') return true;
-      const ea = op.expr;
-      const baseIsIxIy = (base: EaExprNode): boolean =>
-        base.kind === 'EaName' && (base.name.toUpperCase() === 'IX' || base.name.toUpperCase() === 'IY');
-      let dispExpr: ImmExprNode | undefined;
-      if ((ea.kind === 'EaAdd' || ea.kind === 'EaSub') && baseIsIxIy(ea.base)) {
-        dispExpr = ea.offset;
-      } else {
-        return true;
-      }
-      if (!immExprHasFrameSlotName(dispExpr)) return true;
-      const rewritten = rewriteImmExprForFrameOffsets(dispExpr, 'ix_disp');
-      if (!rewritten.ok) return false;
-      const value = evalImmExpr(rewritten.expr, env, diagnostics);
-      if (value === undefined) return false;
-      if (value < -128 || value > 127) {
-        diagAt(diagnostics, op.span, `IX/IY displacement out of range (-128..127): ${value}.`);
-        return false;
-      }
-      return true;
-    };
-    for (const op of operands) {
-      if (!checkFrameDispRange(op)) return false;
-    }
-    const rewritten: AsmOperandNode[] = [];
-    for (const op of operands) {
-      const next = rewriteAsmOperandForFrameOffsets(op);
-      if (!next.ok) return false;
-      rewritten.push(next.op);
-    }
-    return emitInstrBase(head, rewritten, span);
-  };
+  const {
+    resolveLocalAliasTargetName,
+    evalImmExprForAsm,
+    symbolicTargetFromExprForAsm,
+    emitInstrForAsm,
+  } = createFunctionAsmRewritingHelpers({
+    diagnostics,
+    diagAt,
+    evalImmExpr,
+    env,
+    stackSlotOffsets,
+    stackSlotTypes,
+    localAliasTargets,
+    resolveScalarKind,
+    symbolicTargetFromExpr,
+    emitInstr,
+  });
 
   stackSlotOffsets.clear();
   stackSlotTypes.clear();

--- a/src/moduleLoader.ts
+++ b/src/moduleLoader.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
+import { hasErrors, normalizePath } from './compileShared.js';
 import type { Diagnostic } from './diagnostics/types.js';
 import { DiagnosticIds } from './diagnostics/types.js';
 import type { ImportNode, ModuleFileNode, ModuleItemNode, ProgramNode, SectionItemNode } from './frontend/ast.js';
@@ -9,14 +10,6 @@ import { stripLineComment } from './frontend/parseParserShared.js';
 import { makeSourceFile } from './frontend/source.js';
 import { canonicalModuleId } from './moduleIdentity.js';
 import type { CompilerOptions } from './pipeline.js';
-
-function hasErrors(diagnostics: Diagnostic[]): boolean {
-  return diagnostics.some((d) => d.severity === 'error');
-}
-
-function normalizePath(p: string): string {
-  return resolve(p);
-}
 
 function importTargets(moduleFile: ModuleFileNode): ImportNode[] {
   return moduleFile.items.filter((i): i is ImportNode => i.kind === 'Import');


### PR DESCRIPTION
## Summary
- extract raw ASM/frame-offset rewriting out of functionLowering into a dedicated helper module
- deduplicate shared hasErrors/normalizePath helpers between compile and moduleLoader
- ratchet the functionLowering file-size allowlist to the new post-extraction count

## Testing
- npm run typecheck
- npx vitest run test/pr543_function_lowering_integration.test.ts test/pr278_raw_call_typed_target_warning.test.ts test/pr952_raw_ix_slot_offsets.test.ts test/pr472_source_file_size_guard.test.ts
- npm run check:source-file-sizes:enforce