### PR TITLE
learning: apply human writer style to chapters 9–13

### DIFF
--- a/learning/part1/09-a-phase-a-program.md
+++ b/learning/part1/09-a-phase-a-program.md
@@ -80,9 +80,10 @@ explicit: every register used to pass arguments is loaded immediately before eac
 
 The table base address `values` must be loaded into HL again before each call
 because `find_max` advances HL past the end of the table. HL holds different
-values after each call. Nothing in the language tells the caller that HL was modified —
-you find out by reading the function, or by running the program and getting
-wrong results. The caller has to handle it manually.
+values after each call. Nothing in the language tells you that HL was modified —
+I say this directly, because it only surfaces as a bug once a program grows large
+enough. You find out by reading the function, or by running the program and
+getting wrong results.
 
 ---
 
@@ -145,8 +146,8 @@ zero D without disturbing B and C — which carry the function's inputs — is t
 do it before the loop touches B. The `push bc / ld d, 0 / pop bc` block saves
 B and C, performs the initialization, and restores them.
 
-In this specific case, `ld d, 0` does not actually disturb B or C, so the
-push/pop buys nothing mechanically. But the push/pop is here because you cannot
+Actually, `ld d, 0` does not disturb B or C in this specific case, so the
+push/pop achieves nothing mechanically. But the push/pop is here because you cannot
 name your variables in raw Z80 — you have to pick a register, and you cannot
 easily see at a glance which registers are already in use for what. When you
 cannot name things, you save everything and hope.
@@ -208,7 +209,7 @@ function body carefully, or by running the program and seeing wrong output.
 **The double `cp c` exists because there is no greater-than test.** `cp` gives
 you less-than (carry flag) and equal (zero flag). To test strictly greater-than,
 you need both. So the comparison runs twice. A structured `if value > threshold`
-would generate the same two instructions automatically, and the reader would see
+would generate the same two instructions automatically, and you would see
 the intent instead of the mechanism.
 
 ---

--- a/learning/part1/10-functions-and-the-ix-frame.md
+++ b/learning/part1/10-functions-and-the-ix-frame.md
@@ -32,7 +32,7 @@ Three parameters, three registers. And inside `count_above`, the running count h
 
 The problem compounds when functions call other functions. If `main` calls `find_max` and then `count_above`, it has to reload HL before the second call because `find_max` walked HL to the end of the table. The only way to know this is to read `find_max`'s body — the function signature says nothing about side effects.
 
-Raw register passing does not scale. It works for small programs where the programmer holds the entire register map in their head. Beyond that, you need a systematic way to pass values.
+Raw register passing does not scale. It works for small programs where you can hold the entire register map in your head. Beyond that, you need a systematic way to pass values.
 
 ---
 
@@ -58,7 +58,7 @@ pop ix           ; restore caller's IX
 ret
 ```
 
-Six instructions of overhead — three in, three out — plus any register saves. A raw `call` and `ret` are two instructions with no frame at all. The frame is not free. For a tight inner loop calling a tiny helper, the overhead may matter. For a function called a handful of times from a larger program, the cost is small relative to what the function actually does, and the gain in clarity is real.
+Six instructions of overhead — three in, three out — plus any register saves. A raw `call` and `ret` are two instructions with no frame at all. I want to be clear about this: the frame is not free. For a tight inner loop calling a tiny helper, the overhead may matter. For a function called a handful of times from a larger program, the cost is small relative to what the function actually does, and the gain in clarity is real.
 
 ---
 
@@ -179,7 +179,7 @@ end
 
 Three parameters and one local — four named values, each at its own IX-relative offset. In raw Z80, this function needed four registers (HL, B, C, D) and a `push bc / ld d, 0 / pop bc` dance just to initialize the counter without disturbing the inputs. Here, `cnt` has its own frame slot. No juggling.
 
-Notice that `cp (ix+threshold+0)` compares A directly against the frame slot. You do not have to load the threshold into a register first — `cp` accepts `(IX+d)` as its operand. This frees C, which the raw version had tied up holding the threshold.
+`cp (ix+threshold+0)` compares A directly against the frame slot. You do not have to load the threshold into a register first — `cp` accepts `(IX+d)` as its operand. This frees C, which the raw version had tied up holding the threshold.
 
 ---
 

--- a/learning/part1/11-structured-control-flow.md
+++ b/learning/part1/11-structured-control-flow.md
@@ -15,7 +15,7 @@ Chapter 9 ended with two specific annoyances in the raw code.
 The first: invented labels everywhere. Every branch needs at least one label.
 `find_max` needed `find_max_loop:` and `find_max_no_update:`. `count_above`
 needed `count_above_loop:`, `count_above_skip:`. These labels say nothing about
-what the code does — they just give jumps somewhere to point.
+what the code does — they only give jumps somewhere to point.
 
 The second: the double `cp c` in `count_above`. A single `cp` sets carry for
 less-than and Z for equal. Strictly-greater-than needs both. So the raw version
@@ -119,7 +119,7 @@ replaces the pair `loop_top:` + `jr nz, loop_top` and the exit label
 `while NZ` does not set flags. It reads them. The flags at the `while` keyword
 are exactly whatever instruction last set them.
 
-`ld` instructions on the Z80 do not affect flags. The trap is using `while` immediately after `ld`:
+`ld` instructions on the Z80 do not affect flags — this catches almost everyone at some point. The trap is using `while` immediately after `ld`:
 
 ```zax
 ; WRONG — ld b, 10 does not set flags
@@ -298,7 +298,7 @@ end
 
 Labels: `find_max_loop:` (loop top) and `find_max_no_update:` (skip target).
 The jump `jr nc, find_max_no_update` is the only thing connecting the test
-to the effect — a reader must trace the label to understand the structure.
+to the effect — you must trace the label to understand the structure.
 
 **`find_max_cf` — with `while` and `if`:**
 
@@ -368,7 +368,7 @@ end
 ```
 
 The push/pop and the double `cp c` are both present. The skip label serves both
-jump instructions; a reader must check both to understand when the counter is
+jump instructions; you must check both to understand when the counter is
 incremented.
 
 **`count_above_cf` — with typed local and `if`:**

--- a/learning/part1/12-typed-assignment.md
+++ b/learning/part1/12-typed-assignment.md
@@ -135,7 +135,7 @@ Use `:=` when you want the compiler to handle the register selection and multi-i
 
 Use raw `ld a, (ix+name+0)` when you need precise control: choosing which register gets the value, accessing a specific byte lane of a word slot, or when the context makes the raw form clearer.
 
-Both are always available. Neither is required. The choice is about clarity for the reader, not correctness for the compiler.
+Both are always available. Neither is required. The choice is about what reads most clearly — the compiler accepts either.
 
 ---
 

--- a/learning/part1/13-op-macros-and-pseudo-opcodes.md
+++ b/learning/part1/13-op-macros-and-pseudo-opcodes.md
@@ -44,6 +44,8 @@ load_and_or B
 
 ## When to use `op` vs `func`
 
+Here is how I decide between the two.
+
 Use `op` when:
 
 - a short sequence of instructions repeats mechanically


### PR DESCRIPTION
## Summary

Second prose pass over chapters 9–13, informed by the reference Z80 assembly tutorial. The first pass (PR #1091) removed banned patterns. This pass adds the human writer's voice.

**Style elements applied from the reference text:**

- **First person "I"** where the writer has personal experience relevant to the reader: warnings that "only surface as a bug in larger programs," clarifying the frame cost ("I want to be clear about this"), personal decision rules ("Here is how I decide")
- **"actually"** for natural clarifications after an expectation is set — the `push/pop buys nothing mechanically` paragraph
- **"this catches almost everyone"** for naming difficulty honestly — the `ld` instruction flag trap
- **Third-person lapses fixed**: "the programmer holds the register map in their head" → "you can hold"; "a reader must trace" × 2 → "you must"; "clarity for the reader" → "what reads most clearly"
- **Performative "Notice that" removed** — starts directly with the fact
- **"just" minimiser** in Ch11 intro caught and removed

## Changes per file

- **Ch9**: HL-reload warning gains personal framing; `push/pop` clarification uses "actually"; "the reader" → "you"
- **Ch10**: closing sentence of register-passing section personalised; frame-cost warning prefaced; `Notice that` cut
- **Ch11**: `ld` flag-trap acknowledgment added; two "a reader must" → "you must"; "just" → "only"
- **Ch12**: "clarity for the reader" → "what reads most clearly"
- **Ch13**: `op` vs `func` section opens with "Here is how I decide between the two."

🤖 Generated with [Claude Code](https://claude.com/claude-code)