### PR TITLE
test: strengthen isa diagnostic assertions

### DIFF
--- a/test/pr202_add_diag_matrix.test.ts
+++ b/test/pr202_add_diag_matrix.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -14,11 +15,24 @@ describe('PR202: add malformed-form diagnostics parity', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('add expects destination A, HL, IX, or IY');
-    expect(messages).toContain('add HL, rr expects BC/DE/HL/SP');
-    expect(messages).toContain('add IX, rr supports BC/DE/SP and same-index pair only');
-    expect(messages).toContain('add IY, rr supports BC/DE/SP and same-index pair only');
-    expect(messages.some((m) => m.includes('add has unsupported operand form'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'add expects destination A, HL, IX, or IY',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'add HL, rr expects BC/DE/HL/SP',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'add IX, rr supports BC/DE/SP and same-index pair only',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'add IY, rr supports BC/DE/SP and same-index pair only',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'add has unsupported operand form',
+    });
   });
 });

--- a/test/pr203_ld_diag_matrix.test.ts
+++ b/test/pr203_ld_diag_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,16 +13,34 @@ describe('PR203: ld diagnostics parity matrix', () => {
   it('emits explicit ld diagnostics and avoids fallback/unresolved-fixup noise', async () => {
     const entry = join(__dirname, 'fixtures', 'pr203_ld_diag_matrix_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain('ld does not support memory-to-memory transfers');
-    expect(messages).toContain('ld r8, (bc/de) supports destination A only');
-    expect(messages).toContain('ld (bc/de), r8 supports source A only');
-    expect(messages).toContain('ld does not support AF in this form');
-    expect(messages).toContain('ld rr, rr supports SP <- HL/IX/IY only');
-
-    expect(messages).not.toContain('ld has unsupported operand form');
-    expect(messages.some((m) => m.includes('Unresolved symbol "bc" in 16-bit fixup.'))).toBe(false);
-    expect(messages.some((m) => m.includes('Unresolved symbol "de" in 16-bit fixup.'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'ld does not support memory-to-memory transfers',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'ld r8, (bc/de) supports destination A only',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'ld (bc/de), r8 supports source A only',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'ld does not support AF in this form',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'ld rr, rr supports SP <- HL/IX/IY only',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'ld has unsupported operand form',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'Unresolved symbol "bc" in 16-bit fixup.',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'Unresolved symbol "de" in 16-bit fixup.',
+    });
   });
 });

--- a/test/pr204_adc_sbc_diag_matrix.test.ts
+++ b/test/pr204_adc_sbc_diag_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,14 +13,27 @@ describe('PR204: adc/sbc malformed-form diagnostics parity', () => {
   it('emits explicit destination diagnostics for malformed two-operand forms', async () => {
     const entry = join(__dirname, 'fixtures', 'pr204_adc_sbc_diag_matrix_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain('adc expects destination A or HL');
-    expect(messages).toContain('adc HL, rr expects BC/DE/HL/SP');
-    expect(messages).toContain('sbc expects destination A or HL');
-    expect(messages).toContain('sbc HL, rr expects BC/DE/HL/SP');
-
-    expect(messages).not.toContain('adc has unsupported operand form');
-    expect(messages).not.toContain('sbc has unsupported operand form');
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'adc expects destination A or HL',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'adc HL, rr expects BC/DE/HL/SP',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'sbc expects destination A or HL',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'sbc HL, rr expects BC/DE/HL/SP',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'adc has unsupported operand form',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'sbc has unsupported operand form',
+    });
   });
 });

--- a/test/pr205_indexed_cb_destination_diag_matrix.test.ts
+++ b/test/pr205_indexed_cb_destination_diag_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -16,20 +17,49 @@ describe('PR205: indexed CB destination diagnostics parity', () => {
       'pr205_indexed_cb_destination_diag_matrix_invalid.zax',
     );
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain('res indexed destination must use legacy reg8 B/C/D/E/H/L/A');
-    expect(messages).toContain('res indexed destination family must match source index base');
-    expect(messages).toContain('set indexed destination must use legacy reg8 B/C/D/E/H/L/A');
-    expect(messages).toContain('set indexed destination family must match source index base');
-    expect(messages).toContain('rl indexed destination must use legacy reg8 B/C/D/E/H/L/A');
-    expect(messages).toContain('rl indexed destination family must match source index base');
-    expect(messages).toContain('rrc indexed destination must use legacy reg8 B/C/D/E/H/L/A');
-    expect(messages).toContain('rrc indexed destination family must match source index base');
-
-    expect(messages).not.toContain('res b,(ix/iy+disp),r expects reg8 destination');
-    expect(messages).not.toContain('set b,(ix/iy+disp),r expects reg8 destination');
-    expect(messages).not.toContain('rl (ix/iy+disp),r expects reg8 destination');
-    expect(messages).not.toContain('rrc (ix/iy+disp),r expects reg8 destination');
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'res indexed destination must use legacy reg8 B/C/D/E/H/L/A',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'res indexed destination family must match source index base',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'set indexed destination must use legacy reg8 B/C/D/E/H/L/A',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'set indexed destination family must match source index base',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'rl indexed destination must use legacy reg8 B/C/D/E/H/L/A',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'rl indexed destination family must match source index base',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'rrc indexed destination must use legacy reg8 B/C/D/E/H/L/A',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'rrc indexed destination family must match source index base',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'res b,(ix/iy+disp),r expects reg8 destination',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'set b,(ix/iy+disp),r expects reg8 destination',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'rl (ix/iy+disp),r expects reg8 destination',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'rrc (ix/iy+disp),r expects reg8 destination',
+    });
   });
 });

--- a/test/pr206_in_out_indexed_reg_diag_matrix.test.ts
+++ b/test/pr206_in_out_indexed_reg_diag_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,13 +13,22 @@ describe('PR206: in/out indexed-byte-register diagnostics parity', () => {
   it('emits explicit diagnostics for ED in/out forms using IX*/IY* byte registers', async () => {
     const entry = join(__dirname, 'fixtures', 'pr206_in_out_indexed_reg_diag_matrix_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain('in destination must use legacy reg8 B/C/D/E/H/L/A');
-    expect(messages).toContain('out source must use legacy reg8 B/C/D/E/H/L/A');
-
-    expect(messages).not.toContain('in expects a reg8 destination');
-    expect(messages).not.toContain('out expects a reg8 source');
-    expect(messages.some((m) => m.startsWith('Unsupported instruction:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'in destination must use legacy reg8 B/C/D/E/H/L/A',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'out source must use legacy reg8 B/C/D/E/H/L/A',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'in expects a reg8 destination',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'out expects a reg8 source',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported instruction:',
+    });
   });
 });

--- a/test/pr207_jp_indirect_legality_diag_matrix.test.ts
+++ b/test/pr207_jp_indirect_legality_diag_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,10 +13,15 @@ describe('PR207: jp indirect-form legality diagnostics parity', () => {
   it('emits explicit diagnostics for unsupported indirect jp addressing forms', async () => {
     const entry = join(__dirname, 'fixtures', 'pr207_jp_indirect_legality_diag_matrix_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain('jp indirect form supports (hl), (ix), or (iy) only');
-    expect(messages).not.toContain('jp expects imm16');
-    expect(messages.some((m) => m.startsWith('Unsupported instruction:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'jp indirect form supports (hl), (ix), or (iy) only',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'jp expects imm16',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported instruction:',
+    });
   });
 });

--- a/test/pr208_call_indirect_legality_diag_matrix.test.ts
+++ b/test/pr208_call_indirect_legality_diag_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -16,12 +17,22 @@ describe('PR208: call indirect-form legality diagnostics parity', () => {
       'pr208_call_indirect_legality_diag_matrix_invalid.zax',
     );
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain('call does not support indirect targets; use imm16');
-    expect(messages).toContain('call cc, nn does not support indirect targets');
-    expect(messages).not.toContain('call expects imm16');
-    expect(messages).not.toContain('call cc, nn expects condition + imm16');
-    expect(messages.some((m) => m.startsWith('Unsupported instruction:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'call does not support indirect targets; use imm16',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'call cc, nn does not support indirect targets',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'call expects imm16',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'call cc, nn expects condition + imm16',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported instruction:',
+    });
   });
 });

--- a/test/pr209_jp_cc_indirect_legality_diag_matrix.test.ts
+++ b/test/pr209_jp_cc_indirect_legality_diag_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -16,10 +17,15 @@ describe('PR209: jp cc indirect-form legality diagnostics parity', () => {
       'pr209_jp_cc_indirect_legality_diag_matrix_invalid.zax',
     );
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain('jp cc, nn does not support indirect targets');
-    expect(messages).not.toContain('jp cc, nn expects condition + imm16');
-    expect(messages.some((m) => m.startsWith('Unsupported instruction:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'jp cc, nn does not support indirect targets',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'jp cc, nn expects condition + imm16',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported instruction:',
+    });
   });
 });

--- a/test/pr210_jp_call_condition_vs_imm_diag_matrix.test.ts
+++ b/test/pr210_jp_call_condition_vs_imm_diag_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -16,15 +17,30 @@ describe('PR210: conditional jp/call condition-vs-imm diagnostics parity', () =>
       'pr210_jp_call_condition_vs_imm_diag_matrix_invalid.zax',
     );
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain('jp cc expects valid condition code NZ/Z/NC/C/PO/PE/P/M');
-    expect(messages).toContain('jp cc, nn expects imm16');
-    expect(messages).toContain('call cc expects valid condition code NZ/Z/NC/C/PO/PE/P/M');
-    expect(messages).toContain('call cc, nn expects imm16');
-
-    expect(messages).not.toContain('jp cc, nn expects condition + imm16');
-    expect(messages).not.toContain('call cc, nn expects condition + imm16');
-    expect(messages.some((m) => m.startsWith('Unsupported instruction:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'jp cc expects valid condition code NZ/Z/NC/C/PO/PE/P/M',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'jp cc, nn expects imm16',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'call cc expects valid condition code NZ/Z/NC/C/PO/PE/P/M',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'call cc, nn expects imm16',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'jp cc, nn expects condition + imm16',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'call cc, nn expects condition + imm16',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported instruction:',
+    });
   });
 });

--- a/test/pr211_jr_djnz_diag_matrix.test.ts
+++ b/test/pr211_jr_djnz_diag_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,15 +13,31 @@ describe('PR211: jr/djnz malformed-form diagnostics parity', () => {
   it('emits explicit diagnostics for invalid condition, disp, and indirect forms', async () => {
     const entry = join(__dirname, 'fixtures', 'pr211_jr_djnz_diag_matrix_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain('jr cc expects valid condition code NZ/Z/NC/C');
-    expect(messages).toContain('jr cc, disp does not support register targets; expects disp8');
-    expect(messages).toContain('jr cc, disp does not support indirect targets');
-    expect(messages).toContain('jr does not support indirect targets; expects disp8');
-    expect(messages).toContain('djnz does not support indirect targets; expects disp8');
-
-    expect(messages).not.toContain('jr cc, disp expects NZ/Z/NC/C + disp8');
-    expect(messages.some((m) => m.startsWith('Unsupported instruction:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'jr cc expects valid condition code NZ/Z/NC/C',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'jr cc, disp does not support register targets; expects disp8',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'jr cc, disp does not support indirect targets',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'jr does not support indirect targets; expects disp8',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'djnz does not support indirect targets; expects disp8',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'jr cc, disp expects NZ/Z/NC/C + disp8',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported instruction:',
+    });
   });
 });

--- a/test/pr225_indexed_rotate_destination_diag_matrix.test.ts
+++ b/test/pr225_indexed_rotate_destination_diag_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -16,13 +17,19 @@ describe('PR225: indexed rotate/shift destination diagnostics parity matrix', ()
       'pr225_indexed_rotate_destination_diag_matrix_invalid.zax',
     );
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
     const heads = ['rlc', 'rrc', 'rl', 'rr', 'sla', 'sra', 'sll', 'srl'];
     for (const head of heads) {
-      expect(messages).toContain(`${head} indexed destination must use legacy reg8 B/C/D/E/H/L/A`);
-      expect(messages).toContain(`${head} indexed destination family must match source index base`);
-      expect(messages).not.toContain(`${head} (ix/iy+disp),r expects reg8 destination`);
+      expectDiagnostic(res.diagnostics, {
+        severity: 'error',
+        message: `${head} indexed destination must use legacy reg8 B/C/D/E/H/L/A`,
+      });
+      expectDiagnostic(res.diagnostics, {
+        severity: 'error',
+        message: `${head} indexed destination family must match source index base`,
+      });
+      expectNoDiagnostic(res.diagnostics, {
+        message: `${head} (ix/iy+disp),r expects reg8 destination`,
+      });
     }
   });
 });

--- a/test/pr240_isa_register_target_diag_matrix.test.ts
+++ b/test/pr240_isa_register_target_diag_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,19 +13,44 @@ describe('PR240: ISA register-target diagnostics parity', () => {
   it('emits explicit diagnostics for register-target misuse in call/jp/jr/djnz', async () => {
     const entry = join(__dirname, 'fixtures', 'pr240_isa_register_target_diag_matrix_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain('call does not support register targets; use imm16');
-    expect(messages).toContain('jp indirect form requires parentheses; use (hl), (ix), or (iy)');
-    expect(messages).toContain('jp does not support register targets; use imm16');
-    expect(messages).toContain('jr does not support register targets; expects disp8');
-    expect(messages).toContain('jr cc, disp does not support register targets; expects disp8');
-    expect(messages).toContain('djnz does not support register targets; expects disp8');
-
-    expect(messages).not.toContain('call expects imm16');
-    expect(messages).not.toContain('jp expects imm16');
-    expect(messages).not.toContain('jr expects disp8');
-    expect(messages).not.toContain('djnz expects disp8');
-    expect(messages.some((m) => m.startsWith('Unsupported instruction:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'call does not support register targets; use imm16',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'jp indirect form requires parentheses; use (hl), (ix), or (iy)',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'jp does not support register targets; use imm16',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'jr does not support register targets; expects disp8',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'jr cc, disp does not support register targets; expects disp8',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'djnz does not support register targets; expects disp8',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'call expects imm16',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'jp expects imm16',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'jr expects disp8',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'djnz expects disp8',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported instruction:',
+    });
   });
 });


### PR DESCRIPTION
# Summary

- Replace weak ISA/encoder legality-diagnostic assertions with explicit helper assertions in one focused backend-facing batch.
- Preserve compiler behavior and keep the slice limited to assertion hardening in opcode diagnostic tests.

# Scope

- [ ] Docs-only
- [ ] Compiler behavior change
- [x] Tests updated

# Primary Gate Issue

- Required: link one primary tracking issue (for v0.2 work, use `v0.2 change task` format).
- Issue: #1132

# Acceptance Criteria Checklist

- [x] Replace the targeted weak diagnostic assertions in this ISA/encoder batch.
- [x] Keep the batch narrow and behavior-preserving.
- [x] Positive tests identified/updated.
- [x] Negative tests identified/updated.
- [x] Diagnostics impact documented: assertions are stricter, compiler diagnostics unchanged.
- [x] Out-of-scope list included.
- [ ] Repo-wide completion of #1132.
- [ ] Add a lint rule or custom matcher to enforce the new pattern.

# Validation

- Commands run:
  - `npm ci`
  - `npm run typecheck`
  - `npm run lint`
  - `npm test -- --run test/pr202_add_diag_matrix.test.ts test/pr203_ld_diag_matrix.test.ts test/pr204_adc_sbc_diag_matrix.test.ts test/pr205_indexed_cb_destination_diag_matrix.test.ts test/pr206_in_out_indexed_reg_diag_matrix.test.ts test/pr207_jp_indirect_legality_diag_matrix.test.ts test/pr208_call_indirect_legality_diag_matrix.test.ts test/pr209_jp_cc_indirect_legality_diag_matrix.test.ts test/pr210_jp_call_condition_vs_imm_diag_matrix.test.ts test/pr211_jr_djnz_diag_matrix.test.ts test/pr225_indexed_rotate_destination_diag_matrix.test.ts test/pr240_isa_register_target_diag_matrix.test.ts`
- Result summary: local install, typecheck, lint, and all 12 updated ISA/encoder tests passed.

# Merge Risk Notes

- Low risk: assertion-only changes in ISA/encoder diagnostic tests.
- Main risk is mismatching current diagnostic text; the exact updated test set passed locally.

# Out of Scope

- `it.each()` conversions
- parser/semantics batches outside this subsystem
- compiler/source behavior changes
- repo-wide migration of remaining weak diagnostic assertions

Refs #1132