### PR TITLE
Extract parser section header helper

### DIFF
--- a/src/frontend/parseModuleItemDispatch.ts
+++ b/src/frontend/parseModuleItemDispatch.ts
@@ -79,7 +79,7 @@ type CreateModuleItemDispatchTableContext = {
   lineCount: number;
   logicalLines: LogicalLine[];
   modulePath: string;
-  parseNamedSectionHeader: (
+  parseSectionHeader: (
     sectionText: string,
     sectionSpan: NamedSectionNode['span'],
     lineNo: number,
@@ -105,7 +105,7 @@ export function createModuleItemDispatchTable(ctx: CreateModuleItemDispatchTable
     lineCount,
     logicalLines: _logicalLines,
     modulePath: _modulePath,
-    parseNamedSectionHeader,
+    parseSectionHeader,
     parseOpParamsFromText,
     parseParamsFromText,
     parseSectionItems,
@@ -360,7 +360,7 @@ export function createModuleItemDispatchTable(ctx: CreateModuleItemDispatchTable
       /^[A-Za-z_][A-Za-z0-9_]*$/.test(namedTokens[1] ?? '') &&
       !/^(at|size|end)$/i.test(namedTokens[1] ?? '');
     if (namedPrefix) {
-      const header = parseNamedSectionHeader(sectionDecl, stmtSpan, lineNo, text, filePath);
+      const header = parseSectionHeader(sectionDecl, stmtSpan, lineNo, text, filePath);
       if (!header) return { nextIndex: index + 1 };
       const parsedSection = parseSectionItems(index + 1, header.section);
       const sectionEndIndex = Math.max(parsedSection.nextIndex - 1, index);

--- a/src/frontend/parseSectionHeader.ts
+++ b/src/frontend/parseSectionHeader.ts
@@ -1,0 +1,88 @@
+import type { Diagnostic } from '../diagnosticTypes.js';
+import type { NamedSectionNode, SectionAnchorNode } from './ast.js';
+import { NAMED_SECTION_KINDS } from './grammarData.js';
+import { parseImmExprFromText } from './parseImm.js';
+import { diagInvalidHeaderLine } from './parseModuleCommon.js';
+import { parseAlignDirectiveDecl } from './parseTopLevelSimple.js';
+
+export type ParsedSectionHeader = {
+  section: 'code' | 'data';
+  name: string;
+  anchor?: SectionAnchorNode;
+};
+
+type ParseSectionHeaderArgs = {
+  sectionText: string;
+  sectionSpan: NamedSectionNode['span'];
+  lineNo: number;
+  originalText: string;
+  filePath: string;
+  diagnostics: Diagnostic[];
+  isReservedTopLevelName: (name: string) => boolean;
+};
+
+export function parseSectionHeader({
+  sectionText,
+  sectionSpan,
+  lineNo,
+  originalText,
+  filePath,
+  diagnostics,
+  isReservedTopLevelName,
+}: ParseSectionHeaderArgs): ParsedSectionHeader | undefined {
+  const match = /^(\S+)\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s+at\s+(.+?)(?:\s+(size|end)\s+(.+))?)?$/i.exec(
+    sectionText.trim(),
+  );
+  if (!match || !NAMED_SECTION_KINDS.has(match[1]!.toLowerCase())) {
+    diagInvalidHeaderLine(
+      diagnostics,
+      filePath,
+      'named section declaration',
+      originalText,
+      '<code|data> <name> [at <imm16> [size <n> | end <addr>]]',
+      lineNo,
+    );
+    return undefined;
+  }
+
+  const section = match[1]!.toLowerCase() as 'code' | 'data';
+  const name = match[2]!;
+  const atText = match[3]?.trim();
+  const rangeKeyword = match[4]?.toLowerCase();
+  const rangeExprText = match[5]?.trim();
+
+  let anchor: SectionAnchorNode | undefined;
+  if (atText) {
+    const at = parseImmExprFromText(filePath, atText, sectionSpan, diagnostics);
+    if (!at) return undefined;
+    let bound: SectionAnchorNode['bound'] = { kind: 'none' };
+    anchor = {
+      kind: 'SectionAnchor',
+      span: sectionSpan,
+      at,
+      bound,
+    };
+    if (rangeKeyword && rangeExprText) {
+      const rangeExpr = parseAlignDirectiveDecl(
+        `align ${rangeExprText}`,
+        rangeExprText,
+        {
+          diagnostics,
+          modulePath: filePath,
+          lineNo,
+          text: originalText,
+          span: sectionSpan,
+          isReservedTopLevelName,
+        },
+      )?.value;
+      if (!rangeExpr) return undefined;
+      bound =
+        rangeKeyword === 'size'
+          ? { kind: 'size', size: rangeExpr }
+          : { kind: 'end', end: rangeExpr };
+      anchor.bound = bound;
+    }
+  }
+
+  return { section, name, ...(anchor ? { anchor } : {}) };
+}

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -1,22 +1,18 @@
 import type {
   ModuleFileNode,
   ModuleItemNode,
-  NamedSectionNode,
   ProgramNode,
-  SectionAnchorNode,
   SectionItemNode,
 } from './ast.js';
 import type { Diagnostic } from '../diagnosticTypes.js';
 import { canonicalModuleId } from '../moduleIdentity.js';
-import { NAMED_SECTION_KINDS } from './grammarData.js';
-import { parseImmExprFromText } from './parseImm.js';
 import { buildLogicalLines, getLogicalLine, type LogicalLine } from './parseLogicalLines.js';
 import {
   createModuleItemDispatchTable,
   type ParseItemContext,
   type ParseItemResult,
 } from './parseModuleItemDispatch.js';
-import { diagInvalidHeaderLine, topLevelStartKeyword } from './parseModuleCommon.js';
+import { topLevelStartKeyword } from './parseModuleCommon.js';
 import {
   parseExportModifier,
   recoverUnsupportedParserLine,
@@ -27,13 +23,13 @@ import {
   parseSectionBodyItem,
   parseSectionItems as parseSectionItemsFromHelper,
 } from './parseSectionBodies.js';
+import { parseSectionHeader } from './parseSectionHeader.js';
 import { parseOpParamsFromText, parseParamsFromText } from './parseParams.js';
 import {
   isReservedTopLevelDeclName,
   stripLineComment as stripComment,
 } from './parseParserShared.js';
 import { makeSourceFile, span, type SourceFile } from './source.js';
-import { parseAlignDirectiveDecl } from './parseTopLevelSimple.js';
 import { parseDiag as diag } from './parseDiagnostics.js';
 
 /**
@@ -72,69 +68,6 @@ export function parseModuleFile(
 
   const items: ModuleItemNode[] = [];
 
-  function parseNamedSectionHeader(
-    sectionText: string,
-    sectionSpan: NamedSectionNode['span'],
-    lineNo: number,
-    originalText: string,
-    filePath: string,
-  ): { section: 'code' | 'data'; name: string; anchor?: SectionAnchorNode } | undefined {
-    const m = /^(\S+)\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s+at\s+(.+?)(?:\s+(size|end)\s+(.+))?)?$/i.exec(
-      sectionText.trim(),
-    );
-    if (!m || !NAMED_SECTION_KINDS.has(m[1]!.toLowerCase())) {
-      diagInvalidHeaderLine(
-        diagnostics,
-        filePath,
-        'named section declaration',
-        originalText,
-        '<code|data> <name> [at <imm16> [size <n> | end <addr>]]',
-        lineNo,
-      );
-      return undefined;
-    }
-
-    const section = m[1]!.toLowerCase() as 'code' | 'data';
-    const name = m[2]!;
-    const atText = m[3]?.trim();
-    const rangeKeyword = m[4]?.toLowerCase();
-    const rangeExprText = m[5]?.trim();
-    let anchor: SectionAnchorNode | undefined;
-    if (atText) {
-      const at = parseImmExprFromText(filePath, atText, sectionSpan, diagnostics);
-      if (!at) return undefined;
-      let bound: SectionAnchorNode['bound'] = { kind: 'none' };
-      anchor = {
-        kind: 'SectionAnchor',
-        span: sectionSpan,
-        at,
-        bound,
-      };
-      if (rangeKeyword && rangeExprText) {
-        const rangeExpr = parseAlignDirectiveDecl(
-          `align ${rangeExprText}`,
-          rangeExprText,
-          {
-            diagnostics,
-            modulePath: filePath,
-            lineNo,
-            text: originalText,
-            span: sectionSpan,
-            isReservedTopLevelName,
-          },
-        )?.value;
-        if (!rangeExpr) return undefined;
-        bound =
-          rangeKeyword === 'size'
-            ? { kind: 'size', size: rangeExpr }
-            : { kind: 'end', end: rangeExpr };
-        anchor.bound = bound;
-      }
-    }
-
-    return { section, name, ...(anchor ? { anchor } : {}) };
-  }
-
   function parseSectionItems(startIndex: number, sectionKind: 'code' | 'data'): {
     items: SectionItemNode[];
     nextIndex: number;
@@ -161,7 +94,16 @@ export function parseModuleFile(
     lineCount,
     logicalLines,
     modulePath,
-    parseNamedSectionHeader,
+    parseSectionHeader: (sectionText, sectionSpan, lineNo, originalText, filePath) =>
+      parseSectionHeader({
+        sectionText,
+        sectionSpan,
+        lineNo,
+        originalText,
+        filePath,
+        diagnostics,
+        isReservedTopLevelName,
+      }),
     parseOpParamsFromText,
     parseParamsFromText,
     parseSectionItems,


### PR DESCRIPTION
Addresses #1114.

## What changed
- extract named section-header parsing into `src/frontend/parseSectionHeader.ts`
- make `parseModuleFile()` delegate to that helper through the module-item dispatch table
- preserve existing diagnostics and recovery behavior

## Verification
- npm ci
- npm run typecheck
- ./node_modules/.bin/vitest run /Users/johnhardy/.codex/worktrees/parser-section-header/ZAX/test/pr572_named_sections_parser.test.ts /Users/johnhardy/.codex/worktrees/parser-section-header/ZAX/test/pr611_parser_data_marker_enforcement.test.ts /Users/johnhardy/.codex/worktrees/parser-section-header/ZAX/test/pr785_raw_data_parser.test.ts /Users/johnhardy/.codex/worktrees/parser-section-header/ZAX/test/pr193_asm_marker_diagnostics.test.ts /Users/johnhardy/.codex/worktrees/parser-section-header/ZAX/test/pr178_import_enum_section_align_const_malformed_header_matrix.test.ts /Users/johnhardy/.codex/worktrees/parser-section-header/ZAX/test/pr181_top_level_malformed_header_canonical_matrix.test.ts