### PR TITLE
test: strengthen parser diagnostic assertions

### DIFF
--- a/test/pr154_parser_top_level_malformed_keyword_matrix.test.ts
+++ b/test/pr154_parser_top_level_malformed_keyword_matrix.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -18,35 +19,52 @@ describe('PR154 parser: top-level malformed keyword matrix', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('Invalid func header line "func": expected <name>(...): <retType>');
-    expect(messages).toContain('Invalid op header line "op": expected <name>(...)');
-    expect(messages).toContain(
-      'Invalid extern declaration line "extern": expected [<baseName>] or func <name>(...): <retType> at <imm16>',
-    );
-    expect(messages).toContain(
-      'Invalid import statement line "import": expected "<path>.zax" or <moduleId>',
-    );
-    expect(messages).toContain(
-      'Invalid type declaration line "type": expected <name> [<typeExpr>]',
-    );
-    expect(messages).toContain('Invalid union declaration line "union": expected <name>');
-    expect(messages).toContain(
-      'Invalid globals declaration line "globals\tx: byte": expected globals',
-    );
-    expect(messages).toContain('Invalid data declaration line "data\tx: byte = 1": expected data');
-    expect(messages).toContain('Invalid const declaration line "const": expected <name> = <imm>');
-    expect(messages).toContain(
-      'Invalid enum declaration line "enum": expected <name> <member>[, ...]',
-    );
-    expect(messages).toContain(
-      'Invalid section directive line "section\tbad": expected <code|data|var> [at <imm16>]',
-    );
-    expect(messages).toContain('Invalid align directive line "align": expected <imm16>');
-    expect(messages).toContain(
-      'Invalid bin declaration line "bin": expected <name> in <code|data> from "<path>"',
-    );
-    expect(messages).toContain('Invalid hex declaration line "hex": expected <name> from "<path>"');
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid func header line "func": expected <name>(...): <retType>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid op header line "op": expected <name>(...)',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message:
+        'Invalid extern declaration line "extern": expected [<baseName>] or func <name>(...): <retType> at <imm16>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid import statement line "import": expected "<path>.zax" or <moduleId>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid type declaration line "type": expected <name> [<typeExpr>]',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid union declaration line "union": expected <name>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid globals declaration line "globals\tx: byte": expected globals',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid data declaration line "data\tx: byte = 1": expected data',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid const declaration line "const": expected <name> = <imm>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid enum declaration line "enum": expected <name> <member>[, ...]',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message:
+        'Invalid section directive line "section\tbad": expected <code|data|var> [at <imm16>]',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid align directive line "align": expected <imm16>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid bin declaration line "bin": expected <name> in <code|data> from "<path>"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid hex declaration line "hex": expected <name> from "<path>"',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr160_type_union_missing_end_recovery.test.ts
+++ b/test/pr160_type_union_missing_end_recovery.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,11 +14,20 @@ describe('PR160 parser: type/union missing-end recovery', () => {
     const entry = join(__dirname, 'fixtures', 'pr160_type_union_missing_end_recovery.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('Unterminated type "Point": expected "end" before "func"');
-    expect(messages).toContain('Unterminated union "Pair": expected "end" before "const"');
-    expect(messages).not.toContain('Invalid record field declaration');
-    expect(messages).not.toContain('Invalid union field declaration');
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Unterminated type "Point": expected "end" before "func"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Unterminated union "Pair": expected "end" before "const"',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Invalid record field declaration',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Invalid union field declaration',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr161_var_data_keyword_name_matrix.test.ts
+++ b/test/pr161_var_data_keyword_name_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,19 +14,20 @@ describe('PR161 parser: var/data keyword-name diagnostics parity', () => {
     const entry = join(__dirname, 'fixtures', 'pr161_var_data_keyword_name_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain(
-      'Invalid globals declaration name "func": collides with a top-level keyword.',
-    );
-    expect(messages).toContain(
-      'Invalid globals declaration name "data": collides with a top-level keyword.',
-    );
-    expect(messages).toContain(
-      'Invalid data declaration name "op": collides with a top-level keyword.',
-    );
-    expect(messages).toContain(
-      'Invalid data declaration name "import": collides with a top-level keyword.',
-    );
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid globals declaration name "func": collides with a top-level keyword.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid globals declaration name "data": collides with a top-level keyword.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid data declaration name "op": collides with a top-level keyword.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid data declaration name "import": collides with a top-level keyword.',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr164_extern_missing_end_recovery.test.ts
+++ b/test/pr164_extern_missing_end_recovery.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,9 +14,14 @@ describe('PR164 parser: extern missing-end recovery', () => {
     const entry = join(__dirname, 'fixtures', 'pr164_extern_missing_end_recovery.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('Unterminated extern "legacy": expected "end" before "const"');
-    expect(messages).not.toContain('Invalid extern func declaration');
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Unterminated extern "legacy": expected "end" before "const"',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Invalid extern func declaration',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr167_header_param_name_validation_matrix.test.ts
+++ b/test/pr167_header_param_name_validation_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,16 +14,23 @@ describe('PR167 parser: header and parameter name validation matrix', () => {
     const entry = join(__dirname, 'fixtures', 'pr167_header_param_name_validation_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('Invalid func name "data": collides with a top-level keyword.');
-    expect(messages).toContain('Duplicate parameter name "a".');
-    expect(messages).toContain(
-      'Invalid op parameter name "func": collides with a top-level keyword.',
-    );
-    expect(messages).toContain('Duplicate op parameter name "a".');
-    expect(messages).toContain(
-      'Invalid extern func name "const": collides with a top-level keyword.',
-    );
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid func name "data": collides with a top-level keyword.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Duplicate parameter name "a".',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid op parameter name "func": collides with a top-level keyword.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Duplicate op parameter name "a".',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid extern func name "const": collides with a top-level keyword.',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr168_declaration_duplicate_matrix.test.ts
+++ b/test/pr168_declaration_duplicate_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,16 +14,29 @@ describe('PR168 parser: declaration duplicate-name matrix', () => {
     const entry = join(__dirname, 'fixtures', 'pr168_declaration_duplicate_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('Duplicate record field name "X".');
-    expect(messages).toContain('Duplicate union field name "A".');
-    expect(messages).toContain('Duplicate enum member name "red".');
-    expect(messages).toContain(
-      'Invalid enum member name "func": collides with a top-level keyword.',
-    );
-    expect(messages).toContain('Duplicate globals declaration name "Counter".');
-    expect(messages).toContain('Duplicate var declaration name "TMP".');
-    expect(messages).toContain('Duplicate data declaration name "TABLE".');
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Duplicate record field name "X".',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Duplicate union field name "A".',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Duplicate enum member name "red".',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid enum member name "func": collides with a top-level keyword.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Duplicate globals declaration name "Counter".',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Duplicate var declaration name "TMP".',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Duplicate data declaration name "TABLE".',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr169_malformed_decl_header_matrix.test.ts
+++ b/test/pr169_malformed_decl_header_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,14 +14,29 @@ describe('PR169 parser: malformed declaration header diagnostics matrix', () => 
     const entry = join(__dirname, 'fixtures', 'pr169_malformed_decl_header_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('Invalid enum member name "9bad": expected <identifier>.');
-    expect(messages).toContain('Invalid const declaration: missing initializer');
-    expect(messages).toContain('Invalid bin name "1asset": expected <identifier>.');
-    expect(messages).toContain('Invalid bin section "text": expected "code" or "data".');
-    expect(messages).toContain('Invalid bin declaration: expected quoted source path');
-    expect(messages).toContain('Invalid hex name "9dump": expected <identifier>.');
-    expect(messages).toContain('Invalid hex declaration: expected quoted source path');
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid enum member name "9bad": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid const declaration: missing initializer',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid bin name "1asset": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid bin section "text": expected "code" or "data".',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid bin declaration: expected quoted source path',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid hex name "9dump": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid hex declaration: expected quoted source path',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr171_func_missing_asm_recovery.test.ts
+++ b/test/pr171_func_missing_asm_recovery.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,12 +14,17 @@ describe('PR171 parser: function body recovery without explicit asm keyword', ()
     const entry = join(__dirname, 'fixtures', 'pr171_func_missing_asm_recovery.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('Unterminated func "broken": expected function body before "const"');
-    expect(messages).toContain(
-      'Unterminated func "also_broken": expected function body before "section"',
-    );
-    expect(messages).not.toContain('Unterminated func "ok": missing "end"');
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Unterminated func "broken": expected function body before "const"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Unterminated func "also_broken": expected function body before "section"',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'Unterminated func "ok": missing "end"',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr172_block_body_malformed_line_matrix.test.ts
+++ b/test/pr172_block_body_malformed_line_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,21 +14,27 @@ describe('PR172 parser: malformed block-body line diagnostics matrix', () => {
     const entry = join(__dirname, 'fixtures', 'pr172_block_body_malformed_line_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain(
-      'Invalid record field declaration line "x byte": expected <name>: <type>',
-    );
-    expect(messages).toContain(
-      'Invalid union field declaration line "lo byte": expected <name>: <type>',
-    );
-    expect(messages).toContain(
-      'Invalid globals declaration line "g byte": expected <name>: <type>',
-    );
-    expect(messages).toContain('Invalid var declaration line "tmp byte": expected <name>: <type>');
-    expect(messages.some((m) => m.startsWith('Invalid extern func declaration line'))).toBe(true);
-    expect(messages).toContain(
-      'Invalid data declaration line "blob: byte [1]": expected <name>: <type> = <initializer>',
-    );
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid record field declaration line "x byte": expected <name>: <type>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid union field declaration line "lo byte": expected <name>: <type>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid globals declaration line "g byte": expected <name>: <type>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid var declaration line "tmp byte": expected <name>: <type>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      messageIncludes: 'Invalid extern func declaration line',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message:
+        'Invalid data declaration line "blob: byte [1]": expected <name>: <type> = <initializer>',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr173_func_op_body_interruption_recovery.test.ts
+++ b/test/pr173_func_op_body_interruption_recovery.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,11 +14,20 @@ describe('PR173 parser: func/op body interruption recovery', () => {
     const entry = join(__dirname, 'fixtures', 'pr173_func_op_body_interruption_recovery.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('Unterminated func "broken": expected "end" before "const"');
-    expect(messages).toContain('Unterminated op "macro": expected "end" before "enum"');
-    expect(messages).not.toContain('Unterminated func "ok": missing "end"');
-    expect(messages.some((m) => m.startsWith('Unsupported instruction:'))).toBe(false);
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Unterminated func "broken": expected "end" before "const"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Unterminated op "macro": expected "end" before "enum"',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'Unterminated func "ok": missing "end"',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported instruction:',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr175_func_op_extern_malformed_header_matrix.test.ts
+++ b/test/pr175_func_op_extern_malformed_header_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,33 +14,49 @@ describe('PR175 parser: malformed func/op/extern header matrix', () => {
     const entry = join(__dirname, 'fixtures', 'pr175_func_op_extern_malformed_header_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('Invalid func header line "func": expected <name>(...): <retType>');
-    expect(messages).toContain(
-      'Invalid func header line "func main(": expected <name>(...): <retType>',
-    );
-    expect(messages).toContain('Invalid func name "9bad": expected <identifier>.');
-    expect(messages).toContain('Unterminated func "ok": expected function body before "op"');
-
-    expect(messages).toContain('Invalid op header line "op": expected <name>(...)');
-    expect(messages).toContain('Invalid op header line "op macro(": expected <name>(...)');
-    expect(messages).toContain('Invalid op name "9bad": expected <identifier>.');
-    expect(messages).toContain('Invalid op header: unexpected trailing tokens');
-
-    expect(messages).toContain('Invalid extern base name "@bad": expected <identifier>.');
-    expect(messages).toContain(
-      'Invalid extern base name "const": collides with a top-level keyword.',
-    );
-    expect(messages).toContain(
-      'Invalid extern func declaration line "func": expected <name>(...)[ : <retRegs> ] at <imm16>',
-    );
-    expect(messages).toContain(
-      'Invalid extern func declaration line "func x(a: byte) at $1234": expected <name>(...)[ : <retRegs> ] at <imm16>',
-    );
-    expect(messages).toContain(
-      'Invalid extern func name "const": collides with a top-level keyword.',
-    );
-
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid func header line "func": expected <name>(...): <retType>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid func header line "func main(": expected <name>(...): <retType>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid func name "9bad": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Unterminated func "ok": expected function body before "op"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid op header line "op": expected <name>(...)',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid op header line "op macro(": expected <name>(...)',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid op name "9bad": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid op header: unexpected trailing tokens',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid extern base name "@bad": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid extern base name "const": collides with a top-level keyword.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message:
+        'Invalid extern func declaration line "func": expected <name>(...)[ : <retRegs> ] at <imm16>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message:
+        'Invalid extern func declaration line "func x(a: byte) at $1234": expected <name>(...)[ : <retRegs> ] at <imm16>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid extern func name "const": collides with a top-level keyword.',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr176_mixed_keyword_shaped_line_recovery.test.ts
+++ b/test/pr176_mixed_keyword_shaped_line_recovery.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,17 +14,19 @@ describe('PR176 parser: mixed keyword-shaped line recovery parity', () => {
     const entry = join(__dirname, 'fixtures', 'pr176_mixed_keyword_shaped_line_recovery.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain(
-      'Invalid extern func declaration line "data x: byte": expected func <name>(...): <retType> at <imm16>',
-    );
-    expect(messages).toContain(
-      'Invalid data declaration line "op x: byte = [1]": expected <name>: <type> = <initializer>',
-    );
-    expect(messages).toContain(
-      'Invalid var declaration line "extern y: byte": expected <name>: <type>',
-    );
-
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message:
+        'Invalid extern func declaration line "data x: byte": expected func <name>(...): <retType> at <imm16>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message:
+        'Invalid data declaration line "op x: byte = [1]": expected <name>: <type> = <initializer>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid var declaration line "extern y: byte": expected <name>: <type>',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr178_import_enum_section_align_const_malformed_header_matrix.test.ts
+++ b/test/pr178_import_enum_section_align_const_malformed_header_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -17,33 +18,40 @@ describe('PR178 parser: malformed import/enum/section/align/const headers', () =
     );
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain(
-      'Invalid import statement line "import": expected "<path>.zax" or <moduleId>',
-    );
-    expect(messages).toContain(
-      'Invalid import statement line "import \\"x.zax\\" trailing": expected "<path>.zax" or <moduleId>',
-    );
-    expect(messages).toContain(
-      'Invalid import statement line "import 9bad": expected "<path>.zax" or <moduleId>',
-    );
-
-    expect(messages).toContain(
-      'Invalid enum declaration line "enum": expected <name> <member>[, ...]',
-    );
-    expect(messages).toContain('Invalid enum name "9bad": expected <identifier>.');
-
-    expect(messages).toContain(
-      'Invalid section directive line "section": expected <code|data|var> [at <imm16>]',
-    );
-    expect(messages).toContain(
-      'Invalid section directive line "section text at $1000": expected <code|data|var> [at <imm16>]',
-    );
-
-    expect(messages).toContain('Invalid align directive line "align": expected <imm16>');
-
-    expect(messages).toContain('Invalid const declaration line "const": expected <name> = <imm>');
-    expect(messages).toContain('Invalid const name "9bad": expected <identifier>.');
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid import statement line "import": expected "<path>.zax" or <moduleId>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message:
+        'Invalid import statement line "import \\"x.zax\\" trailing": expected "<path>.zax" or <moduleId>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid import statement line "import 9bad": expected "<path>.zax" or <moduleId>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid enum declaration line "enum": expected <name> <member>[, ...]',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid enum name "9bad": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid section directive line "section": expected <code|data|var> [at <imm16>]',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message:
+        'Invalid section directive line "section text at $1000": expected <code|data|var> [at <imm16>]',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid align directive line "align": expected <imm16>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid const declaration line "const": expected <name> = <imm>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid const name "9bad": expected <identifier>.',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr180_bin_hex_malformed_header_matrix.test.ts
+++ b/test/pr180_bin_hex_malformed_header_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,26 +14,40 @@ describe('PR180 parser: malformed bin/hex header matrix', () => {
     const entry = join(__dirname, 'fixtures', 'pr180_bin_hex_malformed_header_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain(
-      'Invalid bin declaration line "bin": expected <name> in <code|data> from "<path>"',
-    );
-    expect(messages).toContain(
-      'Invalid bin declaration line "bin asset": expected <name> in <code|data> from "<path>"',
-    );
-    expect(messages).toContain(
-      'Invalid bin declaration line "bin asset in code": expected <name> in <code|data> from "<path>"',
-    );
-    expect(messages).toContain('Invalid bin section "text": expected "code" or "data".');
-    expect(messages).toContain('Invalid bin name "1asset": expected <identifier>.');
-    expect(messages).toContain('Invalid bin declaration: expected quoted source path');
-
-    expect(messages).toContain('Invalid hex declaration line "hex": expected <name> from "<path>"');
-    expect(messages).toContain(
-      'Invalid hex declaration line "hex dump": expected <name> from "<path>"',
-    );
-    expect(messages).toContain('Invalid hex name "9dump": expected <identifier>.');
-    expect(messages).toContain('Invalid hex declaration: expected quoted source path');
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid bin declaration line "bin": expected <name> in <code|data> from "<path>"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message:
+        'Invalid bin declaration line "bin asset": expected <name> in <code|data> from "<path>"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message:
+        'Invalid bin declaration line "bin asset in code": expected <name> in <code|data> from "<path>"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid bin section "text": expected "code" or "data".',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid bin name "1asset": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid bin declaration: expected quoted source path',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid hex declaration line "hex": expected <name> from "<path>"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid hex declaration line "hex dump": expected <name> from "<path>"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid hex name "9dump": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid hex declaration: expected quoted source path',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr181_top_level_malformed_header_canonical_matrix.test.ts
+++ b/test/pr181_top_level_malformed_header_canonical_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -17,35 +18,50 @@ describe('PR181 parser: canonical top-level malformed-header matrix', () => {
     );
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain(
-      'Invalid import statement line "import": expected "<path>.zax" or <moduleId>',
-    );
-    expect(messages).toContain(
-      'Invalid type declaration line "type": expected <name> [<typeExpr>]',
-    );
-    expect(messages).toContain('Invalid union declaration line "union": expected <name>');
-    expect(messages).toContain(
-      'Invalid globals declaration line "globals extra": expected globals',
-    );
-    expect(messages).toContain('Invalid func header line "func": expected <name>(...): <retType>');
-    expect(messages).toContain('Invalid op header line "op": expected <name>(...)');
-    expect(messages).toContain('Invalid extern base name "(": expected <identifier>.');
-    expect(messages).toContain(
-      'Invalid enum declaration line "enum": expected <name> <member>[, ...]',
-    );
-    expect(messages).toContain(
-      'Invalid section directive line "section": expected <code|data|var> [at <imm16>]',
-    );
-    expect(messages).toContain('Invalid align directive line "align": expected <imm16>');
-    expect(messages).toContain('Invalid const declaration line "const": expected <name> = <imm>');
-    expect(messages).toContain(
-      'Invalid bin declaration line "bin": expected <name> in <code|data> from "<path>"',
-    );
-    expect(messages).toContain('Invalid hex declaration line "hex": expected <name> from "<path>"');
-    expect(messages).toContain('Invalid data declaration line "data extra": expected data');
-
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid import statement line "import": expected "<path>.zax" or <moduleId>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid type declaration line "type": expected <name> [<typeExpr>]',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid union declaration line "union": expected <name>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid globals declaration line "globals extra": expected globals',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid func header line "func": expected <name>(...): <retType>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid op header line "op": expected <name>(...)',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid extern base name "(": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid enum declaration line "enum": expected <name> <member>[, ...]',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid section directive line "section": expected <code|data|var> [at <imm16>]',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid align directive line "align": expected <imm16>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid const declaration line "const": expected <name> = <imm>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid bin declaration line "bin": expected <name> in <code|data> from "<path>"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid hex declaration line "hex": expected <name> from "<path>"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid data declaration line "data extra": expected data',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr182_var_block_inferred_array_recovery.test.ts
+++ b/test/pr182_var_block_inferred_array_recovery.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,14 +14,21 @@ describe('PR182 parser: module var inferred-array recovery', () => {
     const entry = join(__dirname, 'fixtures', 'pr182_var_block_inferred_array_recovery.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain(
-      'Inferred-length arrays (T[]) are only permitted in data declarations with an initializer.',
-    );
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
-    expect(messages.some((m) => m.includes('Invalid var declaration line'))).toBe(false);
-    expect(messages.some((m) => m.includes('const declaration'))).toBe(false);
-    expect(messages.some((m) => m.includes('Unterminated func'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message:
+        'Inferred-length arrays (T[]) are only permitted in data declarations with an initializer.',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Invalid var declaration line',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'const declaration',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unterminated func',
+    });
   });
 });

--- a/test/pr185_block_invalid_identifier_matrix.test.ts
+++ b/test/pr185_block_invalid_identifier_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,17 +14,26 @@ describe('PR185 parser: block invalid identifier diagnostics matrix', () => {
     const entry = join(__dirname, 'fixtures', 'pr185_block_invalid_identifier_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain('Invalid record field name "9field": expected <identifier>.');
-    expect(messages).toContain('Invalid union field name "9part": expected <identifier>.');
-    expect(messages).toContain(
-      'Invalid globals declaration name "9global": expected <identifier>.',
-    );
-    expect(messages).toContain('Invalid data declaration name "9blob": expected <identifier>.');
-    expect(messages).toContain('Invalid enum member name "9bad": expected <identifier>.');
-    expect(messages).toContain('Invalid var declaration name "9local": expected <identifier>.');
-
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid record field name "9field": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid union field name "9part": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid globals declaration name "9global": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid data declaration name "9blob": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid enum member name "9bad": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid var declaration name "9local": expected <identifier>.',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr186_param_list_delimiter_matrix.test.ts
+++ b/test/pr186_param_list_delimiter_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,22 +14,17 @@ describe('PR186 parser: parameter list delimiter diagnostics matrix', () => {
     const entry = join(__dirname, 'fixtures', 'pr186_param_list_delimiter_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain(
-      'Invalid parameter list: trailing or empty entries are not permitted.',
-    );
-    expect(messages).toContain(
-      'Invalid op parameter list: trailing or empty entries are not permitted.',
-    );
-
-    expect(
-      messages.some((m) => m.includes('Invalid parameter declaration: expected <name>: <type>')),
-    ).toBe(false);
-    expect(
-      messages.some((m) =>
-        m.includes('Invalid op parameter declaration: expected <name>: <matcher>'),
-      ),
-    ).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid parameter list: trailing or empty entries are not permitted.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid op parameter list: trailing or empty entries are not permitted.',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Invalid parameter declaration: expected <name>: <type>',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Invalid op parameter declaration: expected <name>: <matcher>',
+    });
   });
 });

--- a/test/pr187_extern_base_name_validation_matrix.test.ts
+++ b/test/pr187_extern_base_name_validation_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,13 +14,14 @@ describe('PR187 parser: extern base-name validation matrix', () => {
     const entry = join(__dirname, 'fixtures', 'pr187_extern_base_name_validation_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain('Invalid extern base name "@bad": expected <identifier>.');
-    expect(messages).toContain(
-      'Invalid extern base name "const": collides with a top-level keyword.',
-    );
-
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid extern base name "@bad": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Invalid extern base name "const": collides with a top-level keyword.',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr217_parser_decl_minimum_shape_and_eof_recovery.test.ts
+++ b/test/pr217_parser_decl_minimum_shape_and_eof_recovery.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,28 +13,36 @@ describe('PR217 parser: declaration minimum-shape and eof recovery diagnostics',
   it('diagnoses empty type/union declarations with stable declaration-minimum messages', async () => {
     const entry = join(__dirname, 'fixtures', 'pr217_parser_decl_minimum_shape_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain('Type "EmptyType" must contain at least one field');
-    expect(messages).toContain('Union "EmptyUnion" must contain at least one field');
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Type "EmptyType" must contain at least one field',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Union "EmptyUnion" must contain at least one field',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 
   it('diagnoses function header at eof without body', async () => {
     const entry = join(__dirname, 'fixtures', 'pr217_parser_func_missing_body_eof.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain('Unterminated func "no_body": expected function body');
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Unterminated func "no_body": expected function body',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 
   it('diagnoses op body missing terminating end at eof', async () => {
     const entry = join(__dirname, 'fixtures', 'pr217_parser_op_missing_end_eof.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain('Unterminated op "no_end": missing "end"');
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Unterminated op "no_end": missing "end"',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });


### PR DESCRIPTION
# Summary

- Replace loose parser diagnostic message-array assertions with explicit diagnostic helper assertions across one coherent parser declaration/header/recovery batch.
- Preserve existing compiler behavior and test intent while making failures more specific and reviewable.

# Scope

- [ ] Docs-only
- [ ] Compiler behavior change
- [x] Tests updated

# Primary Gate Issue

- Required: link one primary tracking issue (for v0.2 work, use `v0.2 change task` format).
- Issue: #1132

# Acceptance Criteria Checklist

- [x] Replace the targeted weak diagnostic assertions in this parser batch.
- [x] Keep the batch narrow and behavior-preserving.
- [x] Positive tests identified/updated.
- [x] Negative tests identified/updated.
- [x] Diagnostics impact documented: assertions are stricter, compiler diagnostics unchanged.
- [x] Out-of-scope list included.
- [ ] Repo-wide completion of #1132.
- [ ] Add a lint rule or custom matcher to enforce the new pattern.

# Validation

- Commands run:
  - `npm ci`
  - `npm run typecheck`
  - `npm run lint`
  - `npm test -- --run test/pr154_parser_top_level_malformed_keyword_matrix.test.ts test/pr160_type_union_missing_end_recovery.test.ts test/pr161_var_data_keyword_name_matrix.test.ts test/pr164_extern_missing_end_recovery.test.ts test/pr167_header_param_name_validation_matrix.test.ts test/pr168_declaration_duplicate_matrix.test.ts test/pr169_malformed_decl_header_matrix.test.ts test/pr171_func_missing_asm_recovery.test.ts test/pr172_block_body_malformed_line_matrix.test.ts test/pr173_func_op_body_interruption_recovery.test.ts test/pr175_func_op_extern_malformed_header_matrix.test.ts test/pr176_mixed_keyword_shaped_line_recovery.test.ts test/pr178_import_enum_section_align_const_malformed_header_matrix.test.ts test/pr180_bin_hex_malformed_header_matrix.test.ts test/pr181_top_level_malformed_header_canonical_matrix.test.ts test/pr182_var_block_inferred_array_recovery.test.ts test/pr185_block_invalid_identifier_matrix.test.ts test/pr186_param_list_delimiter_matrix.test.ts test/pr187_extern_base_name_validation_matrix.test.ts test/pr217_parser_decl_minimum_shape_and_eof_recovery.test.ts`
- Result summary: local install, typecheck, lint, and all 20 updated parser tests passed.

# Merge Risk Notes

- Low risk: assertion-only changes in parser-adjacent tests.
- Main risk is mismatching current diagnostic text; targeted tests passed locally.

# Out of Scope

- `it.each()` conversions
- non-parser subsystems
- compiler/source behavior changes
- repo-wide migration of remaining weak diagnostic assertions

Refs #1132