### PR TITLE
feat(parser): add step aliases and semantic validation

### DIFF
--- a/src/frontend/parseAsmInstruction.ts
+++ b/src/frontend/parseAsmInstruction.ts
@@ -4,7 +4,7 @@ import { parseImmExprFromText } from './parseImm.js';
 import { parseDiag as diag } from './parseDiagnostics.js';
 import { parseAssignmentInstruction } from './parseAssignmentInstruction.js';
 import { parseAsmOperand } from './parseOperands.js';
-import { parseSuccPredInstruction } from './parseSuccPredInstruction.js';
+import { parseStepInstruction } from './parseSuccPredInstruction.js';
 
 function splitTopLevelCommaSeparated(text: string): string[] {
   const parts: string[] = [];
@@ -62,8 +62,8 @@ export function parseAsmInstruction(
   const headLower = head.toLowerCase();
   const rest = firstSpace === -1 ? '' : trimmed.slice(firstSpace).trim();
 
-  if (headLower === 'succ' || headLower === 'pred') {
-    return parseSuccPredInstruction(filePath, headLower, rest, instrSpan, diagnostics);
+  if (headLower === 'step' || headLower === 'succ' || headLower === 'pred') {
+    return parseStepInstruction(filePath, headLower, rest, instrSpan, diagnostics);
   }
 
   if (headLower === 'move') {

--- a/src/frontend/parseSuccPredInstruction.ts
+++ b/src/frontend/parseSuccPredInstruction.ts
@@ -1,26 +1,61 @@
 import type { AsmInstructionNode, SourceSpan } from './ast.js';
 import type { Diagnostic } from '../diagnostics/types.js';
+import { parseImmExprFromText } from './parseImm.js';
 import { parseDiag as diag } from './parseDiagnostics.js';
 import { ALL_REGISTER_NAMES } from './grammarData.js';
 import { isAssignmentStoragePath } from './parseAssignmentInstruction.js';
 import { canonicalRegisterToken, parseEaExprFromText } from './parseOperands.js';
 
-export function parseSuccPredInstruction(
+type StepInstructionHead = 'step' | 'succ' | 'pred';
+
+function splitTopLevelCommaSeparated(text: string): string[] {
+  const parts: string[] = [];
+  let current = '';
+  let parenDepth = 0;
+  let bracketDepth = 0;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]!;
+    if (ch === '(') {
+      parenDepth++;
+      current += ch;
+      continue;
+    }
+    if (ch === ')') {
+      parenDepth = Math.max(parenDepth - 1, 0);
+      current += ch;
+      continue;
+    }
+    if (ch === '[') {
+      bracketDepth++;
+      current += ch;
+      continue;
+    }
+    if (ch === ']') {
+      bracketDepth = Math.max(bracketDepth - 1, 0);
+      current += ch;
+      continue;
+    }
+    if (ch === ',' && parenDepth === 0 && bracketDepth === 0) {
+      parts.push(current.trim());
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+
+  parts.push(current.trim());
+  return parts.filter((part) => part.length > 0);
+}
+
+function parseStepTargetOperand(
   filePath: string,
-  head: 'succ' | 'pred',
+  head: StepInstructionHead,
   operandText: string,
   instrSpan: SourceSpan,
   diagnostics: Diagnostic[],
-): AsmInstructionNode | undefined {
+): AsmInstructionNode['operands'][number] | undefined {
   const text = operandText.trim();
-  if (text.length === 0 || text.includes(',')) {
-    diag(diagnostics, filePath, `"${head}" expects exactly one typed path operand`, {
-      line: instrSpan.start.line,
-      column: instrSpan.start.column,
-    });
-    return undefined;
-  }
-
   const canonicalRegister = canonicalRegisterToken(text);
   if (ALL_REGISTER_NAMES.has(canonicalRegister)) {
     diag(diagnostics, filePath, `"${head}" only accepts typed path operands in this slice`, {
@@ -65,10 +100,54 @@ export function parseSuccPredInstruction(
     return undefined;
   }
 
+  return { kind: 'Ea', span: instrSpan, expr: ea };
+}
+
+export function parseStepInstruction(
+  filePath: string,
+  head: StepInstructionHead,
+  operandText: string,
+  instrSpan: SourceSpan,
+  diagnostics: Diagnostic[],
+): AsmInstructionNode | undefined {
+  const text = operandText.trim();
+  const parts = splitTopLevelCommaSeparated(text);
+
+  if (head === 'step') {
+    if (parts.length < 1 || parts.length > 2) {
+      diag(diagnostics, filePath, '"step" expects a typed path operand and optional amount', {
+        line: instrSpan.start.line,
+        column: instrSpan.start.column,
+      });
+      return undefined;
+    }
+  } else if (parts.length !== 1) {
+    diag(diagnostics, filePath, `"${head}" expects exactly one typed path operand`, {
+      line: instrSpan.start.line,
+      column: instrSpan.start.column,
+    });
+    return undefined;
+  }
+
+  const target = parseStepTargetOperand(filePath, head, parts[0] ?? '', instrSpan, diagnostics);
+  if (!target) return undefined;
+
+  if (head !== 'step' || parts.length === 1) {
+    return {
+      kind: 'AsmInstruction',
+      span: instrSpan,
+      head,
+      operands: [target],
+    };
+  }
+
+  const amountExpr = parseImmExprFromText(filePath, parts[1]!, instrSpan, diagnostics);
+  if (!amountExpr) return undefined;
+
   return {
     kind: 'AsmInstruction',
     span: instrSpan,
     head,
-    operands: [{ kind: 'Ea', span: instrSpan, expr: ea }],
+    operands: [target, { kind: 'Imm', span: instrSpan, expr: amountExpr }],
   };
 }

--- a/src/semantics/succPredAcceptance.ts
+++ b/src/semantics/succPredAcceptance.ts
@@ -1,47 +1,104 @@
 import type { Diagnostic } from '../diagnostics/types.js';
-import type { ProgramNode } from '../frontend/ast.js';
+import type { AsmInstructionNode, ProgramNode } from '../frontend/ast.js';
+import { evalImmExpr } from './env.js';
 import type { CompileEnv } from './env.js';
 import { diagAt } from './storageView.js';
 import { runInstructionAcceptance } from './instructionAcceptance.js';
 import type { InstructionValidator } from './instructionAcceptance.js';
 
-const succPredValidator: InstructionValidator = {
-  validateInstruction(item, _storage, helpers, diagnostics) {
-    if ((item.head !== 'succ' && item.head !== 'pred') || item.operands.length !== 1) return;
-    const operand = item.operands[0];
-    if (operand?.kind !== 'Ea' || operand.explicitAddressOf) return;
+type CanonicalStepInstruction = {
+  amount: number;
+  amountExpr?: Extract<AsmInstructionNode['operands'][number], { kind: 'Imm' }>['expr'];
+  headForDiagnostics: 'step' | 'succ' | 'pred';
+  target: Extract<AsmInstructionNode['operands'][number], { kind: 'Ea' }>;
+};
 
-    const typeExpr = helpers.resolveEaTypeExpr(operand.expr);
-    const scalar = helpers.resolveScalarTypeForLd(operand.expr);
+function getCanonicalStepInstruction(item: AsmInstructionNode): CanonicalStepInstruction | undefined {
+  if (item.head === 'succ' || item.head === 'pred') {
+    if (item.operands.length !== 1) return undefined;
+    const target = item.operands[0];
+    if (target?.kind !== 'Ea' || target.explicitAddressOf) return undefined;
+    return {
+      amount: item.head === 'succ' ? 1 : -1,
+      headForDiagnostics: item.head,
+      target,
+    };
+  }
+
+  if (item.head !== 'step' || item.operands.length < 1 || item.operands.length > 2) return undefined;
+  const target = item.operands[0];
+  if (target?.kind !== 'Ea' || target.explicitAddressOf) return undefined;
+
+  if (item.operands.length === 1) {
+    return {
+      amount: 1,
+      headForDiagnostics: 'step',
+      target,
+    };
+  }
+
+  const amountOperand = item.operands[1];
+  if (amountOperand?.kind !== 'Imm') return undefined;
+
+  return {
+    amount: 1,
+    amountExpr: amountOperand.expr,
+    headForDiagnostics: 'step',
+    target,
+  };
+}
+
+function createStepValidator(env: CompileEnv): InstructionValidator {
+  return {
+  validateInstruction(item, _storage, helpers, diagnostics) {
+    const step = getCanonicalStepInstruction(item);
+    if (!step) return;
+
+    if (step.amountExpr) {
+      const diagCount = diagnostics.length;
+      const amount = evalImmExpr(step.amountExpr, env, diagnostics);
+      if (amount === undefined) {
+        if (diagnostics.length === diagCount) {
+          diagAt(diagnostics, item.span, '"step" amount must be a compile-time integer expression.');
+        }
+        return;
+      }
+      step.amount = amount;
+    }
+
+    const typeExpr = helpers.resolveEaTypeExpr(step.target.expr);
+    const scalar = helpers.resolveScalarTypeForLd(step.target.expr);
     if (!scalar) {
       const detail = typeExpr ? helpers.typeDisplay(typeExpr) : 'unknown';
-      diagAt(diagnostics, item.span, `"${item.head}" requires scalar storage; got ${detail}.`);
+      diagAt(diagnostics, item.span, `"${step.headForDiagnostics}" requires scalar storage; got ${detail}.`);
       return;
     }
     if (scalar !== 'byte' && scalar !== 'word') {
-      diagAt(diagnostics, item.span, `"${item.head}" only supports byte and word scalar paths in this slice.`);
+      diagAt(
+        diagnostics,
+        item.span,
+        `"${step.headForDiagnostics}" only supports byte and word scalar paths in this slice.`,
+      );
     }
   },
 
   validateOpInstruction(item, _op, diagnostics) {
-    if (
-      (item.head === 'succ' || item.head === 'pred') &&
-      item.operands.length === 1 &&
-      item.operands[0]?.kind === 'Ea'
-    ) {
+    const step = getCanonicalStepInstruction(item);
+    if (step) {
       diagAt(
         diagnostics,
         item.span,
-        `"${item.head}" typed-path forms are not supported inside ops in this slice.`,
+        `"${step.headForDiagnostics}" typed-path forms are not supported inside ops in this slice.`,
       );
     }
   },
-};
+  };
+}
 
 export function validateSuccPredAcceptance(
   program: ProgramNode,
   env: CompileEnv,
   diagnostics: Diagnostic[],
 ): void {
-  runInstructionAcceptance(program, env, diagnostics, succPredValidator);
+  runInstructionAcceptance(program, env, diagnostics, createStepValidator(env));
 }

--- a/test/pr899_succ_pred_acceptance.test.ts
+++ b/test/pr899_succ_pred_acceptance.test.ts
@@ -18,11 +18,13 @@ function parseProgram(modulePath: string, source: string): { program: ProgramNod
   return { program, diagnostics };
 }
 
-describe('PR899 succ/pred acceptance', () => {
-  it('accepts scalar byte and word path operands', () => {
+describe('PR899 step/succ/pred acceptance', () => {
+  it('accepts scalar byte and word path operands with default and explicit amounts', () => {
     const { program, diagnostics } = parseProgram(
       'pr899_succ_pred_positive.zax',
       `
+const INC = 3
+
 type Rec
   field: byte
 end
@@ -36,10 +38,12 @@ end
 
 section code text at $0000
 func main()
+  step count
+  step used_slots, 3
+  step arr[1], INC
+  step rec.field, -2
   succ count
   pred used_slots
-  succ arr[1]
-  pred rec.field
   ret
 end
 end
@@ -69,8 +73,8 @@ end
 
 section code text at $0000
 func main()
-  succ rec
-  pred ptr
+  step rec
+  step ptr
   succ raw_buf
   ret
 end
@@ -82,9 +86,34 @@ end
     validateSuccPredAcceptance(program, env, diagnostics);
 
     const messages = diagnostics.map((d) => d.message);
-    expect(messages).toContain('"succ" requires scalar storage; got Rec.');
-    expect(messages).toContain('"pred" only supports byte and word scalar paths in this slice.');
+    expect(messages).toContain('"step" requires scalar storage; got Rec.');
+    expect(messages).toContain('"step" only supports byte and word scalar paths in this slice.');
     expect(messages).toContain('"succ" requires scalar storage; got unknown.');
+  });
+
+  it('rejects step amounts that are not compile-time integer expressions', () => {
+    const { program, diagnostics } = parseProgram(
+      'pr899_succ_pred_amount_negative.zax',
+      `
+section data globals at $8000
+  count: byte
+  delta: byte
+end
+
+section code text at $0000
+func main()
+  step count, delta
+  ret
+end
+end
+      `,
+    );
+
+    const env = buildEnv(program, diagnostics);
+    validateSuccPredAcceptance(program, env, diagnostics);
+
+    const messages = diagnostics.map((d) => d.message);
+    expect(messages).toContain('"step" amount must be a compile-time integer expression.');
   });
 
   it('rejects typed-path forms inside ops in this slice', () => {
@@ -92,6 +121,7 @@ end
       'pr899_succ_pred_op_negative.zax',
       `
 op bump(slot: ea)
+  step slot
   succ slot
 end
 
@@ -105,6 +135,7 @@ end
     validateSuccPredAcceptance(program, env, diagnostics);
 
     const messages = diagnostics.map((d) => d.message);
+    expect(messages).toContain('"step" typed-path forms are not supported inside ops in this slice.');
     expect(messages).toContain('"succ" typed-path forms are not supported inside ops in this slice.');
     expect(messages).toContain('"pred" typed-path forms are not supported inside ops in this slice.');
   });

--- a/test/pr899_succ_pred_parser.test.ts
+++ b/test/pr899_succ_pred_parser.test.ts
@@ -4,7 +4,7 @@ import type { Diagnostic } from '../src/diagnostics/types.js';
 import { parseAsmInstruction } from '../src/frontend/parseAsmInstruction.js';
 import { makeSourceFile, span } from '../src/frontend/source.js';
 
-describe('PR899 succ/pred parser support', () => {
+describe('PR899 step/succ/pred parser support', () => {
   const file = makeSourceFile('pr899_succ_pred_parser.zax', '');
   const zeroSpan = span(file, 0, 0);
 
@@ -16,7 +16,63 @@ describe('PR899 succ/pred parser support', () => {
     return { instr, diagnostics };
   }
 
-  it('parses typed-path forms', () => {
+  it('parses step typed-path forms with optional amounts', () => {
+    let parsed = parse('step count');
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.instr).toMatchObject({
+      kind: 'AsmInstruction',
+      head: 'step',
+      operands: [{ kind: 'Ea', expr: { kind: 'EaName', name: 'count' } }],
+    });
+
+    parsed = parse('step rec.field, 3');
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.instr).toMatchObject({
+      kind: 'AsmInstruction',
+      head: 'step',
+      operands: [
+        {
+          kind: 'Ea',
+          expr: {
+            kind: 'EaField',
+            base: { kind: 'EaName', name: 'rec' },
+            field: 'field',
+          },
+        },
+        { kind: 'Imm', expr: { kind: 'ImmLiteral', value: 3 } },
+      ],
+    });
+
+    parsed = parse('step arr[idx], INC');
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.instr).toMatchObject({
+      kind: 'AsmInstruction',
+      head: 'step',
+      operands: [
+        {
+          kind: 'Ea',
+          expr: {
+            kind: 'EaIndex',
+            base: { kind: 'EaName', name: 'arr' },
+          },
+        },
+        { kind: 'Imm', expr: { kind: 'ImmName', name: 'INC' } },
+      ],
+    });
+
+    parsed = parse('step total, -2');
+    expect(parsed.diagnostics).toEqual([]);
+    expect(parsed.instr).toMatchObject({
+      kind: 'AsmInstruction',
+      head: 'step',
+      operands: [
+        { kind: 'Ea', expr: { kind: 'EaName', name: 'total' } },
+        { kind: 'Imm', expr: { kind: 'ImmUnary', op: '-', expr: { kind: 'ImmLiteral', value: 2 } } },
+      ],
+    });
+  });
+
+  it('parses succ/pred aliases as single-operand typed-path forms', () => {
     let parsed = parse('succ count');
     expect(parsed.diagnostics).toEqual([]);
     expect(parsed.instr).toMatchObject({
@@ -41,30 +97,15 @@ describe('PR899 succ/pred parser support', () => {
         },
       ],
     });
-
-    parsed = parse('succ arr[idx]');
-    expect(parsed.diagnostics).toEqual([]);
-    expect(parsed.instr).toMatchObject({
-      kind: 'AsmInstruction',
-      head: 'succ',
-      operands: [
-        {
-          kind: 'Ea',
-          expr: {
-            kind: 'EaIndex',
-            base: { kind: 'EaName', name: 'arr' },
-          },
-        },
-      ],
-    });
   });
 
   it('rejects registers, indirect forms, address-of forms, and arity errors', () => {
-    for (const text of ['succ hl', 'pred (hl)', 'succ @path', 'pred left, right']) {
+    for (const text of ['step hl', 'step (hl)', 'step @path', 'step left, right, extra', 'pred left, right']) {
       const parsed = parse(text);
       expect(parsed.instr).toBeUndefined();
       expect(parsed.diagnostics.length).toBeGreaterThan(0);
-      expect(parsed.diagnostics[0]?.message.toLowerCase()).toContain(text.startsWith('pred') ? 'pred' : 'succ');
+      const expectedHead = text.startsWith('pred') ? 'pred' : 'step';
+      expect(parsed.diagnostics[0]?.message.toLowerCase()).toContain(expectedHead);
     }
   });
 });


### PR DESCRIPTION
## Summary
- add shared step frontend parsing for `step`, `succ`, and `pred`
- validate `step` typed-path targets with optional compile-time integer amounts
- expand parser and acceptance coverage for step defaults, aliases, and invalid forms

## Testing
- npx vitest run test/pr899_succ_pred_parser.test.ts test/pr899_succ_pred_acceptance.test.ts test/pr900_succ_pred_integration.test.ts
- npm run test

## Notes
- lowering is intentionally excluded from this PR; `succ` and `pred` remain source-compatible aliases and keep existing lowering behavior
