### PR TITLE
Flatten singleton addressing step library

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Current user- and contributor-facing references.
 - [`docs/reference/ZAX-quick-guide.md`](reference/ZAX-quick-guide.md) — practical language guide
 - [`docs/reference/testing-verification-guide.md`](reference/testing-verification-guide.md) — testing and verification flow
 - [`docs/reference/source-overview.md`](reference/source-overview.md) — compiler source structure
-- [`docs/reference/addressing-steps-overview.md`](reference/addressing-steps-overview.md) — map of `addressing/steps.ts` template and EA-builder families
+- [`docs/reference/addressing-steps-overview.md`](reference/addressing-steps-overview.md) — map of `lowering/steps.ts` template and EA-builder families
 - [`docs/reference/zax-dev-playbook.md`](reference/zax-dev-playbook.md) — contributor workflow and review hygiene
 - [`docs/reference/codegen-corpus-workflow.md`](reference/codegen-corpus-workflow.md) — curated corpus workflow
 

--- a/docs/archive/design/type-system-reform-plan.md
+++ b/docs/archive/design/type-system-reform-plan.md
@@ -66,7 +66,7 @@ record.
 
 ### `push IX; pop HL` — full inventory
 
-A codebase sweep confirmed that the `push IX; pop HL` idiom appears in exactly four lowering locations (plus one correct prologue use). The rest of the codebase (`src/addressing/steps.ts`, `scalarWordAccessors.ts`, `ldEncoding.ts`, `addressingPipelines.ts`) is clean and spec-compliant.
+A codebase sweep confirmed that the `push IX; pop HL` idiom appears in exactly four lowering locations (plus one correct prologue use). The rest of the codebase (`src/lowering/steps.ts`, `scalarWordAccessors.ts`, `ldEncoding.ts`, `addressingPipelines.ts`) is clean and spec-compliant.
 
 | # | File | Lines | Triggered by | Semantics | Fixed by |
 |---|---|---|---|---|---|
@@ -366,7 +366,7 @@ For frame-slot bases (function parameters), the fallback also contains Instances
 
 The pipeline should support **any power-of-two element size from 2 up to $8000** (32768). That is shiftCount 1 through 15. The Z80 scaling is just repeated `add hl, hl` — there is nothing special about 4 shifts versus 15 shifts except code size and runtime cost. The type system should not impose an arbitrary implementation ceiling on element sizes.
 
-#### `src/addressing/steps.ts` — `CALC_EA_WIDE(shiftCount)` factory
+#### `src/lowering/steps.ts` — `CALC_EA_WIDE(shiftCount)` factory
 
 Replace the hardcoded constant:
 
@@ -386,7 +386,7 @@ const CALC_EA_2 = () => CALC_EA_WIDE(1);
 
 `CALC_EA_WIDE(0)` = byte (one `add hl, de`, no shifts). This makes byte and wide pipelines a single parameterised family.
 
-#### `src/addressing/steps.ts` — `makeEawPipelines(shiftCount)` generator
+#### `src/lowering/steps.ts` — `makeEawPipelines(shiftCount)` generator
 
 Replace the ten hand-written `EAW_*` closures with a factory:
 
@@ -490,7 +490,7 @@ push hl            ; 11
 
 ### Implementation steps
 
-1. Add `CALC_EA_WIDE(shiftCount)` in `src/addressing/steps.ts`; keep `CALC_EA_2` as alias
+1. Add `CALC_EA_WIDE(shiftCount)` in `src/lowering/steps.ts`; keep `CALC_EA_2` as alias
 2. Add `makeEawPipelines(shiftCount)`; keep backward-compatible named exports
 3. Rename `buildEaWordPipeline` → `buildEaWidePipeline`; replace elemSize-2 guards with `shiftCountForSize`
 4. Export `buildEaWidePipeline` from `addressingPipelines.ts`; update all call sites (`ldEncoding.ts`)
@@ -569,7 +569,7 @@ Phases are ordered by severity — correctness bugs first, then generalisation a
 |---|---|---|---|
 | A | Byte pipeline `IndexImm` gap | Done on `main` | `src/lowering/addressingPipelines.ts` |
 | B | Indirect EA resolution | Done on `main` | `src/lowering/eaResolution.ts`, lowering consumers |
-| C | Wide EAW pipeline (2–$8000) | Done on `main` | `src/addressing/steps.ts`, `src/lowering/addressingPipelines.ts` |
+| C | Wide EAW pipeline (2–$8000) | Done on `main` | `src/lowering/steps.ts`, `src/lowering/addressingPipelines.ts` |
 | D | Packed layout for record fields | Still pending | `src/semantics/layout.ts`, `src/lowering/eaResolution.ts` |
 
 Only Phase D should be treated as live unfinished work from this document.

--- a/docs/archive/reference/addressing-model.md
+++ b/docs/archive/reference/addressing-model.md
@@ -4,7 +4,7 @@ Goal: express every allowed load/store addressing shape as a short pipeline of r
 
 > **Implementation reference only** — This document describes the current handwritten step-pipeline lowering model. It is not the normative language specification.
 >
-> If anything here conflicts with `docs/spec/zax-spec.md` or `docs/spec/zax-grammar.ebnf.md`, the spec documents win. The live implementation remains in `src/addressing/steps.ts` plus its lowering consumers and tests. The intended direction is to codify the step inventory and routing rules in a machine-readable spec-data layer and make this reference mechanically checked against that layer.
+> If anything here conflicts with `docs/spec/zax-spec.md` or `docs/spec/zax-grammar.ebnf.md`, the spec documents win. The live implementation remains in `src/lowering/steps.ts` plus its lowering consumers and tests. The intended direction is to codify the step inventory and routing rules in a machine-readable spec-data layer and make this reference mechanically checked against that layer.
 
 ## Source Semantics
 

--- a/docs/archive/work/design-driven-reform-plan.md
+++ b/docs/archive/work/design-driven-reform-plan.md
@@ -139,7 +139,7 @@ We do **not** need to generate the full parser from EBNF immediately. A handwrit
 
 Current seed:
 
-- `src/addressing/steps.ts`
+- `src/lowering/steps.ts`
 
 This should deliberately mirror the grammar strategy: a privileged addressing reference, a structured data layer behind it, and code that validates against that layer instead of drifting beside it.
 
@@ -205,7 +205,7 @@ But they should consume spec-data instead of restating the same rules.
 
 1. Reframe `docs/reference/addressing-model.md` as an implementation reference, not a normative language spec.
 2. Extract structured addressing definitions into `src/specdata/addressing/`.
-3. Build `src/addressing/steps.ts` exports from those definitions.
+3. Build `src/lowering/steps.ts` exports from those definitions.
 4. Keep `src/lowering/emissionCore.ts` as the interpreter that turns `StepInstr` into emitted instructions.
 5. Refactor `src/lowering/addressingPipelines.ts` so routing comes from a table/matrix rather than open-coded branching.
 6. Generate or verify the addressing-model doc and matrix tests from the same definitions.

--- a/docs/reference/addressing-steps-overview.md
+++ b/docs/reference/addressing-steps-overview.md
@@ -1,4 +1,4 @@
-# Addressing step library (`src/addressing/steps.ts`)
+# Addressing step library (`src/lowering/steps.ts`)
 
 Status: non-normative map of the step-pipeline DSL. The source of truth is the TypeScript module;
 this page helps you jump to the right **family** without reading the file top-to-bottom.

--- a/docs/reference/source-overview.md
+++ b/docs/reference/source-overview.md
@@ -29,9 +29,6 @@ src/
   moduleLoader.ts         Import/include expansion, module graph walk, topo ordering, source capture
   pipeline.ts             Type contracts only: CompilerOptions, CompileResult, PipelineDeps
 
-  addressing/
-    steps.ts              Step-pipeline primitives (EA builders, load/store templates); section comments + see docs/reference/addressing-steps-overview.md
-
   diagnostics/
     types.ts              Diagnostic type + stable ID registry (ZAX000–ZAX501)
 
@@ -72,6 +69,7 @@ src/
     emit.ts               emitProgram orchestrator: wires workspace state (section byte maps, fixup queues, visibility, resolution helpers, createEmitProgramContext); invokes emitPipeline phases
     emitPipeline.ts       Emit phase seams: prescan → lowering → placement & artifacts; typed EmitProgramOptions / EmitProgramResult; delegates to programLowering + emitFinalization
     emitContextBuilder.ts Shared wiring for function/program lowering contexts used by emit.ts
+    steps.ts              Step-pipeline primitives (EA builders, load/store templates); section comments + see docs/reference/addressing-steps-overview.md
     ldLowering.ts         Typed LD lowering facade: form selection + encoding composition
     ldEncoding.ts         LD encoding core: context wiring, assignment plans, scalar/aggregate paths
     ldEncodingRegMemHelpers.ts Register/memory LD templates and EA pipelines for ldEncoding
@@ -90,11 +88,13 @@ src/
     asmInstructionLowering.ts lowerAsmInstructionDispatcher: ret/call/jp/jr/djnz dispatch
     functionBodySetup.ts  Flow state, labels, joinFlows, select helpers, sourceTagForSpan
     valueMaterialization.ts  pushEaAddress, pushMemValue, runtime linear expression analysis
+    valueMaterializationContext.ts  Lowering context for value materialization helpers
     opMatching.ts         Op overload matching, specificity, diagnostic formatting
     opExpansionOrchestration.ts  Op expansion: arity/overload check, stack-policy enforcement
     opExpansionExecution.ts     Op expansion: substitution + re-lowering
     opSubstitution.ts     Op parameter substitution (replace matcher params with args)
     emissionCore.ts       Core byte emission: emitCodeBytes, emitRawCodeBytes, emitStepPipeline
+    emitStepImports.ts    Step-instruction import collection for emit path
     fixupEmission.ts      Fixup emission: ABS16, REL8, condition opcode maps, symbolicTarget
     asmUtils.ts           ASM clone utilities (cloneImmExpr, cloneEaExpr), flattenEaDottedName
     runtimeAtomBudget.ts  Runtime-atom budget enforcement for indexed EA
@@ -325,7 +325,7 @@ uses a DE shuttle (`ex de,hl` / `ld d/e,(ix+d)` / `ex de,hl`) for these cases.
 
 ### 4.7 Lowering: Step Pipelines
 
-`addressing/steps.ts` defines a step-pipeline abstraction. A `StepPipeline` is an ordered list
+`lowering/steps.ts` defines a step-pipeline abstraction. A `StepPipeline` is an ordered list
 of `StepInstr` values. Steps are combined by templates (e.g., `TEMPLATE_L_ABC`,
 `TEMPLATE_LW_HL`) and then executed by `emitStepPipeline` in `emissionCore.ts`.
 

--- a/src/lowering/addressingPipelines.ts
+++ b/src/lowering/addressingPipelines.ts
@@ -24,7 +24,7 @@ import {
   LOAD_BASE_FVAR,
   LOAD_BASE_GLOB,
   type StepPipeline,
-} from '../addressing/steps.js';
+} from './steps.js';
 import type { Diagnostic } from '../diagnosticTypes.js';
 import type { EaExprNode, ImmExprNode, SourceSpan, TypeExprNode } from '../frontend/ast.js';
 import type { EaResolution } from './eaResolution.js';

--- a/src/lowering/emissionCore.ts
+++ b/src/lowering/emissionCore.ts
@@ -1,5 +1,5 @@
 import type { AsmOperandNode, ImmExprNode, SourceSpan } from '../frontend/ast.js';
-import { renderStepInstr, type StepInstr, type StepPipeline } from '../addressing/steps.js';
+import { renderStepInstr, type StepInstr, type StepPipeline } from './steps.js';
 
 type Context = {
   getCodeOffset: () => number;

--- a/src/lowering/emitStepImports.ts
+++ b/src/lowering/emitStepImports.ts
@@ -45,4 +45,4 @@ export {
   TEMPLATE_S_ANY,
   TEMPLATE_S_HL,
   type StepPipeline,
-} from '../addressing/steps.js';
+} from './steps.js';

--- a/src/lowering/functionCallLowering.ts
+++ b/src/lowering/functionCallLowering.ts
@@ -1,4 +1,4 @@
-import { TEMPLATE_SW_DEBC } from '../addressing/steps.js';
+import { TEMPLATE_SW_DEBC } from './steps.js';
 import { DiagnosticIds } from '../diagnosticTypes.js';
 import type { Diagnostic } from '../diagnosticTypes.js';
 import type {
@@ -12,7 +12,7 @@ import type {
   TypeExprNode,
 } from '../frontend/ast.js';
 import type { CompileEnv } from '../semantics/env.js';
-import type { StepPipeline } from '../addressing/steps.js';
+import type { StepPipeline } from './steps.js';
 import type { OpStackPolicyMode } from '../pipeline.js';
 import type { Callable, SourceSegmentTag } from './loweringTypes.js';
 import type { OpOverloadSelection } from './opMatching.js';

--- a/src/lowering/functionLowering.ts
+++ b/src/lowering/functionLowering.ts
@@ -1,4 +1,4 @@
-import type { StepPipeline } from '../addressing/steps.js';
+import type { StepPipeline } from './steps.js';
 import { DiagnosticIds } from '../diagnosticTypes.js';
 import type { Diagnostic, DiagnosticId } from '../diagnosticTypes.js';
 import type {

--- a/src/lowering/ldEncoding.ts
+++ b/src/lowering/ldEncoding.ts
@@ -1,4 +1,4 @@
-import type { StepPipeline } from '../addressing/steps.js';
+import type { StepPipeline } from './steps.js';
 import type { Diagnostic } from '../diagnosticTypes.js';
 import type { AsmOperandNode, EaExprNode } from '../frontend/ast.js';
 import type { ImmExprNode, SourceSpan, TypeExprNode } from '../frontend/ast.js';

--- a/src/lowering/ldEncodingRegMemHelpers.ts
+++ b/src/lowering/ldEncodingRegMemHelpers.ts
@@ -1,4 +1,4 @@
-import type { StepPipeline } from '../addressing/steps.js';
+import type { StepPipeline } from './steps.js';
 import type { AsmOperandNode, SourceSpan } from '../frontend/ast.js';
 import type { LdForm } from './ldFormSelection.js';
 import type { LdEncodingContext } from './ldEncoding.js';

--- a/src/lowering/scalarWordAccessors.ts
+++ b/src/lowering/scalarWordAccessors.ts
@@ -4,7 +4,7 @@ import {
   STORE_RP_FVAR,
   STORE_RP_GLOB,
   type StepPipeline,
-} from '../addressing/steps.js';
+} from './steps.js';
 import type { SourceSpan, TypeExprNode } from '../frontend/ast.js';
 import type { EaResolution } from './eaResolution.js';
 import type { ScalarKind } from './typeResolution.js';

--- a/src/lowering/steps.ts
+++ b/src/lowering/steps.ts
@@ -5,7 +5,7 @@
  * Rendering to pseudo-assembly text is only for tests/document checks.
  *
  * **Navigation:** Section comments below group exports. Family-level map:
- * [`docs/reference/addressing-steps-overview.md`](../../../docs/reference/addressing-steps-overview.md).
+ * [`docs/reference/addressing-steps-overview.md`](../../docs/reference/addressing-steps-overview.md).
  *
  * | Area | Exports (representative) |
  * |------|-------------------------|

--- a/src/lowering/valueMaterializationContext.ts
+++ b/src/lowering/valueMaterializationContext.ts
@@ -1,7 +1,7 @@
 import type { Diagnostic } from '../diagnosticTypes.js';
 import type { AsmOperandNode, EaExprNode, ImmExprNode, SourceSpan, TypeExprNode } from '../frontend/ast.js';
 import type { EaResolution } from './eaResolution.js';
-import type { StepPipeline } from '../addressing/steps.js';
+import type { StepPipeline } from './steps.js';
 
 export type DiagAt = (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
 

--- a/test/addressing_model_steps.test.ts
+++ b/test/addressing_model_steps.test.ts
@@ -20,7 +20,7 @@ import {
   LOAD_RP_FVAR,
   STORE_RP_FVAR,
   renderStepPipeline,
-} from '../src/addressing/steps';
+} from '../src/lowering/steps';
 
 const asm = renderStepPipeline;
 

--- a/test/lowering/pr509_addressing_pipeline_builders.test.ts
+++ b/test/lowering/pr509_addressing_pipeline_builders.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { renderStepPipeline } from '../../src/addressing/steps.js';
+import { renderStepPipeline } from '../../src/lowering/steps.js';
 import { DiagnosticIds, type Diagnostic } from '../../src/diagnosticTypes.js';
 import type { EaExprNode, SourceSpan, TypeExprNode } from '../../src/frontend/ast.js';
 import { createAddressingPipelineBuilders } from '../../src/lowering/addressingPipelines.js';

--- a/test/lowering/pr509_scalar_word_accessors.test.ts
+++ b/test/lowering/pr509_scalar_word_accessors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { renderStepPipeline } from '../../src/addressing/steps.js';
+import { renderStepPipeline } from '../../src/lowering/steps.js';
 import type { SourceSpan, TypeExprNode } from '../../src/frontend/ast.js';
 import { createScalarWordAccessorHelpers } from '../../src/lowering/scalarWordAccessors.js';
 import type { EaResolution } from '../../src/lowering/eaResolution.js';

--- a/test/lowering/pr528_emission_core_helpers.test.ts
+++ b/test/lowering/pr528_emission_core_helpers.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { AsmOperandNode, SourceSpan } from '../../src/frontend/ast.js';
 import { createEmissionCoreHelpers } from '../../src/lowering/emissionCore.js';
-import type { StepPipeline } from '../../src/addressing/steps.js';
+import type { StepPipeline } from '../../src/lowering/steps.js';
 
 const span: SourceSpan = {
   file: 'test.zax',

--- a/test/pr407_step_matrix.test.ts
+++ b/test/pr407_step_matrix.test.ts
@@ -35,7 +35,7 @@ import {
   CALC_EA,
   renderStepPipeline,
   type StepPipeline,
-} from '../src/addressing/steps';
+} from '../src/lowering/steps';
 
 const asm = renderStepPipeline;
 

--- a/test/pr711_wide_eaw.test.ts
+++ b/test/pr711_wide_eaw.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { EAW_FVAR_CONST, EAW_GLOB_CONST, renderStepPipeline } from '../src/addressing/steps.js';
+import { EAW_FVAR_CONST, EAW_GLOB_CONST, renderStepPipeline } from '../src/lowering/steps.js';
 import { DiagnosticIds, type Diagnostic } from '../src/diagnosticTypes.js';
 import type { AsmOperandNode, EaExprNode, SourceSpan, TypeExprNode } from '../src/frontend/ast.js';
 import { createAddressingPipelineBuilders } from '../src/lowering/addressingPipelines.js';

--- a/test/pr819_exact_scale_lowering.test.ts
+++ b/test/pr819_exact_scale_lowering.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { EAW_GLOB_CONST, renderStepPipeline } from '../src/addressing/steps.js';
+import { EAW_GLOB_CONST, renderStepPipeline } from '../src/lowering/steps.js';
 import { DiagnosticIds, type Diagnostic } from '../src/diagnosticTypes.js';
 import type { AsmOperandNode, EaExprNode, SourceSpan, TypeExprNode } from '../src/frontend/ast.js';
 import { createAddressingPipelineBuilders } from '../src/lowering/addressingPipelines.js';


### PR DESCRIPTION
Closes #1106.

## Summary
- move the singleton step library out of `src/addressing/`
- place it under `src/lowering/steps.ts`
- update all live source, test, and documentation references
- remove the now-empty `src/addressing/` directory

## Old Path / New Path
- old: `src/addressing/steps.ts`
- new: `src/lowering/steps.ts`

## Rationale
This module is primarily a lowering support library. Its live product-code imports are all from `src/lowering`, and its consumers are lowering helpers, emission helpers, and lowering-focused tests. Moving it under `src/lowering/` removes the singleton directory without introducing a new root-level singleton utility file.

## Behavior
- unchanged
- this is a path/ownership cleanup only; step semantics were not modified

## Changed Files
- `src/lowering/steps.ts`
- imports in `src/lowering/*` consumers
- step-focused tests under `test/`
- reference/archive docs that pointed at the old path

## Commands Run
```sh
git fetch origin --prune
git branch -f codex/dev-b origin/main
git worktree add /Users/johnhardy/.codex/worktrees/flatten-addressing/ZAX -b codex/flatten-addressing origin/main
npm ci
npm run typecheck
npx vitest run test/pr407_step_matrix.test.ts test/addressing_model_steps.test.ts test/pr711_wide_eaw.test.ts test/pr819_exact_scale_lowering.test.ts test/pr900_step_integration.test.ts test/pr1050_step_lowering.test.ts
```
