### PR TITLE
Extract module item dispatch helper

### DIFF
--- a/src/frontend/parseModuleItemDispatch.ts
+++ b/src/frontend/parseModuleItemDispatch.ts
@@ -27,6 +27,14 @@ import type { PendingRawLabel } from './parseRawDataDirectives.js';
 import type { LogicalLine } from './parseLogicalLines.js';
 import { parseDiag as diag } from './parseDiagnostics.js';
 import type { SourceFile } from './source.js';
+import { parseExportModifier, recoverUnsupportedParserLine } from './parseParserRecovery.js';
+import {
+  looksLikeRawDataDirectiveStart,
+  maybeCloseSection,
+  parseSectionBodyItem,
+} from './parseSectionBodies.js';
+import { topLevelStartKeyword } from './parseModuleCommon.js';
+import { stripLineComment as stripComment } from './parseParserShared.js';
 
 export type ParseItemContext =
   | { scope: 'module' }
@@ -41,6 +49,14 @@ export type ParseItemResult = {
   nextIndex: number;
   node?: ModuleItemNode | SectionItemNode;
   sectionClosed?: boolean;
+};
+
+export type RawModuleLine = {
+  raw: string;
+  startOffset: number;
+  endOffset: number;
+  lineNo: number;
+  filePath: string;
 };
 
 export type ParseModuleItemDispatchArgs = {
@@ -59,6 +75,10 @@ type ParseModuleItemDispatchHandler = (
   args: ParseModuleItemDispatchArgs,
 ) => ParseItemResult | undefined;
 
+export type ModuleItemDispatchTable = Readonly<
+  Partial<Record<string, ParseModuleItemDispatchHandler>>
+>;
+
 type NamedSectionHeader = {
   section: 'code' | 'data';
   name: string;
@@ -68,13 +88,7 @@ type NamedSectionHeader = {
 type CreateModuleItemDispatchTableContext = {
   diagnostics: Diagnostic[];
   file: SourceFile;
-  getRawLine: (lineIndex: number) => {
-    raw: string;
-    startOffset: number;
-    endOffset: number;
-    lineNo: number;
-    filePath: string;
-  };
+  getRawLine: (lineIndex: number) => RawModuleLine;
   isReservedTopLevelName: (name: string) => boolean;
   lineCount: number;
   logicalLines: LogicalLine[];
@@ -95,6 +109,106 @@ type CreateModuleItemDispatchTableContext = {
   };
   span: typeof import('./source.js').span;
 };
+
+type DispatchModuleItemContext = {
+  diagnostics: Diagnostic[];
+  file: SourceFile;
+  getRawLine: (lineIndex: number) => RawModuleLine;
+  logicalLines: LogicalLine[];
+  moduleItemDispatchTable: ModuleItemDispatchTable;
+  modulePath: string;
+  span: typeof import('./source.js').span;
+};
+
+export function dispatchModuleItem(
+  index: number,
+  ctx: ParseItemContext,
+  dispatchContext: DispatchModuleItemContext,
+): ParseItemResult {
+  const {
+    diagnostics,
+    file,
+    getRawLine,
+    logicalLines,
+    moduleItemDispatchTable,
+    modulePath,
+    span,
+  } = dispatchContext;
+  const { raw, startOffset: lineStartOffset, endOffset: lineEndOffset } = getRawLine(index);
+  const text = stripComment(raw).trim();
+  const lineNo = logicalLines[index]?.lineNo ?? index + 1;
+  const filePath = logicalLines[index]?.filePath ?? modulePath;
+
+  if (text.length === 0) return { nextIndex: index + 1 };
+
+  if (ctx.scope === 'section') {
+    const sectionClose = maybeCloseSection(index, text, ctx, diagnostics);
+    if (sectionClose) return sectionClose;
+  }
+
+  const exportParsed = parseExportModifier({
+    text,
+    lineNo,
+    allowAsmSpecialCase: ctx.scope === 'module',
+    filePath,
+    diagnostics,
+  });
+  if (!exportParsed) return { nextIndex: index + 1 };
+
+  const hasExportPrefix = exportParsed.exported;
+  const rest = exportParsed.rest;
+  const stmtSpan = span(file, lineStartOffset, lineEndOffset);
+
+  if (ctx.scope === 'section') {
+    const parsedSectionItem = parseSectionBodyItem({
+      index,
+      ctx,
+      rest,
+      lineNo,
+      filePath,
+      stmtSpan,
+      diagnostics,
+    });
+    if (parsedSectionItem) return parsedSectionItem;
+  } else if (looksLikeRawDataDirectiveStart(rest)) {
+    diag(
+      diagnostics,
+      filePath,
+      `Raw data directives are only permitted inside data sections.`,
+      { line: lineNo, column: 1 },
+    );
+    return { nextIndex: index + 1 };
+  }
+
+  const dispatchKeyword = topLevelStartKeyword(rest);
+  const dispatchHandler =
+    dispatchKeyword === undefined ? undefined : moduleItemDispatchTable[dispatchKeyword];
+  if (dispatchHandler) {
+    const parsed = dispatchHandler({
+      index,
+      lineNo,
+      filePath,
+      text,
+      rest,
+      stmtSpan,
+      lineStartOffset,
+      hasExportPrefix,
+      ctx,
+    });
+    if (parsed) return parsed;
+  }
+
+  return recoverUnsupportedParserLine({
+    index,
+    scope: ctx.scope,
+    text,
+    rest,
+    hasExportPrefix,
+    lineNo,
+    filePath,
+    diagnostics,
+  });
+}
 
 export function createModuleItemDispatchTable(ctx: CreateModuleItemDispatchTableContext) {
   const {
@@ -520,5 +634,5 @@ export function createModuleItemDispatchTable(ctx: CreateModuleItemDispatchTable
     bin: parseBinItem,
     hex: parseHexItem,
     data: parseDataItem,
-  } as Readonly<Partial<Record<string, ParseModuleItemDispatchHandler>>>;
+  } as ModuleItemDispatchTable;
 }

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -9,28 +9,15 @@ import { canonicalModuleId } from '../moduleIdentity.js';
 import { buildLogicalLines, getLogicalLine, type LogicalLine } from './parseLogicalLines.js';
 import {
   createModuleItemDispatchTable,
+  dispatchModuleItem,
   type ParseItemContext,
   type ParseItemResult,
 } from './parseModuleItemDispatch.js';
-import { topLevelStartKeyword } from './parseModuleCommon.js';
-import {
-  parseExportModifier,
-  recoverUnsupportedParserLine,
-} from './parseParserRecovery.js';
-import {
-  looksLikeRawDataDirectiveStart,
-  maybeCloseSection,
-  parseSectionBodyItem,
-  parseSectionItems as parseSectionItemsFromHelper,
-} from './parseSectionBodies.js';
+import { parseSectionItems as parseSectionItemsFromHelper } from './parseSectionBodies.js';
 import { parseSectionHeader } from './parseSectionHeader.js';
 import { parseOpParamsFromText, parseParamsFromText } from './parseParams.js';
-import {
-  isReservedTopLevelDeclName,
-  stripLineComment as stripComment,
-} from './parseParserShared.js';
+import { isReservedTopLevelDeclName } from './parseParserShared.js';
 import { makeSourceFile, span, type SourceFile } from './source.js';
-import { parseDiag as diag } from './parseDiagnostics.js';
 
 /**
  * Parse a single `.zax` module file from an in-memory source string.
@@ -111,79 +98,14 @@ export function parseModuleFile(
   });
 
   function parseModuleItem(index: number, ctx: ParseItemContext): ParseItemResult {
-    const { raw, startOffset: lineStartOffset, endOffset: lineEndOffset } = getRawLine(index);
-    const text = stripComment(raw).trim();
-    const lineNo = logicalLines[index]?.lineNo ?? index + 1;
-    const filePath = logicalLines[index]?.filePath ?? modulePath;
-
-    if (text.length === 0) return { nextIndex: index + 1 };
-
-    if (ctx.scope === 'section') {
-      const sectionClose = maybeCloseSection(index, text, ctx, diagnostics);
-      if (sectionClose) return sectionClose;
-    }
-
-    const exportParsed = parseExportModifier({
-      text,
-      lineNo,
-      allowAsmSpecialCase: ctx.scope === 'module',
-      filePath,
+    return dispatchModuleItem(index, ctx, {
       diagnostics,
-    });
-    if (!exportParsed) return { nextIndex: index + 1 };
-
-    const hasExportPrefix = exportParsed.exported;
-    const rest = exportParsed.rest;
-    const stmtSpan = span(file, lineStartOffset, lineEndOffset);
-
-    if (ctx.scope === 'section') {
-      const parsedSectionItem = parseSectionBodyItem({
-        index,
-        ctx,
-        rest,
-        lineNo,
-        filePath,
-        stmtSpan,
-        diagnostics,
-      });
-      if (parsedSectionItem) return parsedSectionItem;
-    } else if (looksLikeRawDataDirectiveStart(rest)) {
-      diag(
-        diagnostics,
-        filePath,
-        `Raw data directives are only permitted inside data sections.`,
-        { line: lineNo, column: 1 },
-      );
-      return { nextIndex: index + 1 };
-    }
-
-    const dispatchKeyword = topLevelStartKeyword(rest);
-    const dispatchHandler =
-      dispatchKeyword === undefined ? undefined : moduleItemDispatchTable[dispatchKeyword];
-    if (dispatchHandler) {
-      const parsed = dispatchHandler({
-        index,
-        lineNo,
-        filePath,
-        text,
-        rest,
-        stmtSpan,
-        lineStartOffset,
-        hasExportPrefix,
-        ctx,
-      });
-      if (parsed) return parsed;
-    }
-
-    return recoverUnsupportedParserLine({
-      index,
-      scope: ctx.scope,
-      text,
-      rest,
-      hasExportPrefix,
-      lineNo,
-      filePath,
-      diagnostics,
+      file,
+      getRawLine,
+      logicalLines,
+      moduleItemDispatchTable,
+      modulePath,
+      span,
     });
   }
 


### PR DESCRIPTION
Implements #1115.

## What changed
- extracted the main module-item dispatch flow from `parseModuleFile()` into `dispatchModuleItem(...)`
- kept `parseModuleFile()` focused on orchestration and line/section iteration
- preserved existing section/raw-data/export/recovery behavior

## Verification
- `npm ci`
- `npm run typecheck`
- `npx vitest run /Users/johnhardy/.codex/worktrees/parser-dispatch/ZAX/test/pr572_named_sections_parser.test.ts /Users/johnhardy/.codex/worktrees/parser-dispatch/ZAX/test/pr611_parser_data_marker_enforcement.test.ts /Users/johnhardy/.codex/worktrees/parser-dispatch/ZAX/test/pr785_raw_data_parser.test.ts /Users/johnhardy/.codex/worktrees/parser-dispatch/ZAX/test/pr193_asm_marker_diagnostics.test.ts /Users/johnhardy/.codex/worktrees/parser-dispatch/ZAX/test/pr178_import_enum_section_align_const_malformed_header_matrix.test.ts /Users/johnhardy/.codex/worktrees/parser-dispatch/ZAX/test/pr181_top_level_malformed_header_canonical_matrix.test.ts /Users/johnhardy/.codex/worktrees/parser-dispatch/ZAX/test/pr217_parser_decl_minimum_shape_and_eof_recovery.test.ts`