### PR TITLE
Docs: add lowering phase markers

### DIFF
--- a/src/lowering/emitPipeline.ts
+++ b/src/lowering/emitPipeline.ts
@@ -58,6 +58,7 @@ export type EmitProgramResult = {
 /** Environment for finalization that is *not* part of {@link LoweringResult}. */
 export type EmitFinalizationPhaseEnv = Omit<EmitFinalizationContext, keyof LoweringResult>;
 
+// --- Phase handoff: merge lowering output with finalization inputs ---
 /**
  * Combine lowering output with placement/fixup inputs. `lowered` is the typed handoff from
  * the lowering phase; `env` holds shared refs (maps, diagnostics, helpers) held across phases.
@@ -79,11 +80,13 @@ export function emitProgramEmptyResult(): EmitProgramResult {
   };
 }
 
+// --- Phase 2: prescan (callables, ops, storage aliases) ---
 /** Phase 2 — prescan: build visibility maps and alias metadata before emission. */
 export function runEmitPrescanPhase(ctx: ProgramLoweringContext): PrescanResult {
   return preScanProgramDeclarations(ctx);
 }
 
+// --- Phase 3: lowering (emit bytes, fixups, lowered ASM stream) ---
 /** Phase 3 — lowering: emit declarations and functions into section bytes and fixup queues. */
 export function runEmitLoweringPhase(
   ctx: ProgramLoweringContext,
@@ -92,6 +95,7 @@ export function runEmitLoweringPhase(
   return lowerProgramDeclarations(ctx, prescan);
 }
 
+// --- Phase 4: finalization (placement, fixups, artifact assembly) ---
 /** Phase 4 — placement, fixups, merged map and placed lowered ASM. */
 export function runEmitPlacementAndArtifactPhase(
   context: EmitFinalizationContext,

--- a/src/lowering/programLowering.ts
+++ b/src/lowering/programLowering.ts
@@ -43,6 +43,7 @@ import { createProgramLoweringDeclarationHelpers } from './programLoweringDeclar
 
 // Program lowering owns module-wide declaration traversal and the final
 // emission/fixup passes after all symbols and section bases are known.
+// --- Phase 0: shared context and products ---
 export type Context = FunctionLoweringSharedContext & {
   program: ProgramNode;
   includeDirs: string[];
@@ -100,6 +101,7 @@ export type Context = FunctionLoweringSharedContext & {
   withNamedSectionSink: <T>(sink: NamedSectionContributionSink, fn: () => T) => T;
 };
 
+// --- Phase 1 product: prescan metadata for lowering ---
 export type PrescanResult = {
   localCallablesByFile: Context['localCallablesByFile'];
   visibleCallables: Context['visibleCallables'];
@@ -113,6 +115,7 @@ export type PrescanResult = {
   rawAddressSymbols: Context['rawAddressSymbols'];
 };
 
+// --- Phase 2 product: lowered bytes, symbols, and deferred externs ---
 export type LoweringResult = {
   codeOffset: number;
   dataOffset: number;
@@ -126,6 +129,7 @@ export type LoweringResult = {
   hexBytes: Context['hexBytes'];
 };
 
+// --- Phase 3 context: finalization inputs (placement, fixups, artifacts) ---
 export type FinalizationContext = {
   diagnostics: Diagnostic[];
   diag: (diagnostics: Diagnostic[], file: string, message: string) => void;
@@ -173,6 +177,7 @@ export type FinalizationContext = {
   ) => EmittedSourceSegment[];
 };
 
+// --- Phase 1: prescan declarations (callables, ops, storage aliases) ---
 export function preScanProgramDeclarations(ctx: Context): PrescanResult {
   const preScanItem = (
     item: ModuleItemNode | SectionItemNode,
@@ -297,6 +302,7 @@ export function preScanProgramDeclarations(ctx: Context): PrescanResult {
   };
 }
 
+// --- Phase 2: lower declarations and functions into section bytes ---
 export function lowerProgramDeclarations(ctx: Context, _prescan: PrescanResult): LoweringResult {
   const sinkOffsetRef = (sink: NamedSectionContributionSink) => ({
     get current() {
@@ -666,4 +672,5 @@ export function lowerProgramDeclarations(ctx: Context, _prescan: PrescanResult):
   };
 }
 
+// --- Phase 3: finalization (placement, fixups, emission) ---
 export { finalizeProgramEmission } from './programLoweringFinalize.js';


### PR DESCRIPTION
Implements GitHub issue #1146.\n\nSummary:\n- Add phase-boundary comments to program lowering and emit pipeline orchestration.\n\nCommands:\n- npm ci (failed: npm not available)\n- npm run typecheck (failed: npm not available)\n