### PR TITLE
test: strengthen diagnostics (env / place / lowering batch) — #1132

### DIFF
--- a/test/pr275_typed_vs_raw_call_boundary_diagnostics.test.ts
+++ b/test/pr275_typed_vs_raw_call_boundary_diagnostics.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,19 +15,17 @@ describe('PR275: typed vs raw call-boundary diagnostics', () => {
     const entry = join(__dirname, 'fixtures', 'pr275_typed_vs_raw_call_boundary_diag.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(
-      messages.some((m) =>
-        m.includes(
-          'typed call "callee_typed" reached with unknown stack depth; cannot verify typed-call boundary contract.',
-        ),
-      ),
-    ).toBe(true);
-    expect(
-      messages.some((m) =>
-        m.includes('call reached with unknown stack depth; cannot verify callee stack contract.'),
-      ),
-    ).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      messageIncludes:
+        'typed call "callee_typed" reached with unknown stack depth; cannot verify typed-call boundary contract.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      messageIncludes:
+        'call reached with unknown stack depth; cannot verify callee stack contract.',
+    });
   });
 });

--- a/test/pr289_place_expression_contexts.test.ts
+++ b/test/pr289_place_expression_contexts.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { compile } from '../src/compile.js';
 import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostics } from './helpers/diagnostics.js';
 import {
   compilePlacedProgram,
   flattenLoweredInstructions,
@@ -18,7 +19,7 @@ describe('PR289: place-expression semantics for field/element operands', () => {
   it('applies value/store contexts for scalar place expressions and address contexts for ea params', async () => {
     const entry = join(__dirname, 'fixtures', 'pr289_place_expression_contexts_positive.zax');
     const { program, diagnostics } = await compilePlacedProgram(entry);
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     const instrs = flattenLoweredInstructions(program);
 
     // Field place-expression in value/store contexts.
@@ -35,8 +36,15 @@ describe('PR289: place-expression semantics for field/element operands', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
     expect(res.artifacts).toEqual([]);
-    expect(res.diagnostics.some((d) => d.id === DiagnosticIds.OpNoMatchingOverload)).toBe(true);
-    expect(res.diagnostics.some((d) => d.message.includes('No matching op overload'))).toBe(true);
-    expect(res.diagnostics.some((d) => d.message.includes('expects ea, got (p.lo)'))).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpNoMatchingOverload,
+      severity: 'error',
+      messageIncludes: 'No matching op overload',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpNoMatchingOverload,
+      severity: 'error',
+      messageIncludes: 'expects ea, got (p.lo)',
+    });
   });
 });

--- a/test/pr292_local_var_initializer_enforcement.test.ts
+++ b/test/pr292_local_var_initializer_enforcement.test.ts
@@ -3,7 +3,9 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoErrors } from './helpers/diagnostics.js';
 import {
   compilePlacedProgram,
   formatLoweredInstructions,
@@ -18,8 +20,7 @@ describe('PR292 local var initializer completeness', () => {
   it('lowers local scalar value-init at function entry and keeps alias locals slot-free', async () => {
     const entry = join(__dirname, 'fixtures', 'pr292_local_scalar_init_and_alias_positive.zax');
     const { program, diagnostics } = await compilePlacedProgram(entry);
-    const errors = diagnostics.filter((d) => d.severity === 'error');
-    expect(errors).toEqual([]);
+    expectNoErrors(diagnostics);
 
     const lines = formatLoweredInstructions(program);
     expect(lines).toContain('PUSH IX');
@@ -43,10 +44,11 @@ describe('PR292 local var initializer completeness', () => {
   it('rejects non-scalar local value-init declarations with stable diagnostics', async () => {
     const entry = join(__dirname, 'fixtures', 'pr292_local_nonscalar_value_init_negative.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain(
-      'Non-scalar local storage declaration "arr" requires alias form ("arr = rhs").',
-    );
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      message:
+        'Non-scalar local storage declaration "arr" requires alias form ("arr = rhs").',
+    });
   });
 });

--- a/test/pr2_div_zero.test.ts
+++ b/test/pr2_div_zero.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { DiagnosticIds } from '../src/diagnosticTypes.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -17,11 +18,15 @@ describe('PR2 divide by zero', () => {
     expect(res.diagnostics.map((d) => d.id)).toEqual(
       expect.arrayContaining([DiagnosticIds.ImmDivideByZero, DiagnosticIds.SemanticsError]),
     );
-    expect(res.diagnostics.map((d) => d.message)).toEqual(
-      expect.arrayContaining([
-        'Divide by zero in imm expression.',
-        'Failed to evaluate const "Bad".',
-      ]),
-    );
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ImmDivideByZero,
+      severity: 'error',
+      message: 'Divide by zero in imm expression.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.SemanticsError,
+      severity: 'error',
+      message: 'Failed to evaluate const "Bad".',
+    });
   });
 });

--- a/test/pr3_var_duplicates.test.ts
+++ b/test/pr3_var_duplicates.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,8 +14,10 @@ describe('PR3 var symbol collisions', () => {
   it('diagnoses duplicate module-scope var names', async () => {
     const entry = join(__dirname, 'fixtures', 'pr3_var_duplicates.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.map((d) => d.message)).toContain(
-      'Duplicate globals declaration name "p".',
-    );
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      message: 'Duplicate globals declaration name "p".',
+    });
   });
 });

--- a/test/pr507_ea_resolution_helpers.test.ts
+++ b/test/pr507_ea_resolution_helpers.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostics } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,16 +15,17 @@ describe('PR507: extracted EA resolution helpers', () => {
     const entry = join(__dirname, 'fixtures', 'pr260_value_semantics_scalar_index.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    expect(res.diagnostics).toEqual([]);
+    expectNoDiagnostics(res.diagnostics);
   });
 
   it('preserves runtime-affine unsupported-shape diagnostics', async () => {
     const entry = join(__dirname, 'fixtures', 'pr272_runtime_affine_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain(
-      'Runtime array index expression is unsupported. Use a single scalar runtime atom with +, -, *, << and constants (no /, %, &, |, ^, >> on runtime atoms).',
-    );
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      message:
+        'Runtime array index expression is unsupported. Use a single scalar runtime atom with +, -, *, << and constants (no /, %, &, |, ^, >> on runtime atoms).',
+    });
   });
 });


### PR DESCRIPTION
## Summary
Replaces weak diagnostic assertions (`some`/`includes`/`map(message)`) with `expectDiagnostic`, `expectNoDiagnostics`, and `expectNoErrors` in a focused **const evaluation / name resolution / place semantics / EA resolution** batch.

**Related to #1132** (does not close — remaining weak-pattern work continues.)

## Files
- `test/pr2_div_zero.test.ts` — `ImmDivideByZero` + `SemanticsError` const-eval messages
- `test/pr3_var_duplicates.test.ts` — `ParseError` duplicate globals
- `test/pr275_typed_vs_raw_call_boundary_diagnostics.test.ts` — `EmitError` stack-boundary messages
- `test/pr289_place_expression_contexts.test.ts` — `OpNoMatchingOverload` place-expression negative
- `test/pr292_local_var_initializer_enforcement.test.ts` — `EmitError` non-scalar local init
- `test/pr507_ea_resolution_helpers.test.ts` — runtime affine unsupported index message

## Verified
```sh
npm ci
npm run typecheck
npm run lint
npx vitest run test/pr2_div_zero.test.ts test/pr3_var_duplicates.test.ts test/pr275_typed_vs_raw_call_boundary_diagnostics.test.ts test/pr289_place_expression_contexts.test.ts test/pr292_local_var_initializer_enforcement.test.ts test/pr507_ea_resolution_helpers.test.ts
npx vitest run
```


Made with [Cursor](https://cursor.com)