### PR TITLE
test: move pr543/pr544 lowering integration under test/lowering

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -43,7 +43,7 @@ Representative files:
 Representative files:
 
 - `pr468_parser_dispatch_integration.test.ts` for top-level parser dispatch
-- `pr543_function_lowering_integration.test.ts` and `pr544_program_lowering_integration.test.ts` for lowering seams
+- `lowering/pr543_function_lowering_integration.test.ts` and `lowering/pr544_program_lowering_integration.test.ts` for lowering seams
 - `pr511_asm_range_lowering_integration.test.ts` for structured-control lowering
 - `pr582_named_section_*integration.test.ts` and `pr585_named_section_layout_integration.test.ts` for named-section routing/layout
 - `examples_compile.test.ts` for checked-in example programs

--- a/test/lowering/pr543_function_lowering_integration.test.ts
+++ b/test/lowering/pr543_function_lowering_integration.test.ts
@@ -7,12 +7,12 @@ import {
   flattenLoweredItems,
   flattenLoweredInstructions,
   hasRawOpcode,
-} from './helpers/lowered_program.js';
+} from '../helpers/lowered_program.js';
 
 describe('PR543 function lowering integration', () => {
   it('keeps implicit-ret function setup stable', async () => {
     const { program, diagnostics } = await compilePlacedProgram(
-      join(__dirname, 'fixtures', 'pr14_epilogue_locals.zax'),
+      join(__dirname, '..', 'fixtures', 'pr14_epilogue_locals.zax'),
     );
     expect(diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
     const lines = formatLoweredInstructions(program).map((line) => line.toUpperCase());
@@ -27,7 +27,7 @@ describe('PR543 function lowering integration', () => {
 
   it('keeps explicit ret routed through the synthetic epilogue', async () => {
     const { program, diagnostics } = await compilePlacedProgram(
-      join(__dirname, 'fixtures', 'pr543_function_ret_epilogue.zax'),
+      join(__dirname, '..', 'fixtures', 'pr543_function_ret_epilogue.zax'),
     );
     expect(diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
     const lines = formatLoweredInstructions(program).map((line) => line.toUpperCase());

--- a/test/lowering/pr544_program_lowering_integration.test.ts
+++ b/test/lowering/pr544_program_lowering_integration.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { join } from 'node:path';
 
-import { compilePlacedProgram, flattenLoweredItems } from './helpers/lowered_program.js';
+import { compilePlacedProgram, flattenLoweredItems } from '../helpers/lowered_program.js';
 
 describe('PR544 program lowering integration', () => {
   it('keeps top-level declaration traversal stable', async () => {
-    const res = await compilePlacedProgram(join(__dirname, 'fixtures', 'pr544_program_lowering.zax'));
+    const res = await compilePlacedProgram(join(__dirname, '..', 'fixtures', 'pr544_program_lowering.zax'));
     expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
 
     const items = flattenLoweredItems(res.program);


### PR DESCRIPTION
## Summary

Move `pr543_function_lowering_integration.test.ts` and `pr544_program_lowering_integration.test.ts` into `test/lowering/`. Adjust helper imports and fixture `join(__dirname, ...)` paths. Update test discovery README.

Refs #1080

Made with [Cursor](https://cursor.com)