### PR TITLE
refactor(lowering): narrow AsmLoweringHost for asm instruction lowering (#1059)

### DIFF
--- a/src/lowering/asmInstructionLdHelpers.ts
+++ b/src/lowering/asmInstructionLdHelpers.ts
@@ -1,7 +1,11 @@
 import type { AsmInstructionNode, AsmOperandNode, EaExprNode } from '../frontend/ast.js';
 
-type LdHelperContext = {
-  emitInstr: (head: string, operands: AsmOperandNode[], span: AsmInstructionNode['span']) => boolean;
+export type LdHelperContext = {
+  emitInstr: (
+    head: string,
+    operands: AsmOperandNode[],
+    span: AsmInstructionNode['span'],
+  ) => boolean;
   emitAbs16Fixup: (
     opcode: number,
     baseLower: string,
@@ -71,10 +75,20 @@ export function createAsmInstructionLdHelpers(ctx: LdHelperContext) {
     return (
       ctx.emitInstr(
         'ld',
-        [{ kind: 'Reg', span, name: hi }, { kind: 'Imm', span, expr: { kind: 'ImmLiteral', span, value: 0 } }],
+        [
+          { kind: 'Reg', span, name: hi },
+          { kind: 'Imm', span, expr: { kind: 'ImmLiteral', span, value: 0 } },
+        ],
         span,
       ) &&
-      ctx.emitInstr('ld', [{ kind: 'Reg', span, name: lo }, { kind: 'Reg', span, name: srcName }], span)
+      ctx.emitInstr(
+        'ld',
+        [
+          { kind: 'Reg', span, name: lo },
+          { kind: 'Reg', span, name: srcName },
+        ],
+        span,
+      )
     );
   };
 

--- a/src/lowering/asmInstructionLowering.ts
+++ b/src/lowering/asmInstructionLowering.ts
@@ -1,93 +1,14 @@
-import type { Diagnostic } from '../diagnosticTypes.js';
-import type { AsmInstructionNode, AsmOperandNode, EaExprNode, SourceSpan } from '../frontend/ast.js';
-import type { ScalarKind } from './typeResolution.js';
-import type { EaResolution } from './eaResolution.js';
+import type { AsmInstructionNode } from '../frontend/ast.js';
 import { createAsmInstructionLdHelpers } from './asmInstructionLdHelpers.js';
 import { tryLowerBranchCallInstruction } from './asmLoweringBranchCall.js';
 import { tryLowerStepInstruction } from './asmLoweringStep.js';
 import { tryLowerAssignmentInstruction } from './asmLoweringAssign.js';
 import { tryLowerLdInstruction } from './asmLoweringLd.js';
+import type { AsmLoweringHost } from './asmLoweringHost.js';
 
-type DiagAt = (diagnostics: Diagnostic[], span: AsmInstructionNode['span'], message: string) => void;
+export type { AsmLoweringHost } from './asmLoweringHost.js';
 
-type Context = {
-  diagnostics: Diagnostic[];
-  diagAt: DiagAt;
-  emitInstr: (head: string, operands: AsmOperandNode[], span: AsmInstructionNode['span']) => boolean;
-  emitRawCodeBytes: (bytes: Uint8Array, file: string, asmText: string) => void;
-  emitAbs16Fixup: (
-    opcode: number,
-    baseLower: string,
-    addend: number,
-    span: AsmInstructionNode['span'],
-    asmText?: string,
-  ) => void;
-  emitAbs16FixupPrefixed: (
-    prefix: number,
-    opcode2: number,
-    baseLower: string,
-    addend: number,
-    span: AsmInstructionNode['span'],
-    asmText?: string,
-  ) => void;
-  emitRel8Fixup: (
-    opcode: number,
-    baseLower: string,
-    addend: number,
-    span: AsmInstructionNode['span'],
-    mnemonic: string,
-    asmText?: string,
-  ) => void;
-  conditionOpcodeFromName: (nameRaw: string) => number | undefined;
-  conditionNameFromOpcode?: (opcode: number) => string | undefined;
-  callConditionOpcodeFromName: (nameRaw: string) => number | undefined;
-  jrConditionOpcodeFromName: (nameRaw: string) => number | undefined;
-  conditionOpcode: (op: AsmOperandNode) => number | undefined;
-  symbolicTargetFromExpr: (
-    expr: Extract<AsmOperandNode, { kind: 'Imm' }>['expr'],
-  ) => { baseLower: string; addend: number } | undefined;
-  evalImmExpr: (expr: Extract<AsmOperandNode, { kind: 'Imm' }>['expr']) => number | undefined;
-  resolveScalarBinding: (name: string) => 'byte' | 'word' | 'addr' | undefined;
-  resolveRawAliasTargetName: (name: string) => string | undefined;
-  isModuleStorageName: (name: string) => boolean;
-  isFrameSlotName: (name: string) => boolean;
-  resolveScalarTypeForEa: (ea: EaExprNode) => ScalarKind | undefined;
-  resolveScalarTypeForLd: (ea: EaExprNode) => ScalarKind | undefined;
-  resolveEa: (ea: EaExprNode, span: SourceSpan) => EaResolution | undefined;
-  diagIfRetStackImbalanced: (span: AsmInstructionNode['span'], mnemonic?: string) => void;
-  diagIfCallStackUnverifiable: (options: {
-    span: AsmInstructionNode['span'];
-    mnemonic?: string;
-    contractKind?: 'callee' | 'typed-call';
-  }) => void;
-  warnIfRawCallTargetsTypedCallable: (
-    span: AsmInstructionNode['span'],
-    symbolicTarget: { baseLower: string; addend: number } | undefined,
-  ) => void;
-  lowerLdWithEa: (asmItem: AsmInstructionNode) => boolean;
-  pushEaAddress: (ea: EaExprNode, span: AsmInstructionNode['span']) => boolean;
-  materializeEaAddressToHL: (ea: EaExprNode, span: AsmInstructionNode['span']) => boolean;
-  emitScalarWordLoad: (
-    target: 'HL' | 'DE' | 'BC',
-    resolved: EaResolution | undefined,
-    span: AsmInstructionNode['span'],
-  ) => boolean;
-  emitScalarWordStore: (
-    source: 'HL' | 'DE' | 'BC',
-    resolved: EaResolution | undefined,
-    span: AsmInstructionNode['span'],
-  ) => boolean;
-  emitVirtualReg16Transfer: (asmItem: AsmInstructionNode) => boolean;
-  reg16: Set<string>;
-  emitSyntheticEpilogue: boolean;
-  epilogueLabel: string;
-  emitJumpTo: (label: string, span: AsmInstructionNode['span']) => void;
-  emitJumpCondTo: (opcode: number, label: string, span: AsmInstructionNode['span']) => void;
-  syncToFlow: () => void;
-  flowRef: { current: { reachable: boolean } };
-};
-
-export function createAsmInstructionLoweringHelpers(ctx: Context) {
+export function createAsmInstructionLoweringHelpers(host: AsmLoweringHost) {
   const {
     emitAssignmentImmediateToRegister,
     emitAssignmentRegisterTransfer,
@@ -96,67 +17,34 @@ export function createAsmInstructionLoweringHelpers(ctx: Context) {
     isRawLdLabelName,
     emitAbs16LdFixup,
     isRegisterLikeMemEa,
-  } = createAsmInstructionLdHelpers(ctx);
+  } = createAsmInstructionLdHelpers(host);
   const lowerAsmInstructionDispatcher = (asmItem: AsmInstructionNode): void => {
-    const branchResult = tryLowerBranchCallInstruction(asmItem, {
-      diagnostics: ctx.diagnostics,
-      diagAt: ctx.diagAt,
-      emitInstr: ctx.emitInstr,
-      emitRawCodeBytes: ctx.emitRawCodeBytes,
-      emitAbs16Fixup: ctx.emitAbs16Fixup,
-      emitRel8Fixup: ctx.emitRel8Fixup,
-      conditionOpcodeFromName: ctx.conditionOpcodeFromName,
-      callConditionOpcodeFromName: ctx.callConditionOpcodeFromName,
-      jrConditionOpcodeFromName: ctx.jrConditionOpcodeFromName,
-      conditionOpcode: ctx.conditionOpcode,
-      symbolicTargetFromExpr: ctx.symbolicTargetFromExpr,
-      evalImmExpr: ctx.evalImmExpr,
-      diagIfRetStackImbalanced: ctx.diagIfRetStackImbalanced,
-      diagIfCallStackUnverifiable: ctx.diagIfCallStackUnverifiable,
-      warnIfRawCallTargetsTypedCallable: ctx.warnIfRawCallTargetsTypedCallable,
-      emitSyntheticEpilogue: ctx.emitSyntheticEpilogue,
-      epilogueLabel: ctx.epilogueLabel,
-      emitJumpTo: ctx.emitJumpTo,
-      emitJumpCondTo: ctx.emitJumpCondTo,
-      syncToFlow: ctx.syncToFlow,
-      flowRef: ctx.flowRef,
-    });
+    const branchResult = tryLowerBranchCallInstruction(asmItem, host);
     if (branchResult !== undefined) {
       if (!branchResult) return;
       return;
     }
 
-    const stepResult = tryLowerStepInstruction(asmItem, {
-      diagnostics: ctx.diagnostics,
-      diagAt: ctx.diagAt,
-      emitInstr: ctx.emitInstr,
-      evalImmExpr: ctx.evalImmExpr,
-      resolveScalarTypeForLd: ctx.resolveScalarTypeForLd,
-      resolveEa: ctx.resolveEa,
-      materializeEaAddressToHL: ctx.materializeEaAddressToHL,
-      emitScalarWordLoad: ctx.emitScalarWordLoad,
-      emitScalarWordStore: ctx.emitScalarWordStore,
-      syncToFlow: ctx.syncToFlow,
-    });
+    const stepResult = tryLowerStepInstruction(asmItem, host);
     if (stepResult !== undefined) {
       if (!stepResult) return;
       return;
     }
 
     const ldResult = tryLowerLdInstruction(asmItem, {
-      diagnostics: ctx.diagnostics,
-      diagAt: ctx.diagAt,
-      emitAbs16Fixup: ctx.emitAbs16Fixup,
-      emitAbs16FixupPrefixed: ctx.emitAbs16FixupPrefixed,
-      evalImmExpr: ctx.evalImmExpr,
-      resolveScalarBinding: ctx.resolveScalarBinding,
-      lowerLdWithEa: ctx.lowerLdWithEa,
+      diagnostics: host.diagnostics,
+      diagAt: host.diagAt,
+      emitAbs16Fixup: host.emitAbs16Fixup,
+      emitAbs16FixupPrefixed: host.emitAbs16FixupPrefixed,
+      evalImmExpr: host.evalImmExpr,
+      resolveScalarBinding: host.resolveScalarBinding,
+      lowerLdWithEa: host.lowerLdWithEa,
       emitAbs16LdFixup,
       isTypedStorageLdOperand,
       isRawLdLabelName,
       resolveRawLabelName,
       isRegisterLikeMemEa,
-      syncToFlow: ctx.syncToFlow,
+      syncToFlow: host.syncToFlow,
     });
     if (ldResult !== undefined) {
       if (!ldResult) return;
@@ -164,15 +52,15 @@ export function createAsmInstructionLoweringHelpers(ctx: Context) {
     }
 
     const assignResult = tryLowerAssignmentInstruction(asmItem, {
-      diagnostics: ctx.diagnostics,
-      diagAt: ctx.diagAt,
-      emitInstr: ctx.emitInstr,
-      lowerLdWithEa: ctx.lowerLdWithEa,
-      pushEaAddress: ctx.pushEaAddress,
-      reg16: ctx.reg16,
+      diagnostics: host.diagnostics,
+      diagAt: host.diagAt,
+      emitInstr: host.emitInstr,
+      lowerLdWithEa: host.lowerLdWithEa,
+      pushEaAddress: host.pushEaAddress,
+      reg16: host.reg16,
       emitAssignmentImmediateToRegister,
       emitAssignmentRegisterTransfer,
-      syncToFlow: ctx.syncToFlow,
+      syncToFlow: host.syncToFlow,
     });
     if (assignResult !== undefined) {
       if (!assignResult) return;
@@ -181,24 +69,27 @@ export function createAsmInstructionLoweringHelpers(ctx: Context) {
 
     const head = asmItem.head.toLowerCase();
 
-    if (head !== 'ld' && ctx.lowerLdWithEa(asmItem)) {
-      ctx.syncToFlow();
+    if (head !== 'ld' && host.lowerLdWithEa(asmItem)) {
+      host.syncToFlow();
       return;
     }
 
-    if (ctx.emitVirtualReg16Transfer(asmItem)) {
-      ctx.syncToFlow();
+    if (host.emitVirtualReg16Transfer(asmItem)) {
+      host.syncToFlow();
       return;
     }
 
-    if (!ctx.emitInstr(asmItem.head, asmItem.operands, asmItem.span)) return;
+    if (!host.emitInstr(asmItem.head, asmItem.operands, asmItem.span)) return;
 
     if ((head === 'jp' || head === 'jr') && asmItem.operands.length === 1) {
-      ctx.flowRef.current.reachable = false;
-    } else if ((head === 'ret' || head === 'retn' || head === 'reti') && asmItem.operands.length === 0) {
-      ctx.flowRef.current.reachable = false;
+      host.flowRef.current.reachable = false;
+    } else if (
+      (head === 'ret' || head === 'retn' || head === 'reti') &&
+      asmItem.operands.length === 0
+    ) {
+      host.flowRef.current.reachable = false;
     }
-    ctx.syncToFlow();
+    host.syncToFlow();
   };
 
   return { lowerAsmInstructionDispatcher };

--- a/src/lowering/asmLoweringHost.ts
+++ b/src/lowering/asmLoweringHost.ts
@@ -1,0 +1,40 @@
+import type { AsmInstructionNode, EaExprNode } from '../frontend/ast.js';
+import type { BranchCallLoweringContext } from './asmLoweringBranchCall.js';
+import type { StepLoweringContext } from './asmLoweringStep.js';
+import type { LdHelperContext } from './asmInstructionLdHelpers.js';
+
+/**
+ * Fields required by {@link createAsmInstructionLdHelpers} beyond what
+ * {@link BranchCallLoweringContext} already provides (`emitInstr`, `emitAbs16Fixup`).
+ */
+export type AsmLoweringLdHelperSlice = Omit<LdHelperContext, 'emitInstr' | 'emitAbs16Fixup'>;
+
+/**
+ * Step lowering needs EA typing, resolution, and scalar word load/store helpers.
+ */
+export type AsmLoweringStepSlice = Pick<
+  StepLoweringContext,
+  | 'resolveScalarTypeForLd'
+  | 'resolveEa'
+  | 'materializeEaAddressToHL'
+  | 'emitScalarWordLoad'
+  | 'emitScalarWordStore'
+>;
+
+/**
+ * Dispatcher paths shared by assignment lowering and the non-`ld` `lowerLdWithEa` fallback.
+ */
+export type AsmLoweringDispatcherSlice = {
+  lowerLdWithEa: (asmItem: AsmInstructionNode) => boolean;
+  pushEaAddress: (ea: EaExprNode, span: AsmInstructionNode['span']) => boolean;
+};
+
+/**
+ * Narrow surface for {@link createAsmInstructionLoweringHelpers}: branch/call, LD helpers,
+ * step, assignment, and raw-instruction fallback. Composed from family-module contracts plus
+ * LD-helper and dispatcher-only fields (no unused legacy fields).
+ */
+export type AsmLoweringHost = BranchCallLoweringContext &
+  AsmLoweringLdHelperSlice &
+  AsmLoweringStepSlice &
+  AsmLoweringDispatcherSlice;

--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -43,11 +43,7 @@ import {
   type StepPipeline,
 } from '../addressing/steps.js';
 import type { Diagnostic } from '../diagnosticTypes.js';
-import type {
-  EmittedByteMap,
-  EmittedSourceSegment,
-  SymbolEntry,
-} from '../formats/types.js';
+import type { EmittedByteMap, EmittedSourceSegment, SymbolEntry } from '../formats/types.js';
 import type {
   AsmInstructionNode,
   AsmOperandNode,
@@ -80,9 +76,12 @@ import { createAsmBodyOrchestrationHelpers } from './asmBodyOrchestration.js';
 import { createOpMatchingHelpers } from './opMatching.js';
 import { createEmissionCoreHelpers } from './emissionCore.js';
 import { createValueMaterializationHelpers } from './valueMaterialization.js';
-import { createAsmInstructionLoweringHelpers } from './asmInstructionLowering.js';
 import { createFixupEmissionHelpers } from './fixupEmission.js';
-import { createFunctionBodySetupHelpers, type FlowState, type OpExpansionFrame } from './functionBodySetup.js';
+import {
+  createFunctionBodySetupHelpers,
+  type FlowState,
+  type OpExpansionFrame,
+} from './functionBodySetup.js';
 import { lowerFunctionDecl } from './functionLowering.js';
 import { createEmitVisibilityHelpers } from './emitVisibility.js';
 import { lowerProgramDeclarations, preScanProgramDeclarations } from './programLowering.js';
@@ -94,19 +93,20 @@ import {
   diagAtWithSeverityAndId,
   warnAt,
 } from './loweringDiagnostics.js';
-import { cloneEaExpr, cloneImmExpr, cloneOperand, createAsmUtilityHelpers, flattenEaDottedName } from './asmUtils.js';
+import {
+  cloneEaExpr,
+  cloneImmExpr,
+  cloneOperand,
+  createAsmUtilityHelpers,
+  flattenEaDottedName,
+} from './asmUtils.js';
 import {
   alignTo,
   computeWrittenRange,
   rebaseCodeSourceSegments,
   writeSection,
 } from './sectionLayout.js';
-import {
-  formatImmExprForAsm,
-  formatIxDisp,
-  toHexByte,
-  toHexWord,
-} from './traceFormat.js';
+import { formatImmExprForAsm, formatIxDisp, toHexByte, toHexWord } from './traceFormat.js';
 import { createTypeResolutionHelpers } from './typeResolution.js';
 import { createEmitProgramContext } from './emitProgramContext.js';
 import { createEmitStateHelpers } from './emitState.js';
@@ -214,9 +214,7 @@ export function emitProgram(
   const stackSlotTypes = new Map<string, TypeExprNode>();
   const stackSlotOffsets = new Map<string, number>();
   const localAliasTargets = new Map<string, EaExprNode>();
-  let applySpTracking:
-    | ((headRaw: string, operands: AsmOperandNode[]) => void)
-    | undefined;
+  let applySpTracking: ((headRaw: string, operands: AsmOperandNode[]) => void) | undefined;
   let invalidateSpTracking: (() => void) | undefined;
   const traceInstruction = (_offset: number, _bytesOut: Uint8Array, _text: string): void => {};
   let emitCodeBytes: (bs: Uint8Array, file: string) => void;
@@ -305,19 +303,23 @@ export function emitProgram(
 
   const emitInstr = (head: string, operands: AsmOperandNode[], span: SourceSpan) => {
     const start = getCurrentCodeOffset();
-    const syntheticInstruction: AsmInstructionNode = { kind: 'AsmInstruction', span, head, operands };
-    const encoded = encodeInstruction(
-      syntheticInstruction,
-      env,
-      diagnostics,
-    );
-    if (!encoded) return false;
-    recordLoweredAsmItem({
-      kind: 'instr',
+    const syntheticInstruction: AsmInstructionNode = {
+      kind: 'AsmInstruction',
+      span,
       head,
-      operands: operands.map((op) => lowerOperandForLoweredAsm(op)),
-      bytes: [...encoded],
-    }, span);
+      operands,
+    };
+    const encoded = encodeInstruction(syntheticInstruction, env, diagnostics);
+    if (!encoded) return false;
+    recordLoweredAsmItem(
+      {
+        kind: 'instr',
+        head,
+        operands: operands.map((op) => lowerOperandForLoweredAsm(op)),
+        bytes: [...encoded],
+      },
+      span,
+    );
     emitCodeBytes(encoded, span.file);
     applySpTracking?.(head, operands);
     return true;
@@ -349,21 +351,20 @@ export function emitProgram(
     pushRel8Fixup: pushCurrentRel8Fixup,
     traceInstruction,
     recordLoweredInstr: (bytes, _asmText, span) => {
-      recordLoweredAsmItem({
-        kind: 'instr',
-        head: '@raw',
-        operands: [],
-        bytes: [...bytes],
-      }, span);
+      recordLoweredAsmItem(
+        {
+          kind: 'instr',
+          head: '@raw',
+          operands: [],
+          bytes: [...bytes],
+        },
+        span,
+      );
     },
     evalImmExpr: (expr) => evalImmExpr(expr, env, diagnostics),
   });
 
-  ({
-    emitCodeBytes,
-    emitRawCodeBytes,
-    emitStepPipeline,
-  } = createEmissionCoreHelpers({
+  ({ emitCodeBytes, emitRawCodeBytes, emitStepPipeline } = createEmissionCoreHelpers({
     getCodeOffset: getCurrentCodeOffset,
     setCodeOffset: setCurrentCodeOffset,
     setCodeByte: setCurrentCodeByte,
@@ -416,10 +417,7 @@ export function emitProgram(
     return sizeOfTypeExpr(resolved.typeExpr, env, diagnostics);
   };
 
-  const {
-    selectOpOverload,
-    formatAsmOperandForOpDiag,
-  } = createOpMatchingHelpers({
+  const { selectOpOverload, formatAsmOperandForOpDiag } = createOpMatchingHelpers({
     reg8: REG8_NAMES,
     isIxIyIndexedMem,
     flattenEaDottedName,
@@ -454,17 +452,15 @@ export function emitProgram(
     storageTypes.set(aliasLower, inferred);
   }
 
-  const {
-    enforceDirectCallSiteEaBudget,
-    enforceEaRuntimeAtomBudget,
-  } = createRuntimeAtomBudgetHelpers({
-    diagnostics,
-    diagAt,
-    resolveScalarBinding,
-    stackSlotOffsets,
-    stackSlotTypes,
-    storageTypes,
-  });
+  const { enforceDirectCallSiteEaBudget, enforceEaRuntimeAtomBudget } =
+    createRuntimeAtomBudgetHelpers({
+      diagnostics,
+      diagAt,
+      resolveScalarBinding,
+      stackSlotOffsets,
+      stackSlotTypes,
+      storageTypes,
+    });
 
   const { buildEaBytePipeline, buildEaWordPipeline } = createAddressingPipelineBuilders({
     diagnostics,

--- a/src/lowering/functionLowering.ts
+++ b/src/lowering/functionLowering.ts
@@ -16,11 +16,7 @@ import type {
 import type { CompileEnv } from '../semantics/env.js';
 import { resolveVisibleConst, resolveVisibleEnum } from '../moduleVisibility.js';
 import type { OpStackPolicyMode } from '../pipeline.js';
-import type {
-  Callable,
-  PendingSymbol,
-  SourceSegmentTag,
-} from './loweringTypes.js';
+import type { Callable, PendingSymbol, SourceSegmentTag } from './loweringTypes.js';
 import type { OpOverloadSelection } from './opMatching.js';
 import type { OpStackSummary } from './opStackAnalysis.js';
 import type { EaResolution } from './eaResolution.js';
@@ -119,9 +115,7 @@ export type FunctionLoweringConditionContext = {
   jrConditionOpcodeFromName: (name: string) => number | undefined;
   conditionOpcode: (operand: AsmOperandNode) => number | undefined;
   inverseConditionName: (name: string) => string | undefined;
-  symbolicTargetFromExpr: (
-    expr: ImmExprNode,
-  ) => { baseLower: string; addend: number } | undefined;
+  symbolicTargetFromExpr: (expr: ImmExprNode) => { baseLower: string; addend: number } | undefined;
 };
 
 export type FunctionLoweringTypeContext = {
@@ -234,9 +228,15 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
     emitRel8Fixup,
   } = ctx;
   const { conditionOpcodeFromName, conditionNameFromOpcode, callConditionOpcodeFromName } = ctx;
-  const { jrConditionOpcodeFromName, conditionOpcode, inverseConditionName, symbolicTargetFromExpr } = ctx;
+  const {
+    jrConditionOpcodeFromName,
+    conditionOpcode,
+    inverseConditionName,
+    symbolicTargetFromExpr,
+  } = ctx;
   const { evalImmExpr, env, resolveScalarBinding, resolveScalarKind, resolveEaTypeExpr } = ctx;
-  const { resolveScalarTypeForEa, resolveScalarTypeForLd, resolveArrayType, buildEaWordPipeline } = ctx;
+  const { resolveScalarTypeForEa, resolveScalarTypeForLd, resolveArrayType, buildEaWordPipeline } =
+    ctx;
   const { enforceEaRuntimeAtomBudget, enforceDirectCallSiteEaBudget } = ctx;
   const {
     resolveEa,
@@ -247,12 +247,21 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
     pushZeroExtendedReg8,
     loadImm16ToHL,
   } = ctx;
-  const { stackSlotOffsets, stackSlotTypes, localAliasTargets, storageTypes, moduleAliasTargets } = ctx;
-  const { rawTypedCallWarningsEnabled, resolveCallable, resolveOpCandidates, opStackPolicyMode } = ctx;
+  const { stackSlotOffsets, stackSlotTypes, localAliasTargets, storageTypes, moduleAliasTargets } =
+    ctx;
+  const { rawTypedCallWarningsEnabled, resolveCallable, resolveOpCandidates, opStackPolicyMode } =
+    ctx;
   const { formatAsmOperandForOpDiag, selectOpOverload, summarizeOpStackEffect } = ctx;
   const { cloneImmExpr, cloneEaExpr, cloneOperand } = ctx;
   const { flattenEaDottedName, normalizeFixedToken, reg8, reg16, generatedLabelCounterRef } = ctx;
-  const { typeDisplay, sameTypeShape, emitStepPipeline, emitScalarWordLoad, emitScalarWordStore, lowerLdWithEa } = ctx;
+  const {
+    typeDisplay,
+    sameTypeShape,
+    emitStepPipeline,
+    emitScalarWordLoad,
+    emitScalarWordStore,
+    lowerLdWithEa,
+  } = ctx;
   let currentCodeSegmentTag = currentCodeSegmentTagRef.current;
   const setCurrentCodeSegmentTag = (tag: SourceSegmentTag | undefined): void => {
     currentCodeSegmentTag = tag;
@@ -391,7 +400,6 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
     emitAbs16FixupPrefixed,
     emitRel8Fixup,
     conditionOpcodeFromName,
-    conditionNameFromOpcode,
     callConditionOpcodeFromName,
     jrConditionOpcodeFromName,
     conditionOpcode,
@@ -401,7 +409,6 @@ export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
     resolveRawAliasTargetName: (name) => resolveLocalAliasTargetName(name.toLowerCase()),
     isModuleStorageName: (name) => storageTypes.has(name.toLowerCase()),
     isFrameSlotName: (name) => stackSlotOffsets.has(name.toLowerCase()),
-    resolveScalarTypeForEa,
     resolveScalarTypeForLd,
     resolveEa,
     diagIfRetStackImbalanced: (span, mnemonic) => {

--- a/test/pr1050_step_lowering.test.ts
+++ b/test/pr1050_step_lowering.test.ts
@@ -35,9 +35,11 @@ describe('PR1050 step lowering', () => {
           `${head} ${operands
             .map((operand) => {
               if (operand.kind === 'Reg') return operand.name;
-              if (operand.kind === 'Imm' && operand.expr.kind === 'ImmLiteral') return `$${operand.expr.value}`;
+              if (operand.kind === 'Imm' && operand.expr.kind === 'ImmLiteral')
+                return `$${operand.expr.value}`;
               if (operand.kind === 'Mem' && operand.expr.kind === 'EaAdd') return '(IX+disp)';
-              if (operand.kind === 'Mem' && operand.expr.kind === 'EaName') return `(${operand.expr.name})`;
+              if (operand.kind === 'Mem' && operand.expr.kind === 'EaName')
+                return `(${operand.expr.name})`;
               return operand.kind;
             })
             .join(', ')}`,
@@ -49,7 +51,6 @@ describe('PR1050 step lowering', () => {
       emitAbs16FixupPrefixed: () => {},
       emitRel8Fixup: () => {},
       conditionOpcodeFromName: () => undefined,
-      conditionNameFromOpcode: () => undefined,
       callConditionOpcodeFromName: () => undefined,
       jrConditionOpcodeFromName: () => undefined,
       conditionOpcode: () => undefined,
@@ -59,7 +60,6 @@ describe('PR1050 step lowering', () => {
       resolveRawAliasTargetName: () => undefined,
       isModuleStorageName: () => false,
       isFrameSlotName: () => false,
-      resolveScalarTypeForEa: () => undefined,
       resolveScalarTypeForLd: () => 'byte',
       resolveEa: () => ({ kind: 'stack', ixDisp: 4, scalar: 'byte' }),
       diagIfRetStackImbalanced: () => {},
@@ -111,8 +111,10 @@ describe('PR1050 step lowering', () => {
           `${head} ${operands
             .map((operand) => {
               if (operand.kind === 'Reg') return operand.name;
-              if (operand.kind === 'Imm' && operand.expr.kind === 'ImmLiteral') return `$${operand.expr.value}`;
-              if (operand.kind === 'Mem' && operand.expr.kind === 'EaName') return `(${operand.expr.name})`;
+              if (operand.kind === 'Imm' && operand.expr.kind === 'ImmLiteral')
+                return `$${operand.expr.value}`;
+              if (operand.kind === 'Mem' && operand.expr.kind === 'EaName')
+                return `(${operand.expr.name})`;
               return operand.kind;
             })
             .join(', ')}`,
@@ -124,7 +126,6 @@ describe('PR1050 step lowering', () => {
       emitAbs16FixupPrefixed: () => {},
       emitRel8Fixup: () => {},
       conditionOpcodeFromName: () => undefined,
-      conditionNameFromOpcode: () => undefined,
       callConditionOpcodeFromName: () => undefined,
       jrConditionOpcodeFromName: () => undefined,
       conditionOpcode: () => undefined,
@@ -134,9 +135,8 @@ describe('PR1050 step lowering', () => {
       resolveRawAliasTargetName: () => undefined,
       isModuleStorageName: () => false,
       isFrameSlotName: () => false,
-      resolveScalarTypeForEa: () => undefined,
       resolveScalarTypeForLd: () => 'word',
-      resolveEa: () => ({ kind: 'indexed', base: 'IX', disp: 0, scalar: 'word' } as never),
+      resolveEa: () => ({ kind: 'indexed', base: 'IX', disp: 0, scalar: 'word' }) as never,
       diagIfRetStackImbalanced: () => {},
       diagIfCallStackUnverifiable: () => {},
       warnIfRawCallTargetsTypedCallable: () => {},

--- a/test/pr532_asm_instruction_lowering_integration.test.ts
+++ b/test/pr532_asm_instruction_lowering_integration.test.ts
@@ -35,7 +35,6 @@ describe('PR532 asm instruction lowering integration', () => {
         events.push(`rel:${opcode.toString(16)}:${baseLower}:${addend}:${mnemonic}`);
       },
       conditionOpcodeFromName: (name) => (name.toUpperCase() === 'NZ' ? 0xc2 : undefined),
-      conditionNameFromOpcode: (opcode) => (opcode === 0xc2 ? 'NZ' : undefined),
       callConditionOpcodeFromName: (name) => (name.toUpperCase() === 'NZ' ? 0xc4 : undefined),
       jrConditionOpcodeFromName: (name) => (name.toUpperCase() === 'NZ' ? 0x20 : undefined),
       conditionOpcode: (op) =>
@@ -53,7 +52,6 @@ describe('PR532 asm instruction lowering integration', () => {
       resolveRawAliasTargetName: () => undefined,
       isModuleStorageName: () => false,
       isFrameSlotName: () => false,
-      resolveScalarTypeForEa: () => undefined,
       resolveScalarTypeForLd: () => undefined,
       resolveEa: () => undefined,
       diagIfRetStackImbalanced: () => {},

--- a/test/pr781_ld_typed_storage_migration_diag.test.ts
+++ b/test/pr781_ld_typed_storage_migration_diag.test.ts
@@ -33,7 +33,6 @@ describe('PR781 ld typed-storage migration diagnostics', () => {
       emitAbs16FixupPrefixed: () => {},
       emitRel8Fixup: () => {},
       conditionOpcodeFromName: () => undefined,
-      conditionNameFromOpcode: () => undefined,
       callConditionOpcodeFromName: () => undefined,
       jrConditionOpcodeFromName: () => undefined,
       conditionOpcode: () => undefined,
@@ -43,7 +42,6 @@ describe('PR781 ld typed-storage migration diagnostics', () => {
       resolveRawAliasTargetName: () => undefined,
       isModuleStorageName: () => false,
       isFrameSlotName: () => false,
-      resolveScalarTypeForEa: () => undefined,
       resolveScalarTypeForLd: () => undefined,
       resolveEa: () => undefined,
       diagIfRetStackImbalanced: () => {},
@@ -66,7 +64,13 @@ describe('PR781 ld typed-storage migration diagnostics', () => {
       syncToFlow: () => {},
       flowRef: { current: { reachable: true } },
     });
-    return { helper, diagnostics, get ldCalled() { return ldCalled; } };
+    return {
+      helper,
+      diagnostics,
+      get ldCalled() {
+        return ldCalled;
+      },
+    };
   }
 
   it('diagnoses typed storage names in ld immediate form', () => {

--- a/test/pr863_assignment_lowering.test.ts
+++ b/test/pr863_assignment_lowering.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import { DiagnosticIds, type Diagnostic } from '../src/diagnosticTypes.js';
-import type { AsmInstructionNode, AsmOperandNode, EaExprNode, SourceSpan } from '../src/frontend/ast.js';
+import type {
+  AsmInstructionNode,
+  AsmOperandNode,
+  EaExprNode,
+  SourceSpan,
+} from '../src/frontend/ast.js';
 import { createAsmInstructionLoweringHelpers } from '../src/lowering/asmInstructionLowering.js';
 
 const span: SourceSpan = {
@@ -10,7 +15,9 @@ const span: SourceSpan = {
   end: { line: 1, column: 1, offset: 0 },
 };
 
-function makeHelper(overrides: Partial<Parameters<typeof createAsmInstructionLoweringHelpers>[0]> = {}) {
+function makeHelper(
+  overrides: Partial<Parameters<typeof createAsmInstructionLoweringHelpers>[0]> = {},
+) {
   const diagnostics: Diagnostic[] = [];
   const loweredLd: AsmInstructionNode[] = [];
   const emittedInstrs: string[] = [];
@@ -44,7 +51,6 @@ function makeHelper(overrides: Partial<Parameters<typeof createAsmInstructionLow
     emitAbs16FixupPrefixed: () => {},
     emitRel8Fixup: () => {},
     conditionOpcodeFromName: () => undefined,
-    conditionNameFromOpcode: () => undefined,
     callConditionOpcodeFromName: () => undefined,
     jrConditionOpcodeFromName: () => undefined,
     conditionOpcode: () => undefined,
@@ -54,7 +60,6 @@ function makeHelper(overrides: Partial<Parameters<typeof createAsmInstructionLow
     resolveRawAliasTargetName: () => undefined,
     isModuleStorageName: () => false,
     isFrameSlotName: () => false,
-    resolveScalarTypeForEa: () => undefined,
     resolveScalarTypeForLd: () => undefined,
     resolveEa: () => undefined,
     diagIfRetStackImbalanced: () => {},
@@ -72,7 +77,9 @@ function makeHelper(overrides: Partial<Parameters<typeof createAsmInstructionLow
     emitScalarWordLoad: () => false,
     emitScalarWordStore: () => false,
     emitVirtualReg16Transfer: (inst) => {
-      emittedInstrs.push(`virtual ${inst.operands.map((operand) => (operand.kind === 'Reg' ? operand.name : operand.kind)).join(',')}`);
+      emittedInstrs.push(
+        `virtual ${inst.operands.map((operand) => (operand.kind === 'Reg' ? operand.name : operand.kind)).join(',')}`,
+      );
       return true;
     },
     reg16: new Set(['BC', 'DE', 'HL', 'IX', 'IY']),
@@ -85,7 +92,15 @@ function makeHelper(overrides: Partial<Parameters<typeof createAsmInstructionLow
     ...overrides,
   });
 
-  return { helper, diagnostics, loweredLd, emittedInstrs, get pushedEa() { return pushedEa; } };
+  return {
+    helper,
+    diagnostics,
+    loweredLd,
+    emittedInstrs,
+    get pushedEa() {
+      return pushedEa;
+    },
+  };
 }
 
 describe('PR863 := lowering', () => {
@@ -227,7 +242,10 @@ describe('PR863 := lowering', () => {
   });
 
   it('diagnoses unsupported parsed register combinations', () => {
-    const { helper, diagnostics } = makeHelper({ lowerLdWithEa: () => false, emitVirtualReg16Transfer: () => false });
+    const { helper, diagnostics } = makeHelper({
+      lowerLdWithEa: () => false,
+      emitVirtualReg16Transfer: () => false,
+    });
 
     helper.lowerAsmInstructionDispatcher({
       kind: 'AsmInstruction',

--- a/test/pr869_assignment_reg8_lowering.test.ts
+++ b/test/pr869_assignment_reg8_lowering.test.ts
@@ -34,7 +34,6 @@ describe('PR869 := reg8 lowering', () => {
       emitAbs16FixupPrefixed: () => {},
       emitRel8Fixup: () => {},
       conditionOpcodeFromName: () => undefined,
-      conditionNameFromOpcode: () => undefined,
       callConditionOpcodeFromName: () => undefined,
       jrConditionOpcodeFromName: () => undefined,
       conditionOpcode: () => undefined,
@@ -44,7 +43,6 @@ describe('PR869 := reg8 lowering', () => {
       resolveRawAliasTargetName: () => undefined,
       isModuleStorageName: () => false,
       isFrameSlotName: () => false,
-      resolveScalarTypeForEa: () => undefined,
       resolveScalarTypeForLd: () => undefined,
       resolveEa: () => undefined,
       diagIfRetStackImbalanced: () => {},
@@ -131,7 +129,9 @@ describe('PR869 := reg8 lowering', () => {
         });
       },
       emitInstr: (head, operands) => {
-        emitted.push(`${head} ${operands.map((operand) => (operand.kind === 'Reg' ? operand.name : operand.kind)).join(',')}`);
+        emitted.push(
+          `${head} ${operands.map((operand) => (operand.kind === 'Reg' ? operand.name : operand.kind)).join(',')}`,
+        );
         return true;
       },
       emitRawCodeBytes: () => {},
@@ -139,7 +139,6 @@ describe('PR869 := reg8 lowering', () => {
       emitAbs16FixupPrefixed: () => {},
       emitRel8Fixup: () => {},
       conditionOpcodeFromName: () => undefined,
-      conditionNameFromOpcode: () => undefined,
       callConditionOpcodeFromName: () => undefined,
       jrConditionOpcodeFromName: () => undefined,
       conditionOpcode: () => undefined,
@@ -149,7 +148,6 @@ describe('PR869 := reg8 lowering', () => {
       resolveRawAliasTargetName: () => undefined,
       isModuleStorageName: () => false,
       isFrameSlotName: () => false,
-      resolveScalarTypeForEa: () => undefined,
       resolveScalarTypeForLd: () => undefined,
       resolveEa: () => undefined,
       diagIfRetStackImbalanced: () => {},

--- a/test/pr887_assignment_half_index_lowering.test.ts
+++ b/test/pr887_assignment_half_index_lowering.test.ts
@@ -34,7 +34,6 @@ describe('PR887 := half-index lowering', () => {
       emitAbs16FixupPrefixed: () => {},
       emitRel8Fixup: () => {},
       conditionOpcodeFromName: () => undefined,
-      conditionNameFromOpcode: () => undefined,
       callConditionOpcodeFromName: () => undefined,
       jrConditionOpcodeFromName: () => undefined,
       conditionOpcode: () => undefined,
@@ -44,7 +43,6 @@ describe('PR887 := half-index lowering', () => {
       resolveRawAliasTargetName: () => undefined,
       isModuleStorageName: () => false,
       isFrameSlotName: () => false,
-      resolveScalarTypeForEa: () => undefined,
       resolveScalarTypeForLd: () => undefined,
       resolveEa: () => undefined,
       diagIfRetStackImbalanced: () => {},
@@ -131,7 +129,9 @@ describe('PR887 := half-index lowering', () => {
         });
       },
       emitInstr: (head, operands) => {
-        emitted.push(`${head} ${operands.map((operand) => (operand.kind === 'Reg' ? operand.name : operand.kind)).join(',')}`);
+        emitted.push(
+          `${head} ${operands.map((operand) => (operand.kind === 'Reg' ? operand.name : operand.kind)).join(',')}`,
+        );
         return true;
       },
       emitRawCodeBytes: () => {},
@@ -139,7 +139,6 @@ describe('PR887 := half-index lowering', () => {
       emitAbs16FixupPrefixed: () => {},
       emitRel8Fixup: () => {},
       conditionOpcodeFromName: () => undefined,
-      conditionNameFromOpcode: () => undefined,
       callConditionOpcodeFromName: () => undefined,
       jrConditionOpcodeFromName: () => undefined,
       conditionOpcode: () => undefined,
@@ -149,7 +148,6 @@ describe('PR887 := half-index lowering', () => {
       resolveRawAliasTargetName: () => undefined,
       isModuleStorageName: () => false,
       isFrameSlotName: () => false,
-      resolveScalarTypeForEa: () => undefined,
       resolveScalarTypeForLd: () => undefined,
       resolveEa: () => undefined,
       diagIfRetStackImbalanced: () => {},


### PR DESCRIPTION
## Summary
Finishes #1059 on current main: family modules were already split; this pass **narrows the shared context** passed into `createAsmInstructionLoweringHelpers`.

## Changes
- New `src/lowering/asmLoweringHost.ts` defines composable types:
  - `AsmLoweringHost` = `BranchCallLoweringContext` & `AsmLoweringLdHelperSlice` (LD-helper fields beyond branch emit) & `AsmLoweringStepSlice` & `AsmLoweringDispatcherSlice` (`lowerLdWithEa`, `pushEaAddress`).
- Export `LdHelperContext` from `asmInstructionLdHelpers.ts`.
- Dispatcher passes the **same host object** into `tryLowerBranchCallInstruction` and `tryLowerStepInstruction` (structural typing) instead of manual field picks.
- **Removed** from the host contract (were never read by asm lowering): `conditionNameFromOpcode`, `resolveScalarTypeForEa`.
- Dropped unused `createAsmInstructionLoweringHelpers` import from `emit.ts`.

## Testing
- `npm run typecheck`
- `npx vitest run` (full suite)

Fixes #1059

Made with [Cursor](https://cursor.com)