### PR TITLE
test: strengthen lowering diagnostic assertions

### DIFF
--- a/test/pr102_lowering_frame_invariants.test.ts
+++ b/test/pr102_lowering_frame_invariants.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,26 +14,29 @@ describe('PR102 lowering/frame invariants with locals', () => {
     const entry = join(__dirname, 'fixtures', 'pr102_if_stack_mismatch_with_locals.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(res.diagnostics.some((d) => d.message.includes('Stack depth mismatch at if join'))).toBe(
-      true,
-    );
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      messageIncludes: 'Stack depth mismatch at if join',
+    });
   });
 
   it('diagnoses while back-edge stack mismatch when locals are present', async () => {
     const entry = join(__dirname, 'fixtures', 'pr102_while_stack_mismatch_with_locals.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(
-      res.diagnostics.some((d) => d.message.includes('Stack depth mismatch at while back-edge')),
-    ).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      messageIncludes: 'Stack depth mismatch at while back-edge',
+    });
   });
 
   it('diagnoses repeat/until stack mismatch when locals are present', async () => {
     const entry = join(__dirname, 'fixtures', 'pr102_repeat_stack_mismatch_with_locals.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(
-      res.diagnostics.some((d) => d.message.includes('Stack depth mismatch at repeat/until')),
-    ).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      messageIncludes: 'Stack depth mismatch at repeat/until',
+    });
   });
 });

--- a/test/pr103_lowering_mixed_return_paths.test.ts
+++ b/test/pr103_lowering_mixed_return_paths.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostics } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,7 +13,7 @@ describe('PR103 lowering mixed return-path stack diagnostics', () => {
   it('accepts mixed branch returns when plain ret preserves stack balance', async () => {
     const entry = join(__dirname, 'fixtures', 'pr103_mixed_returns_ret_imbalance.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics).toEqual([]);
+    expectNoDiagnostics(res.diagnostics);
     expect(res.artifacts.length).toBeGreaterThan(0);
   });
 
@@ -20,8 +21,9 @@ describe('PR103 lowering mixed return-path stack diagnostics', () => {
     const entry = join(__dirname, 'fixtures', 'pr103_mixed_returns_retcc_imbalance.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(
-      res.diagnostics.some((d) => d.message.includes('Stack depth mismatch at if/else join')),
-    ).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      messageIncludes: 'Stack depth mismatch at if/else join',
+    });
   });
 });

--- a/test/pr219_lowering_retcc_structured_control_matrix.test.ts
+++ b/test/pr219_lowering_retcc_structured_control_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,18 +13,24 @@ describe('PR219 lowering: ret cc invariants across structured-control joins/back
   it('diagnoses exact unknown-stack ret cc contract for while back-edge mismatch', async () => {
     const entry = join(__dirname, 'fixtures', 'pr219_lowering_unknown_retcc_while_backedge.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+    });
   });
 
   it('diagnoses exact unknown-stack ret cc contract for select-join mismatch', async () => {
     const entry = join(__dirname, 'fixtures', 'pr219_lowering_unknown_retcc_select_join.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+    });
   });
 
   it('diagnoses exact untracked-SP ret cc contract for select-join mutation', async () => {
     const entry = join(__dirname, 'fixtures', 'pr219_lowering_untracked_retcc_select_join.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+    });
   });
 });

--- a/test/pr220_lowering_retcc_ifelse_repeat_matrix.test.ts
+++ b/test/pr220_lowering_retcc_ifelse_repeat_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,24 +13,32 @@ describe('PR220 lowering: ret cc invariants across if/else and repeat/until', ()
   it('diagnoses exact unknown-stack ret cc contract for if/else join mismatch', async () => {
     const entry = join(__dirname, 'fixtures', 'pr220_lowering_unknown_retcc_if_else_join.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+    });
   });
 
   it('diagnoses exact untracked-SP ret cc contract for if/else join mutation', async () => {
     const entry = join(__dirname, 'fixtures', 'pr220_lowering_untracked_retcc_if_else_join.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+    });
   });
 
   it('diagnoses exact unknown-stack ret cc contract for repeat/until mismatch', async () => {
     const entry = join(__dirname, 'fixtures', 'pr220_lowering_unknown_retcc_repeat_until.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+    });
   });
 
   it('diagnoses exact untracked-SP ret cc contract for repeat/until mutation', async () => {
     const entry = join(__dirname, 'fixtures', 'pr220_lowering_untracked_retcc_repeat_until.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+    });
   });
 });

--- a/test/pr271_op_stack_policy_alignment.test.ts
+++ b/test/pr271_op_stack_policy_alignment.test.ts
@@ -5,12 +5,7 @@ import { dirname, join } from 'node:path';
 import { compile } from '../src/compile.js';
 import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
-
-type Diag = {
-  id: string;
-  severity: string;
-  message: string;
-};
+import { expectDiagnostic, expectNoDiagnostics } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -19,44 +14,36 @@ describe('PR271: op stack-policy alignment (optional mode)', () => {
   it('is off by default and preserves baseline diagnostics', async () => {
     const entry = join(__dirname, 'fixtures', 'pr271_op_stack_policy_delta_warn.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics).toEqual([]);
+    expectNoDiagnostics(res.diagnostics);
   });
 
   it('warn mode reports non-zero static op stack delta at stack-slot call sites', async () => {
     const entry = join(__dirname, 'fixtures', 'pr271_op_stack_policy_delta_warn.zax');
     const res = await compile(entry, { opStackPolicy: 'warn' }, { formats: defaultFormatWriters });
-    const actual: Diag[] = res.diagnostics.map((d) => ({
-      id: d.id,
-      severity: d.severity,
-      message: d.message,
-    }));
-
-    expect(actual.some((d) => d.id === DiagnosticIds.OpStackPolicyRisk)).toBe(true);
-    expect(actual.some((d) => d.severity === 'warning')).toBe(true);
-    expect(actual.some((d) => d.message.includes('non-zero static stack delta (-2)'))).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpStackPolicyRisk,
+      severity: 'warning',
+      messageIncludes: 'non-zero static stack delta (-2)',
+    });
   });
 
   it('warn mode reports untracked SP mutation risk in op body summaries', async () => {
     const entry = join(__dirname, 'fixtures', 'pr271_op_stack_policy_untracked_warn.zax');
     const res = await compile(entry, { opStackPolicy: 'warn' }, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-    const ids = res.diagnostics.map((d) => d.id);
-
-    expect(ids).toContain(DiagnosticIds.OpStackPolicyRisk);
-    expect(
-      messages.some((m) => m.includes('may mutate SP in an untracked way (static body analysis)')),
-    ).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpStackPolicyRisk,
+      severity: 'warning',
+      messageIncludes: 'may mutate SP in an untracked way (static body analysis)',
+    });
   });
 
   it('error mode upgrades stack-policy risks to errors', async () => {
     const entry = join(__dirname, 'fixtures', 'pr271_op_stack_policy_delta_warn.zax');
     const res = await compile(entry, { opStackPolicy: 'error' }, { formats: defaultFormatWriters });
-
-    expect(
-      res.diagnostics.some(
-        (d) => d.id === DiagnosticIds.OpStackPolicyRisk && d.severity === 'error',
-      ),
-    ).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpStackPolicyRisk,
+      severity: 'error',
+    });
     expect(res.artifacts).toEqual([]);
   });
 });

--- a/test/pr283_hidden_lowering_risk_matrix.test.ts
+++ b/test/pr283_hidden_lowering_risk_matrix.test.ts
@@ -11,6 +11,11 @@ import {
   flattenLoweredInstructions,
   formatLoweredInstructions,
 } from './helpers/lowered_program.js';
+import {
+  expectDiagnostic,
+  expectNoDiagnostics,
+  expectNoErrors,
+} from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -22,7 +27,7 @@ describe('PR283: hidden-lowering risk matrix focused coverage', () => {
       {},
       { formats: defaultFormatWriters },
     );
-    expect(opCallsite.diagnostics).toEqual([]);
+    expectNoDiagnostics(opCallsite.diagnostics);
     const d8m = opCallsite.artifacts.find((a): a is D8mArtifact => a.kind === 'd8m');
     expect(d8m).toBeDefined();
     const fileEntry = (
@@ -33,7 +38,7 @@ describe('PR283: hidden-lowering risk matrix focused coverage', () => {
     const typedPreserve = await compilePlacedProgram(
       join(__dirname, 'fixtures', 'pr276_typed_call_preservation_matrix.zax'),
     );
-    expect(typedPreserve.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    expectNoErrors(typedPreserve.diagnostics);
     const typedInstrs = flattenLoweredInstructions(typedPreserve.program);
     const typedLines = formatLoweredInstructions(typedPreserve.program).map((line) => line.toUpperCase());
     const rawCallCount = typedInstrs.reduce((count, instr) => {
@@ -49,7 +54,7 @@ describe('PR283: hidden-lowering risk matrix focused coverage', () => {
     const frameAccess = await compilePlacedProgram(
       join(__dirname, 'fixtures', 'pr283_local_arg_global_access_matrix.zax'),
     );
-    expect(frameAccess.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    expectNoErrors(frameAccess.diagnostics);
     const frameText = formatLoweredInstructions(frameAccess.program).join('\n').toUpperCase();
     expect(frameText).toContain('PUSH IX');
     expect(frameText).toContain('LD IX, $00');
@@ -62,14 +67,11 @@ describe('PR283: hidden-lowering risk matrix focused coverage', () => {
       { rawTypedCallWarnings: true },
       { formats: defaultFormatWriters },
     );
-    expect(
-      rawTypedWarn.diagnostics.some(
-        (d) => d.id === DiagnosticIds.RawCallTypedTargetWarning && d.severity === 'warning',
-      ),
-    ).toBe(true);
-    expect(
-      rawTypedWarn.diagnostics.some((d) => d.message.includes('Raw call targets typed callable')),
-    ).toBe(true);
+    expectDiagnostic(rawTypedWarn.diagnostics, {
+      id: DiagnosticIds.RawCallTypedTargetWarning,
+      severity: 'warning',
+      messageIncludes: 'Raw call targets typed callable',
+    });
   }, 20_000);
 
   it('covers negative hidden-lowering guardrails for op expansion stack policy and imbalance', async () => {
@@ -78,15 +80,11 @@ describe('PR283: hidden-lowering risk matrix focused coverage', () => {
       { opStackPolicy: 'error' },
       { formats: defaultFormatWriters },
     );
-    expect(stackPolicyError.diagnostics.some((d) => d.severity === 'error')).toBe(true);
-    expect(
-      stackPolicyError.diagnostics.some(
-        (d) =>
-          d.id === DiagnosticIds.OpStackPolicyRisk &&
-          d.severity === 'error' &&
-          d.message.includes('non-zero static stack delta'),
-      ),
-    ).toBe(true);
+    expectDiagnostic(stackPolicyError.diagnostics, {
+      id: DiagnosticIds.OpStackPolicyRisk,
+      severity: 'error',
+      messageIncludes: 'non-zero static stack delta',
+    });
 
     const unbalanced = await compile(
       join(__dirname, 'fixtures', 'pr23_op_unbalanced_stack.zax'),
@@ -102,19 +100,18 @@ describe('PR283: hidden-lowering risk matrix focused coverage', () => {
       {},
       { formats: defaultFormatWriters },
     );
-    const messages = typedVsRaw.diagnostics.map((d) => d.message);
-    expect(
-      messages.some((m) =>
-        m.includes(
-          'typed call "callee_typed" reached with unknown stack depth; cannot verify typed-call boundary contract.',
-        ),
-      ),
-    ).toBe(true);
-    expect(
-      messages.some((m) =>
-        m.includes('call reached with unknown stack depth; cannot verify callee stack contract.'),
-      ),
-    ).toBe(true);
+    expectDiagnostic(typedVsRaw.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      messageIncludes:
+        'typed call "callee_typed" reached with unknown stack depth; cannot verify typed-call boundary contract.',
+    });
+    expectDiagnostic(typedVsRaw.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      messageIncludes:
+        'call reached with unknown stack depth; cannot verify callee stack contract.',
+    });
     expect(typedVsRaw.diagnostics.every((d) => d.id === DiagnosticIds.EmitError)).toBe(true);
   });
 });

--- a/test/pr330_frames_epilogue_and_access.test.ts
+++ b/test/pr330_frames_epilogue_and_access.test.ts
@@ -4,12 +4,13 @@ import { join } from 'node:path';
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { compilePlacedProgram, flattenLoweredInstructions, isMemIxDisp, operandUsesIx } from './helpers/lowered_program.js';
+import { expectDiagnostic, expectNoErrors } from './helpers/diagnostics.js';
 
 describe('PR330: frame access + synthetic epilogue rules', () => {
   it('loads/stores frame slots without illegal IX+H/L forms and uses DE shuttle', async () => {
     const entry = join(__dirname, 'fixtures', 'pr330_frame_access_positive.zax');
     const { program, diagnostics } = await compilePlacedProgram(entry);
-    expect(diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    expectNoErrors(diagnostics);
 
     const instrs = flattenLoweredInstructions(program);
     const hasLdRegFromIx = (reg: string, disp: number) =>
@@ -31,10 +32,9 @@ describe('PR330: frame access + synthetic epilogue rules', () => {
   it('rejects retn/reti when a framed function requires epilogue cleanup', async () => {
     const entry = join(__dirname, 'fixtures', 'pr330_retn_reti_negative.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(
-      messages.some((m) => m.includes('not supported in functions that require cleanup')),
-    ).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      messageIncludes: 'not supported in functions that require cleanup',
+    });
   });
 });

--- a/test/pr555_function_sp_state_integration.test.ts
+++ b/test/pr555_function_sp_state_integration.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,19 +14,17 @@ describe('PR555: function-local SP tracking remains isolated', () => {
   it('preserves typed and raw call-boundary diagnostics across functions', async () => {
     const entry = join(__dirname, 'fixtures', 'pr275_typed_vs_raw_call_boundary_diag.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(
-      messages.some((m) =>
-        m.includes(
-          'typed call "callee_typed" reached with unknown stack depth; cannot verify typed-call boundary contract.',
-        ),
-      ),
-    ).toBe(true);
-    expect(
-      messages.some((m) =>
-        m.includes('call reached with unknown stack depth; cannot verify callee stack contract.'),
-      ),
-    ).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      messageIncludes:
+        'typed call "callee_typed" reached with unknown stack depth; cannot verify typed-call boundary contract.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      messageIncludes:
+        'call reached with unknown stack depth; cannot verify callee stack contract.',
+    });
   });
 });


### PR DESCRIPTION
# Summary

- Replace weak lowering/control-flow diagnostic assertions with helper-based assertions in one focused batch.
- Preserve compiler behavior and keep the slice limited to test hardening across stack invariants, `ret cc` control-flow contracts, stack-policy risk diagnostics, and typed/raw call-boundary diagnostics.

# Scope

- [ ] Docs-only
- [ ] Compiler behavior change
- [x] Tests updated

# Primary Gate Issue

- Required: link one primary tracking issue (for v0.2 work, use `v0.2 change task` format).
- Issue: #1132

# Acceptance Criteria Checklist

- [x] Replace the targeted weak diagnostic assertions in this lowering/control-flow batch.
- [x] Keep the batch narrow and behavior-preserving.
- [x] Positive tests identified/updated.
- [x] Negative tests identified/updated.
- [x] Diagnostics impact documented: assertions are stricter, compiler diagnostics unchanged.
- [x] Out-of-scope list included.
- [ ] Repo-wide completion of #1132.
- [ ] Add a lint rule or custom matcher to enforce the new pattern.

# Validation

- Commands run:
  - `npm ci`
  - `npm run typecheck`
  - `npm run lint`
  - `npm test -- --run test/pr102_lowering_frame_invariants.test.ts test/pr103_lowering_mixed_return_paths.test.ts test/pr219_lowering_retcc_structured_control_matrix.test.ts test/pr220_lowering_retcc_ifelse_repeat_matrix.test.ts test/pr271_op_stack_policy_alignment.test.ts test/pr283_hidden_lowering_risk_matrix.test.ts test/pr330_frames_epilogue_and_access.test.ts test/pr555_function_sp_state_integration.test.ts`
- Result summary: local install, typecheck, lint, and all 8 updated lowering/control-flow tests passed.

# Merge Risk Notes

- Low risk: assertion-only changes in lowering/control-flow tests.
- Main risk is mismatching current diagnostic text or severity; the exact updated test set passed locally.

# Out of Scope

- `it.each()` conversions
- repo-wide migration of remaining weak assertions
- compiler/source behavior changes
- test layout or organization moves

Refs #1132