### PR TITLE
Decompose parser section state and recovery policy

### DIFF
--- a/src/frontend/parseParserRecovery.ts
+++ b/src/frontend/parseParserRecovery.ts
@@ -1,0 +1,140 @@
+import type { Diagnostic } from '../diagnosticTypes.js';
+import {
+  consumeKeywordPrefix,
+  diagInvalidHeaderLine,
+  malformedTopLevelHeaderExpectations,
+  topLevelStartKeyword,
+  unsupportedExportTargetKind,
+} from './parseModuleCommon.js';
+import { parseDiag as diag } from './parseDiagnostics.js';
+
+export function parseExportModifier(args: {
+  text: string;
+  lineNo: number;
+  allowAsmSpecialCase: boolean;
+  filePath: string;
+  diagnostics: Diagnostic[];
+}): { rest: string; exported: boolean } | undefined {
+  const { text, lineNo, allowAsmSpecialCase, filePath, diagnostics } = args;
+  const exportTail = consumeKeywordPrefix(text, 'export');
+  if (exportTail === undefined) return { rest: text, exported: false };
+
+  const rest = exportTail;
+  if (rest.length === 0) {
+    diag(diagnostics, filePath, `Invalid export statement`, { line: lineNo, column: 1 });
+    return undefined;
+  }
+
+  const allowed =
+    consumeKeywordPrefix(rest, 'const') !== undefined ||
+    consumeKeywordPrefix(rest, 'type') !== undefined ||
+    consumeKeywordPrefix(rest, 'union') !== undefined ||
+    consumeKeywordPrefix(rest, 'enum') !== undefined ||
+    consumeKeywordPrefix(rest, 'func') !== undefined ||
+    consumeKeywordPrefix(rest, 'op') !== undefined;
+  if (allowed) return { rest, exported: true };
+
+  if (allowAsmSpecialCase) {
+    const exportAsmTail = consumeKeywordPrefix(rest, 'asm');
+    if (exportAsmTail !== undefined) {
+      diag(
+        diagnostics,
+        filePath,
+        `"asm" is not a top-level construct (function and op bodies are implicit instruction streams)`,
+        {
+          line: lineNo,
+          column: 1,
+        },
+      );
+      return undefined;
+    }
+  }
+
+  const targetKeyword = topLevelStartKeyword(rest);
+  if (targetKeyword !== undefined) {
+    const targetKind = unsupportedExportTargetKind[targetKeyword];
+    if (targetKind !== undefined) {
+      diag(diagnostics, filePath, `export not supported on ${targetKind}`, {
+        line: lineNo,
+        column: 1,
+      });
+    } else {
+      diag(
+        diagnostics,
+        filePath,
+        `export is only permitted on const/type/union/enum/func/op declarations`,
+        {
+          line: lineNo,
+          column: 1,
+        },
+      );
+    }
+  } else {
+    diag(
+      diagnostics,
+      filePath,
+      `export is only permitted on const/type/union/enum/func/op declarations`,
+      {
+        line: lineNo,
+        column: 1,
+      },
+    );
+  }
+  return undefined;
+}
+
+export function recoverUnsupportedParserLine(args: {
+  index: number;
+  scope: 'module' | 'section';
+  text: string;
+  rest: string;
+  hasExportPrefix: boolean;
+  lineNo: number;
+  filePath: string;
+  diagnostics: Diagnostic[];
+}): { nextIndex: number } {
+  const { index, scope, text, rest, hasExportPrefix, lineNo, filePath, diagnostics } = args;
+  const asmTail = consumeKeywordPrefix(text, 'asm');
+  const asmAfterExportTail = hasExportPrefix ? consumeKeywordPrefix(rest, 'asm') : undefined;
+  if (asmTail !== undefined || asmAfterExportTail !== undefined) {
+    diag(
+      diagnostics,
+      filePath,
+      `"asm" is not a top-level construct (function and op bodies are implicit instruction streams)`,
+      {
+        line: lineNo,
+        column: 1,
+      },
+    );
+    return { nextIndex: index + 1 };
+  }
+
+  if (scope === 'module') {
+    const hasTopKeyword = (kw: string): boolean => new RegExp(`^${kw}\\b`, 'i').test(rest);
+    for (const expectation of malformedTopLevelHeaderExpectations) {
+      if (hasTopKeyword(expectation.keyword)) {
+        diagInvalidHeaderLine(
+          diagnostics,
+          filePath,
+          expectation.kind,
+          text,
+          expectation.expected,
+          lineNo,
+        );
+        return { nextIndex: index + 1 };
+      }
+    }
+
+    diag(diagnostics, filePath, `Unsupported top-level construct: ${text}`, {
+      line: lineNo,
+      column: 1,
+    });
+    return { nextIndex: index + 1 };
+  }
+
+  diag(diagnostics, filePath, `Unsupported section-contained construct: ${text}`, {
+    line: lineNo,
+    column: 1,
+  });
+  return { nextIndex: index + 1 };
+}

--- a/src/frontend/parseSectionBodies.ts
+++ b/src/frontend/parseSectionBodies.ts
@@ -1,0 +1,182 @@
+import type { Diagnostic } from '../diagnosticTypes.js';
+import type { SectionItemNode, SourceSpan } from './ast.js';
+import { parseDataDeclLine } from './parseData.js';
+import { parseDiag as diag } from './parseDiagnostics.js';
+import type { ParseItemContext, ParseItemResult } from './parseModuleItemDispatch.js';
+import {
+  parseRawDataDirective,
+  type PendingRawLabel,
+} from './parseRawDataDirectives.js';
+
+export type SectionParseContext = Extract<ParseItemContext, { scope: 'section' }>;
+
+export function looksLikeRawDataDirectiveStart(text: string): boolean {
+  return /^(db|dw|ds)\b/i.test(text) || /^[A-Za-z_][A-Za-z0-9_]*\s*:\s*(db|dw|ds)\b/i.test(text);
+}
+
+function reportMissingRawDataDirective(
+  diagnostics: Diagnostic[],
+  label: PendingRawLabel,
+): void {
+  diag(diagnostics, label.filePath, `Raw data label "${label.name}" is missing a directive`, {
+    line: label.lineNo,
+    column: 1,
+  });
+}
+
+export function maybeCloseSection(
+  index: number,
+  text: string,
+  ctx: SectionParseContext,
+  diagnostics: Diagnostic[],
+): ParseItemResult | undefined {
+  if (text.toLowerCase() !== 'end') return undefined;
+  if (ctx.pendingRawLabel) {
+    reportMissingRawDataDirective(diagnostics, ctx.pendingRawLabel);
+    delete ctx.pendingRawLabel;
+  }
+  return { nextIndex: index + 1, sectionClosed: true };
+}
+
+export function parseSectionBodyItem(args: {
+  index: number;
+  ctx: SectionParseContext;
+  rest: string;
+  lineNo: number;
+  filePath: string;
+  stmtSpan: SourceSpan;
+  diagnostics: Diagnostic[];
+}): ParseItemResult | undefined {
+  const { index, ctx, rest, lineNo, filePath, stmtSpan, diagnostics } = args;
+
+  if (ctx.sectionKind === 'data') {
+    if (ctx.pendingRawLabel) {
+      const parsedRaw = parseRawDataDirective(
+        ctx.pendingRawLabel,
+        rest,
+        lineNo,
+        stmtSpan,
+        filePath,
+        diagnostics,
+      );
+      if (parsedRaw) {
+        ctx.directDeclNamesLower.add(ctx.pendingRawLabel.name.toLowerCase());
+        delete ctx.pendingRawLabel;
+        return { nextIndex: index + 1, node: parsedRaw };
+      }
+      reportMissingRawDataDirective(diagnostics, ctx.pendingRawLabel);
+      delete ctx.pendingRawLabel;
+    }
+
+    const inlineMatch = /^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(db|dw|ds)\b(.*)$/i.exec(rest);
+    if (inlineMatch) {
+      const labelName = inlineMatch[1]!;
+      const labelLower = labelName.toLowerCase();
+      if (ctx.directDeclNamesLower.has(labelLower)) {
+        diag(diagnostics, filePath, `Duplicate data declaration name "${labelName}".`, {
+          line: lineNo,
+          column: 1,
+        });
+        return { nextIndex: index + 1 };
+      }
+      const label: PendingRawLabel = { name: labelName, span: stmtSpan, lineNo, filePath };
+      const parsedRaw = parseRawDataDirective(
+        label,
+        inlineMatch[2]! + inlineMatch[3]!,
+        lineNo,
+        stmtSpan,
+        filePath,
+        diagnostics,
+      );
+      if (!parsedRaw) return { nextIndex: index + 1 };
+      ctx.directDeclNamesLower.add(labelLower);
+      return { nextIndex: index + 1, node: parsedRaw };
+    }
+
+    const labelMatch = /^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*$/.exec(rest);
+    if (labelMatch) {
+      const labelName = labelMatch[1]!;
+      const labelLower = labelName.toLowerCase();
+      if (ctx.directDeclNamesLower.has(labelLower)) {
+        diag(diagnostics, filePath, `Duplicate data declaration name "${labelName}".`, {
+          line: lineNo,
+          column: 1,
+        });
+        return { nextIndex: index + 1 };
+      }
+      ctx.pendingRawLabel = { name: labelName, span: stmtSpan, lineNo, filePath };
+      return { nextIndex: index + 1 };
+    }
+  } else if (looksLikeRawDataDirectiveStart(rest)) {
+    diag(
+      diagnostics,
+      filePath,
+      `Raw data directives are only permitted inside data sections.`,
+      { line: lineNo, column: 1 },
+    );
+    return { nextIndex: index + 1 };
+  }
+
+  const labelOnly = /^[A-Za-z_][A-Za-z0-9_]*\s*:\s*$/.test(rest);
+  if (/^[A-Za-z_][A-Za-z0-9_]*\s*:/.test(rest) && !(ctx.sectionKind === 'code' && labelOnly)) {
+    const sectionDataDecl = parseDataDeclLine({
+      allowOmittedInitializer: true,
+      allowInferredArrayLength: false,
+      modulePath: filePath,
+      diagnostics,
+      lineNo,
+      text: rest,
+      span: stmtSpan,
+      seenNames: ctx.directDeclNamesLower,
+    });
+    if (!sectionDataDecl) return { nextIndex: index + 1 };
+    if (ctx.sectionKind !== 'data') {
+      diag(diagnostics, filePath, `Data declarations are only permitted inside data sections.`, {
+        line: lineNo,
+        column: 1,
+      });
+      return { nextIndex: index + 1 };
+    }
+    return { nextIndex: index + 1, node: sectionDataDecl };
+  }
+
+  return undefined;
+}
+
+export function parseSectionItems(args: {
+  startIndex: number;
+  lineCount: number;
+  sectionKind: 'code' | 'data';
+  diagnostics: Diagnostic[];
+  parseModuleItem: (index: number, ctx: SectionParseContext) => ParseItemResult;
+}): {
+  items: SectionItemNode[];
+  nextIndex: number;
+  closed: boolean;
+} {
+  const { startIndex, lineCount, sectionKind, diagnostics, parseModuleItem } = args;
+  const items: SectionItemNode[] = [];
+  const ctx: SectionParseContext = {
+    scope: 'section',
+    sectionKind,
+    directDeclNamesLower: new Set<string>(),
+  };
+  let index = startIndex;
+
+  while (index < lineCount) {
+    const parsed = parseModuleItem(index, ctx);
+    if (parsed.sectionClosed) {
+      delete ctx.pendingRawLabel;
+      return { items, nextIndex: parsed.nextIndex, closed: true };
+    }
+    if (parsed.node) items.push(parsed.node as SectionItemNode);
+    index = parsed.nextIndex;
+  }
+
+  if (ctx.pendingRawLabel) {
+    reportMissingRawDataDirective(diagnostics, ctx.pendingRawLabel);
+    delete ctx.pendingRawLabel;
+  }
+
+  return { items, nextIndex: index, closed: false };
+}

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -4,57 +4,36 @@ import type {
   NamedSectionNode,
   ProgramNode,
   SectionAnchorNode,
-  SourceSpan,
   SectionItemNode,
 } from './ast.js';
-import { makeSourceFile, span, type SourceFile } from './source.js';
 import type { Diagnostic } from '../diagnosticTypes.js';
-import {
-  TOP_LEVEL_KEYWORDS,
-  consumeKeywordPrefix,
-  consumeTopKeyword,
-  diagInvalidBlockLine,
-  diagInvalidHeaderLine,
-  formatIdentifierToken,
-  isTopLevelStart,
-  looksLikeKeywordBodyDeclLine,
-  malformedTopLevelHeaderExpectations,
-  topLevelStartKeyword,
-  unsupportedExportTargetKind,
-} from './parseModuleCommon.js';
-import { parseTopLevelExternDecl } from './parseExternBlock.js';
-import { parseEnumDecl } from './parseEnum.js';
-import { parseTopLevelFuncDecl } from './parseFunc.js';
-import { parseGlobalsBlock } from './parseGlobals.js';
+import { canonicalModuleId } from '../moduleIdentity.js';
+import { NAMED_SECTION_KINDS } from './grammarData.js';
 import { parseImmExprFromText } from './parseImm.js';
-import { parseTopLevelOpDecl } from './parseOp.js';
 import { buildLogicalLines, getLogicalLine, type LogicalLine } from './parseLogicalLines.js';
-import { parseOpParamsFromText, parseParamsFromText } from './parseParams.js';
-import {
-  parseRawDataDirective,
-  type PendingRawLabel,
-} from './parseRawDataDirectives.js';
 import {
   createModuleItemDispatchTable,
   type ParseItemContext,
   type ParseItemResult,
 } from './parseModuleItemDispatch.js';
-import { parseTypeDecl, parseUnionDecl } from './parseTypes.js';
+import { diagInvalidHeaderLine, topLevelStartKeyword } from './parseModuleCommon.js';
 import {
-  parseAlignDirectiveDecl,
-  parseBinDecl,
-  parseConstDecl,
-  parseHexDecl,
-  parseImportDecl,
-  parseSectionDirectiveDecl,
-} from './parseTopLevelSimple.js';
-import { parseDataBlock, parseDataDeclLine } from './parseData.js';
-import { canonicalModuleId } from '../moduleIdentity.js';
+  parseExportModifier,
+  recoverUnsupportedParserLine,
+} from './parseParserRecovery.js';
+import {
+  looksLikeRawDataDirectiveStart,
+  maybeCloseSection,
+  parseSectionBodyItem,
+  parseSectionItems as parseSectionItemsFromHelper,
+} from './parseSectionBodies.js';
+import { parseOpParamsFromText, parseParamsFromText } from './parseParams.js';
 import {
   isReservedTopLevelDeclName,
   stripLineComment as stripComment,
 } from './parseParserShared.js';
-import { NAMED_SECTION_KINDS } from './grammarData.js';
+import { makeSourceFile, span, type SourceFile } from './source.js';
+import { parseAlignDirectiveDecl } from './parseTopLevelSimple.js';
 import { parseDiag as diag } from './parseDiagnostics.js';
 
 /**
@@ -72,7 +51,6 @@ export function parseModuleFile(
 ): ModuleFileNode {
   const file = sourceFileOverride ?? makeSourceFile(modulePath, sourceText);
   const logicalLines: LogicalLine[] = buildLogicalLines(file, modulePath, diagnostics);
-
   const lineCount = logicalLines.length;
 
   function getRawLine(lineIndex: number): {
@@ -93,79 +71,6 @@ export function parseModuleFile(
   }
 
   const items: ModuleItemNode[] = [];
-
-  function parseExportModifier(
-    text: string,
-    lineNo: number,
-    allowAsmSpecialCase: boolean,
-    filePath: string,
-  ): { rest: string; exported: boolean } | undefined {
-    const exportTail = consumeKeywordPrefix(text, 'export');
-    if (exportTail === undefined) return { rest: text, exported: false };
-
-    const rest = exportTail;
-    if (rest.length === 0) {
-      diag(diagnostics, filePath, `Invalid export statement`, { line: lineNo, column: 1 });
-      return undefined;
-    }
-
-    const allowed =
-      consumeKeywordPrefix(rest, 'const') !== undefined ||
-      consumeKeywordPrefix(rest, 'type') !== undefined ||
-      consumeKeywordPrefix(rest, 'union') !== undefined ||
-      consumeKeywordPrefix(rest, 'enum') !== undefined ||
-      consumeKeywordPrefix(rest, 'func') !== undefined ||
-      consumeKeywordPrefix(rest, 'op') !== undefined;
-    if (allowed) return { rest, exported: true };
-
-    if (allowAsmSpecialCase) {
-      const exportAsmTail = consumeKeywordPrefix(rest, 'asm');
-      if (exportAsmTail !== undefined) {
-        diag(
-          diagnostics,
-          filePath,
-          `"asm" is not a top-level construct (function and op bodies are implicit instruction streams)`,
-          {
-            line: lineNo,
-            column: 1,
-          },
-        );
-        return undefined;
-      }
-    }
-
-    const targetKeyword = topLevelStartKeyword(rest);
-    if (targetKeyword !== undefined) {
-      const targetKind = unsupportedExportTargetKind[targetKeyword];
-      if (targetKind !== undefined) {
-        diag(diagnostics, filePath, `export not supported on ${targetKind}`, {
-          line: lineNo,
-          column: 1,
-        });
-      } else {
-        diag(
-          diagnostics,
-          filePath,
-          `export is only permitted on const/type/union/enum/func/op declarations`,
-          {
-            line: lineNo,
-            column: 1,
-          },
-        );
-      }
-    } else {
-      diag(
-        diagnostics,
-        filePath,
-        `export is only permitted on const/type/union/enum/func/op declarations`,
-        {
-          line: lineNo,
-          column: 1,
-        },
-      );
-    }
-    return undefined;
-  }
 
   function parseNamedSectionHeader(
     sectionText: string,
@@ -219,7 +124,10 @@ export function parseModuleFile(
           },
         )?.value;
         if (!rangeExpr) return undefined;
-        bound = rangeKeyword === 'size' ? { kind: 'size', size: rangeExpr } : { kind: 'end', end: rangeExpr };
+        bound =
+          rangeKeyword === 'size'
+            ? { kind: 'size', size: rangeExpr }
+            : { kind: 'end', end: rangeExpr };
         anchor.bound = bound;
       }
     }
@@ -227,14 +135,23 @@ export function parseModuleFile(
     return { section, name, ...(anchor ? { anchor } : {}) };
   }
 
-  type ParseItemContext =
-    | { scope: 'module' }
-    | {
-        scope: 'section';
-        sectionKind: 'code' | 'data';
-        directDeclNamesLower: Set<string>;
-        pendingRawLabel?: PendingRawLabel;
-      };
+  function parseSectionItems(startIndex: number, sectionKind: 'code' | 'data'): {
+    items: SectionItemNode[];
+    nextIndex: number;
+    closed: boolean;
+  } {
+    return parseSectionItemsFromHelper({
+      startIndex,
+      lineCount,
+      sectionKind,
+      diagnostics,
+      parseModuleItem: (index, ctx) => parseModuleItem(index, ctx),
+    });
+  }
+
+  function isReservedTopLevelName(name: string): boolean {
+    return isReservedTopLevelDeclName(name);
+  }
 
   const moduleItemDispatchTable = createModuleItemDispatchTable({
     diagnostics,
@@ -256,138 +173,48 @@ export function parseModuleFile(
     const text = stripComment(raw).trim();
     const lineNo = logicalLines[index]?.lineNo ?? index + 1;
     const filePath = logicalLines[index]?.filePath ?? modulePath;
-    if (text.length === 0) {
-      if (ctx.scope === 'section') {
-        return { nextIndex: index + 1 };
-      }
-      return { nextIndex: index + 1 };
-    }
-    if (ctx.scope === 'section' && text.toLowerCase() === 'end') {
-      if (ctx.pendingRawLabel) {
-        diag(diagnostics, ctx.pendingRawLabel.filePath, `Raw data label "${ctx.pendingRawLabel.name}" is missing a directive`, {
-          line: ctx.pendingRawLabel.lineNo,
-          column: 1,
-        });
-        delete ctx.pendingRawLabel;
-      }
-      return { nextIndex: index + 1, sectionClosed: true };
+
+    if (text.length === 0) return { nextIndex: index + 1 };
+
+    if (ctx.scope === 'section') {
+      const sectionClose = maybeCloseSection(index, text, ctx, diagnostics);
+      if (sectionClose) return sectionClose;
     }
 
-    const exportParsed = parseExportModifier(text, lineNo, ctx.scope === 'module', filePath);
-    if (!exportParsed) {
-      return { nextIndex: index + 1 };
-    }
+    const exportParsed = parseExportModifier({
+      text,
+      lineNo,
+      allowAsmSpecialCase: ctx.scope === 'module',
+      filePath,
+      diagnostics,
+    });
+    if (!exportParsed) return { nextIndex: index + 1 };
+
     const hasExportPrefix = exportParsed.exported;
     const rest = exportParsed.rest;
     const stmtSpan = span(file, lineStartOffset, lineEndOffset);
 
-    if (ctx.scope === 'section' && ctx.sectionKind === 'data') {
-      if (ctx.pendingRawLabel) {
-        const parsedRaw = parseRawDataDirective(
-          ctx.pendingRawLabel,
-          rest,
-          lineNo,
-          stmtSpan,
-          filePath,
-          diagnostics,
-        );
-        if (parsedRaw) {
-          ctx.directDeclNamesLower.add(ctx.pendingRawLabel.name.toLowerCase());
-          delete ctx.pendingRawLabel;
-          if (ctx.sectionKind !== 'data') {
-            diag(
-              diagnostics,
-              filePath,
-              `Raw data declarations are only permitted inside data sections.`,
-              { line: lineNo, column: 1 },
-            );
-            return { nextIndex: index + 1 };
-          }
-          return { nextIndex: index + 1, node: parsedRaw };
-        }
-        diag(diagnostics, ctx.pendingRawLabel.filePath, `Raw data label "${ctx.pendingRawLabel.name}" is missing a directive`, {
-          line: ctx.pendingRawLabel.lineNo,
-          column: 1,
-        });
-        delete ctx.pendingRawLabel;
-      }
-      const inlineMatch = /^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(db|dw|ds)\b(.*)$/i.exec(rest);
-      if (inlineMatch) {
-        const labelName = inlineMatch[1]!;
-        const labelLower = labelName.toLowerCase();
-        if (ctx.directDeclNamesLower.has(labelLower)) {
-          diag(diagnostics, filePath, `Duplicate data declaration name "${labelName}".`, {
-            line: lineNo,
-            column: 1,
-          });
-          return { nextIndex: index + 1 };
-        }
-        const label: PendingRawLabel = { name: labelName, span: stmtSpan, lineNo, filePath };
-        const parsedRaw = parseRawDataDirective(
-          label,
-          inlineMatch[2]! + inlineMatch[3]!,
-          lineNo,
-          stmtSpan,
-          filePath,
-          diagnostics,
-        );
-        if (!parsedRaw) return { nextIndex: index + 1 };
-        ctx.directDeclNamesLower.add(labelLower);
-        if (ctx.sectionKind !== 'data') {
-          diag(
-            diagnostics,
-            filePath,
-            `Raw data declarations are only permitted inside data sections.`,
-            { line: lineNo, column: 1 },
-          );
-          return { nextIndex: index + 1 };
-        }
-        return { nextIndex: index + 1, node: parsedRaw };
-      }
-      const labelMatch = /^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*$/.exec(rest);
-      if (labelMatch) {
-        const labelName = labelMatch[1]!;
-        const labelLower = labelName.toLowerCase();
-        if (ctx.directDeclNamesLower.has(labelLower)) {
-          diag(diagnostics, filePath, `Duplicate data declaration name "${labelName}".`, {
-            line: lineNo,
-            column: 1,
-          });
-          return { nextIndex: index + 1 };
-        }
-        if (ctx.sectionKind !== 'data') {
-          diag(
-            diagnostics,
-            filePath,
-            `Raw data labels are only permitted inside data sections.`,
-            { line: lineNo, column: 1 },
-          );
-          return { nextIndex: index + 1 };
-        }
-        ctx.pendingRawLabel = { name: labelName, span: stmtSpan, lineNo, filePath };
-        return { nextIndex: index + 1 };
-      }
-    } else if (ctx.scope === 'section' && ctx.sectionKind === 'code') {
-      if (/^(db|dw|ds)\b/i.test(rest) || /^[A-Za-z_][A-Za-z0-9_]*\s*:\s*(db|dw|ds)\b/i.test(rest)) {
-        diag(
-          diagnostics,
-          filePath,
-          `Raw data directives are only permitted inside data sections.`,
-          { line: lineNo, column: 1 },
-        );
-        return { nextIndex: index + 1 };
-      }
-    } else if (ctx.scope === 'module') {
-      if (/^(db|dw|ds)\b/i.test(rest) || /^[A-Za-z_][A-Za-z0-9_]*\s*:\s*(db|dw|ds)\b/i.test(rest)) {
-        diag(
-          diagnostics,
-          filePath,
-          `Raw data directives are only permitted inside data sections.`,
-          { line: lineNo, column: 1 },
-        );
-        return { nextIndex: index + 1 };
-      }
+    if (ctx.scope === 'section') {
+      const parsedSectionItem = parseSectionBodyItem({
+        index,
+        ctx,
+        rest,
+        lineNo,
+        filePath,
+        stmtSpan,
+        diagnostics,
+      });
+      if (parsedSectionItem) return parsedSectionItem;
+    } else if (looksLikeRawDataDirectiveStart(rest)) {
+      diag(
+        diagnostics,
+        filePath,
+        `Raw data directives are only permitted inside data sections.`,
+        { line: lineNo, column: 1 },
+      );
+      return { nextIndex: index + 1 };
     }
+
     const dispatchKeyword = topLevelStartKeyword(rest);
     const dispatchHandler =
       dispatchKeyword === undefined ? undefined : moduleItemDispatchTable[dispatchKeyword];
@@ -406,111 +233,16 @@ export function parseModuleFile(
       if (parsed) return parsed;
     }
 
-    const labelOnly = /^[A-Za-z_][A-Za-z0-9_]*\s*:\s*$/.test(rest);
-    if (ctx.scope === 'section' && /^[A-Za-z_][A-Za-z0-9_]*\s*:/.test(rest) && !(ctx.sectionKind === 'code' && labelOnly)) {
-      const sectionDataDecl = parseDataDeclLine({
-        allowOmittedInitializer: true,
-        allowInferredArrayLength: false,
-        modulePath: filePath,
-        diagnostics,
-        lineNo,
-        text: rest,
-        span: stmtSpan,
-        seenNames: ctx.directDeclNamesLower,
-      });
-      if (!sectionDataDecl) return { nextIndex: index + 1 };
-      if (ctx.sectionKind !== 'data') {
-        diag(diagnostics, filePath, `Data declarations are only permitted inside data sections.`, {
-          line: lineNo,
-          column: 1,
-        });
-        return { nextIndex: index + 1 };
-      }
-      return { nextIndex: index + 1, node: sectionDataDecl };
-    }
-
-    const asmTail = consumeKeywordPrefix(text, 'asm');
-    const asmAfterExportTail = hasExportPrefix ? consumeKeywordPrefix(rest, 'asm') : undefined;
-    if (asmTail !== undefined || asmAfterExportTail !== undefined) {
-      diag(
-        diagnostics,
-        filePath,
-        `"asm" is not a top-level construct (function and op bodies are implicit instruction streams)`,
-        {
-          line: lineNo,
-          column: 1,
-        },
-      );
-      return { nextIndex: index + 1 };
-    }
-
-    if (ctx.scope === 'module') {
-      const hasTopKeyword = (kw: string): boolean => new RegExp(`^${kw}\\b`, 'i').test(rest);
-      for (const expectation of malformedTopLevelHeaderExpectations) {
-        if (hasTopKeyword(expectation.keyword)) {
-          diagInvalidHeaderLine(
-            diagnostics,
-            filePath,
-            expectation.kind,
-            text,
-            expectation.expected,
-            lineNo,
-          );
-          return { nextIndex: index + 1 };
-        }
-      }
-
-      diag(diagnostics, filePath, `Unsupported top-level construct: ${text}`, {
-        line: lineNo,
-        column: 1,
-      });
-      return { nextIndex: index + 1 };
-    }
-
-    diag(diagnostics, filePath, `Unsupported section-contained construct: ${text}`, {
-      line: lineNo,
-      column: 1,
+    return recoverUnsupportedParserLine({
+      index,
+      scope: ctx.scope,
+      text,
+      rest,
+      hasExportPrefix,
+      lineNo,
+      filePath,
+      diagnostics,
     });
-    return { nextIndex: index + 1 };
-  }
-
-  function parseSectionItems(startIndex: number, sectionKind: 'code' | 'data'): {
-    items: SectionItemNode[];
-    nextIndex: number;
-    closed: boolean;
-  } {
-    const sectionItems: SectionItemNode[] = [];
-    const directDeclNamesLower = new Set<string>();
-    const ctx: Extract<ParseItemContext, { scope: 'section' }> = {
-      scope: 'section',
-      sectionKind,
-      directDeclNamesLower,
-    };
-    let index = startIndex;
-
-    while (index < lineCount) {
-      const parsed = parseModuleItem(index, ctx);
-      if (parsed.sectionClosed) {
-        delete ctx.pendingRawLabel;
-        return { items: sectionItems, nextIndex: parsed.nextIndex, closed: true };
-      }
-      if (parsed.node) sectionItems.push(parsed.node as SectionItemNode);
-      index = parsed.nextIndex;
-    }
-
-    if (ctx.pendingRawLabel) {
-      diag(diagnostics, ctx.pendingRawLabel.filePath, `Raw data label "${ctx.pendingRawLabel.name}" is missing a directive`, {
-        line: ctx.pendingRawLabel.lineNo,
-        column: 1,
-      });
-      delete ctx.pendingRawLabel;
-    }
-
-    return { items: sectionItems, nextIndex: index, closed: false };
-  }
-
-  function isReservedTopLevelName(name: string): boolean {
-    return isReservedTopLevelDeclName(name);
   }
 
   let i = 0;


### PR DESCRIPTION
Closes #1063.

## Summary
- move section-body parsing state and raw-data pending-label handling out of `src/frontend/parser.ts`
- move malformed top-level / unsupported-line recovery policy out of `src/frontend/parser.ts`
- preserve parser diagnostics and recovery behavior while making `parser.ts` materially smaller

## Changed Files
- `src/frontend/parser.ts`
- `src/frontend/parseSectionBodies.ts`
- `src/frontend/parseParserRecovery.ts`

## What moved out of `parser.ts`
- section close and pending raw-data label cleanup
- raw-data pending-label parsing and inline raw-data parsing inside named sections
- section-scoped data-declaration fallback
- malformed top-level fallback and unsupported-line recovery policy
- export-prefix validation policy

## Diagnostics / recovery adjustments
- none intended
- the extraction preserves the existing diagnostics and recovery behavior for named sections, raw-data directives, malformed headers, and unsupported constructs

## Commands run
```sh
npm ci
npm run typecheck
npx vitest run test/pr762_grammar_data_conformance.test.ts test/pr808_grammar_drift.test.ts test/pr895_assignment_acceptance.test.ts test/pr899_step_parser.test.ts
npx vitest run test/pr572_named_sections_parser.test.ts test/pr611_parser_data_marker_enforcement.test.ts test/pr785_raw_data_parser.test.ts test/pr193_asm_marker_diagnostics.test.ts
```
