### PR TITLE
#1057 expand lowered-program helpers for symbol-aware assertions

### DIFF
--- a/test/helpers/lowered_program.ts
+++ b/test/helpers/lowered_program.ts
@@ -1,7 +1,7 @@
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import { compile } from '../../src/compile.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
-import type { Asm80Artifact } from '../../src/formats/types.js';
+import type { Asm80Artifact, BinArtifact, EmittedByteMap, SymbolEntry } from '../../src/formats/types.js';
 import type {
   LoweredAsmProgram,
   LoweredAsmBlock,
@@ -11,64 +11,232 @@ import type {
   LoweredEaExpr,
 } from '../../src/lowering/loweredAsmTypes.js';
 
+export type CompiledLoweredProgram = {
+  program: LoweredAsmProgram;
+  diagnostics: Diagnostic[];
+  map: EmittedByteMap;
+  symbols: SymbolEntry[];
+};
+
 export type LoweredInstrView = {
   head: string;
   operands: LoweredOperand[];
   bytes?: number[];
+  resolvedBytes?: number[];
   block: LoweredAsmBlock;
+  address: number;
+  size: number;
+  itemIndex: number;
 };
 
-export async function compilePlacedProgram(entry: string): Promise<{
-  program: LoweredAsmProgram;
-  diagnostics: Diagnostic[];
-}> {
-  let captured: LoweredAsmProgram | undefined;
+export type LoweredLabelView = {
+  name: string;
+  address: number;
+  block: LoweredAsmBlock;
+  itemIndex: number;
+};
+
+export type LoweredBlockMatcher = Partial<
+  Pick<LoweredAsmBlock, 'kind' | 'origin' | 'section' | 'name' | 'contributionOrder'>
+>;
+
+export type OperandPredicate = (op: LoweredOperand | undefined) => boolean;
+
+export type LoweredLabelRange = {
+  startLabel: string;
+  endLabel?: string;
+};
+
+export type RawAbs16TargetSpec = {
+  opcode: number;
+  opcode2?: number;
+  target: string;
+  addend?: number;
+  range?: LoweredLabelRange;
+};
+
+export type ResolvedRawAbs16TargetView = LoweredInstrView & {
+  resolvedTargetAddress: number;
+  resolvedTargetSymbol?: SymbolEntry;
+};
+
+function isCompiledLoweredProgram(value: LoweredAsmProgram | CompiledLoweredProgram): value is CompiledLoweredProgram {
+  return 'program' in value;
+}
+
+function getProgram(value: LoweredAsmProgram | CompiledLoweredProgram): LoweredAsmProgram {
+  return isCompiledLoweredProgram(value) ? value.program : value;
+}
+
+function getMap(value: LoweredAsmProgram | CompiledLoweredProgram): EmittedByteMap | undefined {
+  return isCompiledLoweredProgram(value) ? value.map : undefined;
+}
+
+function readResolvedBytes(map: EmittedByteMap | undefined, address: number, size: number): number[] | undefined {
+  if (!map || size <= 0) return undefined;
+  const bytes: number[] = [];
+  for (let index = 0; index < size; index++) {
+    const byte = map.bytes.get(address + index);
+    if (byte === undefined) return undefined;
+    bytes.push(byte);
+  }
+  return bytes;
+}
+
+function evalStaticLoweredImmExpr(expr: LoweredImmExpr): number | undefined {
+  switch (expr.kind) {
+    case 'literal':
+      return expr.value;
+    case 'symbol':
+    case 'opaque':
+      return undefined;
+    case 'unary': {
+      const value = evalStaticLoweredImmExpr(expr.expr);
+      if (value === undefined) return undefined;
+      switch (expr.op) {
+        case '+':
+          return +value;
+        case '-':
+          return -value;
+        case '~':
+          return ~value;
+      }
+    }
+    case 'binary': {
+      const left = evalStaticLoweredImmExpr(expr.left);
+      const right = evalStaticLoweredImmExpr(expr.right);
+      if (left === undefined || right === undefined) return undefined;
+      switch (expr.op) {
+        case '*':
+          return left * right;
+        case '/':
+          return right === 0 ? undefined : Math.trunc(left / right);
+        case '%':
+          return right === 0 ? undefined : left % right;
+        case '+':
+          return left + right;
+        case '-':
+          return left - right;
+        case '&':
+          return left & right;
+        case '^':
+          return left ^ right;
+        case '|':
+          return left | right;
+        case '<<':
+          return left << right;
+        case '>>':
+          return left >> right;
+      }
+    }
+  }
+}
+
+function loweredItemSize(item: LoweredAsmItem): number {
+  switch (item.kind) {
+    case 'label':
+    case 'const':
+    case 'comment':
+      return 0;
+    case 'db':
+      return item.values.length;
+    case 'dw':
+      return item.values.length * 2;
+    case 'ds':
+      return Math.max(0, evalStaticLoweredImmExpr(item.size) ?? 0);
+    case 'instr':
+      return item.bytes?.length ?? 0;
+  }
+}
+
+export async function compilePlacedProgram(entry: string): Promise<CompiledLoweredProgram> {
+  let capturedProgram: LoweredAsmProgram | undefined;
+  let capturedMap: EmittedByteMap | undefined;
+  let capturedSymbols: SymbolEntry[] | undefined;
   const formats = {
     ...defaultFormatWriters,
+    writeBin: (map: EmittedByteMap, symbols: SymbolEntry[]): BinArtifact => {
+      capturedMap = map;
+      capturedSymbols = symbols;
+      return { kind: 'bin', bytes: new Uint8Array() };
+    },
     writeAsm80: (program: LoweredAsmProgram): Asm80Artifact => {
-      captured = program;
+      capturedProgram = program;
       return { kind: 'asm80', text: '' };
     },
   };
   const res = await compile(
     entry,
-    { emitAsm80: true, emitBin: false, emitHex: false, emitListing: false, emitD8m: false },
+    { emitAsm80: true, emitBin: true, emitHex: false, emitListing: false, emitD8m: false },
     { formats },
   );
-  if (!captured) {
+  if (!capturedProgram) {
     throw new Error('Placed lowered program was not captured from ASM80 emission.');
   }
-  return { program: captured, diagnostics: res.diagnostics };
+  if (!capturedMap || !capturedSymbols) {
+    throw new Error('Resolved byte map and symbols were not captured from BIN emission.');
+  }
+  return { program: capturedProgram, diagnostics: res.diagnostics, map: capturedMap, symbols: capturedSymbols };
 }
 
-export function flattenLoweredInstructions(program: LoweredAsmProgram): LoweredInstrView[] {
+export function flattenLoweredInstructions(
+  program: LoweredAsmProgram,
+  map?: EmittedByteMap,
+): LoweredInstrView[] {
   const out: LoweredInstrView[] = [];
   for (const block of program.blocks) {
-    for (const item of block.items) {
+    let offset = 0;
+    for (let itemIndex = 0; itemIndex < block.items.length; itemIndex++) {
+      const item = block.items[itemIndex]!;
+      const address = block.origin + offset;
       if (item.kind === 'instr') {
-        out.push({
+        const size = loweredItemSize(item);
+        const view: LoweredInstrView = {
           head: item.head,
           operands: item.operands,
-          ...(item.bytes ? { bytes: item.bytes } : {}),
           block,
-        });
+          address,
+          size,
+          itemIndex,
+        };
+        if (item.bytes) view.bytes = item.bytes;
+        const resolvedBytes = map ? readResolvedBytes(map, address, size) : undefined;
+        if (resolvedBytes) view.resolvedBytes = resolvedBytes;
+        out.push(view);
       }
+      offset += loweredItemSize(item);
     }
   }
   return out;
 }
 
-export function hasRawOpcode(
-  instrs: LoweredInstrView[],
-  opcode: number,
-  opcode2?: number,
-): boolean {
-  return instrs.some((ins) => {
-    if (ins.head !== '@raw' || !ins.bytes) return false;
-    if (ins.bytes[0] !== opcode) return false;
-    if (opcode2 === undefined) return true;
-    return ins.bytes[1] === opcode2;
-  });
+export function flattenLoweredLabels(program: LoweredAsmProgram): LoweredLabelView[] {
+  const out: LoweredLabelView[] = [];
+  for (const block of program.blocks) {
+    let offset = 0;
+    for (let itemIndex = 0; itemIndex < block.items.length; itemIndex++) {
+      const item = block.items[itemIndex]!;
+      const address = block.origin + offset;
+      if (item.kind === 'label') {
+        out.push({ name: item.name, address, block, itemIndex });
+      }
+      offset += loweredItemSize(item);
+    }
+  }
+  return out;
+}
+
+export function findLoweredLabel(program: LoweredAsmProgram, name: string): LoweredLabelView | undefined {
+  return flattenLoweredLabels(program).find((label) => label.name.toUpperCase() === name.toUpperCase());
+}
+
+export function findLoweredBlock(
+  program: LoweredAsmProgram,
+  matcher: LoweredBlockMatcher,
+): LoweredAsmBlock | undefined {
+  return program.blocks.find((block) =>
+    Object.entries(matcher).every(([key, value]) => block[key as keyof LoweredBlockMatcher] === value),
+  );
 }
 
 export function flattenLoweredItems(program: LoweredAsmProgram): LoweredAsmItem[] {
@@ -79,16 +247,17 @@ export function flattenLoweredItems(program: LoweredAsmProgram): LoweredAsmItem[
   return out;
 }
 
-const toHex = (value: number, width: number): string =>
-  value.toString(16).toUpperCase().padStart(width, '0');
+function toHex(value: number, width: number): string {
+  return value.toString(16).toUpperCase().padStart(width, '0');
+}
 
-const formatNumber = (value: number): string => {
+function formatNumber(value: number): string {
   if (value < 0) {
     const abs = Math.abs(value);
     return `-$${toHex(abs, abs > 0xff ? 4 : 2)}`;
   }
   return `$${toHex(value, value > 0xff ? 4 : 2)}`;
-};
+}
 
 export function formatLoweredImmExpr(expr: LoweredImmExpr): string {
   switch (expr.kind) {
@@ -152,6 +321,25 @@ export function formatLoweredInstructions(program: LoweredAsmProgram): string[] 
   return flattenLoweredInstructions(program).map(formatLoweredInstruction);
 }
 
+export function instructionsInLabelRange(
+  value: LoweredAsmProgram | CompiledLoweredProgram,
+  startLabel: string,
+  endLabel?: string,
+): LoweredInstrView[] {
+  const program = getProgram(value);
+  const map = getMap(value);
+  const start = findLoweredLabel(program, startLabel);
+  if (!start) return [];
+  const end = endLabel ? findLoweredLabel(program, endLabel) : undefined;
+  if (end && end.block !== start.block) return [];
+  return flattenLoweredInstructions(program, map).filter(
+    (instr) =>
+      instr.block === start.block &&
+      instr.itemIndex > start.itemIndex &&
+      (end ? instr.itemIndex < end.itemIndex : true),
+  );
+}
+
 export function operandUsesIx(op: LoweredOperand): boolean {
   if (op.kind !== 'mem' && op.kind !== 'ea') return false;
   const usesIx = (expr: LoweredEaExpr): boolean => {
@@ -171,8 +359,16 @@ export function operandUsesIx(op: LoweredOperand): boolean {
   return usesIx(op.expr);
 }
 
+export function hasOperands(view: LoweredInstrView, ...predicates: OperandPredicate[]): boolean {
+  return view.operands.length === predicates.length && predicates.every((predicate, index) => predicate(view.operands[index]));
+}
+
 export function isReg(op: LoweredOperand | undefined, name: string): boolean {
   return !!op && op.kind === 'reg' && op.name.toUpperCase() === name.toUpperCase();
+}
+
+export function isImmLiteral(op: LoweredOperand | undefined, value: number): boolean {
+  return !!op && op.kind === 'imm' && op.expr.kind === 'literal' && op.expr.value === value;
 }
 
 export function isImmSymbol(op: LoweredOperand | undefined, name: string, addend = 0): boolean {
@@ -182,6 +378,14 @@ export function isImmSymbol(op: LoweredOperand | undefined, name: string, addend
     op.expr.kind === 'symbol' &&
     op.expr.name.toUpperCase() === name.toUpperCase() &&
     op.expr.addend === addend
+  );
+}
+
+export function isEaName(op: LoweredOperand | undefined, name: string): boolean {
+  return (
+    !!op &&
+    ((op.kind === 'ea' && op.expr.kind === 'name') || (op.kind === 'mem' && op.expr.kind === 'name')) &&
+    op.expr.name.toUpperCase() === name.toUpperCase()
   );
 }
 
@@ -199,4 +403,53 @@ export function isMemIxDisp(op: LoweredOperand | undefined, disp: number): boole
     return sign * expr.offset.value === disp;
   }
   return false;
+}
+
+export function findSymbol(symbols: SymbolEntry[], name: string): SymbolEntry | undefined {
+  return symbols.find((symbol) => symbol.name.toUpperCase() === name.toUpperCase());
+}
+
+export function hasRawOpcode(
+  instrs: LoweredInstrView[],
+  opcode: number,
+  opcode2?: number,
+): boolean {
+  return instrs.some((ins) => {
+    if (ins.head !== '@raw' || !ins.bytes) return false;
+    if (ins.bytes[0] !== opcode) return false;
+    if (opcode2 === undefined) return true;
+    return ins.bytes[1] === opcode2;
+  });
+}
+
+function readResolvedAbs16Target(view: LoweredInstrView): number | undefined {
+  if (view.head !== '@raw' || !view.resolvedBytes) return undefined;
+  if (view.resolvedBytes.length < 3) return undefined;
+  if (view.resolvedBytes[0] === 0xed || view.resolvedBytes[0] === 0xdd || view.resolvedBytes[0] === 0xfd) {
+    if (view.resolvedBytes.length < 4) return undefined;
+    return view.resolvedBytes[2]! | (view.resolvedBytes[3]! << 8);
+  }
+  return view.resolvedBytes[1]! | (view.resolvedBytes[2]! << 8);
+}
+
+export function findRawAbs16Target(
+  lowered: CompiledLoweredProgram,
+  spec: RawAbs16TargetSpec,
+): ResolvedRawAbs16TargetView | undefined {
+  const symbol = findSymbol(lowered.symbols, spec.target);
+  if (!symbol || !('address' in symbol)) return undefined;
+  const expectedAddress = (symbol.address + (spec.addend ?? 0)) & 0xffff;
+  const search = spec.range
+    ? instructionsInLabelRange(lowered, spec.range.startLabel, spec.range.endLabel)
+    : flattenLoweredInstructions(lowered.program, lowered.map);
+
+  for (const instr of search) {
+    if (instr.head !== '@raw' || !instr.bytes) continue;
+    if (instr.bytes[0] !== spec.opcode) continue;
+    if (spec.opcode2 !== undefined && instr.bytes[1] !== spec.opcode2) continue;
+    const resolvedTargetAddress = readResolvedAbs16Target(instr);
+    if (resolvedTargetAddress === undefined || resolvedTargetAddress !== expectedAddress) continue;
+    return { ...instr, resolvedTargetAddress, resolvedTargetSymbol: symbol };
+  }
+  return undefined;
 }

--- a/test/pr405_byte_call_scalar_arg.test.ts
+++ b/test/pr405_byte_call_scalar_arg.test.ts
@@ -3,9 +3,11 @@ import { join } from 'node:path';
 
 import {
   compilePlacedProgram,
-  flattenLoweredInstructions,
-  formatLoweredInstruction,
-  hasRawOpcode,
+  findRawAbs16Target,
+  hasOperands,
+  instructionsInLabelRange,
+  isImmLiteral,
+  isReg,
 } from './helpers/lowered_program.js';
 
 describe('PR405: byte call scalar arg', () => {
@@ -13,14 +15,26 @@ describe('PR405: byte call scalar arg', () => {
     const entry = join(__dirname, 'fixtures', 'pr405_byte_call_scalar_arg.zax');
     const lowered = await compilePlacedProgram(entry);
     expect(lowered.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
-    const instrs = flattenLoweredInstructions(lowered.program);
-    const lines = instrs.map((ins) => formatLoweredInstruction(ins).toUpperCase());
 
-    expect(hasRawOpcode(instrs, 0x3a)).toBe(true);
-    expect(lines).toContain('LD H, $00');
-    expect(lines).toContain('LD L, A');
-    expect(lines).toContain('PUSH HL');
-    expect(hasRawOpcode(instrs, 0xcd)).toBe(true);
-    expect(lines.join('\n')).not.toContain('ADD HL, DE');
+    const mainInstrs = instructionsInLabelRange(lowered, 'main');
+
+    expect(
+      findRawAbs16Target(lowered, {
+        opcode: 0x3a,
+        target: 'glob_b',
+        range: { startLabel: 'main' },
+      }),
+    ).toBeDefined();
+    expect(mainInstrs.some((ins) => ins.head === 'ld' && hasOperands(ins, (op) => isReg(op, 'H'), (op) => isImmLiteral(op, 0)))).toBe(true);
+    expect(mainInstrs.some((ins) => ins.head === 'ld' && hasOperands(ins, (op) => isReg(op, 'L'), (op) => isReg(op, 'A')))).toBe(true);
+    expect(mainInstrs.some((ins) => ins.head === 'push' && hasOperands(ins, (op) => isReg(op, 'HL')))).toBe(true);
+    expect(
+      findRawAbs16Target(lowered, {
+        opcode: 0xcd,
+        target: 'sink',
+        range: { startLabel: 'main' },
+      }),
+    ).toBeDefined();
+    expect(mainInstrs.some((ins) => ins.head === 'add' && hasOperands(ins, (op) => isReg(op, 'HL'), (op) => isReg(op, 'DE')))).toBe(false);
   });
 });

--- a/test/pr406_word_scalar_accessors.test.ts
+++ b/test/pr406_word_scalar_accessors.test.ts
@@ -3,6 +3,8 @@ import { join } from 'node:path';
 
 import {
   compilePlacedProgram,
+  findLoweredBlock,
+  findRawAbs16Target,
   flattenLoweredInstructions,
   formatLoweredInstructions,
   hasRawOpcode,
@@ -14,7 +16,8 @@ const compileLowered = async (entry: string) => {
   const res = await compilePlacedProgram(entry);
   expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
   return {
-    instrs: flattenLoweredInstructions(res.program),
+    ...res,
+    instrs: flattenLoweredInstructions(res.program, res.map),
     text: formatLoweredInstructions(res.program).join('\n').toUpperCase(),
   };
 };
@@ -22,12 +25,20 @@ const compileLowered = async (entry: string) => {
 describe('PR406: word scalar accessors', () => {
   it('uses direct global word accessors for BC/DE', async () => {
     const entry = join(__dirname, 'fixtures', 'pr406_word_global_scalar_accessors.zax');
-    const { instrs } = await compileLowered(entry);
+    const lowered = await compileLowered(entry);
 
-    expect(hasRawOpcode(instrs, 0xed, 0x4b)).toBe(true); // LD BC, (nn)
-    expect(hasRawOpcode(instrs, 0xed, 0x5b)).toBe(true); // LD DE, (nn)
-    expect(hasRawOpcode(instrs, 0xed, 0x43)).toBe(true); // LD (nn), BC
-    expect(hasRawOpcode(instrs, 0xed, 0x53)).toBe(true); // LD (nn), DE
+    expect(
+      findLoweredBlock(lowered.program, {
+        kind: 'section',
+        section: 'code',
+        name: 'main',
+        origin: 0x0100,
+      }),
+    ).toBeDefined();
+    expect(findRawAbs16Target(lowered, { opcode: 0xed, opcode2: 0x4b, target: 'glob_w' })).toBeDefined();
+    expect(findRawAbs16Target(lowered, { opcode: 0xed, opcode2: 0x5b, target: 'glob_w' })).toBeDefined();
+    expect(findRawAbs16Target(lowered, { opcode: 0xed, opcode2: 0x43, target: 'glob_w' })).toBeDefined();
+    expect(findRawAbs16Target(lowered, { opcode: 0xed, opcode2: 0x53, target: 'glob_w' })).toBeDefined();
   });
 
   it('uses direct frame word accessors for BC/DE', async () => {


### PR DESCRIPTION
Closes #1057.

## Summary
- expand `test/helpers/lowered_program.ts` so lowered-program tests can assert symbol-sensitive behavior without falling back to brittle textual ASM checks
- capture the final emitted byte map and symbol table alongside the placed lowered program
- migrate a small focused batch of lowering tests onto the stronger helper seam

## Helpers Added
- `compilePlacedProgram()` now also captures:
  - final `EmittedByteMap`
  - final `SymbolEntry[]`
- label/block lookup:
  - `flattenLoweredLabels()`
  - `findLoweredLabel()`
  - `findLoweredBlock()`
  - `instructionsInLabelRange()`
- operand matching:
  - `hasOperands()`
  - `isImmLiteral()`
  - `isEaName()`
  - existing reg/mem helpers remain available
- symbol-sensitive raw/fixup matching:
  - `findRawAbs16Target()`
  - this matches raw abs16 opcodes against resolved symbol targets using the final byte map + symbol table instead of generic opcode presence

## Tests Migrated
- `test/pr405_byte_call_scalar_arg.test.ts`
  - replaced brittle raw `CALL` presence with a symbol-sensitive `CALL sink` assertion
  - replaced generic raw `LD A,(nn)` presence with a symbol-sensitive `LD A,(glob_b)` assertion
- `test/pr406_word_scalar_accessors.test.ts`
  - replaced generic `LD BC/DE,(nn)` and `LD (nn),BC/DE` opcode checks with symbol-sensitive assertions targeting `glob_w`
  - also demonstrates named block/origin lookup for the placed code section

## Brittle Pattern Covered Now
- old pattern: `hasRawOpcode(instrs, 0xcd)` or `hasRawOpcode(instrs, 0xed, 0x5b)`
- new pattern: assert the raw abs16 opcode resolves to the expected symbol target, scoped to the relevant lowered label range when needed

## Exact Commands Run
- `npm ci`
- `npm run typecheck`
- `npx vitest run test/pr405_byte_call_scalar_arg.test.ts test/pr406_word_scalar_accessors.test.ts`
- `npx vitest run test/pr405_byte_call_scalar_arg.test.ts test/pr406_word_scalar_accessors.test.ts test/pr509_lower_ld_integration.test.ts test/pr364_call_with_arg_and_local_regression.test.ts test/pr320_extern_call_preservation.test.ts`
