### PR TITLE
refactor(lowering): extract asm ld helpers

### DIFF
--- a/src/lowering/asmInstructionLdHelpers.ts
+++ b/src/lowering/asmInstructionLdHelpers.ts
@@ -1,0 +1,241 @@
+import type { AsmInstructionNode, AsmOperandNode, EaExprNode } from '../frontend/ast.js';
+
+type LdHelperContext = {
+  emitInstr: (head: string, operands: AsmOperandNode[], span: AsmInstructionNode['span']) => boolean;
+  emitAbs16Fixup: (
+    opcode: number,
+    baseLower: string,
+    addend: number,
+    span: AsmInstructionNode['span'],
+    asmText?: string,
+  ) => void;
+  emitAbs16FixupPrefixed: (
+    prefix: number,
+    opcode2: number,
+    baseLower: string,
+    addend: number,
+    span: AsmInstructionNode['span'],
+    asmText?: string,
+  ) => void;
+  emitVirtualReg16Transfer: (asmItem: AsmInstructionNode) => boolean;
+  resolveScalarBinding: (name: string) => 'byte' | 'word' | 'addr' | undefined;
+  resolveRawAliasTargetName: (name: string) => string | undefined;
+  isModuleStorageName: (name: string) => boolean;
+  isFrameSlotName: (name: string) => boolean;
+  reg16: Set<string>;
+};
+
+const regOperand = (name: string, span: AsmInstructionNode['span']): AsmOperandNode => ({
+  kind: 'Reg',
+  span,
+  name,
+});
+
+export function createAsmInstructionLdHelpers(ctx: LdHelperContext) {
+  const emitAssignmentImmediateToRegister = (
+    dst: Extract<AsmOperandNode, { kind: 'Reg' }>,
+    src: Extract<AsmOperandNode, { kind: 'Imm' }>,
+    span: AsmInstructionNode['span'],
+  ): boolean => {
+    const dstName = dst.name.toUpperCase();
+    if (
+      dstName === 'A' ||
+      dstName === 'B' ||
+      dstName === 'C' ||
+      dstName === 'D' ||
+      dstName === 'E' ||
+      dstName === 'H' ||
+      dstName === 'L' ||
+      dstName === 'IXH' ||
+      dstName === 'IXL' ||
+      dstName === 'IYH' ||
+      dstName === 'IYL' ||
+      dstName === 'BC' ||
+      dstName === 'DE' ||
+      dstName === 'HL' ||
+      dstName === 'IX' ||
+      dstName === 'IY'
+    ) {
+      return ctx.emitInstr('ld', [{ ...dst, name: dstName }, src], span);
+    }
+    return false;
+  };
+
+  const emitZeroExtendReg8ToReg16 = (
+    dstName: 'BC' | 'DE' | 'HL',
+    srcName: string,
+    span: AsmInstructionNode['span'],
+  ): boolean => {
+    const hi = dstName === 'BC' ? 'B' : dstName === 'DE' ? 'D' : 'H';
+    const lo = dstName === 'BC' ? 'C' : dstName === 'DE' ? 'E' : 'L';
+    return (
+      ctx.emitInstr(
+        'ld',
+        [{ kind: 'Reg', span, name: hi }, { kind: 'Imm', span, expr: { kind: 'ImmLiteral', span, value: 0 } }],
+        span,
+      ) &&
+      ctx.emitInstr('ld', [{ kind: 'Reg', span, name: lo }, { kind: 'Reg', span, name: srcName }], span)
+    );
+  };
+
+  const emitAssignmentRegisterTransfer = (
+    dst: Extract<AsmOperandNode, { kind: 'Reg' }>,
+    src: Extract<AsmOperandNode, { kind: 'Reg' }>,
+    span: AsmInstructionNode['span'],
+  ): boolean => {
+    const dstName = dst.name.toUpperCase();
+    const srcName = src.name.toUpperCase();
+    const halfIndexRegs = new Set(['IXH', 'IXL', 'IYH', 'IYL']);
+    if (dstName === srcName) return true;
+    if (dstName === 'A' && srcName === 'A') return true;
+    if (dstName === 'A') return false;
+    if (halfIndexRegs.has(dstName) || halfIndexRegs.has(srcName)) {
+      return ctx.emitInstr(
+        'ld',
+        [
+          { kind: 'Reg', span, name: dstName },
+          { kind: 'Reg', span, name: srcName },
+        ],
+        span,
+      );
+    }
+    const wideRegs = new Set(['BC', 'DE', 'HL', 'IX', 'IY']);
+    if (dstName === 'BC' || dstName === 'DE' || dstName === 'HL') {
+      if (srcName === 'A') return emitZeroExtendReg8ToReg16(dstName, srcName, span);
+      const asLd: AsmInstructionNode = {
+        kind: 'AsmInstruction',
+        span,
+        head: 'ld',
+        operands: [
+          { kind: 'Reg', span, name: dstName },
+          { kind: 'Reg', span, name: srcName },
+        ],
+      };
+      return ctx.emitVirtualReg16Transfer(asLd);
+    }
+    if (dstName === 'IX' || dstName === 'IY') {
+      if (!wideRegs.has(srcName)) return false;
+      return (
+        ctx.emitInstr('push', [{ kind: 'Reg', span, name: srcName }], span) &&
+        ctx.emitInstr('pop', [{ kind: 'Reg', span, name: dstName }], span)
+      );
+    }
+    return false;
+  };
+
+  const isTypedStorageLdOperand = (op: AsmOperandNode): boolean => {
+    if (op.kind === 'Ea') return true;
+    if (op.kind === 'Imm' && op.expr.kind === 'ImmName') {
+      return ctx.resolveScalarBinding(op.expr.name) !== undefined;
+    }
+    if (op.kind === 'Reg') {
+      return ctx.resolveScalarBinding(op.name) !== undefined;
+    }
+    return false;
+  };
+
+  const resolveRawLabelName = (name: string): string => ctx.resolveRawAliasTargetName(name) ?? name;
+
+  const isRawLdLabelName = (name: string): boolean => {
+    const resolved = resolveRawLabelName(name);
+    return ctx.isModuleStorageName(resolved) && !ctx.isFrameSlotName(resolved);
+  };
+
+  const emitAbs16LdFixup = (
+    dst: AsmOperandNode,
+    src: AsmOperandNode,
+    span: AsmInstructionNode['span'],
+  ): boolean => {
+    const dstName = dst.kind === 'Reg' ? dst.name.toUpperCase() : undefined;
+    const srcName = src.kind === 'Reg' ? src.name.toUpperCase() : undefined;
+    const memExpr = dst.kind === 'Mem' ? dst.expr : src.kind === 'Mem' ? src.expr : undefined;
+    if (!memExpr || memExpr.kind !== 'EaName') return false;
+    const baseLower = resolveRawLabelName(memExpr.name).toLowerCase();
+    if (ctx.isFrameSlotName(baseLower)) return false;
+
+    if (dst.kind === 'Reg' && src.kind === 'Mem') {
+      if (dstName === 'A') {
+        ctx.emitAbs16Fixup(0x3a, baseLower, 0, span);
+        return true;
+      }
+      if (dstName === 'HL') {
+        ctx.emitAbs16Fixup(0x2a, baseLower, 0, span);
+        return true;
+      }
+      if (dstName === 'BC') {
+        ctx.emitAbs16FixupPrefixed(0xed, 0x4b, baseLower, 0, span);
+        return true;
+      }
+      if (dstName === 'DE') {
+        ctx.emitAbs16FixupPrefixed(0xed, 0x5b, baseLower, 0, span);
+        return true;
+      }
+      if (dstName === 'SP') {
+        ctx.emitAbs16FixupPrefixed(0xed, 0x7b, baseLower, 0, span);
+        return true;
+      }
+      if (dstName === 'IX') {
+        ctx.emitAbs16FixupPrefixed(0xdd, 0x2a, baseLower, 0, span);
+        return true;
+      }
+      if (dstName === 'IY') {
+        ctx.emitAbs16FixupPrefixed(0xfd, 0x2a, baseLower, 0, span);
+        return true;
+      }
+    }
+
+    if (dst.kind === 'Mem' && src.kind === 'Reg') {
+      if (srcName === 'A') {
+        ctx.emitAbs16Fixup(0x32, baseLower, 0, span);
+        return true;
+      }
+      if (srcName === 'HL') {
+        ctx.emitAbs16Fixup(0x22, baseLower, 0, span);
+        return true;
+      }
+      if (srcName === 'BC') {
+        ctx.emitAbs16FixupPrefixed(0xed, 0x43, baseLower, 0, span);
+        return true;
+      }
+      if (srcName === 'DE') {
+        ctx.emitAbs16FixupPrefixed(0xed, 0x53, baseLower, 0, span);
+        return true;
+      }
+      if (srcName === 'SP') {
+        ctx.emitAbs16FixupPrefixed(0xed, 0x73, baseLower, 0, span);
+        return true;
+      }
+      if (srcName === 'IX') {
+        ctx.emitAbs16FixupPrefixed(0xdd, 0x22, baseLower, 0, span);
+        return true;
+      }
+      if (srcName === 'IY') {
+        ctx.emitAbs16FixupPrefixed(0xfd, 0x22, baseLower, 0, span);
+        return true;
+      }
+    }
+
+    return false;
+  };
+
+  const isRegisterLikeMemEa = (ea: EaExprNode): boolean => {
+    if (ea.kind === 'EaName') {
+      return ctx.reg16.has(ea.name.toUpperCase());
+    }
+    if ((ea.kind === 'EaAdd' || ea.kind === 'EaSub') && ea.base.kind === 'EaName') {
+      const base = ea.base.name.toUpperCase();
+      return base === 'IX' || base === 'IY';
+    }
+    return false;
+  };
+
+  return {
+    emitAssignmentImmediateToRegister,
+    emitAssignmentRegisterTransfer,
+    isTypedStorageLdOperand,
+    resolveRawLabelName,
+    isRawLdLabelName,
+    emitAbs16LdFixup,
+    isRegisterLikeMemEa,
+  };
+}

--- a/src/lowering/asmInstructionLowering.ts
+++ b/src/lowering/asmInstructionLowering.ts
@@ -2,6 +2,7 @@ import type { Diagnostic } from '../diagnostics/types.js';
 import type { AsmInstructionNode, AsmOperandNode, EaExprNode, SourceSpan } from '../frontend/ast.js';
 import type { EaResolution } from './eaResolution.js';
 import type { ScalarKind } from './typeResolution.js';
+import { createAsmInstructionLdHelpers } from './asmInstructionLdHelpers.js';
 
 type DiagAt = (diagnostics: Diagnostic[], span: AsmInstructionNode['span'], message: string) => void;
 
@@ -123,205 +124,15 @@ export function createAsmInstructionLoweringHelpers(ctx: Context) {
     if (!ctx.emitInstr('pop', [regOperand('BC', span)], span)) return false;
     return ctx.emitInstr('pop', [regOperand('DE', span)], span);
   };
-
-  const emitAssignmentImmediateToRegister = (
-    dst: Extract<AsmOperandNode, { kind: 'Reg' }>,
-    src: Extract<AsmOperandNode, { kind: 'Imm' }>,
-    span: AsmInstructionNode['span'],
-  ): boolean => {
-    const dstName = dst.name.toUpperCase();
-    if (
-      dstName === 'A' ||
-      dstName === 'B' ||
-      dstName === 'C' ||
-      dstName === 'D' ||
-      dstName === 'E' ||
-      dstName === 'H' ||
-      dstName === 'L' ||
-      dstName === 'IXH' ||
-      dstName === 'IXL' ||
-      dstName === 'IYH' ||
-      dstName === 'IYL' ||
-      dstName === 'BC' ||
-      dstName === 'DE' ||
-      dstName === 'HL' ||
-      dstName === 'IX' ||
-      dstName === 'IY'
-    ) {
-      return ctx.emitInstr('ld', [{ ...dst, name: dstName }, src], span);
-    }
-    return false;
-  };
-
-  const emitZeroExtendReg8ToReg16 = (
-    dstName: 'BC' | 'DE' | 'HL',
-    srcName: string,
-    span: AsmInstructionNode['span'],
-  ): boolean => {
-    const hi = dstName === 'BC' ? 'B' : dstName === 'DE' ? 'D' : 'H';
-    const lo = dstName === 'BC' ? 'C' : dstName === 'DE' ? 'E' : 'L';
-    return (
-      ctx.emitInstr(
-        'ld',
-        [{ kind: 'Reg', span, name: hi }, { kind: 'Imm', span, expr: { kind: 'ImmLiteral', span, value: 0 } }],
-        span,
-      ) &&
-      ctx.emitInstr('ld', [{ kind: 'Reg', span, name: lo }, { kind: 'Reg', span, name: srcName }], span)
-    );
-  };
-
-  const emitAssignmentRegisterTransfer = (
-    dst: Extract<AsmOperandNode, { kind: 'Reg' }>,
-    src: Extract<AsmOperandNode, { kind: 'Reg' }>,
-    span: AsmInstructionNode['span'],
-  ): boolean => {
-    const dstName = dst.name.toUpperCase();
-    const srcName = src.name.toUpperCase();
-    const halfIndexRegs = new Set(['IXH', 'IXL', 'IYH', 'IYL']);
-    if (dstName === srcName) return true;
-    if (dstName === 'A' && srcName === 'A') return true;
-    if (dstName === 'A') return false;
-    if (halfIndexRegs.has(dstName) || halfIndexRegs.has(srcName)) {
-      return ctx.emitInstr(
-        'ld',
-        [
-          { kind: 'Reg', span, name: dstName },
-          { kind: 'Reg', span, name: srcName },
-        ],
-        span,
-      );
-    }
-    const wideRegs = new Set(['BC', 'DE', 'HL', 'IX', 'IY']);
-    if (dstName === 'BC' || dstName === 'DE' || dstName === 'HL') {
-      if (srcName === 'A') return emitZeroExtendReg8ToReg16(dstName, srcName, span);
-      const asLd: AsmInstructionNode = {
-        kind: 'AsmInstruction',
-        span,
-        head: 'ld',
-        operands: [
-          { kind: 'Reg', span, name: dstName },
-          { kind: 'Reg', span, name: srcName },
-        ],
-      };
-      return ctx.emitVirtualReg16Transfer(asLd);
-    }
-    if (dstName === 'IX' || dstName === 'IY') {
-      if (!wideRegs.has(srcName)) return false;
-      return (
-        ctx.emitInstr('push', [{ kind: 'Reg', span, name: srcName }], span) &&
-        ctx.emitInstr('pop', [{ kind: 'Reg', span, name: dstName }], span)
-      );
-    }
-    return false;
-  };
-
-  const isTypedStorageLdOperand = (op: AsmOperandNode): boolean => {
-    if (op.kind === 'Ea') return true;
-    if (op.kind === 'Imm' && op.expr.kind === 'ImmName') {
-      return ctx.resolveScalarBinding(op.expr.name) !== undefined;
-    }
-    if (op.kind === 'Reg') {
-      return ctx.resolveScalarBinding(op.name) !== undefined;
-    }
-    return false;
-  };
-
-  const resolveRawLabelName = (name: string): string =>
-    ctx.resolveRawAliasTargetName(name) ?? name;
-
-  const isRawLdLabelName = (name: string): boolean => {
-    const resolved = resolveRawLabelName(name);
-    return ctx.isModuleStorageName(resolved) && !ctx.isFrameSlotName(resolved);
-  };
-
-  const emitAbs16LdFixup = (
-    dst: AsmOperandNode,
-    src: AsmOperandNode,
-    span: AsmInstructionNode['span'],
-  ): boolean => {
-    const dstName = dst.kind === 'Reg' ? dst.name.toUpperCase() : undefined;
-    const srcName = src.kind === 'Reg' ? src.name.toUpperCase() : undefined;
-    const memExpr = dst.kind === 'Mem' ? dst.expr : src.kind === 'Mem' ? src.expr : undefined;
-    if (!memExpr || memExpr.kind !== 'EaName') return false;
-    const baseLower = resolveRawLabelName(memExpr.name).toLowerCase();
-    if (ctx.isFrameSlotName(baseLower)) return false;
-
-    if (dst.kind === 'Reg' && src.kind === 'Mem') {
-      if (dstName === 'A') {
-        ctx.emitAbs16Fixup(0x3a, baseLower, 0, span);
-        return true;
-      }
-      if (dstName === 'HL') {
-        ctx.emitAbs16Fixup(0x2a, baseLower, 0, span);
-        return true;
-      }
-      if (dstName === 'BC') {
-        ctx.emitAbs16FixupPrefixed(0xed, 0x4b, baseLower, 0, span);
-        return true;
-      }
-      if (dstName === 'DE') {
-        ctx.emitAbs16FixupPrefixed(0xed, 0x5b, baseLower, 0, span);
-        return true;
-      }
-      if (dstName === 'SP') {
-        ctx.emitAbs16FixupPrefixed(0xed, 0x7b, baseLower, 0, span);
-        return true;
-      }
-      if (dstName === 'IX') {
-        ctx.emitAbs16FixupPrefixed(0xdd, 0x2a, baseLower, 0, span);
-        return true;
-      }
-      if (dstName === 'IY') {
-        ctx.emitAbs16FixupPrefixed(0xfd, 0x2a, baseLower, 0, span);
-        return true;
-      }
-    }
-
-    if (dst.kind === 'Mem' && src.kind === 'Reg') {
-      if (srcName === 'A') {
-        ctx.emitAbs16Fixup(0x32, baseLower, 0, span);
-        return true;
-      }
-      if (srcName === 'HL') {
-        ctx.emitAbs16Fixup(0x22, baseLower, 0, span);
-        return true;
-      }
-      if (srcName === 'BC') {
-        ctx.emitAbs16FixupPrefixed(0xed, 0x43, baseLower, 0, span);
-        return true;
-      }
-      if (srcName === 'DE') {
-        ctx.emitAbs16FixupPrefixed(0xed, 0x53, baseLower, 0, span);
-        return true;
-      }
-      if (srcName === 'SP') {
-        ctx.emitAbs16FixupPrefixed(0xed, 0x73, baseLower, 0, span);
-        return true;
-      }
-      if (srcName === 'IX') {
-        ctx.emitAbs16FixupPrefixed(0xdd, 0x22, baseLower, 0, span);
-        return true;
-      }
-      if (srcName === 'IY') {
-        ctx.emitAbs16FixupPrefixed(0xfd, 0x22, baseLower, 0, span);
-        return true;
-      }
-    }
-
-    return false;
-  };
-
-  const isRegisterLikeMemEa = (ea: EaExprNode): boolean => {
-    if (ea.kind === 'EaName') {
-      const upper = ea.name.toUpperCase();
-      return ctx.reg16.has(upper);
-    }
-    if ((ea.kind === 'EaAdd' || ea.kind === 'EaSub') && ea.base.kind === 'EaName') {
-      const upper = ea.base.name.toUpperCase();
-      return upper === 'IX' || upper === 'IY';
-    }
-    return false;
-  };
+  const {
+    emitAssignmentImmediateToRegister,
+    emitAssignmentRegisterTransfer,
+    isTypedStorageLdOperand,
+    resolveRawLabelName,
+    isRawLdLabelName,
+    emitAbs16LdFixup,
+    isRegisterLikeMemEa,
+  } = createAsmInstructionLdHelpers(ctx);
 
   const lowerSuccPredOnTypedPath = (
     asmItem: AsmInstructionNode,
@@ -766,17 +577,6 @@ export function createAsmInstructionLoweringHelpers(ctx: Context) {
       ctx.diagAt(ctx.diagnostics, asmItem.span, `":=" form is not supported.`);
       return;
     }
-
-    const isRegisterLikeMemEa = (ea: EaExprNode): boolean => {
-      if (ea.kind === 'EaName') {
-        return ctx.reg16.has(ea.name.toUpperCase());
-      }
-      if ((ea.kind === 'EaAdd' || ea.kind === 'EaSub') && ea.base.kind === 'EaName') {
-        const base = ea.base.name.toUpperCase();
-        return base === 'IX' || base === 'IY';
-      }
-      return false;
-    };
 
     if (
       head === 'ld' &&


### PR DESCRIPTION
## Summary
- extract ld and := special-case lowering helpers into a dedicated module
- slim asmInstructionLowering.ts from 834 lines to 634 lines
- keep dispatcher behavior unchanged while removing the soft-limit warning for asmInstructionLowering.ts

## Testing
- npm run typecheck
- npx vitest run test/pr532_asm_instruction_lowering_integration.test.ts test/pr863_assignment_lowering.test.ts test/pr869_assignment_reg8_lowering.test.ts test/pr887_assignment_half_index_lowering.test.ts test/pr781_ld_typed_storage_migration_diag.test.ts test/pr278_raw_call_typed_target_warning.test.ts test/pr900_succ_pred_integration.test.ts
- npx vitest run --testTimeout 20000 test/pr472_source_file_size_guard.test.ts
- npm run check:source-file-sizes:enforce