### PR TITLE
1104: simplify CLI build infrastructure

### DIFF
--- a/test/cli/cli_zax_smoke.test.ts
+++ b/test/cli/cli_zax_smoke.test.ts
@@ -6,7 +6,7 @@ import { runCli } from '../helpers/cli.js';
 describe('npm zax smoke', () => {
   beforeAll(async () => {
     await ensureCliBuilt();
-  });
+  }, 180_000);
 
   it('builds and prints version via npm script wrapper', async () => {
     const res = await runCli(['--version']);

--- a/test/helpers/cliBuild.ts
+++ b/test/helpers/cliBuild.ts
@@ -1,6 +1,5 @@
 import { execFile } from 'node:child_process';
-import { createHash } from 'node:crypto';
-import { access, mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { access, readdir, stat } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
@@ -10,20 +9,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const repoRoot = resolve(__dirname, '..', '..');
 const cliPath = resolve(repoRoot, 'dist', 'src', 'cli.js');
-const buildTmpDir = resolve(repoRoot, '.tmp');
-const buildLockPath = resolve(buildTmpDir, 'cli-build.lock');
-const buildStampPath = resolve(buildTmpDir, 'cli-build.stamp');
-const lockWaitSliceMs = 250;
-const lockWaitMaxMs = 90_000;
-const lockStaleMs = 5 * 60_000;
-const lockAcquireTimeoutMs = 10 * 60_000;
 
 let buildPromise: Promise<void> | undefined;
-let buildPromiseKey: string | undefined;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
-}
 
 async function pathExists(path: string): Promise<boolean> {
   try {
@@ -32,101 +19,6 @@ async function pathExists(path: string): Promise<boolean> {
   } catch {
     return false;
   }
-}
-
-type LockMeta = { pid?: number; createdAt?: number };
-
-function parsePid(value: unknown): number | undefined {
-  if (typeof value !== 'number' || !Number.isFinite(value) || !Number.isInteger(value)) {
-    return undefined;
-  }
-  return value > 0 ? value : undefined;
-}
-
-function parseCreatedAt(value: unknown): number | undefined {
-  if (typeof value !== 'number' || !Number.isFinite(value) || !Number.isInteger(value)) {
-    return undefined;
-  }
-  return value >= 0 ? value : undefined;
-}
-
-function parseLockMeta(raw: string): LockMeta | undefined {
-  const trimmed = raw.trim();
-  if (!trimmed) return undefined;
-  try {
-    const parsedUnknown = JSON.parse(trimmed) as unknown;
-    const parsedNumber = parseCreatedAt(parsedUnknown);
-    if (parsedNumber !== undefined) {
-      return { createdAt: parsedNumber };
-    }
-    if (parsedUnknown === null || typeof parsedUnknown !== 'object') {
-      return undefined;
-    }
-    const parsed = parsedUnknown as { pid?: unknown; createdAt?: unknown };
-    const pid = parsePid(parsed.pid);
-    const createdAt = parseCreatedAt(parsed.createdAt);
-    if (pid === undefined && createdAt === undefined) return undefined;
-    const lockMeta: LockMeta = {};
-    if (pid !== undefined) lockMeta.pid = pid;
-    if (createdAt !== undefined) lockMeta.createdAt = createdAt;
-    return lockMeta;
-  } catch {
-    const numeric = parseCreatedAt(Number(trimmed));
-    return numeric === undefined ? undefined : { createdAt: numeric };
-  }
-}
-
-function isProcessAlive(pid: number): boolean {
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-  if (pid === process.pid) return true;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err) {
-    const e = err as NodeJS.ErrnoException;
-    return e.code === 'EPERM';
-  }
-}
-
-function computeWaitDeadline(
-  nowMs: number,
-  acquireDeadlineMs: number,
-  waitWindowMs: number,
-): number {
-  return Math.min(nowMs + waitWindowMs, acquireDeadlineMs);
-}
-
-function hasLockAcquireTimedOut(nowMs: number, acquireDeadlineMs: number): boolean {
-  return nowMs >= acquireDeadlineMs;
-}
-
-function shouldEvictLock(
-  lockMeta: LockMeta | undefined,
-  options: { nowMs: number; staleMs: number; isOwnerAlive: (pid: number) => boolean },
-): boolean {
-  if (lockMeta === undefined) return false;
-
-  const ownerAlive = lockMeta.pid !== undefined ? options.isOwnerAlive(lockMeta.pid) : undefined;
-  if (ownerAlive === false) return true;
-
-  if (lockMeta.createdAt === undefined) return false;
-  if (options.nowMs - lockMeta.createdAt < options.staleMs) return false;
-  if (ownerAlive === true) return false;
-
-  return true;
-}
-
-async function clearStaleLockIfNeeded(): Promise<void> {
-  const lockText = await readFile(buildLockPath, 'utf8').catch(() => '');
-  const lockMeta = parseLockMeta(lockText);
-  const evict = shouldEvictLock(lockMeta, {
-    nowMs: Date.now(),
-    staleMs: lockStaleMs,
-    isOwnerAlive: isProcessAlive,
-  });
-  if (!evict) return;
-
-  await rm(buildLockPath, { force: true });
 }
 
 async function listBuildInputFiles(rootPath: string): Promise<string[]> {
@@ -146,102 +38,48 @@ async function listBuildInputFiles(rootPath: string): Promise<string[]> {
   return paths.flat();
 }
 
-async function computeCliBuildKey(): Promise<string> {
-  const hash = createHash('sha1');
-  const roots = [
+async function latestInputMtimeMsForRoots(roots: string[]): Promise<number> {
+  let latest = 0;
+  for (const root of roots) {
+    for (const file of await listBuildInputFiles(root)) {
+      const fileInfo = await stat(file);
+      if (fileInfo.mtimeMs > latest) latest = fileInfo.mtimeMs;
+    }
+  }
+  return latest;
+}
+
+async function latestInputMtimeMs(): Promise<number> {
+  return latestInputMtimeMsForRoots([
     resolve(repoRoot, 'package.json'),
     resolve(repoRoot, 'package-lock.json'),
     resolve(repoRoot, 'tsconfig.json'),
     resolve(repoRoot, 'src'),
-  ];
-  for (const root of roots) {
-    for (const file of await listBuildInputFiles(root)) {
-      const fileInfo = await stat(file);
-      hash.update(file);
-      hash.update(':');
-      hash.update(String(fileInfo.size));
-      hash.update(':');
-      hash.update(String(fileInfo.mtimeMs));
-      hash.update('\n');
-    }
-  }
-  return hash.digest('hex');
+  ]);
 }
 
-async function isCliBuildFresh(buildKey: string): Promise<boolean> {
+async function isCliBuildFresh(): Promise<boolean> {
   if (!(await pathExists(cliPath))) return false;
-  const stamp = await readFile(buildStampPath, 'utf8').catch(() => '');
-  return stamp.trim() === buildKey;
-}
-
-async function buildCliWithLock(buildKey: string): Promise<void> {
-  if (await isCliBuildFresh(buildKey)) return;
-  await mkdir(buildTmpDir, { recursive: true });
-  const acquireDeadlineMs = Date.now() + lockAcquireTimeoutMs;
-
-  const timeoutError = (): Error =>
-    new Error(
-      `Timed out waiting ${Math.floor(lockAcquireTimeoutMs / 1000)}s for CLI build lock at ${buildLockPath}`,
-    );
-
-  while (true) {
-    if (hasLockAcquireTimedOut(Date.now(), acquireDeadlineMs)) {
-      throw timeoutError();
-    }
-
-    try {
-      await writeFile(buildLockPath, JSON.stringify({ pid: process.pid, createdAt: Date.now() }), {
-        flag: 'wx',
-      });
-      try {
-        if (await isCliBuildFresh(buildKey)) return;
-        await execFileAsync('npm', ['run', 'build'], {
-          encoding: 'utf8',
-          shell: process.platform === 'win32',
-        });
-        await writeFile(buildStampPath, `${buildKey}\n`, 'utf8');
-      } finally {
-        await rm(buildLockPath, { force: true });
-      }
-      return;
-    } catch (err) {
-      const e = err as NodeJS.ErrnoException;
-      if (e.code && e.code !== 'EEXIST') throw err;
-      if (hasLockAcquireTimedOut(Date.now(), acquireDeadlineMs)) {
-        throw timeoutError();
-      }
-      const waitDeadlineMs = computeWaitDeadline(Date.now(), acquireDeadlineMs, lockWaitMaxMs);
-      while (Date.now() < waitDeadlineMs) {
-        if (!(await pathExists(buildLockPath))) break;
-        await clearStaleLockIfNeeded();
-        if (!(await pathExists(buildLockPath))) break;
-        await sleep(lockWaitSliceMs);
-      }
-      await clearStaleLockIfNeeded();
-    }
-  }
+  const cliStat = await stat(cliPath);
+  const latestInput = await latestInputMtimeMs();
+  return cliStat.mtimeMs >= latestInput;
 }
 
 export async function ensureCliBuilt(): Promise<void> {
-  const buildKey = await computeCliBuildKey();
-  if (await isCliBuildFresh(buildKey)) return;
-
-  if (!buildPromise || buildPromiseKey !== buildKey) {
-    buildPromiseKey = buildKey;
-    buildPromise = buildCliWithLock(buildKey).catch((err) => {
+  if (!buildPromise) {
+    buildPromise = (async () => {
+      if (await isCliBuildFresh()) return;
+      await execFileAsync('npm', ['run', 'build'], {
+        encoding: 'utf8',
+        shell: process.platform === 'win32',
+      });
+    })().finally(() => {
       buildPromise = undefined;
-      buildPromiseKey = undefined;
-      throw err;
     });
   }
   return buildPromise;
 }
 
-export const __cliBuildLockInternals = {
-  computeCliBuildKey,
-  computeWaitDeadline,
-  hasLockAcquireTimedOut,
-  isCliBuildFresh,
-  parseLockMeta,
-  shouldEvictLock,
+export const __cliBuildInternals = {
+  latestInputMtimeMsForRoots,
 };

--- a/test/pr249_cli_lock_eviction_matrix.test.ts
+++ b/test/pr249_cli_lock_eviction_matrix.test.ts
@@ -1,114 +1,29 @@
+import { mkdtemp, stat, utimes, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
-import { __cliBuildLockInternals } from './helpers/cliBuild.js';
+import { __cliBuildInternals } from './helpers/cliBuild.js';
 
-describe('PR249 CLI build-lock eviction matrix', () => {
-  const { computeWaitDeadline, hasLockAcquireTimedOut, parseLockMeta, shouldEvictLock } =
-    __cliBuildLockInternals;
-  const nowMs = 1_000_000;
-  const staleMs = 300_000;
+describe('PR249 CLI build infrastructure checks', () => {
+  const { latestInputMtimeMsForRoots } = __cliBuildInternals;
 
-  it('parses lock metadata from json and legacy numeric formats', () => {
-    expect(parseLockMeta('')).toBeUndefined();
-    expect(parseLockMeta('not-json')).toBeUndefined();
-    expect(parseLockMeta('{}')).toBeUndefined();
-    expect(parseLockMeta('{"pid": 1234}')).toEqual({ pid: 1234 });
-    expect(parseLockMeta('{"createdAt": 42}')).toEqual({ createdAt: 42 });
-    expect(parseLockMeta('{"pid": 1234, "createdAt": 42}')).toEqual({
-      pid: 1234,
-      createdAt: 42,
-    });
-    expect(parseLockMeta('123')).toEqual({ createdAt: 123 });
-  });
+  it('scans roots and returns the latest mtime for inputs', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zax-cli-build-'));
+    const older = join(root, 'older.txt');
+    const newer = join(root, 'newer.txt');
 
-  it('rejects invalid pid/createdAt values in parsed lock metadata', () => {
-    expect(parseLockMeta('{"pid": -1, "createdAt": 42}')).toEqual({ createdAt: 42 });
-    expect(parseLockMeta('{"pid": 0, "createdAt": 42}')).toEqual({ createdAt: 42 });
-    expect(parseLockMeta('{"pid": 12.5, "createdAt": 42}')).toEqual({ createdAt: 42 });
-    expect(parseLockMeta('{"pid": 1234, "createdAt": -1}')).toEqual({ pid: 1234 });
-    expect(parseLockMeta('{"pid": 1234, "createdAt": 12.5}')).toEqual({ pid: 1234 });
-    expect(parseLockMeta('{"pid": -1, "createdAt": -1}')).toBeUndefined();
-    expect(parseLockMeta('-1')).toBeUndefined();
-    expect(parseLockMeta('12.5')).toBeUndefined();
-  });
+    await writeFile(older, 'old');
+    await writeFile(newer, 'new');
 
-  it('never evicts unknown or malformed lock metadata', () => {
-    const isOwnerAlive = () => true;
-    expect(
-      shouldEvictLock(undefined, {
-        nowMs,
-        staleMs,
-        isOwnerAlive,
-      }),
-    ).toBe(false);
-    expect(
-      shouldEvictLock(parseLockMeta(''), {
-        nowMs,
-        staleMs,
-        isOwnerAlive,
-      }),
-    ).toBe(false);
-    expect(
-      shouldEvictLock(parseLockMeta('not-json'), {
-        nowMs,
-        staleMs,
-        isOwnerAlive,
-      }),
-    ).toBe(false);
-  });
+    const oldTime = new Date(Date.now() - 10_000);
+    const newTime = new Date(Date.now());
+    await utimes(older, oldTime, oldTime);
+    await utimes(newer, newTime, newTime);
 
-  it('evicts dead owners immediately, even without createdAt', () => {
-    const meta = { pid: 99999 };
-    expect(
-      shouldEvictLock(meta, {
-        nowMs,
-        staleMs,
-        isOwnerAlive: () => false,
-      }),
-    ).toBe(true);
-  });
-
-  it('keeps live owners even when lock age is stale', () => {
-    const meta = { pid: 1234, createdAt: nowMs - staleMs - 1 };
-    expect(
-      shouldEvictLock(meta, {
-        nowMs,
-        staleMs,
-        isOwnerAlive: () => true,
-      }),
-    ).toBe(false);
-  });
-
-  it('evicts stale lock with no pid owner signal', () => {
-    const meta = { createdAt: nowMs - staleMs - 1 };
-    expect(
-      shouldEvictLock(meta, {
-        nowMs,
-        staleMs,
-        isOwnerAlive: () => true,
-      }),
-    ).toBe(true);
-  });
-
-  it('keeps fresh lock with no pid owner signal', () => {
-    const meta = { createdAt: nowMs - staleMs + 1 };
-    expect(
-      shouldEvictLock(meta, {
-        nowMs,
-        staleMs,
-        isOwnerAlive: () => true,
-      }),
-    ).toBe(false);
-  });
-
-  it('caps each wait window to the overall acquire deadline', () => {
-    expect(computeWaitDeadline(10_000, 60_000, 90_000)).toBe(60_000);
-    expect(computeWaitDeadline(10_000, 80_000, 30_000)).toBe(40_000);
-  });
-
-  it('times out lock acquire only at or after the deadline', () => {
-    expect(hasLockAcquireTimedOut(59_999, 60_000)).toBe(false);
-    expect(hasLockAcquireTimedOut(60_000, 60_000)).toBe(true);
-    expect(hasLockAcquireTimedOut(60_001, 60_000)).toBe(true);
+    const latest = await latestInputMtimeMsForRoots([root]);
+    const newerStat = await stat(newer);
+    expect(latest).toBeGreaterThanOrEqual(newerStat.mtimeMs);
   });
 });


### PR DESCRIPTION
Implements #1104.

Chosen approach: simplified protocol (build helper is lighter, still explicit).

Summary
- replaced lock/stamp-based build coordination with a simple freshness check via latest input mtime
- ensured only one build is launched per test run via a single in-flight promise
- kept build behavior explicit and isolated to `test/helpers/cliBuild.ts`
- updated the PR249 infra test to validate the new freshness scan helper
- extended the CLI smoke test hook timeout to avoid false timeouts during build

Changed files
- `test/helpers/cliBuild.ts`
- `test/pr249_cli_lock_eviction_matrix.test.ts`
- `test/cli/cli_zax_smoke.test.ts`

Commands run
- `npm ci`
- `npm run typecheck`
- `npx vitest run --reporter=dot test/cli/cli_artifacts.test.ts test/cli/cli_contract_matrix.test.ts test/cli/cli_path_parity_contract.test.ts test/cli/cli_zax_smoke.test.ts test/pr249_cli_lock_eviction_matrix.test.ts`

Reliability
- ensures only one build per test run
- beforeAll timeout raised in CLI smoke test to accommodate build duration

No CLI product behavior changes intended.