### PR TITLE
test-quality: convert semantics diagnostic assertion batch

### DIFF
--- a/test/pr277_index_redundant_paren_warning.test.ts
+++ b/test/pr277_index_redundant_paren_warning.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 import { compile } from '../src/compile.js';
 import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoErrors } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -16,7 +17,11 @@ describe('PR277: redundant grouped index warning', () => {
 
     const warnings = res.diagnostics.filter((d) => d.id === DiagnosticIds.IndexParenRedundant);
     expect(warnings).toHaveLength(1);
-    expect(warnings[0]?.message).toContain('Redundant outer parentheses in constant index');
-    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(false);
+    expectDiagnostic(warnings, {
+      id: DiagnosticIds.IndexParenRedundant,
+      severity: 'warning',
+      messageIncludes: 'Redundant outer parentheses in constant index',
+    });
+    expectNoErrors(res.diagnostics);
   });
 });

--- a/test/pr4_enum.test.ts
+++ b/test/pr4_enum.test.ts
@@ -4,6 +4,8 @@ import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
+import { expectDiagnostic, expectNoErrors } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,33 +14,38 @@ describe('PR4 enum parsing', () => {
   it('evaluates enum members in imm expressions', async () => {
     const entry = join(__dirname, 'fixtures', 'pr4_enum.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(false);
+    expectNoErrors(res.diagnostics);
   });
 
   it('rejects unqualified enum member references', async () => {
     const entry = join(__dirname, 'fixtures', 'pr259_enum_unqualified_member.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(
-      res.diagnostics.some((d) =>
-        d.message.includes('Unqualified enum member "Write" is not allowed; use "Mode.Write".'),
-      ),
-    ).toBe(true);
-    expect(res.diagnostics.some((d) => d.message.includes('Failed to evaluate const "Bad".'))).toBe(
-      true,
-    );
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.SemanticsError,
+      severity: 'error',
+      message: 'Unqualified enum member "Write" is not allowed; use "Mode.Write".',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.SemanticsError,
+      severity: 'error',
+      message: 'Failed to evaluate const "Bad".',
+    });
   });
 
   it('diagnoses ambiguous unqualified enum member references', async () => {
     const entry = join(__dirname, 'fixtures', 'pr265_enum_unqualified_ambiguous.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(
-      res.diagnostics.some((d) =>
-        d.message.includes(
-          'Unqualified enum member "On" is ambiguous; use one of: ModeA.On, ModeB.On.',
-        ),
-      ),
-    ).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.SemanticsError,
+      severity: 'error',
+      message: 'Unqualified enum member "On" is ambiguous; use one of: ModeA.On, ModeB.On.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.SemanticsError,
+      severity: 'error',
+      message: 'Failed to evaluate const "Bad".',
+    });
   });
 });

--- a/test/pr54_inferred_array_len_invalid.test.ts
+++ b/test/pr54_inferred_array_len_invalid.test.ts
@@ -4,6 +4,8 @@ import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,8 +15,10 @@ describe('PR54: restrict inferred-length arrays to data declarations', () => {
     const entry = join(__dirname, 'fixtures', 'pr54_inferred_array_len_invalid_var.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(res.diagnostics.some((d) => d.message.includes('Inferred-length arrays (T[])'))).toBe(
-      true,
-    );
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      messageIncludes: 'Inferred-length arrays (T[])',
+    });
   });
 });

--- a/test/pr575_callable_visibility.test.ts
+++ b/test/pr575_callable_visibility.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
+import { expectDiagnostic, expectNoErrors } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,26 +14,44 @@ const fixture = (name: string) => join(__dirname, 'fixtures', name);
 describe('PR575 callable visibility', () => {
   it('allows qualified imported function and op references', async () => {
     const res = await compile(fixture('pr575_callable_root_ok.zax'), {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    expectNoErrors(res.diagnostics);
   });
 
   it('rejects unqualified imported function and op references', async () => {
     const res = await compile(fixture('pr575_callable_root_unqualified.zax'), {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EncodeError,
+      severity: 'error',
+      message: 'Unsupported instruction: helper',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EncodeError,
+      severity: 'error',
+      message: 'Unsupported instruction: bump',
+    });
   });
 
   it('rejects qualified function and op references without a direct import', async () => {
     const res = await compile(fixture('pr575_callable_root_noimport.zax'), {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EncodeError,
+      severity: 'error',
+      message: 'Unsupported instruction: pr575_callable_dep.helper',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EncodeError,
+      severity: 'error',
+      message: 'Unsupported instruction: pr575_callable_dep.bump',
+    });
   });
 
   it('allows same-module qualified function and op references', async () => {
     const res = await compile(fixture('pr575_callable_self_qualified.zax'), {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    expectNoErrors(res.diagnostics);
   });
 
   it('allows same-module qualified private function and op references', async () => {
     const res = await compile(fixture('pr575_callable_self_private_qualified.zax'), {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    expectNoErrors(res.diagnostics);
   });
 });

--- a/test/pr575_module_visibility_scaffolding.test.ts
+++ b/test/pr575_module_visibility_scaffolding.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import type { ProgramNode } from '../src/frontend/ast.js';
 import { parseModuleFile } from '../src/frontend/parser.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { canAccessQualifiedName } from '../src/moduleVisibility.js';
 import { buildEnv, evalImmExpr } from '../src/semantics/env.js';
 import { sizeOfTypeExpr } from '../src/semantics/layout.js';
+import { expectDiagnostic, expectNoDiagnostics } from './helpers/diagnostics.js';
 
 describe('PR575 module visibility scaffolding', () => {
   it('parses exported sectionless declarations and dotted type names', () => {
@@ -22,7 +24,7 @@ describe('PR575 module visibility scaffolding', () => {
       diagnostics,
     );
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(moduleFile.moduleId).toBe('root');
     expect(moduleFile.items[0]).toMatchObject({ kind: 'TypeDecl', exported: true, typeExpr: { kind: 'TypeName', name: 'dep.Word' } });
     expect(moduleFile.items[1]).toMatchObject({ kind: 'UnionDecl', exported: true });
@@ -50,7 +52,7 @@ describe('PR575 module visibility scaffolding', () => {
       diagnostics,
     );
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     const program = {
       kind: 'Program',
       span: root.span,
@@ -60,7 +62,7 @@ describe('PR575 module visibility scaffolding', () => {
 
     const env = buildEnv(program, diagnostics);
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(env.importedModuleIds!.get(root.path)).toEqual(new Set(['dep']));
     expect(env.visibleConsts!.get('dep.FOO')).toBe(7);
     expect(env.consts.has('dep.FOO')).toBe(false);
@@ -119,7 +121,16 @@ describe('PR575 module visibility scaffolding', () => {
       ),
     ).toBeUndefined();
     expect(sizeOfTypeExpr({ kind: 'TypeName', span: other.items[1]!.span, name: 'dep.Word' }, env, diagnostics)).toBeUndefined();
-    expect(diagnostics.some((d) => d.message === 'Unknown type "dep.Word".')).toBe(true);
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.SemanticsError,
+      severity: 'error',
+      message: 'Failed to evaluate const "FAIL".',
+    });
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.TypeError,
+      severity: 'error',
+      message: 'Unknown type "dep.Word".',
+    });
   });
 
   it('fails closed for qualified access when import entry is unavailable', () => {
@@ -150,7 +161,7 @@ describe('PR575 module visibility scaffolding', () => {
     const env = buildEnv(program, diagnostics);
     env.importedModuleIds!.delete(root.path);
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(canAccessQualifiedName('dep.FOO', root.path, env)).toBe(false);
     expect(canAccessQualifiedName('root.Local', root.path, env)).toBe(true);
     expect(
@@ -161,7 +172,11 @@ describe('PR575 module visibility scaffolding', () => {
       ),
     ).toBeUndefined();
     expect(sizeOfTypeExpr({ kind: 'TypeName', span: root.span, name: 'dep.Word' }, env, diagnostics)).toBeUndefined();
-    expect(diagnostics.some((d) => d.message === 'Unknown type "dep.Word".')).toBe(true);
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.TypeError,
+      severity: 'error',
+      message: 'Unknown type "dep.Word".',
+    });
   });
 
   it('uses resolved path-form import edges to determine visibility', () => {
@@ -191,7 +206,7 @@ describe('PR575 module visibility scaffolding', () => {
       ]),
     });
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(env.importedModuleIds!.get(root.path)).toEqual(new Set([dep.moduleId]));
     expect(env.consts.get('LOCAL')).toBe(7);
   });
@@ -219,7 +234,7 @@ describe('PR575 module visibility scaffolding', () => {
       ]),
     });
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(env.importedModuleIds!.get(root.path)).toEqual(new Set([dep.moduleId]));
     expect(env.consts.get('LOCAL')).toBe(7);
   });

--- a/test/pr8_sizeof.test.ts
+++ b/test/pr8_sizeof.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { DiagnosticIds } from '../src/diagnosticTypes.js';
+import { expectDiagnostic, expectNoErrors } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,18 +14,22 @@ describe('PR8 sizeof() in imm expressions', () => {
   it('evaluates sizeof(TypeName) using PR3 layouts', async () => {
     const entry = join(__dirname, 'fixtures', 'pr8_sizeof.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(false);
+    expectNoErrors(res.diagnostics);
   });
 
   it('diagnoses unknown types used in sizeof()', async () => {
     const entry = join(__dirname, 'fixtures', 'pr8_sizeof_unknown.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(res.diagnostics.map((d) => d.id)).toEqual(
-      expect.arrayContaining([DiagnosticIds.TypeError, DiagnosticIds.SemanticsError]),
-    );
-    expect(res.diagnostics.map((d) => d.message)).toEqual(
-      expect.arrayContaining(['Unknown type "Nope".', 'Failed to evaluate const "SzNope".']),
-    );
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.TypeError,
+      severity: 'error',
+      message: 'Unknown type "Nope".',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.SemanticsError,
+      severity: 'error',
+      message: 'Failed to evaluate const "SzNope".',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- continue `#1132` with a focused semantics-heavy diagnostic batch
- replace weak `.some()` diagnostic assertions with explicit helper-based checks
- keep scope to test code only

## Changed Files
- `test/pr4_enum.test.ts`
- `test/pr54_inferred_array_len_invalid.test.ts`
- `test/pr8_sizeof.test.ts`
- `test/pr575_module_visibility_scaffolding.test.ts`
- `test/pr575_callable_visibility.test.ts`
- `test/pr277_index_redundant_paren_warning.test.ts`

## What Changed
- replaced 11 weak `diagnostics.some(...)` assertions with `expectDiagnostic(...)` / `expectNoErrors(...)` / `expectNoDiagnostics(...)`
- tightened several adjacent empty-diagnostics and message-array checks in the same subsystem slice so the files use one consistent helper pattern
- preserved existing compiler behavior and test intent

## Verification
- `npm ci`
- `npm run typecheck`
- `npm run lint`
- `npx vitest run test/pr4_enum.test.ts test/pr54_inferred_array_len_invalid.test.ts test/pr8_sizeof.test.ts test/pr575_module_visibility_scaffolding.test.ts test/pr575_callable_visibility.test.ts test/pr277_index_redundant_paren_warning.test.ts`

## Deferred
- broader repo-wide migration of remaining weak diagnostic assertions
- `it.each()` cleanup
- any compiler code changes
