### PR TITLE
refactor(lowering): explicit emit pipeline phases (#1060)

### DIFF
--- a/src/lowering/emit.ts
+++ b/src/lowering/emit.ts
@@ -43,7 +43,7 @@ import {
   type StepPipeline,
 } from '../addressing/steps.js';
 import type { Diagnostic } from '../diagnosticTypes.js';
-import type { EmittedByteMap, EmittedSourceSegment, SymbolEntry } from '../formats/types.js';
+import type { EmittedSourceSegment, SymbolEntry } from '../formats/types.js';
 import type {
   AsmInstructionNode,
   AsmOperandNode,
@@ -61,7 +61,6 @@ import { sizeOfTypeExpr } from '../semantics/layout.js';
 import { encodeInstruction } from '../z80/encode.js';
 import type { Callable, PendingSymbol, SectionKind } from './loweringTypes.js';
 import { createOpStackAnalysisHelpers } from './opStackAnalysis.js';
-import type { OpStackPolicyMode } from '../pipeline.js';
 import { loadBinInput, loadHexInput } from './inputAssets.js';
 import { createEaResolutionHelpers, type EaResolution } from './eaResolution.js';
 import { createEaMaterializationHelpers } from './eaMaterialization.js';
@@ -84,8 +83,15 @@ import {
 } from './functionBodySetup.js';
 import { lowerFunctionDecl } from './functionLowering.js';
 import { createEmitVisibilityHelpers } from './emitVisibility.js';
-import { lowerProgramDeclarations, preScanProgramDeclarations } from './programLowering.js';
-import { finalizeEmitProgram } from './emitFinalization.js';
+import {
+  emitProgramEmptyResult,
+  mergeEmitFinalizationContext,
+  runEmitLoweringPhase,
+  runEmitPlacementAndArtifactPhase,
+  runEmitPrescanPhase,
+  type EmitProgramOptions,
+  type EmitProgramResult,
+} from './emitPipeline.js';
 import {
   diag,
   diagAt,
@@ -133,6 +139,10 @@ const REG8_CODES = new Map([
 /**
  * Emit machine-code bytes for a parsed program into an address->byte map.
  *
+ * Orchestration follows the phased pipeline in `emitPipeline.ts`. Phase 1 (workspace wiring)
+ * is implemented in this file; phases 2–4 use `runEmitPrescanPhase`, `runEmitLoweringPhase`,
+ * and `runEmitPlacementAndArtifactPhase`.
+ *
  * Implementation notes:
  * - Uses 3 independent section counters: `code`, `data`, `var`.
  * - `section` / `align` directives affect only the selected section counter.
@@ -144,21 +154,8 @@ export function emitProgram(
   program: ProgramNode,
   env: CompileEnv,
   diagnostics: Diagnostic[],
-  options?: {
-    includeDirs?: string[];
-    opStackPolicy?: OpStackPolicyMode;
-    rawTypedCallWarnings?: boolean;
-    defaultCodeBase?: number;
-    namedSectionKeys?: import('../sectionKeys.js').NonBankedSectionKeyCollection;
-    sourceTexts?: Map<string, string>;
-    sourceLineComments?: Map<string, Map<number, string>>;
-  },
-): {
-  map: EmittedByteMap;
-  symbols: SymbolEntry[];
-  loweredAsmStream: LoweredAsmStream;
-  placedLoweredAsmProgram: import('./loweredAsmTypes.js').LoweredAsmProgram;
-} {
+  options?: EmitProgramOptions,
+): EmitProgramResult {
   const bytes = new Map<number, number>();
   const codeBytes = new Map<number, number>();
   const dataBytes = new Map<number, number>();
@@ -248,12 +245,7 @@ export function emitProgram(
   const firstModule = program.files[0];
   if (!firstModule) {
     diag(diagnostics, program.entryFile, 'No module files to compile.');
-    return {
-      map: { bytes },
-      symbols,
-      loweredAsmStream,
-      placedLoweredAsmProgram: { blocks: [] },
-    };
+    return emitProgramEmptyResult();
   }
 
   const primaryFile = firstModule.span.file ?? program.entryFile;
@@ -694,40 +686,39 @@ export function emitProgram(
     currentNamedSectionSinkRef,
   });
 
-  const prescan = preScanProgramDeclarations(programLoweringContext);
-  const lowered = lowerProgramDeclarations(programLoweringContext, prescan);
+  // --- Phase 2: prescan (visibility / alias metadata) ---
+  const prescan = runEmitPrescanPhase(programLoweringContext);
+  // --- Phase 3: lowering (bytes + fixup queues) ---
+  const lowered = runEmitLoweringPhase(programLoweringContext, prescan);
 
   flushTrailingUserComments();
 
-  const finalized = finalizeEmitProgram({
-    namedSectionSinks,
-    diagnostics,
-    diag,
-    diagAt,
-    primaryFile,
-    baseExprs,
-    evalImmExpr,
-    env,
-    loweredAsmStream,
-    codeOffset: lowered.codeOffset,
-    dataOffset: lowered.dataOffset,
-    varOffset: lowered.varOffset,
-    pending: lowered.pending,
-    symbols: lowered.symbols,
-    absoluteSymbols: lowered.absoluteSymbols,
-    deferredExterns: lowered.deferredExterns,
-    fixups,
-    rel8Fixups,
-    codeBytes: lowered.codeBytes,
-    dataBytes: lowered.dataBytes,
-    hexBytes: lowered.hexBytes,
-    bytes,
-    codeSourceSegments,
-    alignTo,
-    writeSection,
-    computeWrittenRange,
-    rebaseCodeSourceSegments,
-    ...(options?.defaultCodeBase !== undefined ? { defaultCodeBase: options.defaultCodeBase } : {}),
-  });
+  // --- Phase 4: placement, fixup resolution, merged `EmittedByteMap` ---
+  const finalized = runEmitPlacementAndArtifactPhase(
+    mergeEmitFinalizationContext(lowered, {
+      namedSectionSinks,
+      diagnostics,
+      diag,
+      diagAt,
+      primaryFile,
+      baseExprs,
+      evalImmExpr,
+      env,
+      loweredAsmStream,
+      fixups,
+      rel8Fixups,
+      bytes,
+      codeSourceSegments,
+      alignTo,
+      writeSection,
+      computeWrittenRange,
+      rebaseCodeSourceSegments,
+      ...(options?.defaultCodeBase !== undefined
+        ? { defaultCodeBase: options.defaultCodeBase }
+        : {}),
+    }),
+  );
   return { ...finalized, loweredAsmStream };
 }
+
+export type { EmitProgramOptions, EmitProgramResult } from './emitPipeline.js';

--- a/src/lowering/emitPipeline.ts
+++ b/src/lowering/emitPipeline.ts
@@ -1,0 +1,100 @@
+/**
+ * Emit orchestration phases for `emitProgram`.
+ *
+ * Pipeline (conceptual):
+ *
+ * 1. **Workspace setup** — lives in `emit.ts`: section byte maps, fixup queues, visibility,
+ *    resolution helpers, and the program-lowering context (`createEmitProgramContext`). This
+ *    phase wires mutable state and callbacks; it does not traverse the whole program yet.
+ *
+ * 2. **Prescan** — `runEmitPrescanPhase`: discover callables, ops, storage aliases, and
+ *    raw-address names so later lowering can resolve symbols. Product: {@link PrescanResult}.
+ *
+ * 3. **Lowering** — `runEmitLoweringPhase`: traverse declarations and functions, emit bytes
+ *    into section maps, enqueue fixups. Product: {@link LoweringResult}.
+ *
+ * 4. **Placement & artifacts** — `runEmitPlacementAndArtifactPhase`: named-section placement,
+ *    fixup resolution, merged `EmittedByteMap`, symbol table, placed lowered-ASM program.
+ *    Input: {@link EmitFinalizationContext} (built via {@link mergeEmitFinalizationContext}).
+ *
+ * Format writers stay in `compile.ts` / `PipelineDeps`; this module only produces the
+ * in-memory products they consume.
+ */
+
+import type { EmittedByteMap, SymbolEntry } from '../formats/types.js';
+import type { NonBankedSectionKeyCollection } from '../sectionKeys.js';
+import type { OpStackPolicyMode } from '../pipeline.js';
+import { finalizeEmitProgram, type EmitFinalizationContext } from './emitFinalization.js';
+import type { LoweredAsmProgram, LoweredAsmStream } from './loweredAsmTypes.js';
+import {
+  lowerProgramDeclarations,
+  preScanProgramDeclarations,
+  type Context as ProgramLoweringContext,
+  type LoweringResult,
+  type PrescanResult,
+} from './programLowering.js';
+
+export type { LoweringResult, PrescanResult };
+
+/** Options for `emitProgram` (include paths, policy flags, listing sources). */
+export type EmitProgramOptions = {
+  includeDirs?: string[];
+  opStackPolicy?: OpStackPolicyMode;
+  rawTypedCallWarnings?: boolean;
+  defaultCodeBase?: number;
+  namedSectionKeys?: NonBankedSectionKeyCollection;
+  sourceTexts?: Map<string, string>;
+  sourceLineComments?: Map<string, Map<number, string>>;
+};
+
+/** In-memory compile products passed to format writers (plus trace stream). */
+export type EmitProgramResult = {
+  map: EmittedByteMap;
+  symbols: SymbolEntry[];
+  loweredAsmStream: LoweredAsmStream;
+  placedLoweredAsmProgram: LoweredAsmProgram;
+};
+
+/** Environment for finalization that is *not* part of {@link LoweringResult}. */
+export type EmitFinalizationPhaseEnv = Omit<EmitFinalizationContext, keyof LoweringResult>;
+
+/**
+ * Combine lowering output with placement/fixup inputs. `lowered` is the typed handoff from
+ * the lowering phase; `env` holds shared refs (maps, diagnostics, helpers) held across phases.
+ */
+export function mergeEmitFinalizationContext(
+  lowered: LoweringResult,
+  env: EmitFinalizationPhaseEnv,
+): EmitFinalizationContext {
+  return { ...lowered, ...env };
+}
+
+/** Deterministic empty result when compilation aborts before lowering (e.g. no modules). */
+export function emitProgramEmptyResult(): EmitProgramResult {
+  return {
+    map: { bytes: new Map() },
+    symbols: [],
+    loweredAsmStream: { blocks: [] },
+    placedLoweredAsmProgram: { blocks: [] },
+  };
+}
+
+/** Phase 2 — prescan: build visibility maps and alias metadata before emission. */
+export function runEmitPrescanPhase(ctx: ProgramLoweringContext): PrescanResult {
+  return preScanProgramDeclarations(ctx);
+}
+
+/** Phase 3 — lowering: emit declarations and functions into section bytes and fixup queues. */
+export function runEmitLoweringPhase(
+  ctx: ProgramLoweringContext,
+  prescan: PrescanResult,
+): LoweringResult {
+  return lowerProgramDeclarations(ctx, prescan);
+}
+
+/** Phase 4 — placement, fixups, merged map and placed lowered ASM. */
+export function runEmitPlacementAndArtifactPhase(
+  context: EmitFinalizationContext,
+): Omit<EmitProgramResult, 'loweredAsmStream'> {
+  return finalizeEmitProgram(context);
+}


### PR DESCRIPTION
## Summary
Implements [#1060](https://github.com/jhlagado/ZAX/issues/1060): **explicit multi-phase emit orchestration** with **named, typed handoffs** instead of an opaque tail in `emit.ts`.

## Phases (see `emitPipeline.ts` module doc)
1. **Workspace setup** — remains in `emit.ts` (section maps, helpers, `createEmitProgramContext`).
2. **Prescan** — `runEmitPrescanPhase` → `PrescanResult`.
3. **Lowering** — `runEmitLoweringPhase` → `LoweringResult`.
4. **Placement & artifacts** — `mergeEmitFinalizationContext` + `runEmitPlacementAndArtifactPhase` → `EmittedByteMap`, symbols, placed lowered ASM.

## API
- `EmitProgramOptions` / `EmitProgramResult` single source of truth for `emitProgram` signature.
- `emitProgramEmptyResult` for the no-modules early exit.

## Testing
- `npm run typecheck`
- `npx vitest run` (full suite, 754 tests)

Fixes #1060

Made with [Cursor](https://cursor.com)