### PR TITLE
learning: prose review fixes for chapters 6, 7, and 8

### DIFF
--- a/learning/part1/06-data-tables-and-indexed-access.md
+++ b/learning/part1/06-data-tables-and-indexed-access.md
@@ -2,13 +2,9 @@
 
 # Chapter 6 — Data Tables and Indexed Access
 
-This chapter shows how to lay out a byte or word table in memory, and how to
-read entries from it using HL as a sequential pointer and IX as a displaced-
-access pointer. After reading it you will be able to define a small table,
-load its base address into HL or IX, and read elements either sequentially in
-a loop or by fixed offset.
-
-Prerequisites: Chapters 3–5 (registers, `ld` modes, labels, DJNZ loops).
+This chapter shows how to lay out a byte or word table in memory and read
+entries from it — using HL as a sequential pointer and IX as a displaced-access
+pointer.
 
 ---
 
@@ -50,7 +46,7 @@ HL holds an address. `ld a, (hl)` reads the byte at that address. `inc hl`
 advances HL to the next byte. Repeating those two operations steps through a
 byte table one entry at a time.
 
-The standard pattern for reading a table with a DJNZ loop:
+A DJNZ loop over a byte table looks like this:
 
 ```zax
 ld hl, scores      ; HL = address of first entry
@@ -66,8 +62,7 @@ After the loop, HL points one byte past the last entry. The order matters: read
 the entry first (`ld a, (hl)`), process it, then advance (`inc hl`). If you
 advance before reading, you skip the first entry.
 
-For word tables, `inc hl` is not enough between entries — each word is two bytes
-wide. Use `inc hl / inc hl` to advance by two:
+Word entries are two bytes wide, so advance HL by two between them:
 
 ```zax
 ld hl, widths
@@ -93,17 +88,15 @@ element's value).
 produces the value stored in the table.
 
 This distinction matters most when a function receives a table to process. The
-function receives the address (loaded into HL or another pair by the caller) and
-uses `(hl)` to reach the values. The address is the handle; the values are what
-the memory at that address contains.
+function receives the address — loaded into HL or another pair by the caller —
+and uses `(hl)` to reach the values.
 
 ---
 
 ## Labels, variables, and code share the same memory
 
-An important fact to internalise: assembly does **not** distinguish between
-a label that names a variable and a label that marks a point in code. Both are
-memory addresses — plain 16-bit numbers. `scores` is the address where the
+Assembly makes no distinction between a label that names a variable and one
+that marks a point in code. Both are memory addresses — plain 16-bit numbers. `scores` is the address where the
 table starts. `loop_top` is the address where the loop body starts. To the CPU,
 both are just numbers. You could load data from a code address, and you could
 jump to a data address. The CPU would blindly obey, attempting to execute your
@@ -120,16 +113,12 @@ space, and it is your job to keep them organised.
 
 ## IX-based displaced access
 
-IX is a 16-bit index register. Unlike HL, IX is not used for arithmetic or as a
-general register pair in most instructions. Its specific capability is the
-`(ix+d)` addressing mode, where `d` is a signed 8-bit displacement — any value
-from -128 to +127.
+IX is a 16-bit index register. Its specific capability is the `(ix+d)`
+addressing mode: `d` is a signed byte offset, any value from -128 to +127, and
+`ld a, (ix+d)` reads the byte at address IX + d without touching IX itself.
 
-`ld a, (ix+0)` reads the byte at the address in IX. `ld a, (ix+1)` reads the
-byte one position after IX. `ld a, (ix+2)` reads two bytes after IX.
-
-This mode is useful when you want to access several fields at fixed offsets from
-a base address, without changing the base pointer between accesses:
+Load IX to the base of a record once, and you can name every field by its
+offset — no incrementing between reads:
 
 ```zax
 ; A three-byte record: offset 0 = id, offset 1 = high byte, offset 2 = low byte
@@ -140,8 +129,8 @@ ld c, (ix+2)         ; C = low byte field
 ; IX is unchanged throughout — all three fields read from one base address
 ```
 
-With HL you would need to load the address and then increment between fields.
-With IX+d you load the base once and name each field by its offset.
+With HL you would increment between each read. With IX you load the base once
+and name each field by its offset.
 
 The displacement `d` is a byte-sized signed offset. Offsets larger than 127 or
 smaller than -128 are not encodable and will cause an assembler error.
@@ -306,9 +295,7 @@ set if a match was found, and HL points one past the matching byte. `cpdr` is
 the same scan in the decrementing direction.
 
 `ldir`, `lddr`, `cpir`, and `cpdr` are raw Z80 mnemonics used directly in ZAX,
-exactly like `djnz`. There is no ZAX-typed construct wrapping them. When you
-see `ldir` in code, it is the hardware instruction itself, not a ZAX function
-call.
+exactly like `djnz` — the assembler emits them as-is.
 
 ---
 
@@ -327,12 +314,6 @@ call.
   name each field by its offset without moving IX.
 - To reach entry `n` at runtime, either load `table_base + n` into IX using
   compile-time arithmetic, or add the index to HL with `add hl, de`.
-
-## What Comes Next
-
-Chapter 7 introduces `call` and `ret`, explains how the hardware stack works,
-and shows how to write reusable subroutines that receive values in registers and
-return results to the caller.
 
 ---
 

--- a/learning/part1/07-stack-and-subroutines.md
+++ b/learning/part1/07-stack-and-subroutines.md
@@ -2,13 +2,9 @@
 
 # Chapter 7 — Stack and Subroutines
 
-This chapter explains how `call` and `ret` work, how the hardware stack operates,
-and how to write reusable subroutines that receive values through registers and
-return results to the caller. After reading it you will be able to write a
-subroutine, call it with values in registers, preserve the caller's registers
-using `push` and `pop`, and return a result.
-
-Prerequisites: Chapters 3–6 (registers, flags, `ld`, labels, DJNZ, tables).
+This chapter explains how `call` and `ret` work, how the hardware stack
+operates, and how to write reusable subroutines that receive values through
+registers and return results to the caller.
 
 ---
 
@@ -28,17 +24,15 @@ single `call`.
 
 ## How `call` works
 
-`call label` does two things:
+`call label` is a push of the return address followed by a jump — two operations
+in one opcode. Concretely:
 
 1. Pushes the address of the instruction following the `call` onto the hardware
    stack (this is the **return address**).
 2. Jumps to `label`.
 
-In other words, `call` is equivalent to a `push` of the return address followed
-by a `jp`. The instruction is always 3 bytes long, so the return address pushed
-is always the address of the byte immediately after the `call` instruction.
-There is nothing magical about it — it is a push and a jump combined into one
-opcode.
+The instruction is always 3 bytes long, so the return address pushed is always
+the address of the byte immediately after the `call` instruction.
 
 The hardware stack is a region of RAM used as a last-in-first-out buffer. The
 stack pointer SP always holds the address of the most recently pushed value.
@@ -52,13 +46,9 @@ subroutine does not know which call site reached it.
 
 ## How `ret` works
 
-`ret` is even simpler: it pops two bytes from the stack into the program
-counter. That is the return address that `call` pushed. Execution resumes at
-the instruction after the original `call`.
-
-In other words, `ret` is equivalent to `pop pc` — if such an instruction
-existed. The CPU reads the top of the stack, increments SP by two, and jumps
-to the address it just read. Nothing more.
+`ret` is equivalent to `pop pc` — if such an instruction existed. The CPU reads
+the top two bytes of the stack into the program counter, increments SP by two,
+and execution resumes at the instruction after the original `call`.
 
 If `ret` runs when the stack does not contain a valid return address — because
 of a push/pop mismatch, for example — the CPU jumps to whatever bytes are at
@@ -156,24 +146,22 @@ result. If A carries the result, declare `: AF`.
 
 ## `push` and `pop`: saving and restoring registers
 
-`push` and `pop` are simple operations, described most clearly in terms of
-virtual `ld` instructions:
+`push` and `pop` are most clearly described in terms of virtual `ld`
+instructions.
 
-`push hl` does two things: first SP is decremented by two, then the equivalent
-of `ld (sp), hl` happens — the contents of HL are written to the two bytes at
-the new SP address. (I say "equivalent" because `ld (sp), hl` is not an actual
-Z80 instruction — you cannot use it directly. But it describes exactly what
-`push` does internally.)
+`push hl`: SP is decremented by two, then virtually `ld (sp), hl` happens —
+the contents of HL are written to the two bytes at the new SP address. I say
+virtually because `ld (sp), hl` is not an actual Z80 instruction, but it
+describes exactly what happens.
 
-`pop hl` is the inverse: the equivalent of `ld hl, (sp)` happens first — two
-bytes are read from the address in SP into HL — then SP is incremented by two.
+`pop hl` is the inverse: virtually `ld hl, (sp)` happens first — two bytes are
+read from SP into HL — then SP is incremented by two.
 
-The operand can be any of AF, BC, DE, HL, IX, or IY. The important thing to
-remember is that the stack does not know whose value it is holding. All register
-pairs are saved to and restored from the same area of memory — the bytes at and
-below SP. The stack is the very same RAM where your program and variables
-reside. There is nothing magical about it; it is ordinary memory that SP
-happens to point at.
+The operand can be any of AF, BC, DE, HL, IX, or IY. Many people misunderstand
+how the stack works, so let me be clear about this: the stack does not know
+whose value it is holding. All register pairs are saved to the same area of
+memory — the bytes at and below SP. The stack is the same RAM where your
+program and variables reside. There is nothing "magical" about it.
 
 A subroutine uses `push` / `pop` to preserve registers it needs to modify
 internally. The pattern:
@@ -277,9 +265,9 @@ return, the stack remains balanced and execution returns correctly through each
 level.
 
 The only limit is the size of the RAM region allocated to the stack. A program
-that calls too many levels deep (or forgets to pop before returning) will
-overwrite RAM that the program uses for other purposes. On the Z80, there is no
-hardware guard against stack overflow.
+that calls too many levels deep — or forgets to pop before returning — will
+overwrite RAM used for other purposes. The Z80 has no hardware guard against
+stack overflow.
 
 ---
 
@@ -355,10 +343,9 @@ After `sbc hl, de`, the carry flag indicates the comparison result:
 - **Carry set** — HL was less than DE (unsigned borrow occurred). DE is the
   larger value. `ex de, hl` puts DE into HL and returns.
 
-The `or a / sbc hl, de / add hl, de` restore pattern is the standard way to do
-an unsigned 16-bit comparison in Z80 when you need the original HL after the
-test. `sbc hl, de` is destructive; `add hl, de` undoes the subtraction when the
-result was that HL was the larger value.
+The `or a / sbc hl, de / add hl, de` sequence is how you do an unsigned 16-bit
+comparison when you need the original HL back after the test. `sbc hl, de` is
+destructive; `add hl, de` undoes the subtraction when HL was the larger value.
 
 The caller passes 80 (`$0050`) in HL and 200 (`$00C8`) in DE:
 
@@ -399,10 +386,9 @@ This trick demonstrates the freedom assembly gives you: `call` and `ret` are
 not ceremonial pairs that must always appear together. They are stack
 operations, and you can use them however the stack discipline permits.
 
-You are unlikely to need this technique early on, but it illustrates an
-important principle: every instruction in the Z80 does exactly one mechanical
-thing. There is no hidden contract between `call` and `ret` — only the stack
-connects them.
+`call` and `ret` are stack operations that happen to pair up in normal use.
+Nothing binds them mechanically — only the stack does. `call` pushed one word;
+`pop hl` consumed it. That is the whole contract.
 
 ---
 
@@ -428,12 +414,6 @@ connects them.
   trailing `ret` is not needed. Use `ret` inside a `func` only for early exits.
   Raw labeled subroutines — code reached by `call label` outside a ZAX `func`
   — are plain Z80 and do require an explicit `ret`.
-
-## What Comes Next
-
-Chapter 9 builds a complete program using everything from Chapters 3–7
-together, then shows the points where raw Z80 starts to get unwieldy — the
-same points that Chapters 10–13 address.
 
 ---
 

--- a/learning/part1/08-io-and-ports.md
+++ b/learning/part1/08-io-and-ports.md
@@ -9,10 +9,9 @@ without touching memory at all.
 
 On real hardware, ports connect to peripherals: keyboard controllers, display
 chips, timers, serial interfaces. The port number selects which device the CPU
-is talking to. Chapter 8 treats port numbers as abstract placeholders — the
-Z80 mechanism is what matters here; the mapping of numbers to devices varies by
-platform and is for the hardware documentation of whichever machine you are
-targeting.
+is talking to. This chapter treats port numbers as abstract placeholders — the Z80 mechanism
+is what matters here; the mapping of numbers to devices varies by platform and
+is for your hardware documentation to define.
 
 ---
 
@@ -55,9 +54,7 @@ out (C), a       ; write A to the same port
 ```
 
 The register-addressed form uses C as the port selector regardless of what other
-register supplies the data. On some Z80 platforms B is visible on the high byte
-of the address bus during `out (C), r`, which some hardware uses as a secondary
-selector; this is a hardware detail, not something you need to worry about here.
+register supplies the data.
 
 ---
 
@@ -88,10 +85,9 @@ Unlike `out`, the `in` instruction **sets flags**. After `in r, (C)`:
 - H and N are reset.
 - C (carry) is unaffected.
 
-`in a, (n)` (the immediate form) does **not** set flags. Only the
-register-addressed form `in r, (C)` does. If you need to branch on whether the
-input is zero, use `in a, (C)` and then `or a` to establish flags, or use
-`in r, (C)` directly and branch on the flags it sets.
+`in r, (C)` sets flags; the immediate form `in a, (n)` leaves them unchanged.
+If you need to branch on whether the input is zero and you used the immediate
+form, follow it with `or a` to test A.
 
 ---
 
@@ -129,9 +125,7 @@ difference is where the port number comes from.
 ## Sending a block of bytes
 
 A counted loop can send a sequence of bytes to a port one at a time. HL points
-to the data; BC holds the count; C holds the port number. There is no
-block-copy instruction for I/O on the Z80 (unlike the `ldir` memory copy from
-Chapter 6), so you write the loop yourself.
+to the data; B holds the count; C holds the port number.
 
 ```zax
 func send_block()
@@ -263,12 +257,6 @@ three before the call.
   then reads the data port.
 - Port numbers are platform-defined. The examples here use abstract constants
   and demonstrate the instructions themselves, not any specific hardware.
-
-## What Comes Next
-
-Chapter 9 brings everything together: a complete program that uses every
-instruction form from Chapters 3–8. It also names the specific places where
-raw Z80 starts to get tedious — which sets up what Chapters 10–13 address.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes all findings from the course-writing skill review of chapters 6, 7, and 8. Prose voice is informed by the Z80 assembly reference text style: direct, conversational, leads with what something *is* rather than what it is not.

One technical blocker fixed in chapter 8.

## Style notes

- "I say virtually" inline (ch7 push/pop section) — matching reference text's natural hedging style rather than parenthetical apologising
- "nothing magical" kept for the stack section (reference text uses the same phrase for stacks) but restructured: moved to end of paragraph, quoted, preceded by context ("many people misunderstand how the stack works")
- "Let's" / direct example intros rather than "The standard pattern for"
- "What Comes Next" sections cut from all three chapters — forward references not needed when the nav links serve the same purpose

## Changes by chapter

**Chapter 6 — Data Tables and Indexed Access**
- Cut syllabus opener and "Prerequisites:" meta-note
- "standard pattern for" → "A DJNZ loop over a byte table looks like this:"
- "inc hl is not enough between entries" → "Word entries are two bytes wide; advance HL by two between them"
- "An important fact to internalise:" performative opener → cut
- IX section rewritten to lead with positive capability, not "Unlike HL, IX is not used for..."
- Weak closing metaphor ("the address is the handle") → cut
- "There is no ZAX-typed construct wrapping them" two-sentence dead opener → one direct sentence
- Cut "What Comes Next"

**Chapter 7 — Stack and Subroutines**
- Cut syllabus opener and "Prerequisites:" meta-note
- Two "In other words" essay connectors → cut preamble, lead with the cleaner statement
- "There is nothing magical about it" (for `call`) → cut; replaced with direct description
- Push/pop parenthetical hedge → "I say virtually" inline
- "nothing magical" (for the stack) → restructured as summative with context
- "there is no hardware guard" dead opener → "The Z80 has no hardware guard"
- "the standard way to do" → "how you do"
- Hedge + dead opener in advanced-trick section → direct statement
- Cut "What Comes Next"

**Chapter 8 — I/O and Ports**
- **Blocker fix:** "There is no block-copy instruction for I/O on the Z80" — factually wrong (OTIR, OTDR, INIR, INDR exist); removed the false claim
- "Chapter 8 treats" self-reference → "This chapter treats"
- B-on-address-bus aside cut entirely
- `in a,(n)` flag behaviour rewritten as a direct contrast pair
- Cut "What Comes Next"

## Test plan

- [ ] Grep confirms no banned patterns remain in the three files
- [ ] Chapter 8 no longer claims there are no block I/O instructions
- [ ] Chapter 7 stack section: "nothing magical" appears at end of paragraph with context, not as dead opener
- [ ] Chapter 7 `call` section: leads with "is a push... followed by a jump"

🤖 Generated with [Claude Code](https://claude.com/claude-code)