### PR TITLE
test: strengthen parser recovery diagnostics

### DIFF
--- a/test/pr153_parser_control_keyword_malformed_matrix.test.ts
+++ b/test/pr153_parser_control_keyword_malformed_matrix.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -14,16 +15,44 @@ describe('PR153 parser: malformed control-keyword matrix', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('"repeat" does not take operands');
-    expect(messages).toContain('"until" without matching "repeat"');
-    expect(messages).toContain('"if" expects a condition code');
-    expect(messages).toContain('"while" expects a condition code');
-    expect(messages).toContain('Invalid select selector');
-    expect(messages).toContain('Invalid case value');
-    expect(messages).toContain('"else" does not take operands');
-    expect(messages).toContain('"select" must contain at least one arm ("case" or "else")');
-    expect(messages).toContain('"end" does not take operands');
-    expect(messages.some((m) => m.startsWith('Unsupported instruction:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: '"repeat" does not take operands',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: '"until" without matching "repeat"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: '"if" expects a condition code',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: '"while" expects a condition code',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid select selector',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid case value',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: '"else" does not take operands',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: '"select" must contain at least one arm ("case" or "else")',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: '"end" does not take operands',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported instruction:',
+    });
   });
 });

--- a/test/pr157_export_malformed_matrix.test.ts
+++ b/test/pr157_export_malformed_matrix.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -14,23 +15,57 @@ describe('PR157 parser: malformed export matrix', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toEqual([
-      'Invalid export statement',
-      'Invalid export statement',
-      'export is only permitted on const/type/union/enum/func/op declarations',
-      'export not supported on import statements',
-      'Unterminated union "U": expected "end" before "globals"',
-      'Union "U" must contain at least one field',
-      'export not supported on globals declarations',
-      'export not supported on legacy "var" declarations (use "globals")',
-      'export not supported on section directives',
-      'export not supported on align directives',
-      'export not supported on extern declarations',
-      'export not supported on data declarations',
-      'export not supported on bin declarations',
-      'export not supported on hex declarations',
-    ]);
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expect(res.diagnostics.filter((d) => d.message === 'Invalid export statement')).toHaveLength(2);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'export is only permitted on const/type/union/enum/func/op declarations',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'export not supported on import statements',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Unterminated union "U": expected "end" before "globals"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Union "U" must contain at least one field',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'export not supported on globals declarations',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'export not supported on legacy "var" declarations (use "globals")',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'export not supported on section directives',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'export not supported on align directives',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'export not supported on extern declarations',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'export not supported on data declarations',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'export not supported on bin declarations',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'export not supported on hex declarations',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr165_data_keyword_name_recovery.test.ts
+++ b/test/pr165_data_keyword_name_recovery.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,14 +14,19 @@ describe('PR165 parser: data keyword-name recovery', () => {
     const entry = join(__dirname, 'fixtures', 'pr165_data_keyword_name_recovery.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain(
-      'Invalid data declaration name "func": collides with a top-level keyword.',
-    );
-    expect(messages).toContain(
-      'Invalid data declaration name "op": collides with a top-level keyword.',
-    );
-    expect(messages).not.toContain('Invalid func header');
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid data declaration name "func": collides with a top-level keyword.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid data declaration name "op": collides with a top-level keyword.',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Invalid func header',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr166_top_level_keyword_name_collisions.test.ts
+++ b/test/pr166_top_level_keyword_name_collisions.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,16 +14,36 @@ describe('PR166 parser: top-level keyword-name collisions', () => {
     const entry = join(__dirname, 'fixtures', 'pr166_top_level_keyword_name_collisions.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('Invalid type name "func": collides with a top-level keyword.');
-    expect(messages).toContain('Invalid union name "data": collides with a top-level keyword.');
-    expect(messages).toContain('Invalid enum name "import": collides with a top-level keyword.');
-    expect(messages).toContain('Invalid const name "op": collides with a top-level keyword.');
-    expect(messages).toContain('Invalid bin name "extern": collides with a top-level keyword.');
-    expect(messages).toContain('Invalid hex name "section": collides with a top-level keyword.');
-    expect(messages).toContain(
-      'Invalid extern func name "type": collides with a top-level keyword.',
-    );
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid type name "func": collides with a top-level keyword.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid union name "data": collides with a top-level keyword.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid enum name "import": collides with a top-level keyword.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid const name "op": collides with a top-level keyword.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid bin name "extern": collides with a top-level keyword.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid hex name "section": collides with a top-level keyword.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid extern func name "type": collides with a top-level keyword.',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr170_block_termination_recovery_matrix.test.ts
+++ b/test/pr170_block_termination_recovery_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,10 +14,20 @@ describe('PR170 parser: block termination recovery matrix', () => {
     const entry = join(__dirname, 'fixtures', 'pr170_block_termination_recovery_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('Unterminated type "Point": expected "end" before "const"');
-    expect(messages).toContain('Unterminated union "Pair": expected "end" before "globals"');
-    expect(messages).toContain('Unterminated extern "legacy": expected "end" before "data"');
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Unterminated type "Point": expected "end" before "const"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Unterminated union "Pair": expected "end" before "globals"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Unterminated extern "legacy": expected "end" before "data"',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr179_type_union_var_data_malformed_header_matrix.test.ts
+++ b/test/pr179_type_union_var_data_malformed_header_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -17,27 +18,44 @@ describe('PR179 parser: malformed type/union/var/data headers', () => {
     );
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain(
-      'Invalid type declaration line "type": expected <name> [<typeExpr>]',
-    );
-    expect(messages).toContain('Invalid type name "9Bad": expected <identifier>.');
-    expect(messages).toContain(
-      'Invalid type declaration line "type Word =": expected <name> [<typeExpr>]',
-    );
-    expect(messages).toContain(
-      'Invalid type declaration line "type Word [byte]": expected <name> [<typeExpr>]',
-    );
-
-    expect(messages).toContain('Invalid union declaration line "union": expected <name>');
-    expect(messages).toContain('Invalid union name "9Pair": expected <identifier>.');
-    expect(messages).toContain('Invalid union name "Pair extra": expected <identifier>.');
-
-    expect(messages).toContain(
-      'Invalid globals declaration line "globals extra": expected globals',
-    );
-    expect(messages).toContain('Invalid data declaration line "data extra": expected data');
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid type declaration line "type": expected <name> [<typeExpr>]',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid type name "9Bad": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid type declaration line "type Word =": expected <name> [<typeExpr>]',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid type declaration line "type Word [byte]": expected <name> [<typeExpr>]',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid union declaration line "union": expected <name>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid union name "9Pair": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid union name "Pair extra": expected <identifier>.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid globals declaration line "globals extra": expected globals',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid data declaration line "data extra": expected data',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/pr183_block_invalid_type_shape_matrix.test.ts
+++ b/test/pr183_block_invalid_type_shape_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,23 +14,31 @@ describe('PR183 parser: invalid block type shape diagnostics matrix', () => {
     const entry = join(__dirname, 'fixtures', 'pr183_block_invalid_type_shape_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain(
-      'Invalid record field declaration line "bad: [byte]": expected <name>: <type>',
-    );
-    expect(messages).toContain(
-      'Invalid union field declaration line "bad: [word]": expected <name>: <type>',
-    );
-    expect(messages).toContain(
-      'Invalid globals declaration line "bad: [byte]": expected <name>: <type>',
-    );
-    expect(messages).toContain(
-      'Invalid data declaration line "bad: [byte] = 2": expected <name>: <type> = <initializer>',
-    );
-
-    expect(messages.some((m) => m.includes('Unsupported field type'))).toBe(false);
-    expect(messages.some((m) => m.includes('Unsupported type in var declaration'))).toBe(false);
-    expect(messages.some((m) => m.includes('Unsupported type in data declaration'))).toBe(false);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid record field declaration line "bad: [byte]": expected <name>: <type>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid union field declaration line "bad: [word]": expected <name>: <type>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid globals declaration line "bad: [byte]": expected <name>: <type>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message:
+        'Invalid data declaration line "bad: [byte] = 2": expected <name>: <type> = <initializer>',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported field type',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported type in var declaration',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported type in data declaration',
+    });
   });
 });

--- a/test/pr189_globals_parser_matrix.test.ts
+++ b/test/pr189_globals_parser_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,15 +13,21 @@ describe('PR189 parser: globals keyword diagnostics matrix', () => {
   it('emits globals-specific diagnostics for malformed module globals blocks', async () => {
     const entry = join(__dirname, 'fixtures', 'pr189_globals_parser_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain(
-      'Invalid globals declaration line "globals extra": expected globals',
-    );
-    expect(messages).toContain(
-      'Invalid globals declaration name "func": collides with a top-level keyword.',
-    );
-    expect(messages).toContain('Duplicate globals declaration name "a".');
-    expect(messages).toContain('Invalid var declaration line "tmp byte": expected <name>: <type>');
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid globals declaration line "globals extra": expected globals',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid globals declaration name "func": collides with a top-level keyword.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Duplicate globals declaration name "a".',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message: 'Invalid var declaration line "tmp byte": expected <name>: <type>',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- strengthen parser-recovery diagnostic tests by replacing weak message-array assertions with helper-based checks
- keep this batch limited to malformed declaration and recovery follow-up coverage
- preserve existing compiler behavior and test intent

## Testing
- npm ci
- npm run typecheck
- npm run lint
- npm test -- --run test/pr153_parser_control_keyword_malformed_matrix.test.ts test/pr157_export_malformed_matrix.test.ts test/pr165_data_keyword_name_recovery.test.ts test/pr166_top_level_keyword_name_collisions.test.ts test/pr170_block_termination_recovery_matrix.test.ts test/pr179_type_union_var_data_malformed_header_matrix.test.ts test/pr183_block_invalid_type_shape_matrix.test.ts test/pr189_globals_parser_matrix.test.ts

Part of #1132