### PR TITLE
learning: prose review fixes for chapters 9–13

### DIFF
--- a/learning/part1/09-a-phase-a-program.md
+++ b/learning/part1/09-a-phase-a-program.md
@@ -4,12 +4,9 @@
 
 This chapter builds a complete program using everything from Chapters 3–7:
 a data table, a DJNZ loop, subroutines called from the loop, conditional
-branches, and push/pop register preservation. By the end you will be able to
-follow and write a complete raw Z80 program in ZAX. You will also be able to
-see the specific places where writing raw Z80 gets unwieldy — which is exactly
-what Chapters 10–13 address.
-
-Prerequisites: Chapters 3–7.
+branches, and push/pop register preservation. The two subroutines that result
+expose every friction point in raw Z80 programming — the exact problems
+Chapters 10–13 address.
 
 ---
 
@@ -166,17 +163,16 @@ is performed twice for each element.
 
 The program has real strengths at the raw level:
 
-The data layout is explicit. The programmer placed `values` at `$8000` and
-`max_val` and `above_64` at `$8020`. The two regions do not overlap, and the
-programmer knows exactly what lives at each address. There is no hidden
-allocation.
+The data layout is explicit. You placed `values` at `$8000` and
+`max_val` and `above_64` at `$8020`. The two regions do not overlap, and you
+know exactly what lives at each address — nothing is allocated behind your back.
 
-The register usage is explicit. A reader who traces through `main` can follow
-exactly which registers carry which values at each line. There is no compiler-
-invisible magic.
+The register usage is explicit. Tracing through `main`, you can follow
+exactly which registers carry which values at each line. The compiler adds
+nothing you did not write.
 
-The subroutine call cost is explicit. Every `call` costs a stack push, and the
-programmer can count those pushes. There is no invisible calling machinery.
+The subroutine call cost is explicit. Every `call` costs a stack push, and you
+can count those pushes. No calling machinery is hidden.
 
 For a short, performance-sensitive routine — a counted loop over a small table
 — the raw approach produces code that maps directly to Z80 instructions with
@@ -186,14 +182,13 @@ no overhead between what you wrote and what the CPU executes.
 
 ## What gets harder as programs grow
 
-These are not complaints about the Z80. They are the specific things that get
-tedious once programs grow past a handful of subroutines.
+These are the specific things that get tedious once programs grow past a handful of subroutines.
 
 **Label names are structural noise.** Every loop needs at least two labels: the
 top-of-loop label and the skip label for the conditional update. Every
 if-like branch needs at least one label for the not-taken path. None of these
-carry meaning about what the code is doing — they are just targets for jumps.
-The programmer has to invent names for them, place them correctly, and make sure
+carry meaning about what the code is doing — they are only targets for jumps.
+You have to invent names for them, place them correctly, and make sure
 every branch reaches the right one. In a ten-line subroutine this is fine. In a
 program with twenty subroutines it becomes work that has nothing to do with the
 actual problem.
@@ -232,8 +227,6 @@ Chapters 10–13 each fix one of the problems above.
 
 None of this hides the machine. Everything translates to the same Z80 instructions as before. What changes is that the source shows the intent, and the compiler writes the scaffolding.
 
-Chapter 10 starts there.
-
 ---
 
 ## Summary
@@ -245,18 +238,12 @@ Chapter 10 starts there.
 - The caller must reload any register that the callee modified before the next
   call. Nothing enforces this.
 - Loop labels, skip labels, and conditional branch labels are structural noise:
-  they give jumps a target, but carry no meaning about what the code does. The
-  programmer has to manage them correctly.
+  they give jumps a target, but carry no meaning about what the code does. You
+  have to manage them correctly.
 - Push/pop pairs appear when a function needs to initialize a register that
   already holds an input. The real problem is not having named variables.
 - Chapters 10–13 — ZAX functions, `if`/`while`, `:=`, and `op` — each address
   one of these problems, while generating the same Z80 output.
-
-## What Comes Next
-
-Chapter 10 introduces the first ZAX-specific feature beyond the program shell:
-functions with named parameters and local variables, accessed through raw
-IX-relative addressing.
 
 ---
 

--- a/learning/part1/10-functions-and-the-ix-frame.md
+++ b/learning/part1/10-functions-and-the-ix-frame.md
@@ -90,7 +90,7 @@ find_max_skip:
 end
 ```
 
-Look at what happened. The comment block is gone — the parameter names `tbl` and `len` say what the function expects. The local `running_max` says what it holds. And every access is a standard Z80 `ld` instruction with an IX-relative offset. The compiler resolves `(ix+tbl+0)` to the correct numeric displacement. You never count stack slots by hand.
+The comment block is gone — the parameter names `tbl` and `len` say what the function expects. The local `running_max` says what it holds. And every access is a standard Z80 `ld` instruction with an IX-relative offset. The compiler resolves `(ix+tbl+0)` to the correct numeric displacement. You never count stack slots by hand.
 
 `tbl: addr` is a 16-bit address parameter — it occupies a two-byte frame slot. To load it into HL you need two byte-wide loads: `(ix+tbl+0)` for the low byte into L, `(ix+tbl+1)` for the high byte into H.
 
@@ -133,7 +133,7 @@ The return clause controls which registers carry the result and which ones the c
 | `func f(): AF` | A carries the result | BC, DE, HL saved; AF is not |
 | `func f(): HL` | Typed return in HL (byte in L, H = 0) | AF, BC, DE saved; HL is not |
 
-`: AF` does **not** deliver A through a typed mechanism. It simply removes AF from the save/restore set, so whatever value A holds at function exit survives into the caller. This is the same convention from Chapter 7 — caller and callee agree that A carries the result. The declaration tells the compiler not to clobber it with a `pop AF` in the epilogue.
+`: AF` removes AF from the save/restore set, so whatever value A holds at function exit survives into the caller. This is the same convention from Chapter 7 — caller and callee agree that A carries the result. The declaration tells the compiler not to clobber it with a `pop AF` in the epilogue.
 
 `: HL` is the typed return: byte values go in L (H zeroed), word values fill all of HL.
 
@@ -145,7 +145,7 @@ Omitting the return clause when the function leaves a meaningful value in A is a
 
 Everything in this chapter uses raw Z80 instructions to access frame slots. You write `ld a, (ix+running_max+0)` and the compiler resolves the name to an offset. This is deliberate: you already know IX-relative addressing from Chapter 6. The frame is just a structured use of what you already learned.
 
-ZAX also provides a typed assignment operator — `:=` — that handles frame access at a higher level. It picks the right registers, handles word-sized slots that need multi-instruction sequences, and checks types. Chapter 12 covers `:=` in full. By the time you get there, you will understand exactly what it generates, because you will have written the raw version by hand.
+ZAX also provides a typed assignment operator — `:=` — that handles frame access at a higher level. It picks the right registers, handles word-sized slots that need multi-instruction sequences, and checks types. Chapter 12 covers `:=` in full. You will have written the raw version by hand by then, so you will know exactly what it generates.
 
 ---
 

--- a/learning/part1/11-structured-control-flow.md
+++ b/learning/part1/11-structured-control-flow.md
@@ -2,12 +2,9 @@
 
 # Chapter 11 — Structured Control Flow
 
-This chapter introduces `if`/`else`, `while`, `break`, and `continue`. After
-reading it you will be able to replace raw flag-test-and-jump sequences with
-`if`/`else`, replace manual loop-label structures with `while`, and use `break`
-and `continue` to exit or restart a loop without writing explicit jump targets.
-
-Prerequisites: Chapters 3–10.
+This chapter introduces `if`/`else`, `while`, `break`, and `continue` — the
+structured replacements for manual flag-test-and-jump sequences and invented
+loop labels.
 
 ---
 
@@ -48,8 +45,7 @@ end
 
 The compiler emits a conditional jump over the first body and an unconditional
 jump over the second, along with the hidden labels needed to make them target the
-right locations. The programmer writes the intent; the compiler manages the
-targets.
+right locations. You write the intent; the compiler manages the targets.
 
 `else` is optional. `if NC ... end` with no `else` branch is the direct
 replacement for the raw pattern:
@@ -114,8 +110,7 @@ loop_exit:
 
 Both forms check the condition before executing the body even once. `while NZ`
 replaces the pair `loop_top:` + `jr nz, loop_top` and the exit label
-`loop_exit:`, while keeping the entry check. The programmer writes one `while NZ`
-line instead of managing two labels and two jump instructions.
+`loop_exit:`, while keeping the entry check. You write one `while NZ` line instead of managing two labels and two jump instructions.
 
 ---
 
@@ -124,7 +119,7 @@ line instead of managing two labels and two jump instructions.
 `while NZ` does not set flags. It reads them. The flags at the `while` keyword
 are exactly whatever instruction last set them.
 
-`ld` instructions on the Z80 do not affect flags. This is the most common mistake:
+`ld` instructions on the Z80 do not affect flags. The trap is using `while` immediately after `ld`:
 
 ```zax
 ; WRONG — ld b, 10 does not set flags
@@ -136,8 +131,8 @@ while NZ          ; tests stale flags from whatever ran before
 end
 ```
 
-The fix is to establish flags explicitly before the loop. The standard pattern
-for a loop over B counts is to copy B into A and `or a`:
+The fix is to establish flags explicitly before the loop. To drive a `while NZ`
+loop from B, copy B into A and `or a`:
 
 ```zax
 ld b, 10
@@ -201,9 +196,8 @@ end
 the flags must correctly represent the intended condition at the moment
 `continue` executes.
 
-`break` and `continue` only affect the immediately enclosing loop. If you have
-nested `while` loops, `break` exits the inner one. There is no labeled-loop form
-in the current language.
+`break` and `continue` only affect the immediately enclosing loop. Nested `while`
+loops have no labeled form — `break` always exits the innermost one.
 
 ---
 
@@ -345,15 +339,12 @@ the branch-back. `djnz` fused decrement-and-branch into one instruction; with
 **Flag behavior: `djnz` vs `dec b`.** `djnz` does not affect the Z flag — it
 uses its own internal decrement-and-branch without touching the flag register.
 `dec b`, by contrast, does set the Z flag (as well as S, H, and P/V). When
-using `dec b` to drive a `while NZ` loop, the `dec b / ld a, b / or a`
-back-edge sequence is needed because `or a` re-establishes the Z flag from the
-current value of A (which was just loaded from B). This extra step is required
-because `dec b` alone sets Z correctly, but the back-edge test in the `while`
-loop reads the flags at the `end` line, and any instruction between `dec b` and
-`end` may have changed them. The `ld a, b / or a` sequence ensures the final
-flag state before the back-edge test reflects B's value, not whatever a previous
-instruction left in the flags. Note: `djnz` cannot be directly replaced by `dec b / jr nz` in a `while` loop
-without this extra flag-establishment step.
+using `dec b` to drive a `while NZ` loop, the back-edge needs the
+`ld a, b / or a` sequence: `dec b` alone sets Z correctly, but any instruction
+between `dec b` and `end` can change the flags before the back-edge test reads
+them. The `ld a, b / or a` re-establishes the flag state from B's current
+value. `djnz` cannot be directly replaced by `dec b / jr nz` in a `while` loop
+without this flag-establishment step.
 
 **`count_above` — raw (Chapter 9):**
 
@@ -462,14 +453,6 @@ jump. In the structured version, each is expressed by the keyword that carries i
 - Structured control flow does not hide the machine. Each `if`/`else`/`end` and
   `while`/`end` generates the same conditional jumps and labels. The compiler manages the labels;
   you manage the flags.
-
-## What Comes Next
-
-Chapter 12 introduces `:=`, the typed assignment operator. You have been writing
-`ld a, (ix+running_max+0)` and `ld (ix+cnt+0), a` by hand. `:=` automates
-these frame accesses — the compiler picks the right registers, handles
-word-sized slots, and checks types. By the time you read Chapter 12, you will
-understand exactly what `:=` generates.
 
 ---
 

--- a/learning/part1/12-typed-assignment.md
+++ b/learning/part1/12-typed-assignment.md
@@ -2,9 +2,7 @@
 
 # Chapter 12 — Typed Assignment
 
-You have spent two chapters writing `ld a, (ix+running_max+0)` and `ld (ix+cnt+0), a` by hand. You know what each frame access costs, you know where the offsets come from, and you know the low-byte / high-byte drill for word-sized slots. This chapter introduces `:=`, the typed assignment operator, which automates all of that. It is not a new concept — it is shorthand for what you already do.
-
-Prerequisites: Chapters 3–11.
+You have spent two chapters writing `ld a, (ix+running_max+0)` and `ld (ix+cnt+0), a` by hand. You know what each frame access costs, you know where the offsets come from, and you know the low-byte / high-byte drill for word-sized slots. This chapter introduces `:=`, the typed assignment operator, which automates all of that — shorthand for what you already do.
 
 The companion example is `learning/part1/examples/11_functions_and_op.zax`.
 
@@ -21,7 +19,7 @@ hl := total     ; load the 16-bit value of 'total' into HL
 total := hl     ; store HL into 'total'
 ```
 
-`:=` is not another spelling of `ld`. `ld` is a raw Z80 instruction — you choose the operand form and the assembler encodes it exactly as written. `:=` is a typed assignment: the compiler checks that the left side is writable storage, checks that the right side is a compatible value, and emits whatever instruction sequence is needed.
+`ld` is a raw Z80 instruction — you choose the operand form and the assembler encodes it exactly as written. `:=` is a typed assignment: the compiler checks that the left side is writable storage, checks that the right side is a compatible value, and emits whatever instruction sequence is needed.
 
 For a byte-sized local, `count := a` emits a single `ld (ix-N), a` — exactly what you wrote by hand in Chapters 10 and 11.
 
@@ -103,7 +101,7 @@ find_max_skip:
   a := running_max
 ```
 
-The generated code is identical. `running_max := a` emits `ld (ix-N), a`. `a := running_max` emits `ld a, (ix-N)`. The names resolve to the same offsets. The `:=` form is just easier to read.
+The generated code is identical. `running_max := a` emits `ld (ix-N), a`. `a := running_max` emits `ld a, (ix-N)`. The names resolve to the same offsets. The `:=` form is easier to read.
 
 **`count_above` — raw IX (Chapter 10):**
 
@@ -150,10 +148,6 @@ Both are always available. Neither is required. The choice is about clarity for 
 - Use bare names with `:=` for typed locals. Do not use `(name)` — that means something different.
 - Raw Z80 instructions can still use typed names as operands. The compiler resolves them to IX-relative offsets.
 - `:=` and raw access are complementary. Use whichever is clearest.
-
-## What Comes Next
-
-Chapter 13 introduces `op` — inline named operations that expand at every call site with no frame overhead — and the ZAX pseudo-opcodes for 16-bit register moves.
 
 ---
 

--- a/learning/part1/13-op-macros-and-pseudo-opcodes.md
+++ b/learning/part1/13-op-macros-and-pseudo-opcodes.md
@@ -4,13 +4,11 @@
 
 This chapter covers two features that extend the Z80's native instruction set without adding run-time cost: `op`, which lets you name a short instruction sequence and expand it inline at every call site, and the ZAX pseudo-opcodes, which let you write `ld hl, de` as if the Z80 had a 16-bit register copy instruction.
 
-Prerequisites: Chapters 3–12.
-
 ---
 
 ## `op`: inline named operations
 
-`op` defines a named operation whose body is copied into the instruction stream at every call site. There is no `call`, no frame, and no `ret`. The body is pasted directly where the op is invoked, as if you had written the instructions there yourself.
+`op` defines a named operation whose body is pasted into the instruction stream at every call site — no `call`, no frame, no `ret` — as if you had written the instructions there yourself.
 
 ```zax
 op load_and_or(src: reg8)
@@ -26,7 +24,7 @@ ld a, b
 or a
 ```
 
-The "copy B into A and set flags" pattern appears before every `while NZ` loop and at every back edge. Without the op, you write those two instructions by hand in every place. With the op, you write them once in the declaration and once at each invocation. The reader sees `load_and_or B` and knows immediately what instruction pair will appear.
+The "copy B into A and set flags" pattern appears before every `while NZ` loop and at every back edge. Without the op, you write those two instructions by hand in every place. With the op, you write them once in the declaration and once at each invocation. You see `load_and_or B` and know immediately what instruction pair will appear.
 
 **`reg8` parameters accept only physical register names.** At the call site, a `reg8` parameter must be one of the seven physical registers: A, B, C, D, E, H, or L. A frame-slot name like `len` is not valid — the compiler substitutes the register token directly into the body instruction, and that substitution only makes sense if the operand is a register. If the value lives in a frame slot, load it into a register first:
 
@@ -66,7 +64,7 @@ Use `func` when:
 
 ## ZAX pseudo-opcodes: synthetic 16-bit register moves
 
-The Z80 has no instruction to copy one register pair into another. To copy HL into DE in raw Z80, you write two 8-bit moves:
+Copying HL into DE in raw Z80 takes two 8-bit moves:
 
 ```zax
 ld d, h
@@ -106,7 +104,7 @@ Each expands to exactly two bytes of machine code. The cost is the same as writi
 
 ---
 
-## What Comes Next
+## Part 1 complete
 
 You have completed Volume 1.
 


### PR DESCRIPTION
## Summary

Three-pass prose review (technical accuracy, structural, AI-tic check) applied to the final five chapters of Part 1.

- **Ch9**: cut syllabus opener and `Prerequisites:` meta-note; replace `the programmer` with `you` throughout; cut negative opener "These are not complaints about the Z80"; fix three `There is no hidden/invisible/calling` dead openers; cut "What Comes Next" section; cut hollow "Chapter 10 starts there."
- **Ch10**: cut "Look at what happened." performative opener; remove "`: AF` does **not** deliver A... It simply removes" (negative definition + "simply" minimiser); soften "By the time you get there" deferral
- **Ch11**: cut syllabus opener and `Prerequisites:`; fix two "The programmer" → "you"; replace "This is the most common mistake" classification and "The standard pattern for" (Pattern 8); cut "There is no labeled-loop form" dead opener; rewrite tangled `djnz` vs `dec b` run-on sentence into three clear sentences; cut "What Comes Next" section
- **Ch12**: cut `Prerequisites:`; cut "`:=` is not another spelling of `ld`" negative definition (positive stands alone); cut "It is not a new concept"; remove "just" minimiser; cut "What Comes Next" section
- **Ch13**: cut `Prerequisites:`; rewrite "There is no `call`, no frame, and no `ret`." to lead with positive form; cut "The Z80 has no instruction to copy" negative definition; fix "The reader sees" → "you see"; rename "What Comes Next" → "Part 1 complete" (section content is a graduation summary, not a deferral — heading was the only problem)

No blockers found. All fixes are Significant or Polish severity.

## Test plan

- [ ] Read each chapter introduction: no syllabus opener, no `Prerequisites:` line
- [ ] Grep for "the programmer" in part1/ — should return zero matches in ch9–13
- [ ] Grep for "standard pattern" in ch11 — gone
- [ ] Grep for "most common mistake" in ch11 — gone
- [ ] Grep for "What Comes Next" in ch9–13 — gone (ch13 now says "Part 1 complete")
- [ ] Grep for ":= is not another" in ch12 — gone
- [ ] Verify ch13 graduation section content intact (bullet list of skills + Vol 2 intro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)