### PR TITLE
test: strengthen semantics diagnostic assertions

### DIFF
--- a/test/pr285_alias_init_parser_semantics_matrix.test.ts
+++ b/test/pr285_alias_init_parser_semantics_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoErrors } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,37 +14,35 @@ describe('PR285 parser/AST closure: alias-init vs value-init', () => {
     const entry = join(__dirname, 'fixtures', 'pr285_alias_init_globals_locals_positive.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const errors = res.diagnostics.filter((d) => d.severity === 'error');
-    expect(errors).toEqual([]);
+    expectNoErrors(res.diagnostics);
   });
 
   it('rejects non-constant names in typed local initializers', async () => {
     const entry = join(__dirname, 'fixtures', 'pr285_typed_alias_invalid_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain(
-      'Invalid local constant initializer for "bad_local": "base" is not a compile-time constant.',
-    );
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message:
+        'Invalid local constant initializer for "bad_local": "base" is not a compile-time constant.',
+    });
   });
 
   it('rejects local inferred alias declarations when rhs is not an address expression', async () => {
     const entry = join(__dirname, 'fixtures', 'pr285_incompatible_inferred_alias_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain(
-      'Function-local alias "bad_local" must target a direct module-scope storage name.',
-    );
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Function-local alias "bad_local" must target a direct module-scope storage name.',
+    });
   });
 
   it('rejects non-scalar local storage declarations without alias form', async () => {
     const entry = join(__dirname, 'fixtures', 'pr285_local_nonscalar_without_alias_negative.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain(
-      'Non-scalar local storage declaration "local_arr" requires alias form ("local_arr = rhs").',
-    );
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message:
+        'Non-scalar local storage declaration "local_arr" requires alias form ("local_arr = rhs").',
+    });
   });
 });

--- a/test/pr287_address_of_operator.test.ts
+++ b/test/pr287_address_of_operator.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -17,20 +18,29 @@ describe('PR287 explicit address-of operator (@place)', () => {
       { formats: defaultFormatWriters },
     );
 
-    const errors = res.diagnostics.filter((d) => d.severity === 'error');
-    expect(errors.map((d) => d.message)).toContain(
-      '"@<path>" is only supported with ":=" in this phase.',
-    );
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: '"@<path>" is only supported with ":=" in this phase.',
+    });
   });
 
   it('rejects invalid @ targets with stable diagnostics', async () => {
     const entry = join(__dirname, 'fixtures', 'pr287_address_of_invalid_targets_negative.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages.filter((m) => m.includes('Invalid address-of target')).length).toBe(3);
-    expect(messages).toContain('Invalid address-of target "@": expected @<place>.');
-    expect(messages).toContain('Invalid address-of target "@(3 + 2)": expected @<place>.');
-    expect(messages).toContain('Invalid address-of target "@3": expected @<place>.');
+    expect(
+      res.diagnostics.filter((d) => d.message.startsWith('Invalid address-of target ')).length,
+    ).toBe(3);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid address-of target "@": expected @<place>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid address-of target "@(3 + 2)": expected @<place>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid address-of target "@3": expected @<place>.',
+    });
   });
 });

--- a/test/pr849_local_init_consts.test.ts
+++ b/test/pr849_local_init_consts.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoErrors, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,53 +14,52 @@ describe('GitHub issue #849 local constant initializers', () => {
     const entry = join(__dirname, 'fixtures', 'pr849_local_init_consts_positive.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const errors = res.diagnostics.filter((d) => d.severity === 'error');
-    expect(errors).toEqual([]);
+    expectNoErrors(res.diagnostics);
   });
 
   it('diagnoses unknown compile-time names in typed local initializers', async () => {
     const entry = join(__dirname, 'fixtures', 'pr849_local_init_unknown_name_negative.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain(
-      'Unknown compile-time name "MissingConst" in local initializer for "high_index".',
-    );
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Unknown compile-time name "MissingConst" in local initializer for "high_index".',
+    });
   });
 
   it('diagnoses non-constant names in typed local initializers', async () => {
     const entry = join(__dirname, 'fixtures', 'pr849_local_init_nonconstant_negative.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain(
-      'Invalid local constant initializer for "high_index": "base" is not a compile-time constant.',
-    );
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message:
+        'Invalid local constant initializer for "high_index": "base" is not a compile-time constant.',
+    });
   });
 
   it('diagnoses EA-shaped local initializer expressions as invalid local constant initializers', async () => {
     const entry = join(__dirname, 'fixtures', 'pr849_local_init_ea_shape_negative.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain(
-      'Invalid local constant initializer for "value": expected compile-time immediate expression.',
-    );
-    expect(messages).not.toContain(
-      'Invalid var declaration line "value: word = arr[0]": expected <name>: <type>',
-    );
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message:
+        'Invalid local constant initializer for "value": expected compile-time immediate expression.',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      message: 'Invalid var declaration line "value: word = arr[0]": expected <name>: <type>',
+    });
   });
 
   it('diagnoses type-fit failures with existing immediate ranges', async () => {
     const entry = join(__dirname, 'fixtures', 'pr849_local_init_type_fit_negative.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain(
-      'Local initializer for "too_big_byte" does not fit byte range (-128..255); got 300.',
-    );
-    expect(messages).toContain(
-      'Local initializer for "too_big_word" does not fit word/addr range (-32768..65535); got 70000.',
-    );
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Local initializer for "too_big_byte" does not fit byte range (-128..255); got 300.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message:
+        'Local initializer for "too_big_word" does not fit word/addr range (-32768..65535); got 70000.',
+    });
   });
 });

--- a/test/pr980_local_alias_legality.test.ts
+++ b/test/pr980_local_alias_legality.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostics } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -16,57 +17,69 @@ const compileFixture = async (name: string) => {
 describe('PR980 local alias legality + raw access', () => {
   it('accepts alias to global aggregate in typed code', async () => {
     const res = await compileFixture('pr980_local_alias_global_typed.zax');
-    expect(res.diagnostics).toEqual([]);
+    expectNoDiagnostics(res.diagnostics);
   });
 
   it('accepts alias to global aggregate in raw code', async () => {
     const res = await compileFixture('pr980_local_alias_raw_aggregate.zax');
-    expect(res.diagnostics).toEqual([]);
+    expectNoDiagnostics(res.diagnostics);
   });
 
   it('accepts alias to global scalar in raw code', async () => {
     const res = await compileFixture('pr980_local_alias_raw_scalar.zax');
-    expect(res.diagnostics).toEqual([]);
+    expectNoDiagnostics(res.diagnostics);
   });
 
   it('keeps non-scalar parameter forwarding working', async () => {
     const res = await compileFixture('pr980_local_alias_param_forwarding.zax');
-    expect(res.diagnostics).toEqual([]);
+    expectNoDiagnostics(res.diagnostics);
   });
 
   it('rejects alias to parameter', async () => {
     const res = await compileFixture('pr980_local_alias_bad_param.zax');
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('Function-local alias "a" cannot target parameter "buf".');
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Function-local alias "a" cannot target parameter "buf".',
+    });
   });
 
   it('rejects alias to local', async () => {
     const res = await compileFixture('pr980_local_alias_bad_local.zax');
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('Function-local alias "c" cannot target local "count".');
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Function-local alias "c" cannot target local "count".',
+    });
   });
 
   it('rejects alias to alias', async () => {
     const res = await compileFixture('pr980_local_alias_bad_alias.zax');
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('Function-local alias "b" cannot target alias "a".');
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Function-local alias "b" cannot target alias "a".',
+    });
   });
 
   it('rejects alias to field path', async () => {
     const res = await compileFixture('pr980_local_alias_bad_field.zax');
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('Function-local alias "p" must target a direct module-scope storage name.');
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Function-local alias "p" must target a direct module-scope storage name.',
+    });
   });
 
   it('rejects alias to indexed path', async () => {
     const res = await compileFixture('pr980_local_alias_bad_index.zax');
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('Function-local alias "x" must target a direct module-scope storage name.');
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Function-local alias "x" must target a direct module-scope storage name.',
+    });
   });
 
   it('rejects alias to constant', async () => {
     const res = await compileFixture('pr980_local_alias_bad_const.zax');
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('Function-local alias "s" must target a direct module-scope storage name.');
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Function-local alias "s" must target a direct module-scope storage name.',
+    });
   });
 });

--- a/test/semantics/pr505_type_resolution_helpers.test.ts
+++ b/test/semantics/pr505_type_resolution_helpers.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../../src/compile.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,19 +14,21 @@ describe('PR505: extracted type-resolution helpers', () => {
     const entry = join(__dirname, '..', 'fixtures', 'pr260_value_semantics_scalar_index.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    expect(res.diagnostics).toEqual([]);
+    expectNoDiagnostics(res.diagnostics);
   });
 
   it('preserves non-scalar typed-call compatibility diagnostics', async () => {
     const entry = join(__dirname, '..', 'fixtures', 'pr286_nonscalar_param_compat_negative.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain(
-      'Incompatible non-scalar argument for parameter "values": expected byte[10], got byte[] (exact length proof required).',
-    );
-    expect(messages).toContain(
-      'Incompatible non-scalar argument for parameter "values": expected element type byte, got word.',
-    );
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message:
+        'Incompatible non-scalar argument for parameter "values": expected byte[10], got byte[] (exact length proof required).',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message:
+        'Incompatible non-scalar argument for parameter "values": expected element type byte, got word.',
+    });
   });
 });

--- a/test/semantics/semantics_layout.test.ts
+++ b/test/semantics/semantics_layout.test.ts
@@ -11,6 +11,7 @@ import type {
   TypeExprNode,
   UnionDeclNode,
 } from '../../src/frontend/ast.js';
+import { expectDiagnostic, expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 const s = (file = 'test.zax'): SourceSpan => ({
   file,
@@ -53,8 +54,11 @@ describe('sizeOfTypeExpr', () => {
     const env = emptyEnv();
     const res = sizeOfTypeExpr({ kind: 'TypeName', span: s(), name: 'Nope' }, env, diagnostics);
     expect(res).toBeUndefined();
-    expect(diagnostics[0]?.id).toBe(DiagnosticIds.TypeError);
-    expect(diagnostics.map((d) => d.message)).toContain('Unknown type "Nope".');
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.TypeError,
+      severity: 'error',
+      message: 'Unknown type "Nope".',
+    });
   });
 
   it('diagnoses recursive type definitions', () => {
@@ -80,10 +84,11 @@ describe('sizeOfTypeExpr', () => {
 
     const res = sizeOfTypeExpr({ kind: 'TypeName', span: s(), name: 'A' }, env, diagnostics);
     expect(res).toBeUndefined();
-    expect(diagnostics[0]?.id).toBe(DiagnosticIds.TypeError);
-    expect(diagnostics.map((d) => d.message)).toContain(
-      'Recursive type definition detected for "A".',
-    );
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.TypeError,
+      severity: 'error',
+      message: 'Recursive type definition detected for "A".',
+    });
   });
 
   it('requires array length outside data declarations', () => {
@@ -99,10 +104,12 @@ describe('sizeOfTypeExpr', () => {
       diagnostics,
     );
     expect(res).toBeUndefined();
-    expect(diagnostics[0]?.id).toBe(DiagnosticIds.TypeError);
-    expect(diagnostics.map((d) => d.message)).toContain(
-      'Array length is required here (inferred-length arrays like "T[]" are only permitted in data declarations with an initializer).',
-    );
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.TypeError,
+      severity: 'error',
+      message:
+        'Array length is required here (inferred-length arrays like "T[]" are only permitted in data declarations with an initializer).',
+    });
   });
 
   it('computes union sizes as max field size', () => {
@@ -117,7 +124,7 @@ describe('sizeOfTypeExpr', () => {
     );
     const res = sizeOfTypeExpr({ kind: 'TypeName', span: s(), name: 'Value' }, env, diagnostics);
     expect(res).toBe(2);
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
   });
 
   it('treats ptr as 16-bit scalar', () => {
@@ -125,6 +132,6 @@ describe('sizeOfTypeExpr', () => {
     const env = emptyEnv();
     const res = sizeOfTypeExpr({ kind: 'TypeName', span: s(), name: 'ptr' }, env, diagnostics);
     expect(res).toBe(2);
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
   });
 });


### PR DESCRIPTION
# Summary

- Replace weak semantics/env and layout-adjacent diagnostic assertions with helper-based assertions in one focused batch.
- Preserve compiler behavior and keep the slice limited to semantics/type-resolution, alias legality, local initializer, and address-of diagnostic tests.

# Scope

- [ ] Docs-only
- [ ] Compiler behavior change
- [x] Tests updated

# Primary Gate Issue

- Required: link one primary tracking issue (for v0.2 work, use `v0.2 change task` format).
- Issue: #1132

# Acceptance Criteria Checklist

- [x] Replace the targeted weak diagnostic assertions in this semantics/env batch.
- [x] Keep the batch narrow and behavior-preserving.
- [x] Positive tests identified/updated.
- [x] Negative tests identified/updated.
- [x] Diagnostics impact documented: assertions are stricter, compiler diagnostics unchanged.
- [x] Out-of-scope list included.
- [ ] Repo-wide completion of #1132.
- [ ] Add a lint rule or custom matcher to enforce the new pattern.

# Validation

- Commands run:
  - `npm ci`
  - `npm run typecheck`
  - `npm run lint`
  - `npm test -- --run test/semantics/semantics_layout.test.ts test/semantics/pr505_type_resolution_helpers.test.ts test/pr285_alias_init_parser_semantics_matrix.test.ts test/pr980_local_alias_legality.test.ts test/pr849_local_init_consts.test.ts test/pr287_address_of_operator.test.ts`
- Result summary: local install, typecheck, lint, and all 6 updated semantics/env tests passed.

# Merge Risk Notes

- Low risk: assertion-only changes in semantics/env tests.
- Main risk is mismatching current diagnostic text or severity; the exact updated test set passed locally.

# Out of Scope

- `it.each()` conversions
- repo-wide migration of remaining weak assertions
- compiler/source behavior changes
- test layout or organization moves
- parser-recovery and other non-semantics batches

Refs #1132