### PR TITLE
refactor(lowering): extract function frame setup

### DIFF
--- a/scripts/source-file-size-allowlist.json
+++ b/scripts/source-file-size-allowlist.json
@@ -1,5 +1,3 @@
 {
-  "hardCap": {
-    "src/lowering/functionLowering.ts": 1014
-  }
+  "hardCap": {}
 }

--- a/src/lowering/functionFrameSetup.ts
+++ b/src/lowering/functionFrameSetup.ts
@@ -1,0 +1,523 @@
+import type { Diagnostic } from '../diagnostics/types.js';
+import type {
+  AsmOperandNode,
+  EaExprNode,
+  FuncDeclNode,
+  ImmExprNode,
+  SourceSpan,
+  TypeExprNode,
+} from '../frontend/ast.js';
+import type { CompileEnv } from '../semantics/env.js';
+import { resolveVisibleConst, resolveVisibleEnum } from '../moduleVisibility.js';
+import type { PendingSymbol, SourceSegmentTag } from './loweringTypes.js';
+import type { ScalarKind } from './typeResolution.js';
+
+type LocalInitializerNameStatus = 'constant' | 'non-constant' | 'unknown';
+
+type TrackedSpState = {
+  delta: number;
+  valid: boolean;
+  invalid: boolean;
+};
+
+type LocalScalarInitializer = {
+  name: string;
+  expr?: ImmExprNode;
+  span: SourceSpan;
+  scalarKind: 'byte' | 'word' | 'addr';
+};
+
+export type FunctionFrameSetupContext = {
+  item: FuncDeclNode;
+  diagnostics: Diagnostic[];
+  diag: (diagnostics: Diagnostic[], file: string, message: string) => void;
+  diagAt: (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
+  env: CompileEnv;
+  resolveScalarBinding: (name: string) => ScalarKind | undefined;
+  resolveScalarKind: (typeExpr: TypeExprNode) => ScalarKind | undefined;
+  resolveEaTypeExpr: (ea: EaExprNode) => TypeExprNode | undefined;
+  evalImmExpr: (
+    expr: ImmExprNode,
+    env: CompileEnv,
+    diagnostics: Diagnostic[],
+  ) => number | undefined;
+  stackSlotOffsets: Map<string, number>;
+  stackSlotTypes: Map<string, TypeExprNode>;
+  localAliasTargets: Map<string, EaExprNode>;
+  storageTypes: Map<string, TypeExprNode>;
+  moduleAliasTargets: Map<string, EaExprNode>;
+  taken: Set<string>;
+  pending: PendingSymbol[];
+  traceComment: (offset: number, text: string) => void;
+  traceLabel: (offset: number, name: string, span?: SourceSpan) => void;
+  generatedLabelCounterRef: { current: number };
+  getCodeOffset: () => number;
+  getCurrentCodeSegmentTag: () => SourceSegmentTag | undefined;
+  setCurrentCodeSegmentTag: (tag: SourceSegmentTag | undefined) => void;
+  emitInstr: (head: string, operands: AsmOperandNode[], span: SourceSpan) => boolean;
+  loadImm16ToHL: (value: number, span: SourceSpan) => boolean;
+  bindSpTracking: (
+    callbacks?: {
+      applySpTracking: (headRaw: string, operands: AsmOperandNode[]) => void;
+      invalidateSpTracking: () => void;
+    },
+  ) => void;
+};
+
+export type FunctionFrameSetupResult = {
+  hasStackSlots: boolean;
+  emitSyntheticEpilogue: boolean;
+  epilogueLabel: string;
+  preserveSet: string[];
+  trackedSp: TrackedSpState;
+};
+
+function collectImmExprNames(expr: ImmExprNode): string[] {
+  switch (expr.kind) {
+    case 'ImmLiteral':
+    case 'ImmSizeof':
+      return [];
+    case 'ImmName':
+      return [expr.name];
+    case 'ImmOffsetof':
+      return expr.path.steps.flatMap((step) =>
+        step.kind === 'OffsetofIndex' ? collectImmExprNames(step.expr) : [],
+      );
+    case 'ImmUnary':
+      return collectImmExprNames(expr.expr);
+    case 'ImmBinary':
+      return [...collectImmExprNames(expr.left), ...collectImmExprNames(expr.right)];
+  }
+}
+
+function classifyLocalInitializerName(
+  name: string,
+  file: string,
+  env: CompileEnv,
+  resolveScalarBinding: (name: string) => ScalarKind | undefined,
+  stackSlotTypes: Map<string, TypeExprNode>,
+  localAliasTargets: Map<string, EaExprNode>,
+  storageTypes: Map<string, TypeExprNode>,
+): LocalInitializerNameStatus {
+  if (resolveVisibleConst(name, file, env) !== undefined) return 'constant';
+  if (resolveVisibleEnum(name, file, env) !== undefined) return 'constant';
+
+  const lower = name.toLowerCase();
+  if (
+    resolveScalarBinding(name) !== undefined ||
+    stackSlotTypes.has(lower) ||
+    localAliasTargets.has(lower) ||
+    storageTypes.has(lower)
+  ) {
+    return 'non-constant';
+  }
+
+  return 'unknown';
+}
+
+function localInitializerFitsScalarKind(value: number, scalarKind: 'byte' | 'word' | 'addr'): boolean {
+  if (scalarKind === 'byte') return value >= -0x80 && value <= 0xff;
+  return value >= -0x8000 && value <= 0xffff;
+}
+
+function localInitializerRangeLabel(scalarKind: 'byte' | 'word' | 'addr'): string {
+  return scalarKind === 'byte' ? 'byte range (-128..255)' : 'word/addr range (-32768..65535)';
+}
+
+function newSyntheticEpilogueLabel(
+  taken: Set<string>,
+  generatedLabelCounterRef: { current: number },
+): string {
+  let epilogueLabel = `__zax_epilogue_${generatedLabelCounterRef.current++}`;
+  while (taken.has(epilogueLabel)) {
+    epilogueLabel = `__zax_epilogue_${generatedLabelCounterRef.current++}`;
+  }
+  return epilogueLabel;
+}
+
+export function initializeFunctionFrame(ctx: FunctionFrameSetupContext): FunctionFrameSetupResult {
+  const {
+    item,
+    diagnostics,
+    diag,
+    diagAt,
+    env,
+    resolveScalarBinding,
+    resolveScalarKind,
+    resolveEaTypeExpr,
+    evalImmExpr,
+    stackSlotOffsets,
+    stackSlotTypes,
+    localAliasTargets,
+    storageTypes,
+    moduleAliasTargets,
+    taken,
+    pending,
+    traceComment,
+    traceLabel,
+    generatedLabelCounterRef,
+    getCodeOffset,
+    getCurrentCodeSegmentTag,
+    setCurrentCodeSegmentTag,
+    emitInstr,
+    loadImm16ToHL,
+    bindSpTracking,
+  } = ctx;
+
+  stackSlotOffsets.clear();
+  stackSlotTypes.clear();
+  localAliasTargets.clear();
+
+  const localDecls = item.locals.decls;
+  const localAliasNames = new Set(
+    localDecls.filter((decl) => decl.form === 'alias').map((decl) => decl.name.toLowerCase()),
+  );
+  const localTypedNames = new Set(
+    localDecls.filter((decl) => decl.form === 'typed').map((decl) => decl.name.toLowerCase()),
+  );
+  const paramNames = new Set(item.params.map((param) => param.name.toLowerCase()));
+  const returnRegs = item.returnRegs.map((r: string) => r.toUpperCase());
+  const basePreserveOrder: string[] = ['AF', 'BC', 'DE', 'HL'];
+  const preserveSet = basePreserveOrder.filter((r) => !returnRegs.includes(r));
+  const preserveBytes = preserveSet.length * 2;
+  const shouldPreserveTypedBoundary = preserveSet.length > 0;
+  const hlPreserved = preserveSet.includes('HL');
+  let localSlotCount = 0;
+  const localScalarInitializers: LocalScalarInitializer[] = [];
+  for (let li = 0; li < localDecls.length; li++) {
+    const decl = localDecls[li]!;
+    const declLower = decl.name.toLowerCase();
+    if (decl.form === 'typed') {
+      const scalarKind = resolveScalarKind(decl.typeExpr);
+      if (!scalarKind) {
+        diagAt(
+          diagnostics,
+          decl.span,
+          `Non-scalar local storage declaration "${decl.name}" requires alias form ("${decl.name} = rhs").`,
+        );
+        continue;
+      }
+      const localIxDisp = -(2 * (localSlotCount + 1));
+      stackSlotOffsets.set(declLower, localIxDisp);
+      stackSlotTypes.set(declLower, decl.typeExpr);
+      localSlotCount++;
+      const init = decl.initializer;
+      localScalarInitializers.push({
+        name: decl.name,
+        ...(init ? { expr: init.expr } : {}),
+        span: decl.span,
+        scalarKind,
+      });
+      continue;
+    }
+
+    const init = decl.initializer;
+    if (init.expr.kind !== 'EaName') {
+      diagAt(
+        diagnostics,
+        decl.span,
+        `Function-local alias "${decl.name}" must target a direct module-scope storage name.`,
+      );
+      continue;
+    }
+    const targetLower = init.expr.name.toLowerCase();
+    if (paramNames.has(targetLower)) {
+      diagAt(
+        diagnostics,
+        decl.span,
+        `Function-local alias "${decl.name}" cannot target parameter "${init.expr.name}".`,
+      );
+      continue;
+    }
+    if (localAliasNames.has(targetLower) || moduleAliasTargets.has(targetLower)) {
+      diagAt(
+        diagnostics,
+        decl.span,
+        `Function-local alias "${decl.name}" cannot target alias "${init.expr.name}".`,
+      );
+      continue;
+    }
+    if (localTypedNames.has(targetLower)) {
+      diagAt(
+        diagnostics,
+        decl.span,
+        `Function-local alias "${decl.name}" cannot target local "${init.expr.name}".`,
+      );
+      continue;
+    }
+    if (!storageTypes.has(targetLower)) {
+      diagAt(
+        diagnostics,
+        decl.span,
+        `Function-local alias "${decl.name}" must target a direct module-scope storage name.`,
+      );
+      continue;
+    }
+    localAliasTargets.set(declLower, init.expr);
+    const inferred = resolveEaTypeExpr(init.expr);
+    if (!inferred) {
+      diagAt(
+        diagnostics,
+        decl.span,
+        `Incompatible inferred alias binding for "${decl.name}": unable to infer type from alias source.`,
+      );
+      continue;
+    }
+    stackSlotTypes.set(declLower, inferred);
+  }
+
+  const localBytes = localSlotCount * 2;
+  const frameSize = localBytes + preserveBytes;
+  const argc = item.params.length;
+  const hasStackSlots = frameSize > 0 || argc > 0;
+  for (let paramIndex = 0; paramIndex < argc; paramIndex++) {
+    const p = item.params[paramIndex]!;
+    const base = 4 + 2 * paramIndex;
+    stackSlotOffsets.set(p.name.toLowerCase(), base);
+    stackSlotTypes.set(p.name.toLowerCase(), p.typeExpr);
+  }
+
+  const epilogueLabel = newSyntheticEpilogueLabel(taken, generatedLabelCounterRef);
+  const emitSyntheticEpilogue =
+    preserveSet.length > 0 || hasStackSlots || localScalarInitializers.length > 0;
+
+  traceComment(getCodeOffset(), `func ${item.name} begin`);
+  if (taken.has(item.name)) {
+    diag(diagnostics, item.span.file, `Duplicate symbol name "${item.name}".`);
+  } else {
+    taken.add(item.name);
+    traceLabel(getCodeOffset(), item.name, item.span);
+    pending.push({
+      kind: 'label',
+      name: item.name,
+      section: 'code',
+      offset: getCodeOffset(),
+      file: item.span.file,
+      line: item.span.start.line,
+      scope: 'global',
+    });
+  }
+
+  if (hasStackSlots) {
+    const prevTag = getCurrentCodeSegmentTag();
+    setCurrentCodeSegmentTag({
+      file: item.span.file,
+      line: item.span.start.line,
+      column: item.span.start.column,
+      kind: 'code',
+      confidence: 'high',
+    });
+    try {
+      emitInstr('push', [{ kind: 'Reg', span: item.span, name: 'IX' }], item.span);
+      emitInstr(
+        'ld',
+        [
+          { kind: 'Reg', span: item.span, name: 'IX' },
+          {
+            kind: 'Imm',
+            span: item.span,
+            expr: { kind: 'ImmLiteral', span: item.span, value: 0 },
+          },
+        ],
+        item.span,
+      );
+      emitInstr(
+        'add',
+        [
+          { kind: 'Reg', span: item.span, name: 'IX' },
+          { kind: 'Reg', span: item.span, name: 'SP' },
+        ],
+        item.span,
+      );
+    } finally {
+      setCurrentCodeSegmentTag(prevTag);
+    }
+  }
+
+  for (const init of localScalarInitializers) {
+    const prevTag = getCurrentCodeSegmentTag();
+    setCurrentCodeSegmentTag({
+      file: init.span.file,
+      line: init.span.start.line,
+      column: init.span.start.column,
+      kind: 'code',
+      confidence: 'high',
+    });
+    try {
+      let initValue = 0;
+      if (init.expr !== undefined) {
+        const referencedNames = [...new Set(collectImmExprNames(init.expr))];
+        const nonConstantName = referencedNames.find(
+          (name) =>
+            classifyLocalInitializerName(
+              name,
+              init.span.file,
+              env,
+              resolveScalarBinding,
+              stackSlotTypes,
+              localAliasTargets,
+              storageTypes,
+            ) === 'non-constant',
+        );
+        if (nonConstantName) {
+          diagAt(
+            diagnostics,
+            init.span,
+            `Invalid local constant initializer for "${init.name}": "${nonConstantName}" is not a compile-time constant.`,
+          );
+          continue;
+        }
+
+        const unknownName = referencedNames.find(
+          (name) =>
+            classifyLocalInitializerName(
+              name,
+              init.span.file,
+              env,
+              resolveScalarBinding,
+              stackSlotTypes,
+              localAliasTargets,
+              storageTypes,
+            ) === 'unknown',
+        );
+        if (unknownName) {
+          diagAt(
+            diagnostics,
+            init.span,
+            `Unknown compile-time name "${unknownName}" in local initializer for "${init.name}".`,
+          );
+          continue;
+        }
+
+        const initDiagnostics: Diagnostic[] = [];
+        const evaluated = evalImmExpr(init.expr, env, initDiagnostics);
+        if (evaluated === undefined) {
+          diagnostics.push(...initDiagnostics);
+          if (initDiagnostics.length === 0) {
+            diagAt(
+              diagnostics,
+              init.span,
+              `Invalid local constant initializer for "${init.name}".`,
+            );
+          }
+          continue;
+        }
+        initValue = evaluated;
+      }
+
+      if (!localInitializerFitsScalarKind(initValue, init.scalarKind)) {
+        diagAt(
+          diagnostics,
+          init.span,
+          `Local initializer for "${init.name}" does not fit ${localInitializerRangeLabel(init.scalarKind)}; got ${initValue}.`,
+        );
+        continue;
+      }
+      const narrowed = init.scalarKind === 'byte' ? initValue & 0xff : initValue & 0xffff;
+      if (hlPreserved) {
+        emitInstr('push', [{ kind: 'Reg', span: init.span, name: 'HL' }], init.span);
+        if (!loadImm16ToHL(narrowed, init.span)) continue;
+        emitInstr(
+          'ex',
+          [
+            {
+              kind: 'Mem',
+              span: init.span,
+              expr: { kind: 'EaName', span: init.span, name: 'SP' },
+            },
+            { kind: 'Reg', span: init.span, name: 'HL' },
+          ],
+          init.span,
+        );
+      } else {
+        if (!loadImm16ToHL(narrowed, init.span)) continue;
+        emitInstr('push', [{ kind: 'Reg', span: init.span, name: 'HL' }], init.span);
+      }
+    } finally {
+      setCurrentCodeSegmentTag(prevTag);
+    }
+  }
+
+  if (shouldPreserveTypedBoundary) {
+    const prevTag = getCurrentCodeSegmentTag();
+    setCurrentCodeSegmentTag({
+      file: item.span.file,
+      line: item.span.start.line,
+      column: item.span.start.column,
+      kind: 'code',
+      confidence: 'high',
+    });
+    try {
+      for (const reg of preserveSet) {
+        emitInstr('push', [{ kind: 'Reg', span: item.span, name: reg }], item.span);
+      }
+    } finally {
+      setCurrentCodeSegmentTag(prevTag);
+    }
+  }
+
+  const trackedSp: TrackedSpState = {
+    delta: 0,
+    valid: true,
+    invalid: false,
+  };
+  bindSpTracking({
+    applySpTracking: (headRaw: string, operands: AsmOperandNode[]) => {
+      const head = headRaw.toLowerCase();
+      if (
+        head === 'ld' &&
+        operands.length === 2 &&
+        operands[0]?.kind === 'Reg' &&
+        operands[0].name.toUpperCase() === 'SP'
+      ) {
+        if (operands[1]?.kind === 'Reg' && operands[1].name.toUpperCase() === 'IX') {
+          trackedSp.delta = -2;
+          trackedSp.valid = true;
+          trackedSp.invalid = false;
+        } else {
+          trackedSp.valid = false;
+          trackedSp.invalid = true;
+        }
+        return;
+      }
+      if (!trackedSp.valid) return;
+      if (head === 'push' && operands.length === 1) {
+        trackedSp.delta -= 2;
+        return;
+      }
+      if (head === 'pop' && operands.length === 1) {
+        trackedSp.delta += 2;
+        return;
+      }
+      if (
+        head === 'inc' &&
+        operands.length === 1 &&
+        operands[0]?.kind === 'Reg' &&
+        operands[0].name.toUpperCase() === 'SP'
+      ) {
+        trackedSp.delta += 1;
+        return;
+      }
+      if (
+        head === 'dec' &&
+        operands.length === 1 &&
+        operands[0]?.kind === 'Reg' &&
+        operands[0].name.toUpperCase() === 'SP'
+      ) {
+        trackedSp.delta -= 1;
+      }
+    },
+    invalidateSpTracking: () => {
+      trackedSp.valid = false;
+      trackedSp.invalid = true;
+    },
+  });
+
+  return {
+    hasStackSlots,
+    emitSyntheticEpilogue,
+    epilogueLabel,
+    preserveSet,
+    trackedSp,
+  };
+}

--- a/src/lowering/functionLowering.ts
+++ b/src/lowering/functionLowering.ts
@@ -34,10 +34,11 @@ import {
 } from './functionBodySetup.js';
 import { createFunctionAsmRewritingHelpers } from './functionAsmRewriting.js';
 import { createFunctionCallLoweringHelpers } from './functionCallLowering.js';
+import { initializeFunctionFrame } from './functionFrameSetup.js';
 
 // This module owns the per-function lowering coordinator. It assembles the
 // function-local helpers, state, and diagnostics around the extracted
-// body-setup and call-lowering submodules.
+// rewriting, frame-setup, body-setup, and call-lowering submodules.
 type ResolvedArrayType = { element: TypeExprNode; length?: number };
 export type FunctionLoweringItemContext = {
   item: FuncDeclNode;
@@ -214,60 +215,6 @@ export type FunctionLoweringSharedContext = FunctionLoweringDiagnosticsContext &
 
 export type FunctionLoweringContext = FunctionLoweringItemContext & FunctionLoweringSharedContext;
 
-type LocalInitializerNameStatus = 'constant' | 'non-constant' | 'unknown';
-
-function collectImmExprNames(expr: ImmExprNode): string[] {
-  switch (expr.kind) {
-    case 'ImmLiteral':
-    case 'ImmSizeof':
-      return [];
-    case 'ImmName':
-      return [expr.name];
-    case 'ImmOffsetof':
-      return expr.path.steps.flatMap((step) =>
-        step.kind === 'OffsetofIndex' ? collectImmExprNames(step.expr) : [],
-      );
-    case 'ImmUnary':
-      return collectImmExprNames(expr.expr);
-    case 'ImmBinary':
-      return [...collectImmExprNames(expr.left), ...collectImmExprNames(expr.right)];
-  }
-}
-
-function classifyLocalInitializerName(
-  name: string,
-  file: string,
-  env: CompileEnv,
-  resolveScalarBinding: (name: string) => ScalarKind | undefined,
-  stackSlotTypes: Map<string, TypeExprNode>,
-  localAliasTargets: Map<string, EaExprNode>,
-  storageTypes: Map<string, TypeExprNode>,
-): LocalInitializerNameStatus {
-  if (resolveVisibleConst(name, file, env) !== undefined) return 'constant';
-  if (resolveVisibleEnum(name, file, env) !== undefined) return 'constant';
-
-  const lower = name.toLowerCase();
-  if (
-    resolveScalarBinding(name) !== undefined ||
-    stackSlotTypes.has(lower) ||
-    localAliasTargets.has(lower) ||
-    storageTypes.has(lower)
-  ) {
-    return 'non-constant';
-  }
-
-  return 'unknown';
-}
-
-function localInitializerFitsScalarKind(value: number, scalarKind: 'byte' | 'word' | 'addr'): boolean {
-  if (scalarKind === 'byte') return value >= -0x80 && value <= 0xff;
-  return value >= -0x8000 && value <= 0xffff;
-}
-
-function localInitializerRangeLabel(scalarKind: 'byte' | 'word' | 'addr'): string {
-  return scalarKind === 'byte' ? 'byte range (-128..255)' : 'word/addr range (-32768..65535)';
-}
-
 export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
   const { item, diagnostics, diag, diagAt, diagAtWithId, diagAtWithSeverityAndId, warnAt } = ctx;
   const {
@@ -329,368 +276,34 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
     symbolicTargetFromExpr,
     emitInstr,
   });
-
-  stackSlotOffsets.clear();
-  stackSlotTypes.clear();
-  localAliasTargets.clear();
-
-  const localDecls = item.locals.decls;
-  const localAliasNames = new Set(
-    localDecls.filter((decl) => decl.form === 'alias').map((decl) => decl.name.toLowerCase()),
-  );
-  const localTypedNames = new Set(
-    localDecls.filter((decl) => decl.form === 'typed').map((decl) => decl.name.toLowerCase()),
-  );
-  const paramNames = new Set(item.params.map((param) => param.name.toLowerCase()));
-  const returnRegs = item.returnRegs.map((r: string) => r.toUpperCase());
-  const basePreserveOrder: string[] = ['AF', 'BC', 'DE', 'HL'];
-  let preserveSet = basePreserveOrder.filter((r) => !returnRegs.includes(r));
-  const preserveBytes = preserveSet.length * 2;
-  const shouldPreserveTypedBoundary = preserveSet.length > 0;
-  const hlPreserved = preserveSet.includes('HL');
-  let localSlotCount = 0;
-  const localScalarInitializers: Array<{
-    name: string;
-    expr?: ImmExprNode;
-    span: SourceSpan;
-    scalarKind: 'byte' | 'word' | 'addr';
-  }> = [];
-  for (let li = 0; li < localDecls.length; li++) {
-    const decl = localDecls[li]!;
-    const declLower = decl.name.toLowerCase();
-    if (decl.form === 'typed') {
-      const scalarKind = resolveScalarKind(decl.typeExpr);
-      if (!scalarKind) {
-        diagAt(
-          diagnostics,
-          decl.span,
-          `Non-scalar local storage declaration "${decl.name}" requires alias form ("${decl.name} = rhs").`,
-        );
-        continue;
-      }
-      // Locals are packed tightly starting at IX-2, independent of preserve bytes.
-      const localIxDisp = -(2 * (localSlotCount + 1));
-      stackSlotOffsets.set(declLower, localIxDisp);
-      stackSlotTypes.set(declLower, decl.typeExpr);
-      localSlotCount++;
-      const init = decl.initializer;
-      localScalarInitializers.push({
-        name: decl.name,
-        ...(init ? { expr: init.expr } : {}),
-        span: decl.span,
-        scalarKind,
-      });
-      continue;
-    }
-    const init = decl.initializer;
-    if (init.expr.kind !== 'EaName') {
-      diagAt(
-        diagnostics,
-        decl.span,
-        `Function-local alias "${decl.name}" must target a direct module-scope storage name.`,
-      );
-      continue;
-    }
-    const targetLower = init.expr.name.toLowerCase();
-    if (paramNames.has(targetLower)) {
-      diagAt(
-        diagnostics,
-        decl.span,
-        `Function-local alias "${decl.name}" cannot target parameter "${init.expr.name}".`,
-      );
-      continue;
-    }
-    if (localAliasNames.has(targetLower) || moduleAliasTargets.has(targetLower)) {
-      diagAt(
-        diagnostics,
-        decl.span,
-        `Function-local alias "${decl.name}" cannot target alias "${init.expr.name}".`,
-      );
-      continue;
-    }
-    if (localTypedNames.has(targetLower)) {
-      diagAt(
-        diagnostics,
-        decl.span,
-        `Function-local alias "${decl.name}" cannot target local "${init.expr.name}".`,
-      );
-      continue;
-    }
-    if (!storageTypes.has(targetLower)) {
-      diagAt(
-        diagnostics,
-        decl.span,
-        `Function-local alias "${decl.name}" must target a direct module-scope storage name.`,
-      );
-      continue;
-    }
-    localAliasTargets.set(declLower, init.expr);
-    const inferred = resolveEaTypeExpr(init.expr);
-    if (!inferred) {
-      diagAt(
-        diagnostics,
-        decl.span,
-        `Incompatible inferred alias binding for "${decl.name}": unable to infer type from alias source.`,
-      );
-      continue;
-    }
-    stackSlotTypes.set(declLower, inferred);
-  }
-  const localBytes = localSlotCount * 2;
-  const frameSize = localBytes + preserveBytes;
-  const argc = item.params.length;
-  const hasStackSlots = frameSize > 0 || argc > 0;
-  for (let paramIndex = 0; paramIndex < argc; paramIndex++) {
-    const p = item.params[paramIndex]!;
-    const base = 4 + 2 * paramIndex;
-    stackSlotOffsets.set(p.name.toLowerCase(), base);
-    stackSlotTypes.set(p.name.toLowerCase(), p.typeExpr);
-  }
-
-  let epilogueLabel = `__zax_epilogue_${generatedLabelCounterRef.current++}`;
-  while (taken.has(epilogueLabel)) {
-    epilogueLabel = `__zax_epilogue_${generatedLabelCounterRef.current++}`;
-  }
-  const emitSyntheticEpilogue =
-    preserveSet.length > 0 || hasStackSlots || localScalarInitializers.length > 0;
-
-  // Function entry label.
-  traceComment(getCodeOffset(), `func ${item.name} begin`);
-  if (taken.has(item.name)) {
-    diag(diagnostics, item.span.file, `Duplicate symbol name "${item.name}".`);
-  } else {
-    taken.add(item.name);
-    traceLabel(getCodeOffset(), item.name, item.span);
-    pending.push({
-      kind: 'label',
-      name: item.name,
-      section: 'code',
-      offset: getCodeOffset(),
-      file: item.span.file,
-      line: item.span.start.line,
-      scope: 'global',
+  const { hasStackSlots, emitSyntheticEpilogue, epilogueLabel, preserveSet, trackedSp } =
+    initializeFunctionFrame({
+      item,
+      diagnostics,
+      diag,
+      diagAt,
+      env,
+      resolveScalarBinding,
+      resolveScalarKind,
+      resolveEaTypeExpr,
+      evalImmExpr,
+      stackSlotOffsets,
+      stackSlotTypes,
+      localAliasTargets,
+      storageTypes,
+      moduleAliasTargets,
+      taken,
+      pending,
+      traceComment,
+      traceLabel,
+      generatedLabelCounterRef,
+      getCodeOffset,
+      getCurrentCodeSegmentTag: () => currentCodeSegmentTag,
+      setCurrentCodeSegmentTag,
+      emitInstr,
+      loadImm16ToHL,
+      bindSpTracking,
     });
-  }
-
-  if (hasStackSlots) {
-    const prevTag = currentCodeSegmentTag;
-    setCurrentCodeSegmentTag({
-      file: item.span.file,
-      line: item.span.start.line,
-      column: item.span.start.column,
-      kind: 'code',
-      confidence: 'high',
-    });
-    try {
-      emitInstr('push', [{ kind: 'Reg', span: item.span, name: 'IX' }], item.span);
-      emitInstr(
-        'ld',
-        [
-          { kind: 'Reg', span: item.span, name: 'IX' },
-          {
-            kind: 'Imm',
-            span: item.span,
-            expr: { kind: 'ImmLiteral', span: item.span, value: 0 },
-          },
-        ],
-        item.span,
-      );
-      emitInstr(
-        'add',
-        [
-          { kind: 'Reg', span: item.span, name: 'IX' },
-          { kind: 'Reg', span: item.span, name: 'SP' },
-        ],
-        item.span,
-      );
-    } finally {
-      setCurrentCodeSegmentTag(prevTag);
-    }
-  }
-
-  for (const init of localScalarInitializers) {
-    const prevTag = currentCodeSegmentTag;
-    setCurrentCodeSegmentTag({
-      file: init.span.file,
-      line: init.span.start.line,
-      column: init.span.start.column,
-      kind: 'code',
-      confidence: 'high',
-    });
-    try {
-      let initValue = 0;
-      if (init.expr !== undefined) {
-        const referencedNames = [...new Set(collectImmExprNames(init.expr))];
-        const nonConstantName = referencedNames.find(
-          (name) =>
-            classifyLocalInitializerName(
-              name,
-              init.span.file,
-              env,
-              resolveScalarBinding,
-              stackSlotTypes,
-              localAliasTargets,
-              storageTypes,
-            ) === 'non-constant',
-        );
-        if (nonConstantName) {
-          diagAt(
-            diagnostics,
-            init.span,
-            `Invalid local constant initializer for "${init.name}": "${nonConstantName}" is not a compile-time constant.`,
-          );
-          continue;
-        }
-
-        const unknownName = referencedNames.find(
-          (name) =>
-            classifyLocalInitializerName(
-              name,
-              init.span.file,
-              env,
-              resolveScalarBinding,
-              stackSlotTypes,
-              localAliasTargets,
-              storageTypes,
-            ) === 'unknown',
-        );
-        if (unknownName) {
-          diagAt(
-            diagnostics,
-            init.span,
-            `Unknown compile-time name "${unknownName}" in local initializer for "${init.name}".`,
-          );
-          continue;
-        }
-
-        const initDiagnostics: Diagnostic[] = [];
-        const evaluated = evalImmExpr(init.expr, env, initDiagnostics);
-        if (evaluated === undefined) {
-          diagnostics.push(...initDiagnostics);
-          if (initDiagnostics.length === 0) {
-            diagAt(
-              diagnostics,
-              init.span,
-              `Invalid local constant initializer for "${init.name}".`,
-            );
-          }
-          continue;
-        }
-        initValue = evaluated;
-      }
-
-      if (!localInitializerFitsScalarKind(initValue, init.scalarKind)) {
-        diagAt(
-          diagnostics,
-          init.span,
-          `Local initializer for "${init.name}" does not fit ${localInitializerRangeLabel(init.scalarKind)}; got ${initValue}.`,
-        );
-        continue;
-      }
-      const narrowed = init.scalarKind === 'byte' ? initValue & 0xff : initValue & 0xffff;
-      if (hlPreserved) {
-        // Preserve caller-visible HL by swapping the initialized local word with
-        // the saved HL already at the top of the stack.
-        emitInstr('push', [{ kind: 'Reg', span: init.span, name: 'HL' }], init.span);
-        if (!loadImm16ToHL(narrowed, init.span)) continue;
-        emitInstr(
-          'ex',
-          [
-            {
-              kind: 'Mem',
-              span: init.span,
-              expr: { kind: 'EaName', span: init.span, name: 'SP' },
-            },
-            { kind: 'Reg', span: init.span, name: 'HL' },
-          ],
-          init.span,
-        );
-      } else {
-        if (!loadImm16ToHL(narrowed, init.span)) continue;
-        emitInstr('push', [{ kind: 'Reg', span: init.span, name: 'HL' }], init.span);
-      }
-    } finally {
-      setCurrentCodeSegmentTag(prevTag);
-    }
-  }
-
-  if (shouldPreserveTypedBoundary) {
-    const prevTag = currentCodeSegmentTag;
-    setCurrentCodeSegmentTag({
-      file: item.span.file,
-      line: item.span.start.line,
-      column: item.span.start.column,
-      kind: 'code',
-      confidence: 'high',
-    });
-    try {
-      for (const reg of preserveSet) {
-        emitInstr('push', [{ kind: 'Reg', span: item.span, name: reg }], item.span);
-      }
-    } finally {
-      setCurrentCodeSegmentTag(prevTag);
-    }
-  }
-
-  // Track SP deltas relative to the start of user asm, after prologue reservation.
-  const trackedSp = {
-    delta: 0,
-    valid: true,
-    invalid: false,
-  };
-  const applySpTracking = (headRaw: string, operands: AsmOperandNode[]) => {
-    const head = headRaw.toLowerCase();
-    if (
-      head === 'ld' &&
-      operands.length === 2 &&
-      operands[0]?.kind === 'Reg' &&
-      operands[0].name.toUpperCase() === 'SP'
-    ) {
-      if (operands[1]?.kind === 'Reg' && operands[1].name.toUpperCase() === 'IX') {
-        trackedSp.delta = -2;
-        trackedSp.valid = true;
-        trackedSp.invalid = false;
-      } else {
-        trackedSp.valid = false;
-        trackedSp.invalid = true;
-      }
-      return;
-    }
-    if (!trackedSp.valid) return;
-    if (head === 'push' && operands.length === 1) {
-      trackedSp.delta -= 2;
-      return;
-    }
-    if (head === 'pop' && operands.length === 1) {
-      trackedSp.delta += 2;
-      return;
-    }
-    if (
-      head === 'inc' &&
-      operands.length === 1 &&
-      operands[0]?.kind === 'Reg' &&
-      operands[0].name.toUpperCase() === 'SP'
-    ) {
-      trackedSp.delta += 1;
-      return;
-    }
-    if (
-      head === 'dec' &&
-      operands.length === 1 &&
-      operands[0]?.kind === 'Reg' &&
-      operands[0].name.toUpperCase() === 'SP'
-    ) {
-      trackedSp.delta -= 1;
-      return;
-    }
-  };
-  bindSpTracking({
-    applySpTracking,
-    invalidateSpTracking: () => {
-      trackedSp.valid = false;
-      trackedSp.invalid = true;
-    },
-  });
 
   let flow: FlowState = {
     reachable: true,


### PR DESCRIPTION
## Summary
- extract function frame analysis, prologue emission, local initializer emission, and SP tracking into a dedicated helper
- keep functionLowering.ts focused on orchestration and helper wiring
- remove functionLowering.ts from the hard-cap source-size allowlist now that it is below the threshold

## Testing
- npm run typecheck
- npx vitest run test/pr543_function_lowering_integration.test.ts
- npx vitest run test/pr680_asm_golden_contract.test.ts test/examples_compile.test.ts
- npm run check:source-file-sizes
- npm run check:source-file-sizes:enforce
- npx vitest run --testTimeout 20000 test/pr472_source_file_size_guard.test.ts