### PR TITLE
Issue 1105: migrate tests and add top-level guardrail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,23 @@ jobs:
           fi
           echo "changed_count=$(wc -l < changed_files.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
 
+      - name: Test layout guardrail
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+            head_sha="${{ github.event.pull_request.head.sha }}"
+          else
+            before_sha="${{ github.event.before }}"
+            head_sha="${{ github.sha }}"
+            if [[ "$before_sha" == "0000000000000000000000000000000000000000" ]]; then
+              echo "test layout guardrail: initial push detected, skipping"
+              exit 0
+            fi
+            base_sha="$before_sha"
+          fi
+          git diff --name-status "$base_sha" "$head_sha" | node ./scripts/ci/test-layout-guardrail.js
+
       - name: Classify change set
         id: classify
         shell: bash

--- a/scripts/ci/test-layout-guardrail.js
+++ b/scripts/ci/test-layout-guardrail.js
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+
+const TOP_LEVEL_PR_TEST = /^test\/pr\d+_.*\.test\.ts$/;
+
+function normalizePath(path) {
+  return path.replaceAll('\\', '/');
+}
+
+const input = readFileSync(0, 'utf8').trim();
+if (!input) {
+  process.stdout.write('test layout guardrail: no changed files\n');
+  process.exit(0);
+}
+
+const violations = [];
+for (const rawLine of input.split(/\r?\n/)) {
+  const line = rawLine.trim();
+  if (!line) continue;
+  const parts = line.split(/\t+/);
+  const status = parts[0] ?? '';
+  const kind = status[0];
+  let path;
+  if (kind === 'A') {
+    path = parts[1];
+  } else if (kind === 'R' || kind === 'C') {
+    path = parts[2];
+  } else {
+    continue;
+  }
+  if (!path) continue;
+  const normalized = normalizePath(path);
+  if (TOP_LEVEL_PR_TEST.test(normalized)) violations.push(normalized);
+}
+
+if (violations.length === 0) {
+  process.stdout.write('test layout guardrail: no new top-level PR tests\n');
+  process.exit(0);
+}
+
+for (const file of violations) {
+  process.stderr.write(`New top-level PR test file added: ${file}\n`);
+}
+process.stderr.write(
+  `test layout guardrail: ${violations.length} new top-level PR test file(s) added\n`,
+);
+process.exit(1);

--- a/test/README.md
+++ b/test/README.md
@@ -13,6 +13,7 @@ Tests are migrating from a flat `test/prNNN_*.test.ts` layout into subsystem fol
 - `test/lowering/` — lowering helper seams and asm-emission integration tests (most lowering seams now live here; a few broad integration files may still be top-level)
 
 New tests should prefer the subsystem directory that matches the code under test. Older tests may still live at `test/prNNN_*.test.ts` until moved.
+CI now rejects newly added top-level `test/prNNN_*.test.ts` files unless you explicitly update the guardrail.
 
 ## How to navigate this tree
 
@@ -56,7 +57,7 @@ Representative files:
 
 Representative files:
 
-- `pr680_asm_golden_contract.test.ts` for checked-in codegen goldens
+- `backend/pr680_asm_golden_contract.test.ts` for checked-in codegen goldens
 - `determinism_artifacts.test.ts` for artifact stability
 - `smoke_language_tour_compile.test.ts` for generated language-tour coverage
 - `cli/pr990_asm80_emitter_validation.test.ts` when external ASM80 compatibility is the contract
@@ -73,10 +74,10 @@ Representative files:
 | Lowering helper seams                      | `lowering/pr509_*.test.ts`, `lowering/pr510_*.test.ts`, `lowering/pr511_*.test.ts`, `lowering/pr528_emission_core_helpers.test.ts`, `lowering/pr529_fixup_emission_helpers.test.ts`, `lowering/pr530_asm_utils_helpers.test.ts`, `lowering/pr531_value_materialization_helpers.test.ts`, `lowering/pr532_asm_instruction_lowering_integration.test.ts` | Prefer these before adding another broad compile test. |
 | Named sections and placement               | `pr572_named_sections_parser.test.ts`, `pr582_section_contribution_sinks.test.ts`, `pr583_section_placement_helpers.test.ts`, `pr584_named_section_fixups_integration.test.ts`, `pr585_named_section_layout_integration.test.ts`                                     | Use when section routing, anchors, or fixups change.                                                                                   |
 | Assignment and storage legality            | `pr862_assignment_parser.test.ts`, `pr863_assignment_lowering.test.ts`, `pr869_assignment_reg8_*`, `pr875_assignment_ixiy_integration.test.ts`, `pr895_assignment_acceptance.test.ts`                                                                                | Parser, lowering, and acceptance coverage are already split.                                                                           |
-| Encoder behavior                           | `pr24_isa_core.test.ts`, `backend/pr477_encode_*.test.ts`, `pr203_ld_diag_matrix.test.ts`, `pr240_isa_register_target_diag_matrix.test.ts`                                                                                                                           | Prefer direct encoder tests when lowering is not involved.                                                                             |
+| Encoder behavior                           | `pr24_isa_core.test.ts`, `backend/pr477_encode_*.test.ts`, `backend/pr468_encoder_dispatch_integration.test.ts`, `backend/pr694_encoder_registry_dispatch.test.ts`, `pr203_ld_diag_matrix.test.ts`, `pr240_isa_register_target_diag_matrix.test.ts`                   | Prefer direct encoder tests when lowering is not involved.                                                                             |
 | Examples, smoke, and determinism           | `examples_compile.test.ts`, `smoke.test.ts`, `smoke_language_tour_compile.test.ts`, `determinism_artifacts.test.ts`                                                                                                                                                  | Use for broad regressions and checked-in examples.                                                                                     |
-| Corpus and external backend compatibility  | `pr680_asm_golden_contract.test.ts`, `cli/pr990_asm80_emitter_validation.test.ts`, `pr991_asm80_comment_preservation.test.ts`                                                                                                                                        | Only use these when emitted artifact text or external-tool compatibility is the contract.                                              |
-| Policy and infrastructure                  | `ci_change_classifier.test.ts`, `pr472_source_file_size_guard.test.ts`, `pr241_d8m_contract_hardening.test.ts`                                                                                                                                                       | For repo policy, CI classification, and artifact contract checks.                                                                      |
+| Corpus and external backend compatibility  | `backend/pr680_asm_golden_contract.test.ts`, `cli/pr990_asm80_emitter_validation.test.ts`, `pr991_asm80_comment_preservation.test.ts`                                                                                                                                | Only use these when emitted artifact text or external-tool compatibility is the contract.                                              |
+| Policy and infrastructure                  | `ci_change_classifier.test.ts`, `pr472_source_file_size_guard.test.ts`, `backend/pr241_d8m_contract_hardening.test.ts`                                                                                                                                               | For repo policy, CI classification, and artifact contract checks.                                                                      |
 
 ## Where to put new tests
 

--- a/test/backend/pr119_d8m_path_normalization.test.ts
+++ b/test/backend/pr119_d8m_path_normalization.test.ts
@@ -2,16 +2,16 @@ import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
-import type { D8mArtifact } from '../src/formats/types.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import type { D8mArtifact } from '../../src/formats/types.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR119 D8M path normalization', () => {
   it('normalizes symbol file paths to project-relative with forward slashes', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr10_import_main.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr10_import_main.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics).toEqual([]);
 

--- a/test/backend/pr200_d8m_appendix_mapping.test.ts
+++ b/test/backend/pr200_d8m_appendix_mapping.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
-import type { D8mArtifact } from '../src/formats/types.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import type { D8mArtifact } from '../../src/formats/types.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -29,7 +29,7 @@ type D8mFileEntry = {
 
 describe('PR200 D8M appendix mapping closure', () => {
   it('emits files-object grouped symbols/segments with deterministic baseline metadata', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr200_d8m_appendix_mapping.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr200_d8m_appendix_mapping.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics).toEqual([]);
 

--- a/test/backend/pr241_d8m_contract_hardening.test.ts
+++ b/test/backend/pr241_d8m_contract_hardening.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { writeD8m } from '../src/formats/writeD8m.js';
-import type { EmittedByteMap, SymbolEntry } from '../src/formats/types.js';
+import { writeD8m } from '../../src/formats/writeD8m.js';
+import type { EmittedByteMap, SymbolEntry } from '../../src/formats/types.js';
 
 type D8mView = {
   segments: Array<{ start: number; end: number }>;

--- a/test/backend/pr284_entry_contract_main_and_d8m_metadata.test.ts
+++ b/test/backend/pr284_entry_contract_main_and_d8m_metadata.test.ts
@@ -2,16 +2,16 @@ import { describe, expect, it } from 'vitest';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
-import type { D8mArtifact } from '../src/formats/types.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import type { D8mArtifact } from '../../src/formats/types.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR284: entry contract requires main and emits D8 metadata', () => {
   it('fails when requireMain is enabled and no main function exists', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr284_require_main_missing.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr284_require_main_missing.zax');
     const res = await compile(entry, { requireMain: true }, { formats: defaultFormatWriters });
 
     expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(true);
@@ -24,7 +24,7 @@ describe('PR284: entry contract requires main and emits D8 metadata', () => {
   });
 
   it('emits generator entry metadata in d8dbg when main exists', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr1_minimal.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr1_minimal.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics).toEqual([]);
 

--- a/test/backend/pr468_encoder_dispatch_integration.test.ts
+++ b/test/backend/pr468_encoder_dispatch_integration.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnosticTypes.js';
-import type { AsmInstructionNode, AsmOperandNode, SourceSpan } from '../src/frontend/ast.js';
-import { encodeInstruction } from '../src/z80/encode.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import type { AsmInstructionNode, AsmOperandNode, SourceSpan } from '../../src/frontend/ast.js';
+import { encodeInstruction } from '../../src/z80/encode.js';
 
 const span: SourceSpan = {
   file: 'pr468_encoder_dispatch_integration.zax',

--- a/test/backend/pr680_asm_golden_contract.test.ts
+++ b/test/backend/pr680_asm_golden_contract.test.ts
@@ -3,9 +3,9 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
-import type { HexArtifact } from '../src/formats/types.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import type { HexArtifact } from '../../src/formats/types.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -25,7 +25,7 @@ type CorpusManifest = {
 };
 
 async function readManifest(): Promise<CorpusManifest> {
-  const path = join(__dirname, 'fixtures', 'corpus', 'manifest.json');
+  const path = join(__dirname, '..', 'fixtures', 'corpus', 'manifest.json');
   return JSON.parse(await readFile(path, 'utf8')) as CorpusManifest;
 }
 
@@ -34,8 +34,14 @@ describe('PR680: asm80 golden contract coverage for curated corpus', () => {
     const manifest = await readManifest();
 
     for (const entry of manifest.curatedCases) {
-      const sourcePath = join(__dirname, '..', entry.source);
-      const expectedHexPath = join(__dirname, '..', manifest.opcodeHexDir, `${entry.name}.hex`);
+      const sourcePath = join(__dirname, '..', '..', entry.source);
+      const expectedHexPath = join(
+        __dirname,
+        '..',
+        '..',
+        manifest.opcodeHexDir,
+        `${entry.name}.hex`,
+      );
       const expectedHex = await readFile(expectedHexPath, 'utf8');
 
       const result = await compile(

--- a/test/backend/pr694_encoder_registry_dispatch.test.ts
+++ b/test/backend/pr694_encoder_registry_dispatch.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnosticTypes.js';
-import type { AsmInstructionNode, AsmOperandNode, SourceSpan } from '../src/frontend/ast.js';
-import { getEncoderRegistryEntry } from '../src/z80/encoderRegistry.js';
-import { encodeInstruction } from '../src/z80/encode.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import type { AsmInstructionNode, AsmOperandNode, SourceSpan } from '../../src/frontend/ast.js';
+import { getEncoderRegistryEntry } from '../../src/z80/encoderRegistry.js';
+import { encodeInstruction } from '../../src/z80/encode.js';
 
 const span: SourceSpan = {
   file: 'pr694_encoder_registry_dispatch.zax',

--- a/test/semantics/pr260_value_semantics_scalar_index.test.ts
+++ b/test/semantics/pr260_value_semantics_scalar_index.test.ts
@@ -2,16 +2,16 @@ import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
-import type { BinArtifact } from '../src/formats/types.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import type { BinArtifact } from '../../src/formats/types.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR260: scalar variable indices in array access', () => {
   it('lowers byte/word scalar indices in ld array forms', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr260_value_semantics_scalar_index.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr260_value_semantics_scalar_index.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics).toEqual([]);
 

--- a/test/semantics/pr274_type_padding_warning.test.ts
+++ b/test/semantics/pr274_type_padding_warning.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR274: exact-size layout no longer emits padding warnings', () => {
   it('keeps exact-size composite layouts warning-free', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr274_type_padding_warning.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr274_type_padding_warning.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
     expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(false);
@@ -18,7 +18,7 @@ describe('PR274: exact-size layout no longer emits padding warnings', () => {
   });
 
   it('keeps explicitly padded layouts warning-free', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr274_type_padding_explicit_ok.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr274_type_padding_explicit_ok.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics).toEqual([]);
   });

--- a/test/semantics/pr505_type_resolution_helpers.test.ts
+++ b/test/semantics/pr505_type_resolution_helpers.test.ts
@@ -2,22 +2,22 @@ import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR505: extracted type-resolution helpers', () => {
   it('preserves scalar index value semantics for ld lowering', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr260_value_semantics_scalar_index.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr260_value_semantics_scalar_index.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
     expect(res.diagnostics).toEqual([]);
   });
 
   it('preserves non-scalar typed-call compatibility diagnostics', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr286_nonscalar_param_compat_negative.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr286_nonscalar_param_compat_negative.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     const messages = res.diagnostics.map((d) => d.message);
 


### PR DESCRIPTION
## Summary
- Move a backend/semantics test batch into subsystem directories.
- Add a CI guardrail that rejects new top-level test/prNNN_*.test.ts additions.
- Update test/README layout guidance for the new guardrail and moved files.

## Moved files
- test/pr119_d8m_path_normalization.test.ts -> test/backend/pr119_d8m_path_normalization.test.ts
- test/pr200_d8m_appendix_mapping.test.ts -> test/backend/pr200_d8m_appendix_mapping.test.ts
- test/pr241_d8m_contract_hardening.test.ts -> test/backend/pr241_d8m_contract_hardening.test.ts
- test/pr284_entry_contract_main_and_d8m_metadata.test.ts -> test/backend/pr284_entry_contract_main_and_d8m_metadata.test.ts
- test/pr468_encoder_dispatch_integration.test.ts -> test/backend/pr468_encoder_dispatch_integration.test.ts
- test/pr680_asm_golden_contract.test.ts -> test/backend/pr680_asm_golden_contract.test.ts
- test/pr694_encoder_registry_dispatch.test.ts -> test/backend/pr694_encoder_registry_dispatch.test.ts
- test/pr260_value_semantics_scalar_index.test.ts -> test/semantics/pr260_value_semantics_scalar_index.test.ts
- test/pr274_type_padding_warning.test.ts -> test/semantics/pr274_type_padding_warning.test.ts
- test/pr505_type_resolution_helpers.test.ts -> test/semantics/pr505_type_resolution_helpers.test.ts

## Guardrail
- scripts/ci/test-layout-guardrail.js (new)
- .github/workflows/ci.yml (new guardrail step)

## Test layout counts
- Top-level prNNN tests: 274 -> 264
- Subsystem tests: 40 -> 50

## Commands
- npm ci
- npm run typecheck
- npx vitest run test/backend/pr241_d8m_contract_hardening.test.ts test/backend/pr200_d8m_appendix_mapping.test.ts test/backend/pr119_d8m_path_normalization.test.ts test/backend/pr284_entry_contract_main_and_d8m_metadata.test.ts test/backend/pr468_encoder_dispatch_integration.test.ts test/backend/pr694_encoder_registry_dispatch.test.ts test/backend/pr680_asm_golden_contract.test.ts test/semantics/pr260_value_semantics_scalar_index.test.ts test/semantics/pr274_type_padding_warning.test.ts test/semantics/pr505_type_resolution_helpers.test.ts
