### PR TITLE
fix: align imports after diagnostics flattening

### DIFF
--- a/src/compileShared.ts
+++ b/src/compileShared.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path';
 
-import type { Diagnostic } from './diagnostics/types.js';
+import type { Diagnostic } from './diagnosticTypes.js';
 
 export function hasErrors(diagnostics: Diagnostic[]): boolean {
   return diagnostics.some((d) => d.severity === 'error');

--- a/src/frontend/parseLogicalLines.ts
+++ b/src/frontend/parseLogicalLines.ts
@@ -1,4 +1,4 @@
-import type { Diagnostic } from '../diagnostics/types.js';
+import type { Diagnostic } from '../diagnosticTypes.js';
 
 import { parseDiag as diag } from './parseDiagnostics.js';
 import type { SourceFile } from './source.js';

--- a/src/frontend/parseModuleItemDispatch.ts
+++ b/src/frontend/parseModuleItemDispatch.ts
@@ -5,7 +5,7 @@ import type {
   SectionItemNode,
   SourceSpan,
 } from './ast.js';
-import type { Diagnostic } from '../diagnostics/types.js';
+import type { Diagnostic } from '../diagnosticTypes.js';
 import { consumeTopKeyword, diagInvalidHeaderLine } from './parseModuleCommon.js';
 import { parseTopLevelExternDecl } from './parseExternBlock.js';
 import { parseEnumDecl } from './parseEnum.js';

--- a/src/frontend/parseRawDataDirectives.ts
+++ b/src/frontend/parseRawDataDirectives.ts
@@ -1,4 +1,4 @@
-import type { Diagnostic } from '../diagnostics/types.js';
+import type { Diagnostic } from '../diagnosticTypes.js';
 
 import type { ImmExprNode, RawDataDeclNode, SourceSpan } from './ast.js';
 import { parseImmExprFromText } from './parseImm.js';

--- a/src/lowering/emitProgramContext.ts
+++ b/src/lowering/emitProgramContext.ts
@@ -1,4 +1,4 @@
-import type { Diagnostic, DiagnosticId } from '../diagnostics/types.js';
+import type { Diagnostic, DiagnosticId } from '../diagnosticTypes.js';
 import type {
   AsmOperandNode,
   EaExprNode,

--- a/src/lowering/functionAsmRewriting.ts
+++ b/src/lowering/functionAsmRewriting.ts
@@ -1,4 +1,4 @@
-import type { Diagnostic } from '../diagnostics/types.js';
+import type { Diagnostic } from '../diagnosticTypes.js';
 import type {
   AsmOperandNode,
   EaExprNode,

--- a/src/lowering/functionFrameSetup.ts
+++ b/src/lowering/functionFrameSetup.ts
@@ -1,4 +1,4 @@
-import type { Diagnostic } from '../diagnostics/types.js';
+import type { Diagnostic } from '../diagnosticTypes.js';
 import type {
   AsmOperandNode,
   EaExprNode,

--- a/src/lowering/ldEncodingRegMemHelpers.ts
+++ b/src/lowering/ldEncodingRegMemHelpers.ts
@@ -1,5 +1,5 @@
 import type { StepPipeline } from '../addressing/steps.js';
-import type { Diagnostic } from '../diagnostics/types.js';
+import type { Diagnostic } from '../diagnosticTypes.js';
 import type { AsmOperandNode, SourceSpan } from '../frontend/ast.js';
 import type { EaResolution } from './eaResolution.js';
 import type { LdForm } from './ldFormSelection.js';

--- a/src/moduleLoader.ts
+++ b/src/moduleLoader.ts
@@ -2,8 +2,8 @@ import { readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
 import { hasErrors, normalizePath } from './compileShared.js';
-import type { Diagnostic } from './diagnostics/types.js';
-import { DiagnosticIds } from './diagnostics/types.js';
+import type { Diagnostic } from './diagnosticTypes.js';
+import { DiagnosticIds } from './diagnosticTypes.js';
 import type { ImportNode, ModuleFileNode, ModuleItemNode, ProgramNode, SectionItemNode } from './frontend/ast.js';
 import { parseModuleFile } from './frontend/parser.js';
 import { stripLineComment } from './frontend/parseParserShared.js';

--- a/test/pr1050_step_lowering.test.ts
+++ b/test/pr1050_step_lowering.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnostics/types.js';
-import { DiagnosticIds } from '../src/diagnostics/types.js';
+import type { Diagnostic } from '../src/diagnosticTypes.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import type { AsmInstructionNode, AsmOperandNode, SourceSpan } from '../src/frontend/ast.js';
 import { createAsmInstructionLoweringHelpers } from '../src/lowering/asmInstructionLowering.js';
 

--- a/test/pr472_source_file_size_guard.test.ts
+++ b/test/pr472_source_file_size_guard.test.ts
@@ -34,18 +34,29 @@ describe('PR472: source file size guard', () => {
     const { stdout } = await execFileAsync('node', ['scripts/check-source-file-sizes.mjs'], {
       cwd: process.cwd(),
     });
+    const asmInstructionLoweringLines = await currentLineCount('src/lowering/asmInstructionLowering.ts');
     const emitLines = await currentLineCount('src/lowering/emit.ts');
     const emitCeiling = await currentHardCapCeiling('src/lowering/emit.ts');
     const parserLines = await currentLineCount('src/frontend/parser.ts');
     const parserCeiling = await currentHardCapCeiling('src/frontend/parser.ts');
     const encodeLines = await currentLineCount('src/z80/encode.ts');
     const normalizedStdout = normalizeGuardOutput(stdout);
-    const hasOversizedFiles = emitLines > 750 || parserLines > 750 || encodeLines > 750;
+    const hasOversizedFiles =
+      asmInstructionLoweringLines > 750 || emitLines > 750 || parserLines > 750 || encodeLines > 750;
 
     if (hasOversizedFiles) {
       expect(normalizedStdout).toContain('source-file-size-guard: soft>750, hard>1000');
     } else {
       expect(normalizedStdout).toContain('source-file-size-guard: ok (soft 750, hard 1000)');
+    }
+    if (asmInstructionLoweringLines > 750) {
+      expect(normalizedStdout).toContain(
+        `src/lowering/asmInstructionLowering.ts: ${asmInstructionLoweringLines}`,
+      );
+    } else {
+      expect(normalizedStdout).not.toContain(
+        `src/lowering/asmInstructionLowering.ts: ${asmInstructionLoweringLines}`,
+      );
     }
     if (emitLines > 1000) {
       if (emitCeiling !== null) {


### PR DESCRIPTION
## Summary
- update remaining runtime and test imports to the flattened `diagnosticTypes` path after #1050
- adjust the source-file-size guard test to account for the current soft warning on `src/lowering/asmInstructionLowering.ts`

## Validation
- npx vitest run --reporter=basic
