### PR TITLE
test: move pr509–pr531 lowering seams under test/lowering/ (#1080)

### DIFF
--- a/docs/archive/design/type-system-reform-plan.md
+++ b/docs/archive/design/type-system-reform-plan.md
@@ -73,7 +73,7 @@ A codebase sweep confirmed that the `push IX; pop HL` idiom appears in exactly f
 | 1 | `src/lowering/valueMaterialization.ts` | 181–182 | IndexReg8/Reg16, fvar base, elemSize > 2 | ❌ wrong address (`IX+ixDisp+idx` not `*(IX+ixDisp)+idx`) | Phase B (indirect EA) / Phase C (wide pipeline) |
 | 2 | `src/lowering/valueMaterialization.ts` | 473–474 | General runtime index, fvar base, elemSize > 2 | ❌ wrong address (same) | Phase B / Phase C |
 | 3 | `src/lowering/valueMaterialization.ts` | 497–498 | Plain scalar `stack` EA in `pushEaAddress` | ✅ scalar locals only after Phase B; also ❌ reachable for param array slots via byte-pipeline IndexImm gap | Phase A fixes param-array case; scalar case possibly unavoidable (no `LD HL,IX` on Z80) |
-| 4 | `src/lowering/eaMaterialization.ts` | 27–28 | `materializeEaAddressToHL`, `resolved.kind === 'stack'` | ⚠️ stack imbalance: `push DE` at line 26 never restored; locked in by `test/pr509_ea_materialization_helpers.test.ts` lines 51–63 | Phase B eliminates non-scalar case; scalar case needs audit |
+| 4 | `src/lowering/eaMaterialization.ts` | 27–28 | `materializeEaAddressToHL`, `resolved.kind === 'stack'` | ⚠️ stack imbalance: `push DE` at line 26 never restored; locked in by `test/lowering/pr509_ea_materialization_helpers.test.ts` lines 51–63 | Phase B eliminates non-scalar case; scalar case needs audit |
 | — | `src/lowering/functionLowering.ts` | 341 | Function prologue | ✅ correct (saves IX for frame setup) | N/A |
 
 ### Historical wrong golden files
@@ -264,7 +264,7 @@ After Phase B, non-scalar stack slots become `kind: 'indirect'` and will hit the
 
 This has two problems:
 
-**Stack imbalance:** `push DE` at line 26 saves DE onto the stack. The function then does `push HL; pop DE` at lines 44–45, which copies the address into DE but never pops the original saved DE. The net effect is one extra word on the stack. Test `test/pr509_ea_materialization_helpers.test.ts` lines 51–63 locks in this exact sequence as expected output — the test must be updated.
+**Stack imbalance:** `push DE` at line 26 saves DE onto the stack. The function then does `push HL; pop DE` at lines 44–45, which copies the address into DE but never pops the original saved DE. The net effect is one extra word on the stack. Test `test/lowering/pr509_ea_materialization_helpers.test.ts` lines 51–63 locks in this exact sequence as expected output — the test must be updated.
 
 **Semantics for non-scalar slots:** After Phase B, `kind: 'stack'` will no longer be returned for non-scalar parameter slots. If this code path was ever reached for a parameter array before Phase B, it suffered the same wrong-address error. After Phase B that path becomes `indirect` instead.
 
@@ -330,7 +330,7 @@ ld a, (hl)
 7. Handle `indirect` in `ldEncoding.ts` load path
 8. Handle `indirect` in `valueMaterialization.ts` `pushEaAddress` path
 9. Return `null` from both `buildEaBytePipeline` and `buildEaWordPipeline` for `indirect` bases
-10. Update `test/pr509_ea_materialization_helpers.test.ts` (currently locks in buggy sequence)
+10. Update `test/lowering/pr509_ea_materialization_helpers.test.ts` (currently locks in buggy sequence)
 11. Add golden test: `func render(s: Sprite[8]): void` with `ld a, (s[2].flags)`
 
 ### Risk

--- a/test/README.md
+++ b/test/README.md
@@ -10,7 +10,7 @@ Tests are migrating from a flat `test/prNNN_*.test.ts` layout into subsystem fol
 - `test/backend/` — Z80 encoder and opcode-family unit tests
 - `test/frontend/` — parser, grammar, and frontend-adjacent tests (migration ongoing)
 - `test/semantics/` — semantics, env, and layout tests (migration ongoing)
-- `test/lowering/` — lowering and asm-emission integration tests (migration ongoing; not every lowering test has moved yet)
+- `test/lowering/` — lowering helper seams and asm-emission integration tests (most lowering seams now live here; a few broad integration files may still be top-level)
 
 New tests should prefer the subsystem directory that matches the code under test. Older tests may still live at `test/prNNN_*.test.ts` until moved.
 
@@ -32,7 +32,7 @@ Representative files:
 
 - `pr476_parse_*.test.ts` for parser helpers
 - `backend/pr477_encode_*.test.ts` for encoder families
-- `pr509_*.test.ts`, `pr510_*.test.ts`, `pr528_*.test.ts`, `pr529_*.test.ts`, `pr530_*.test.ts`, `pr531_*.test.ts`, and `lowering/pr532_asm_instruction_lowering_integration.test.ts` for lowering helper seams (more will move under `test/lowering/` over time)
+- `lowering/pr509_*.test.ts`, `lowering/pr510_*.test.ts`, `lowering/pr528_*.test.ts`, `lowering/pr529_*.test.ts`, `lowering/pr530_*.test.ts`, `lowering/pr531_*.test.ts`, and `lowering/pr532_asm_instruction_lowering_integration.test.ts` for lowering helper seams
 
 ### Prefer an integration test when
 
@@ -44,7 +44,7 @@ Representative files:
 
 - `pr468_parser_dispatch_integration.test.ts` for top-level parser dispatch
 - `lowering/pr543_function_lowering_integration.test.ts` and `lowering/pr544_program_lowering_integration.test.ts` for lowering seams
-- `pr511_asm_range_lowering_integration.test.ts` for structured-control lowering
+- `lowering/pr511_asm_range_lowering_integration.test.ts` for structured-control lowering
 - `pr582_named_section_*integration.test.ts` and `pr585_named_section_layout_integration.test.ts` for named-section routing/layout
 - `examples_compile.test.ts` for checked-in example programs
 
@@ -70,7 +70,7 @@ Representative files:
 | Grammar and token tables                   | `frontend/pr762_grammar_data_conformance.test.ts`, `frontend/pr808_grammar_drift.test.ts`, `pr250_parser_instruction_head_casing.test.ts`, `pr252_parser_register_token_canonicalization.test.ts`                                                                    | Good home for reserved-word and canonicalization changes.                                                                              |
 | Semantics and layout                       | `semantics/semantics_layout.test.ts`, `semantics/semantics_layout_extra.test.ts`, `pr285_alias_init_parser_semantics_matrix.test.ts`, `pr980_local_alias_legality.test.ts`                                                                                           | Use these when type size, offsets, alias legality, or compile-time rules change.                                                       |
 | Lowering frame and control-flow invariants | `pr102_lowering_frame_invariants.test.ts`, `pr103_lowering_mixed_return_paths.test.ts`, `pr555_function_sp_state_integration.test.ts`, `pr848_break_continue_integration.test.ts`                                                                                    | Covers epilogue cleanup, SP tracking, and structured control lowering.                                                                 |
-| Lowering helper seams                      | `lowering/pr532_asm_instruction_lowering_integration.test.ts`, `pr509_*.test.ts`, `pr510_*.test.ts`, `pr528_emission_core_helpers.test.ts`, `pr529_fixup_emission_helpers.test.ts`, `pr530_asm_utils_helpers.test.ts`, `pr531_value_materialization_helpers.test.ts` | Migrated files use the `lowering/` prefix; others remain top-level until moved. Prefer these before adding another broad compile test. |
+| Lowering helper seams                      | `lowering/pr509_*.test.ts`, `lowering/pr510_*.test.ts`, `lowering/pr511_*.test.ts`, `lowering/pr528_emission_core_helpers.test.ts`, `lowering/pr529_fixup_emission_helpers.test.ts`, `lowering/pr530_asm_utils_helpers.test.ts`, `lowering/pr531_value_materialization_helpers.test.ts`, `lowering/pr532_asm_instruction_lowering_integration.test.ts` | Prefer these before adding another broad compile test. |
 | Named sections and placement               | `pr572_named_sections_parser.test.ts`, `pr582_section_contribution_sinks.test.ts`, `pr583_section_placement_helpers.test.ts`, `pr584_named_section_fixups_integration.test.ts`, `pr585_named_section_layout_integration.test.ts`                                     | Use when section routing, anchors, or fixups change.                                                                                   |
 | Assignment and storage legality            | `pr862_assignment_parser.test.ts`, `pr863_assignment_lowering.test.ts`, `pr869_assignment_reg8_*`, `pr875_assignment_ixiy_integration.test.ts`, `pr895_assignment_acceptance.test.ts`                                                                                | Parser, lowering, and acceptance coverage are already split.                                                                           |
 | Encoder behavior                           | `pr24_isa_core.test.ts`, `backend/pr477_encode_*.test.ts`, `pr203_ld_diag_matrix.test.ts`, `pr240_isa_register_target_diag_matrix.test.ts`                                                                                                                           | Prefer direct encoder tests when lowering is not involved.                                                                             |

--- a/test/lowering/pr509_addressing_pipeline_builders.test.ts
+++ b/test/lowering/pr509_addressing_pipeline_builders.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { renderStepPipeline } from '../src/addressing/steps.js';
-import { DiagnosticIds, type Diagnostic } from '../src/diagnosticTypes.js';
-import type { EaExprNode, SourceSpan, TypeExprNode } from '../src/frontend/ast.js';
-import { createAddressingPipelineBuilders } from '../src/lowering/addressingPipelines.js';
-import type { EaResolution } from '../src/lowering/eaResolution.js';
+import { renderStepPipeline } from '../../src/addressing/steps.js';
+import { DiagnosticIds, type Diagnostic } from '../../src/diagnosticTypes.js';
+import type { EaExprNode, SourceSpan, TypeExprNode } from '../../src/frontend/ast.js';
+import { createAddressingPipelineBuilders } from '../../src/lowering/addressingPipelines.js';
+import type { EaResolution } from '../../src/lowering/eaResolution.js';
 
 const span: SourceSpan = {
   file: 'test.zax',

--- a/test/lowering/pr509_ea_materialization_helpers.test.ts
+++ b/test/lowering/pr509_ea_materialization_helpers.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import type { AsmOperandNode, EaExprNode, SourceSpan } from '../src/frontend/ast.js';
-import { createEaMaterializationHelpers } from '../src/lowering/eaMaterialization.js';
-import type { EaResolution } from '../src/lowering/eaResolution.js';
+import type { AsmOperandNode, EaExprNode, SourceSpan } from '../../src/frontend/ast.js';
+import { createEaMaterializationHelpers } from '../../src/lowering/eaMaterialization.js';
+import type { EaResolution } from '../../src/lowering/eaResolution.js';
 
 const span: SourceSpan = {
   file: 'test.zax',

--- a/test/lowering/pr509_lower_ld_integration.test.ts
+++ b/test/lowering/pr509_lower_ld_integration.test.ts
@@ -7,14 +7,14 @@ import {
   formatLoweredInstructions,
   flattenLoweredInstructions,
   hasRawOpcode,
-} from './helpers/lowered_program.js';
+} from '../helpers/lowered_program.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('#509 lowerLdWithEa integration', () => {
   it('still lowers representative byte and word ld shapes through the moved helper', async () => {
-    const byteEntry = join(__dirname, 'fixtures', 'pr405_byte_global_non_a_symbols.zax');
+    const byteEntry = join(__dirname, '..', 'fixtures', 'pr405_byte_global_non_a_symbols.zax');
     const byteRes = await compilePlacedProgram(byteEntry);
     expect(byteRes.diagnostics).toEqual([]);
     const byteLines = formatLoweredInstructions(byteRes.program).map((line) => line.toUpperCase());
@@ -23,7 +23,7 @@ describe('#509 lowerLdWithEa integration', () => {
     expect(hasRawOpcode(byteInstrs, 0x3a)).toBe(true);
     expect(byteLines).toContain('LD B, A');
 
-    const wordEntry = join(__dirname, 'fixtures', 'pr406_word_mem_to_mem_mixed_reverse.zax');
+    const wordEntry = join(__dirname, '..', 'fixtures', 'pr406_word_mem_to_mem_mixed_reverse.zax');
     const wordRes = await compilePlacedProgram(wordEntry);
     expect(wordRes.diagnostics).toEqual([]);
     const wordLines = formatLoweredInstructions(wordRes.program).map((line) => line.toUpperCase());

--- a/test/lowering/pr509_scalar_word_accessors.test.ts
+++ b/test/lowering/pr509_scalar_word_accessors.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { renderStepPipeline } from '../src/addressing/steps.js';
-import type { SourceSpan, TypeExprNode } from '../src/frontend/ast.js';
-import { createScalarWordAccessorHelpers } from '../src/lowering/scalarWordAccessors.js';
-import type { EaResolution } from '../src/lowering/eaResolution.js';
+import { renderStepPipeline } from '../../src/addressing/steps.js';
+import type { SourceSpan, TypeExprNode } from '../../src/frontend/ast.js';
+import { createScalarWordAccessorHelpers } from '../../src/lowering/scalarWordAccessors.js';
+import type { EaResolution } from '../../src/lowering/eaResolution.js';
 
 const span: SourceSpan = {
   file: 'test.zax',

--- a/test/lowering/pr510_op_expansion_execution_helpers.test.ts
+++ b/test/lowering/pr510_op_expansion_execution_helpers.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { DiagnosticIds, type Diagnostic } from '../src/diagnosticTypes.js';
-import type { AsmItemNode, OpDeclNode, SourceSpan } from '../src/frontend/ast.js';
-import { createOpExpansionExecutionHelpers } from '../src/lowering/opExpansionExecution.js';
+import { DiagnosticIds, type Diagnostic } from '../../src/diagnosticTypes.js';
+import type { AsmItemNode, OpDeclNode, SourceSpan } from '../../src/frontend/ast.js';
+import { createOpExpansionExecutionHelpers } from '../../src/lowering/opExpansionExecution.js';
 
 const span: SourceSpan = {
   file: 'test.zax',

--- a/test/lowering/pr510_op_expansion_orchestration_helpers.test.ts
+++ b/test/lowering/pr510_op_expansion_orchestration_helpers.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { DiagnosticIds, type Diagnostic } from '../src/diagnosticTypes.js';
-import type { AsmInstructionNode, AsmOperandNode, OpDeclNode, SourceSpan } from '../src/frontend/ast.js';
-import { createOpExpansionOrchestrationHelpers } from '../src/lowering/opExpansionOrchestration.js';
+import { DiagnosticIds, type Diagnostic } from '../../src/diagnosticTypes.js';
+import type { AsmInstructionNode, AsmOperandNode, OpDeclNode, SourceSpan } from '../../src/frontend/ast.js';
+import { createOpExpansionOrchestrationHelpers } from '../../src/lowering/opExpansionOrchestration.js';
 
 const span: SourceSpan = {
   file: 'test.zax',

--- a/test/lowering/pr510_op_substitution_helpers.test.ts
+++ b/test/lowering/pr510_op_substitution_helpers.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { DiagnosticIds, type Diagnostic } from '../src/diagnosticTypes.js';
-import type { AsmOperandNode, EaExprNode, ImmExprNode, SourceSpan } from '../src/frontend/ast.js';
-import { createOpSubstitutionHelpers } from '../src/lowering/opSubstitution.js';
+import { DiagnosticIds, type Diagnostic } from '../../src/diagnosticTypes.js';
+import type { AsmOperandNode, EaExprNode, ImmExprNode, SourceSpan } from '../../src/frontend/ast.js';
+import { createOpSubstitutionHelpers } from '../../src/lowering/opSubstitution.js';
 
 const span: SourceSpan = {
   file: 'test.zax',

--- a/test/lowering/pr511_asm_body_orchestration_helpers.test.ts
+++ b/test/lowering/pr511_asm_body_orchestration_helpers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import type { AsmItemNode, SourceSpan } from '../src/frontend/ast.js';
-import { createAsmBodyOrchestrationHelpers } from '../src/lowering/asmBodyOrchestration.js';
+import type { AsmItemNode, SourceSpan } from '../../src/frontend/ast.js';
+import { createAsmBodyOrchestrationHelpers } from '../../src/lowering/asmBodyOrchestration.js';
 
 const span: SourceSpan = {
   file: 'test.zax',

--- a/test/lowering/pr511_asm_range_lowering_integration.test.ts
+++ b/test/lowering/pr511_asm_range_lowering_integration.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
-import type { BinArtifact } from '../src/formats/types.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import type { BinArtifact } from '../../src/formats/types.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,7 +12,7 @@ const __dirname = dirname(__filename);
 describe('#511 asm range lowering integration', () => {
   it('keeps structured if/else lowering stable through the extracted asm-range helper', async () => {
     const res = await compile(
-      join(__dirname, 'fixtures', 'pr15_if_else.zax'),
+      join(__dirname, '..', 'fixtures', 'pr15_if_else.zax'),
       {},
       { formats: defaultFormatWriters },
     );
@@ -29,7 +29,7 @@ describe('#511 asm range lowering integration', () => {
 
   it('keeps structured select lowering stable through the extracted asm-range helper', async () => {
     const res = await compile(
-      join(__dirname, 'fixtures', 'pr15_select_cases.zax'),
+      join(__dirname, '..', 'fixtures', 'pr15_select_cases.zax'),
       {},
       { formats: defaultFormatWriters },
     );

--- a/test/lowering/pr528_emission_core_helpers.test.ts
+++ b/test/lowering/pr528_emission_core_helpers.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import type { AsmOperandNode, SourceSpan } from '../src/frontend/ast.js';
-import { createEmissionCoreHelpers } from '../src/lowering/emissionCore.js';
-import type { StepPipeline } from '../src/addressing/steps.js';
+import type { AsmOperandNode, SourceSpan } from '../../src/frontend/ast.js';
+import { createEmissionCoreHelpers } from '../../src/lowering/emissionCore.js';
+import type { StepPipeline } from '../../src/addressing/steps.js';
 
 const span: SourceSpan = {
   file: 'test.zax',

--- a/test/lowering/pr529_fixup_emission_helpers.test.ts
+++ b/test/lowering/pr529_fixup_emission_helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { createFixupEmissionHelpers } from '../src/lowering/fixupEmission.js';
+import { createFixupEmissionHelpers } from '../../src/lowering/fixupEmission.js';
 
 describe('PR529 fixup emission helpers', () => {
   it('emits abs16 and rel8 fixups with the current trace shape', () => {

--- a/test/lowering/pr530_asm_utils_helpers.test.ts
+++ b/test/lowering/pr530_asm_utils_helpers.test.ts
@@ -6,8 +6,8 @@ import {
   cloneOperand,
   createAsmUtilityHelpers,
   flattenEaDottedName,
-} from '../src/lowering/asmUtils.js';
-import type { AsmOperandNode, EaExprNode, ImmExprNode, SourceSpan } from '../src/frontend/ast.js';
+} from '../../src/lowering/asmUtils.js';
+import type { AsmOperandNode, EaExprNode, ImmExprNode, SourceSpan } from '../../src/frontend/ast.js';
 
 const span: SourceSpan = {
   file: 'fixture.zax',

--- a/test/lowering/pr531_value_materialization_helpers.test.ts
+++ b/test/lowering/pr531_value_materialization_helpers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { createValueMaterializationHelpers } from '../src/lowering/valueMaterialization.js';
-import type { AsmOperandNode, EaExprNode, SourceSpan, TypeExprNode } from '../src/frontend/ast.js';
+import { createValueMaterializationHelpers } from '../../src/lowering/valueMaterialization.js';
+import type { AsmOperandNode, EaExprNode, SourceSpan, TypeExprNode } from '../../src/frontend/ast.js';
 
 const span: SourceSpan = {
   file: 'fixture.zax',


### PR DESCRIPTION
## Summary
Migrates the remaining **lowering helper seam** batch (pr509–pr511, pr528–pr531) from flat `test/` into `test/lowering/` with path/import fixes only.

## Changes
- `git mv` 13 test files → `test/lowering/`
- `../src` → `../../src`; integration tests use `../helpers` and `../fixtures` as appropriate
- `test/README.md`: index + subsystem note updated for `lowering/pr509_* … pr531_*`
- Archive design doc: update path to `pr509_ea_materialization_helpers` test (discoverability)

## Verification
- `npm run typecheck`
- `npm run lint`
- `npx vitest run` (318 files, 762 tests)

Fixes #1080

Made with [Cursor](https://cursor.com)