### PR TITLE
Split module loader responsibilities

### DIFF
--- a/src/moduleLoader.ts
+++ b/src/moduleLoader.ts
@@ -30,6 +30,350 @@ export type LoadedProgram = {
   resolvedImportGraph: Map<string, string[]>;
 };
 
+type ExpandedSource = { text: string; lineFiles: string[]; lineBaseLines: number[] };
+type ModuleEdges = Map<string, Map<string, { line: number; column: number }>>;
+type ImportTarget = ReturnType<typeof importTargets>[number];
+
+async function readModuleSource(
+  modulePath: string,
+  diagnostics: Diagnostic[],
+  importer?: string,
+  preloadedText?: string,
+): Promise<string | undefined> {
+  try {
+    return preloadedText ?? (await readFile(modulePath, 'utf8'));
+  } catch (err) {
+    diagnostics.push({
+      id: DiagnosticIds.IoReadFailed,
+      severity: 'error',
+      message: importer
+        ? `Failed to read imported module "${modulePath}" (imported by "${importer}"): ${String(err)}`
+        : `Failed to read entry file: ${String(err)}`,
+      file: importer ?? modulePath,
+    });
+    return undefined;
+  }
+}
+
+function recordSourceLineComments(
+  sourceLineComments: Map<string, Map<number, string>>,
+  expanded: ExpandedSource,
+): void {
+  const lines = expanded.text.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    const semi = line.indexOf(';');
+    if (semi < 0) continue;
+    const commentText = line.slice(semi + 1).trim();
+    if (!commentText) continue;
+    const fileRaw = expanded.lineFiles[i];
+    if (!fileRaw) continue;
+    const file = normalizePath(fileRaw);
+    const lineNo = expanded.lineBaseLines[i] ?? i + 1;
+    let lineMap = sourceLineComments.get(file);
+    if (!lineMap) {
+      lineMap = new Map();
+      sourceLineComments.set(file, lineMap);
+    }
+    lineMap.set(lineNo, commentText);
+  }
+}
+
+async function resolveIncludeSource(
+  modulePath: string,
+  rawLine: string,
+  spec: string,
+  lineNo: number,
+  includeDirs: string[],
+  diagnostics: Diagnostic[],
+  sourceTexts: Map<string, string>,
+): Promise<{ resolved: string; resolvedText: string } | 'hard-failure' | undefined> {
+  const candidates = resolveIncludeCandidates(modulePath, spec, includeDirs);
+
+  for (const c of candidates) {
+    try {
+      const resolvedText = await readFile(c, 'utf8');
+      const resolvedKey = normalizePath(c);
+      if (!sourceTexts.has(resolvedKey)) sourceTexts.set(resolvedKey, resolvedText);
+      return { resolved: c, resolvedText };
+    } catch (err) {
+      if (isIgnorableImportProbeError(err)) continue;
+      diagnostics.push({
+        id: DiagnosticIds.IoReadFailed,
+        severity: 'error',
+        message: `Failed to read include candidate "${c}" while resolving includes for "${modulePath}": ${String(
+          err,
+        )}`,
+        file: modulePath,
+        line: lineNo,
+        column: rawLine.indexOf('include') + 1 || 1,
+      });
+      return 'hard-failure';
+    }
+  }
+
+  diagnostics.push({
+    id: DiagnosticIds.ImportNotFound,
+    severity: 'error',
+    message: `Failed to resolve include "${spec}" from "${modulePath}". Tried:\n${candidates
+      .map((c) => `- ${c}`)
+      .join('\n')}`,
+    file: modulePath,
+    line: lineNo,
+    column: rawLine.indexOf('include') + 1 || 1,
+  });
+  return undefined;
+}
+
+async function expandIncludesForFile(args: {
+  modulePath: string;
+  sourceText: string;
+  includeDirs: string[];
+  diagnostics: Diagnostic[];
+  sourceTexts: Map<string, string>;
+  includeStack: string[];
+}): Promise<ExpandedSource | undefined> {
+  const { modulePath, sourceText, includeDirs, diagnostics, sourceTexts, includeStack } = args;
+  const moduleKey = normalizePath(modulePath);
+  if (!sourceTexts.has(moduleKey)) sourceTexts.set(moduleKey, sourceText);
+  const lines = sourceText.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+  const out: string[] = [];
+  const lineFiles: string[] = [];
+  const lineBaseLines: number[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i] ?? '';
+    const stripped = stripLineComment(raw).trim();
+    const lineNo = i + 1;
+    const match = /^\s*include\s+"([^"]+)"\s*$/.exec(stripped);
+    if (!match) {
+      out.push(raw);
+      lineFiles.push(modulePath);
+      lineBaseLines.push(lineNo);
+      continue;
+    }
+
+    const spec = match[1]!;
+    const resolvedInclude = await resolveIncludeSource(
+      modulePath,
+      raw,
+      spec,
+      lineNo,
+      includeDirs,
+      diagnostics,
+      sourceTexts,
+    );
+    if (resolvedInclude === 'hard-failure') return undefined;
+    if (!resolvedInclude) {
+      out.push(raw);
+      lineFiles.push(modulePath);
+      lineBaseLines.push(lineNo);
+      continue;
+    }
+
+    if (includeStack.includes(resolvedInclude.resolved)) {
+      diagnostics.push({
+        id: DiagnosticIds.SemanticsError,
+        severity: 'error',
+        message: `Include cycle detected: "${resolvedInclude.resolved}" is already active in the include stack.`,
+        file: modulePath,
+        line: lineNo,
+        column: raw.indexOf('include') + 1 || 1,
+      });
+      out.push(raw);
+      lineFiles.push(modulePath);
+      lineBaseLines.push(lineNo);
+      continue;
+    }
+
+    const expanded = await expandIncludesForFile({
+      modulePath: resolvedInclude.resolved,
+      sourceText: resolvedInclude.resolvedText,
+      includeDirs,
+      diagnostics,
+      sourceTexts,
+      includeStack: [...includeStack, resolvedInclude.resolved],
+    });
+    if (expanded === undefined) return undefined;
+
+    const expandedLines = expanded.text.split('\n');
+    for (let j = 0; j < expandedLines.length; j++) {
+      out.push(expandedLines[j]!);
+      lineFiles.push(expanded.lineFiles[j] ?? resolvedInclude.resolved);
+      lineBaseLines.push(expanded.lineBaseLines[j] ?? j + 1);
+    }
+  }
+
+  return { text: out.join('\n'), lineFiles, lineBaseLines };
+}
+
+function parseExpandedModuleFile(
+  modulePath: string,
+  expanded: ExpandedSource,
+  diagnostics: Diagnostic[],
+): ModuleFileNode | undefined {
+  try {
+    const sourceFile = makeSourceFile(modulePath, expanded.text);
+    sourceFile.lineFiles = expanded.lineFiles;
+    sourceFile.lineBaseLines = expanded.lineBaseLines;
+    return parseModuleFile(modulePath, expanded.text, diagnostics, sourceFile);
+  } catch (err) {
+    diagnostics.push({
+      id: DiagnosticIds.InternalParseError,
+      severity: 'error',
+      message: `Internal error during parse: ${String(err)}`,
+      file: modulePath,
+    });
+    return undefined;
+  }
+}
+
+async function resolveImportSource(
+  modulePath: string,
+  imp: ImportTarget,
+  includeDirs: string[],
+  diagnostics: Diagnostic[],
+): Promise<{ resolved: string; resolvedText: string } | 'hard-failure' | undefined> {
+  const candidates = resolveImportCandidates(modulePath, imp, includeDirs);
+
+  for (const c of candidates) {
+    try {
+      return { resolved: c, resolvedText: await readFile(c, 'utf8') };
+    } catch (err) {
+      if (isIgnorableImportProbeError(err)) continue;
+      diagnostics.push({
+        id: DiagnosticIds.IoReadFailed,
+        severity: 'error',
+        message: `Failed to read import candidate "${c}" while resolving imports for "${modulePath}": ${String(
+          err,
+        )}`,
+        file: modulePath,
+        line: imp.span.start.line,
+        column: imp.span.start.column,
+      });
+      return 'hard-failure';
+    }
+  }
+
+  const pretty = imp.form === 'path' ? `"${imp.specifier}"` : imp.specifier;
+  diagnostics.push({
+    id: DiagnosticIds.ImportNotFound,
+    severity: 'error',
+    message: `Failed to resolve import ${pretty} from "${modulePath}". Tried:\n${candidates
+      .map((c) => `- ${c}`)
+      .join('\n')}`,
+    file: modulePath,
+    line: imp.span.start.line,
+    column: imp.span.start.column,
+  });
+  return undefined;
+}
+
+function recordImportEdge(
+  edges: ModuleEdges,
+  modulePath: string,
+  resolved: string,
+  imp: ImportTarget,
+): void {
+  const moduleEdges = edges.get(modulePath)!;
+  if (!moduleEdges.has(resolved)) {
+    moduleEdges.set(resolved, {
+      line: imp.span.start.line,
+      column: imp.span.start.column,
+    });
+  }
+}
+
+function validateCanonicalModuleIds(
+  modules: Map<string, ModuleFileNode>,
+  moduleIdRootDir: string,
+  diagnostics: Diagnostic[],
+): boolean {
+  const idSeen = new Map<string, string>();
+  for (const modulePath of modules.keys()) {
+    const id = canonicalModuleId(modulePath, moduleIdRootDir);
+    const loweredId = id.toLowerCase();
+    const prev = idSeen.get(loweredId);
+    if (prev && prev !== modulePath) {
+      const moduleSpan = modules.get(modulePath)?.span.start;
+      diagnostics.push({
+        id: DiagnosticIds.SemanticsError,
+        severity: 'error',
+        message: `Module ID collision: "${id}" maps to both "${prev}" and "${modulePath}".`,
+        file: modulePath,
+        ...(moduleSpan !== undefined ? { line: moduleSpan.line, column: moduleSpan.column } : {}),
+      });
+    } else {
+      idSeen.set(loweredId, modulePath);
+    }
+  }
+  return !hasErrors(diagnostics);
+}
+
+function topologicallyOrderModules(
+  entryPath: string,
+  edges: ModuleEdges,
+  moduleIdRootDir: string,
+  diagnostics: Diagnostic[],
+): string[] | undefined {
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const order: string[] = [];
+  const sortKey = (modulePath: string) =>
+    `${canonicalModuleId(modulePath, moduleIdRootDir).toLowerCase()}\n${modulePath}`;
+
+  const visit = (modulePath: string, stack: string[], fromModule?: string): void => {
+    if (visited.has(modulePath)) return;
+    if (visiting.has(modulePath)) {
+      const cycleStart = stack.indexOf(modulePath);
+      const cycle =
+        cycleStart >= 0 ? stack.slice(cycleStart).concat([modulePath]) : stack.concat([modulePath]);
+      const edge = fromModule ? edges.get(fromModule)?.get(modulePath) : undefined;
+      diagnostics.push({
+        id: DiagnosticIds.SemanticsError,
+        severity: 'error',
+        message: `Import cycle detected: ${cycle.join(' -> ')}`,
+        file: fromModule ?? entryPath,
+        ...(edge !== undefined ? { line: edge.line, column: edge.column } : {}),
+      });
+      return;
+    }
+
+    visiting.add(modulePath);
+    const deps = Array.from((edges.get(modulePath) ?? new Map()).keys()).sort((a, b) =>
+      sortKey(a).localeCompare(sortKey(b)),
+    );
+    for (const dep of deps) {
+      visit(dep, stack.concat([modulePath]), modulePath);
+      if (hasErrors(diagnostics)) return;
+    }
+    visiting.delete(modulePath);
+    visited.add(modulePath);
+    order.push(modulePath);
+  };
+
+  visit(entryPath, []);
+  if (hasErrors(diagnostics)) return undefined;
+  return order;
+}
+
+function collectModuleTraversal(entryPath: string, edges: ModuleEdges): string[] {
+  const traversalVisited = new Set<string>();
+  const moduleTraversal: string[] = [];
+
+  const walkTraversal = (modulePath: string): void => {
+    if (traversalVisited.has(modulePath)) return;
+    traversalVisited.add(modulePath);
+    moduleTraversal.push(modulePath);
+    for (const dep of (edges.get(modulePath) ?? new Map()).keys()) {
+      walkTraversal(dep);
+    }
+  };
+
+  walkTraversal(entryPath);
+  return moduleTraversal;
+}
+
 export async function loadProgram(
   entryFile: string,
   diagnostics: Diagnostic[],
@@ -43,132 +387,6 @@ export async function loadProgram(
   const includeDirs = (options.includeDirs ?? []).map(normalizePath);
   const moduleIdRootDir = dirname(entryPath);
 
-  type ExpandedSource = { text: string; lineFiles: string[]; lineBaseLines: number[] };
-
-  const recordSourceLineComments = (expanded: ExpandedSource): void => {
-    const lines = expanded.text.split(/\r?\n/);
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i] ?? '';
-      const semi = line.indexOf(';');
-      if (semi < 0) continue;
-      const commentText = line.slice(semi + 1).trim();
-      if (!commentText) continue;
-      const fileRaw = expanded.lineFiles[i];
-      if (!fileRaw) continue;
-      const file = normalizePath(fileRaw);
-      const lineNo = expanded.lineBaseLines[i] ?? i + 1;
-      let lineMap = sourceLineComments.get(file);
-      if (!lineMap) {
-        lineMap = new Map();
-        sourceLineComments.set(file, lineMap);
-      }
-      lineMap.set(lineNo, commentText);
-    }
-  };
-
-  const expandIncludes = async (
-    modulePath: string,
-    sourceText: string,
-    includeStack: string[],
-  ): Promise<ExpandedSource | undefined> => {
-    const moduleKey = normalizePath(modulePath);
-    if (!sourceTexts.has(moduleKey)) sourceTexts.set(moduleKey, sourceText);
-    const lines = sourceText.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
-    const out: string[] = [];
-    const lineFiles: string[] = [];
-    const lineBaseLines: number[] = [];
-
-    for (let i = 0; i < lines.length; i++) {
-      const raw = lines[i] ?? '';
-      const stripped = stripLineComment(raw).trim();
-      const lineNo = i + 1;
-      const match = /^\s*include\s+"([^"]+)"\s*$/.exec(stripped);
-      if (!match) {
-        out.push(raw);
-        lineFiles.push(modulePath);
-        lineBaseLines.push(lineNo);
-        continue;
-      }
-
-      const spec = match[1]!;
-      const candidates = resolveIncludeCandidates(modulePath, spec, includeDirs);
-      let resolved: string | undefined;
-      let resolvedText: string | undefined;
-      let hardFailure = false;
-
-      for (const c of candidates) {
-        try {
-          resolvedText = await readFile(c, 'utf8');
-          resolved = c;
-          const resolvedKey = normalizePath(c);
-          if (!sourceTexts.has(resolvedKey)) sourceTexts.set(resolvedKey, resolvedText);
-          break;
-        } catch (err) {
-          if (isIgnorableImportProbeError(err)) {
-            continue;
-          }
-          diagnostics.push({
-            id: DiagnosticIds.IoReadFailed,
-            severity: 'error',
-            message: `Failed to read include candidate "${c}" while resolving includes for "${modulePath}": ${String(
-              err,
-            )}`,
-            file: modulePath,
-            line: lineNo,
-            column: raw.indexOf('include') + 1 || 1,
-          });
-          hardFailure = true;
-          break;
-        }
-      }
-
-      if (hardFailure) return undefined;
-
-      if (!resolved || resolvedText === undefined) {
-        diagnostics.push({
-          id: DiagnosticIds.ImportNotFound,
-          severity: 'error',
-          message: `Failed to resolve include "${spec}" from "${modulePath}". Tried:\n${candidates
-            .map((c) => `- ${c}`)
-            .join('\n')}`,
-          file: modulePath,
-          line: lineNo,
-          column: raw.indexOf('include') + 1 || 1,
-        });
-        out.push(raw);
-        lineFiles.push(modulePath);
-        lineBaseLines.push(lineNo);
-        continue;
-      }
-
-      if (includeStack.includes(resolved)) {
-        diagnostics.push({
-          id: DiagnosticIds.SemanticsError,
-          severity: 'error',
-          message: `Include cycle detected: "${resolved}" is already active in the include stack.`,
-          file: modulePath,
-          line: lineNo,
-          column: raw.indexOf('include') + 1 || 1,
-        });
-        out.push(raw);
-        lineFiles.push(modulePath);
-        lineBaseLines.push(lineNo);
-        continue;
-      }
-
-      const expanded = await expandIncludes(resolved, resolvedText, [...includeStack, resolved]);
-      if (expanded === undefined) return undefined;
-      const expandedLines = expanded.text.split('\n');
-      for (let j = 0; j < expandedLines.length; j++) {
-        out.push(expandedLines[j]!);
-        lineFiles.push(expanded.lineFiles[j] ?? resolved);
-        lineBaseLines.push(expanded.lineBaseLines[j] ?? j + 1);
-      }
-    }
-
-    return { text: out.join('\n'), lineFiles, lineBaseLines };
-  };
-
   const loadModule = async (
     modulePath: string,
     importer?: string,
@@ -177,185 +395,52 @@ export async function loadProgram(
     const p = normalizePath(modulePath);
     if (modules.has(p)) return;
 
-    let sourceText: string;
-    try {
-      sourceText = preloadedText ?? (await readFile(p, 'utf8'));
-    } catch (err) {
-      diagnostics.push({
-        id: DiagnosticIds.IoReadFailed,
-        severity: 'error',
-        message: importer
-          ? `Failed to read imported module "${p}" (imported by "${importer}"): ${String(err)}`
-          : `Failed to read entry file: ${String(err)}`,
-        file: importer ?? p,
-      });
-      return;
-    }
-
+    const sourceText = await readModuleSource(p, diagnostics, importer, preloadedText);
+    if (sourceText === undefined) return;
     if (!sourceTexts.has(p)) sourceTexts.set(p, sourceText);
-    const expanded = await expandIncludes(p, sourceText, [p]);
+    const expanded = await expandIncludesForFile({
+      modulePath: p,
+      sourceText,
+      includeDirs,
+      diagnostics,
+      sourceTexts,
+      includeStack: [p],
+    });
     if (expanded === undefined) return;
 
-    let moduleFile: ModuleFileNode;
-    try {
-      const sourceFile = makeSourceFile(p, expanded.text);
-      sourceFile.lineFiles = expanded.lineFiles;
-      sourceFile.lineBaseLines = expanded.lineBaseLines;
-      moduleFile = parseModuleFile(p, expanded.text, diagnostics, sourceFile);
-    } catch (err) {
-      diagnostics.push({
-        id: DiagnosticIds.InternalParseError,
-        severity: 'error',
-        message: `Internal error during parse: ${String(err)}`,
-        file: p,
-      });
-      return;
-    }
-
+    const moduleFile = parseExpandedModuleFile(p, expanded, diagnostics);
+    if (!moduleFile) return;
     modules.set(p, moduleFile);
-    recordSourceLineComments(expanded);
+    recordSourceLineComments(sourceLineComments, expanded);
     edges.set(p, new Map());
 
     for (const imp of importTargets(moduleFile)) {
-      const candidates = resolveImportCandidates(p, imp, includeDirs);
-      let resolved: string | undefined;
-      let resolvedText: string | undefined;
-      let hardFailure = false;
+      const resolvedImport = await resolveImportSource(p, imp, includeDirs, diagnostics);
+      if (resolvedImport === 'hard-failure') return;
+      if (!resolvedImport) continue;
 
-      for (const c of candidates) {
-        try {
-          resolvedText = await readFile(c, 'utf8');
-          resolved = c;
-          break;
-        } catch (err) {
-          if (isIgnorableImportProbeError(err)) {
-            continue;
-          }
-
-          diagnostics.push({
-            id: DiagnosticIds.IoReadFailed,
-            severity: 'error',
-            message: `Failed to read import candidate "${c}" while resolving imports for "${p}": ${String(
-              err,
-            )}`,
-            file: p,
-            line: imp.span.start.line,
-            column: imp.span.start.column,
-          });
-          hardFailure = true;
-          break;
-        }
-      }
-
-      if (hardFailure) return;
-
-      if (!resolved || resolvedText === undefined) {
-        const pretty = imp.form === 'path' ? `"${imp.specifier}"` : imp.specifier;
-        diagnostics.push({
-          id: DiagnosticIds.ImportNotFound,
-          severity: 'error',
-          message: `Failed to resolve import ${pretty} from "${p}". Tried:\n${candidates
-            .map((c) => `- ${c}`)
-            .join('\n')}`,
-          file: p,
-          line: imp.span.start.line,
-          column: imp.span.start.column,
-        });
-        continue;
-      }
-
-      const moduleEdges = edges.get(p)!;
-      if (!moduleEdges.has(resolved)) {
-        moduleEdges.set(resolved, {
-          line: imp.span.start.line,
-          column: imp.span.start.column,
-        });
-      }
-      await loadModule(resolved, p, resolvedText);
+      recordImportEdge(edges, p, resolvedImport.resolved, imp);
+      await loadModule(resolvedImport.resolved, p, resolvedImport.resolvedText);
     }
   };
 
   await loadModule(entryPath);
   if (hasErrors(diagnostics)) return undefined;
 
-  const idSeen = new Map<string, string>();
-  for (const p of modules.keys()) {
-    const id = canonicalModuleId(p, moduleIdRootDir);
-    const k = id.toLowerCase();
-    const prev = idSeen.get(k);
-    if (prev && prev !== p) {
-      const moduleSpan = modules.get(p)?.span.start;
-      diagnostics.push({
-        id: DiagnosticIds.SemanticsError,
-        severity: 'error',
-        message: `Module ID collision: "${id}" maps to both "${prev}" and "${p}".`,
-        file: p,
-        ...(moduleSpan !== undefined ? { line: moduleSpan.line, column: moduleSpan.column } : {}),
-      });
-    } else {
-      idSeen.set(k, p);
-    }
-  }
-  if (hasErrors(diagnostics)) return undefined;
+  if (!validateCanonicalModuleIds(modules, moduleIdRootDir, diagnostics)) return undefined;
 
-  const visiting = new Set<string>();
-  const visited = new Set<string>();
-  const order: string[] = [];
-
-  const sortKey = (p: string) => `${canonicalModuleId(p, moduleIdRootDir).toLowerCase()}\n${p}`;
-
-  const visit = (p: string, stack: string[], fromModule?: string) => {
-    if (visited.has(p)) return;
-    if (visiting.has(p)) {
-      const cycleStart = stack.indexOf(p);
-      const cycle = cycleStart >= 0 ? stack.slice(cycleStart).concat([p]) : stack.concat([p]);
-      const edge = fromModule ? edges.get(fromModule)?.get(p) : undefined;
-      diagnostics.push({
-        id: DiagnosticIds.SemanticsError,
-        severity: 'error',
-        message: `Import cycle detected: ${cycle.join(' -> ')}`,
-        file: fromModule ?? entryPath,
-        ...(edge !== undefined ? { line: edge.line, column: edge.column } : {}),
-      });
-      return;
-    }
-    visiting.add(p);
-    const deps = Array.from((edges.get(p) ?? new Map()).keys()).sort((a, b) =>
-      sortKey(a).localeCompare(sortKey(b)),
-    );
-    for (const d of deps) {
-      visit(d, stack.concat([p]), p);
-      if (hasErrors(diagnostics)) return;
-    }
-    visiting.delete(p);
-    visited.add(p);
-    order.push(p);
-  };
-
-  visit(entryPath, []);
-  if (hasErrors(diagnostics)) return undefined;
+  const order = topologicallyOrderModules(entryPath, edges, moduleIdRootDir, diagnostics);
+  if (!order) return undefined;
 
   const moduleFiles = order.map((p) => modules.get(p)!).filter(Boolean);
   const entryModule = modules.get(entryPath);
   if (!entryModule) return undefined;
 
-  const traversalVisited = new Set<string>();
-  const moduleTraversal: string[] = [];
-  const walkTraversal = (modulePath: string) => {
-    if (traversalVisited.has(modulePath)) return;
-    traversalVisited.add(modulePath);
-    moduleTraversal.push(modulePath);
-    for (const dep of (edges.get(modulePath) ?? new Map()).keys()) {
-      walkTraversal(dep);
-    }
-  };
-  walkTraversal(entryPath);
-
   return {
     program: { kind: 'Program', span: entryModule.span, entryFile: entryPath, files: moduleFiles },
     sourceTexts,
     sourceLineComments,
-    moduleTraversal,
+    moduleTraversal: collectModuleTraversal(entryPath, edges),
     resolvedImportGraph: new Map(
       Array.from(edges.entries(), ([modulePath, moduleEdges]) => [modulePath, Array.from(moduleEdges.keys())]),
     ),


### PR DESCRIPTION
Addresses #1113, with cycle/topology extraction folded in from the same `loadProgram()` hotspot.

## What changed
- extract top-level helpers for source read, include expansion, import resolution, parse, edge recording, module-id validation, topological ordering, and traversal collection
- reduce `loadProgram()` from 330 lines to 72 lines
- preserve import/include diagnostics, ordering, and traversal behavior

## Verification
- npm ci
- npm run typecheck
- ./node_modules/.bin/vitest run /Users/johnhardy/.codex/worktrees/module-loader-split/ZAX/test/pr575_callable_visibility.test.ts /Users/johnhardy/.codex/worktrees/module-loader-split/ZAX/test/pr575_module_visibility_scaffolding.test.ts
- ./node_modules/.bin/vitest run /Users/johnhardy/.codex/worktrees/module-loader-split/ZAX/test/moduleLoader_include_paths.test.ts /Users/johnhardy/.codex/worktrees/module-loader-split/ZAX/test/pr242_import_resolution_diag_spans.test.ts /Users/johnhardy/.codex/worktrees/module-loader-split/ZAX/test/pr950_include_text_only.test.ts /Users/johnhardy/.codex/worktrees/module-loader-split/ZAX/test/pr163_import_extern_base_relative_call.test.ts

Note: the task brief referenced `test/pr10_imports.test.ts` and `test/pr67_include.test.ts`, but those files do not exist in this worktree; I ran the current import/include loader coverage instead.