### PR TITLE
docs(addressing): navigable steps.ts sections and overview (#1082)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Current user- and contributor-facing references.
 - [`docs/reference/ZAX-quick-guide.md`](reference/ZAX-quick-guide.md) — practical language guide
 - [`docs/reference/testing-verification-guide.md`](reference/testing-verification-guide.md) — testing and verification flow
 - [`docs/reference/source-overview.md`](reference/source-overview.md) — compiler source structure
+- [`docs/reference/addressing-steps-overview.md`](reference/addressing-steps-overview.md) — map of `addressing/steps.ts` template and EA-builder families
 - [`docs/reference/zax-dev-playbook.md`](reference/zax-dev-playbook.md) — contributor workflow and review hygiene
 - [`docs/reference/codegen-corpus-workflow.md`](reference/codegen-corpus-workflow.md) — curated corpus workflow
 

--- a/docs/reference/addressing-steps-overview.md
+++ b/docs/reference/addressing-steps-overview.md
@@ -1,0 +1,71 @@
+# Addressing step library (`src/addressing/steps.ts`)
+
+Status: non-normative map of the step-pipeline DSL. The source of truth is the TypeScript module;
+this page helps you jump to the right **family** without reading the file top-to-bottom.
+
+**Register roles (typical):** `DE` holds a base address, `HL` holds an index or computed EA after
+`CALC_EA` / `CALC_EA_WIDE`. Templates save/restore registers around nested EA work.
+
+---
+
+## 1. Types and rendering
+
+- **`StepInstr`**, **`StepPipeline`** — serializable micro-ops (`push`/`pop`, `ld`, IX+disp, …).
+- **`renderStepInstr`**, **`renderStepPipeline`** — pseudo-assembly strings for tests and debugging.
+
+---
+
+## 2. Save / restore and exchange
+
+- **`SAVE_HL`**, **`SAVE_DE`**, **`RESTORE_HL`**, **`RESTORE_DE`**, **`SWAP_HL_DE`** — stack/exchange
+  glue used by templates.
+
+---
+
+## 3. Base and index loaders
+
+- **Base (into DE):** `LOAD_BASE_GLOB`, `LOAD_BASE_FVAR`
+- **Index (into HL):** `LOAD_IDX_CONST`, `LOAD_IDX_REG`, `LOAD_IDX_RP`, `LOAD_IDX_GLOB`, `LOAD_IDX_FVAR`
+
+---
+
+## 4. EA combination
+
+- **`CALC_EA`** — `HL ← HL + DE` (byte stride).
+- **`CALC_EA_2`**, **`CALC_EA_WIDE`** — wider or scaled indexing (e.g. word-sized elements).
+
+---
+
+## 5. Direct accessors (byte and word)
+
+- **Byte at EA in HL:** `LOAD_REG_EA`, `STORE_REG_EA`; reg↔glob: `LOAD_REG_GLOB`, `STORE_REG_GLOB`,
+  `LOAD_REG_REG`.
+- **Word at EA:** `LOAD_RP_EA`, `STORE_RP_EA`, `STORE_RP_EA_FROM_STACK`; glob/fvar:
+  `LOAD_RP_GLOB`, `STORE_RP_GLOB`, `LOAD_RP_FVAR`, `STORE_RP_FVAR`.
+
+---
+
+## 6. EA builder families (`EA_*` / `EAW_*`)
+
+Named for **base × index** shape: glob vs frame-var (`FVAR`), const vs reg vs RP vs nested glob.
+
+- **Byte (`EA_*`):** e.g. `EA_GLOB_CONST`, `EA_FVAR_REG`, `EA_GLOB_GLOB`, … — finish with `CALC_EA`.
+- **Word (`EAW_*`):** same naming pattern — use `CALC_EA_WIDE` with default `elemSize` (typically 2).
+
+---
+
+## 7. Templates (compose builders + accessors)
+
+High-level patterns that wrap an inner `ea: StepPipeline` with saves/restores and the right load/store:
+
+- **Byte load:** `TEMPLATE_L_ABC`, `TEMPLATE_L_HL`, `TEMPLATE_L_DE`
+- **Byte store:** `TEMPLATE_S_ANY`, `TEMPLATE_S_HL`
+- **Word load:** `TEMPLATE_LW_HL`, `TEMPLATE_LW_DE`, `TEMPLATE_LW_BC`
+- **Word store:** `TEMPLATE_SW_DEBC`, `TEMPLATE_SW_HL`
+
+---
+
+## 8. In-file section markers
+
+`steps.ts` uses `// --- Section: … ---` comments aligned with the groups above. For the exact export
+list, search by prefix (`EA_`, `TEMPLATE_`, …) or follow those section headers.

--- a/docs/reference/source-overview.md
+++ b/docs/reference/source-overview.md
@@ -30,7 +30,7 @@ src/
   pipeline.ts             Type contracts only: CompilerOptions, CompileResult, PipelineDeps
 
   addressing/
-    steps.ts              Step-pipeline primitives (EA builders, load/store templates)
+    steps.ts              Step-pipeline primitives (EA builders, load/store templates); section comments + see docs/reference/addressing-steps-overview.md
 
   diagnostics/
     types.ts              Diagnostic type + stable ID registry (ZAX000–ZAX501)
@@ -326,8 +326,12 @@ uses a DE shuttle (`ex de,hl` / `ld d/e,(ix+d)` / `ex de,hl`) for these cases.
 ### 4.7 Lowering: Step Pipelines
 
 `addressing/steps.ts` defines a step-pipeline abstraction. A `StepPipeline` is an ordered list
-of `AddressingStep` values. Steps are combined by templates (e.g., `TEMPLATE_L_ABC`,
+of `StepInstr` values. Steps are combined by templates (e.g., `TEMPLATE_L_ABC`,
 `TEMPLATE_LW_HL`) and then executed by `emitStepPipeline` in `emissionCore.ts`.
+
+For a **family-level map** of EA builders, load/store templates, and EA-combine helpers (without
+reading the whole source linearly), see [`addressing-steps-overview.md`](addressing-steps-overview.md).
+The module itself uses `// --- Section: … ---` comments grouping exports the same way.
 
 Steps encode operations like:
 

--- a/src/addressing/steps.ts
+++ b/src/addressing/steps.ts
@@ -3,8 +3,23 @@
  *
  * These helpers are pure: they return typed step pipelines.
  * Rendering to pseudo-assembly text is only for tests/document checks.
+ *
+ * **Navigation:** Section comments below group exports. Family-level map:
+ * [`docs/reference/addressing-steps-overview.md`](../../../docs/reference/addressing-steps-overview.md).
+ *
+ * | Area | Exports (representative) |
+ * |------|-------------------------|
+ * | Types / render | `StepInstr`, `StepPipeline`, `renderStepInstr`, `renderStepPipeline` |
+ * | Save/restore | `SAVE_*`, `RESTORE_*`, `SWAP_HL_DE` |
+ * | Base & index | `LOAD_BASE_*`, `LOAD_IDX_*` |
+ * | EA combine | `CALC_EA`, `CALC_EA_2`, `CALC_EA_WIDE` |
+ * | Byte accessors | `LOAD_REG_EA`, `STORE_REG_EA`, `LOAD_REG_GLOB`, … |
+ * | Word accessors | `LOAD_RP_EA`, `STORE_RP_EA`, `LOAD_RP_GLOB`, `LOAD_RP_FVAR`, … |
+ * | EA builders (byte / word) | `EA_*`, `EAW_*` |
+ * | Templates | `TEMPLATE_L_*`, `TEMPLATE_S_*`, `TEMPLATE_LW_*`, `TEMPLATE_SW_*` |
  */
 
+// --- Section: Types, StepInstr, and rendering helpers ---
 export type StepReg8 =
   | 'A'
   | 'B'
@@ -113,18 +128,14 @@ export function renderStepInstr(instr: StepInstr): string {
 export const renderStepPipeline = (pipeline: StepPipeline): string[] =>
   pipeline.map(renderStepInstr);
 
-// ---------------------------------------------------------------------------
-// Save / restore
-// ---------------------------------------------------------------------------
+// --- Section: Save / restore ---
 export const SAVE_HL = (): StepPipeline => [step({ kind: 'push', reg: 'HL' })];
 export const SAVE_DE = (): StepPipeline => [step({ kind: 'push', reg: 'DE' })];
 export const RESTORE_HL = (): StepPipeline => [step({ kind: 'pop', reg: 'HL' })];
 export const RESTORE_DE = (): StepPipeline => [step({ kind: 'pop', reg: 'DE' })];
 export const SWAP_HL_DE = (): StepPipeline => [step({ kind: 'exDeHl' })];
 
-// ---------------------------------------------------------------------------
-// Base loaders (DE = base)
-// ---------------------------------------------------------------------------
+// --- Section: Base loaders (DE = base) ---
 export const LOAD_BASE_GLOB = (glob: string): StepPipeline => [
   step({ kind: 'ldRpGlob', rp: 'DE', glob }),
 ];
@@ -134,9 +145,7 @@ export const LOAD_BASE_FVAR = (disp: number): StepPipeline => [
   step({ kind: 'ldRegIxDisp', reg: 'd', disp: disp + 1 }),
 ];
 
-// ---------------------------------------------------------------------------
-// Index loaders (HL = index)
-// ---------------------------------------------------------------------------
+// --- Section: Index loaders (HL = index) ---
 export const LOAD_IDX_CONST = (value: number): StepPipeline => [
   step({ kind: 'ldRpImm', rp: 'HL', value }),
 ];
@@ -158,9 +167,7 @@ export const LOAD_IDX_FVAR = (disp: number): StepPipeline => [
   ...SWAP_HL_DE(),
 ];
 
-// ---------------------------------------------------------------------------
-// Combine
-// ---------------------------------------------------------------------------
+// --- Section: Combine (HL + DE → EA) ---
 export const CALC_EA = (): StepPipeline => [step({ kind: 'addHlDe' })];
 
 export const CALC_EA_2 = (): StepPipeline => [step({ kind: 'addHlHl' }), step({ kind: 'addHlDe' })];
@@ -207,9 +214,7 @@ export const CALC_EA_WIDE = (elemSize: number): StepPipeline => {
   return shiftCount !== undefined ? calcEaShift(shiftCount) : calcEaExact(elemSize);
 };
 
-// ---------------------------------------------------------------------------
-// Accessors (byte)
-// ---------------------------------------------------------------------------
+// --- Section: Accessors (byte) ---
 export const LOAD_REG_EA = (reg: string): StepPipeline => [
   step({ kind: 'ldRegMemHl', reg: reg as StepReg8 }),
 ];
@@ -248,9 +253,7 @@ export const LOAD_REG_REG = (dst: string, src: string): StepPipeline => [
   }),
 ];
 
-// ---------------------------------------------------------------------------
-// Accessors (word)
-// ---------------------------------------------------------------------------
+// --- Section: Accessors (word) ---
 export const LOAD_RP_EA = (rp: string): StepPipeline => [
   step({ kind: 'ldRegMemHl', reg: 'e' }),
   step({ kind: 'incHl' }),
@@ -336,9 +339,7 @@ export const STORE_RP_FVAR = (rp: string, disp: number): StepPipeline => [
       ]),
 ];
 
-// ---------------------------------------------------------------------------
-// EA builders (byte size, HL=EA)
-// ---------------------------------------------------------------------------
+// --- Section: EA builders (byte size, HL = EA) ---
 export const EA_GLOB_CONST = (glob: string, idxConst: number): StepPipeline => [
   ...LOAD_BASE_GLOB(glob),
   ...LOAD_IDX_CONST(idxConst),
@@ -398,9 +399,7 @@ export const EA_GLOB_GLOB = (globBase: string, globIdx: string): StepPipeline =>
   ...CALC_EA(),
 ];
 
-// ---------------------------------------------------------------------------
-// EA builders (word size, HL=EA, scaled by 2)
-// ---------------------------------------------------------------------------
+// --- Section: EA builders (word size, HL = EA, scaled) ---
 export const EAW_GLOB_CONST = (glob: string, idxConst: number, elemSize = 2): StepPipeline => [
   ...LOAD_BASE_GLOB(glob),
   ...LOAD_IDX_CONST(idxConst),
@@ -460,9 +459,7 @@ export const EAW_GLOB_GLOB = (globBase: string, globIdx: string, elemSize = 2): 
   ...CALC_EA_WIDE(elemSize),
 ];
 
-// ---------------------------------------------------------------------------
-// Templates: byte loads
-// ---------------------------------------------------------------------------
+// --- Section: Templates — byte loads ---
 export const TEMPLATE_L_ABC = (dest: string, ea: StepPipeline): StepPipeline => [
   ...SAVE_DE(),
   ...SAVE_HL(),
@@ -492,9 +489,7 @@ export const TEMPLATE_L_DE = (dest: 'D' | 'E', ea: StepPipeline): StepPipeline =
   ...RESTORE_HL(),
 ];
 
-// ---------------------------------------------------------------------------
-// Templates: byte stores
-// ---------------------------------------------------------------------------
+// --- Section: Templates — byte stores ---
 export const TEMPLATE_S_ANY = (vreg: string, ea: StepPipeline): StepPipeline => [
   ...SAVE_DE(),
   ...SAVE_HL(),
@@ -513,9 +508,7 @@ export const TEMPLATE_S_HL = (vreg: 'H' | 'L', ea: StepPipeline): StepPipeline =
   ...RESTORE_DE(),
 ];
 
-// ---------------------------------------------------------------------------
-// Templates: word loads
-// ---------------------------------------------------------------------------
+// --- Section: Templates — word loads ---
 export const TEMPLATE_LW_HL = (ea: StepPipeline): StepPipeline => [
   ...SAVE_DE(),
   ...ea,
@@ -542,9 +535,7 @@ export const TEMPLATE_LW_BC = (ea: StepPipeline): StepPipeline => [
   ...RESTORE_DE(),
 ];
 
-// ---------------------------------------------------------------------------
-// Templates: word stores
-// ---------------------------------------------------------------------------
+// --- Section: Templates — word stores ---
 export const TEMPLATE_SW_DEBC = (vpair: 'DE' | 'BC', ea: StepPipeline): StepPipeline =>
   vpair === 'DE'
     ? [...SAVE_HL(), ...SAVE_DE(), ...ea, ...RESTORE_DE(), ...STORE_RP_EA('DE'), ...RESTORE_HL()]
@@ -558,6 +549,7 @@ export const TEMPLATE_SW_HL = (ea: StepPipeline): StepPipeline => [
   ...RESTORE_DE(),
 ];
 
+// --- Section: Private helpers ---
 function formatDisp(disp: number): string {
   const hex = Math.abs(disp).toString(16).padStart(2, '0');
   const sign = disp >= 0 ? '+' : '-';


### PR DESCRIPTION
## Summary
Fixes #1082 — make `addressing/steps.ts` navigable without reading linearly.

## Changes
- **`src/addressing/steps.ts`**: `// --- Section: … ---` line markers; expanded file-header JSDoc with TOC table + link to markdown overview.
- **`docs/reference/addressing-steps-overview.md`** (new): family-level map of EA builders, accessors, templates, save/restore.
- **`docs/reference/source-overview.md`**: paragraph + link in §4.7; repo layout line for `steps.ts`; `AddressingStep` → `StepInstr` wording fix.
- **`docs/README.md`**: index entry for the new reference doc.

No emitted code / semantics change.

## Testing
- `npm run typecheck`
- `npx vitest run test/addressing_model_steps.test.ts`
- `npx vitest run` (full suite) run before commit

Fixes #1082

Made with [Cursor](https://cursor.com)