### PR TITLE
test: move pr468, pr798, pr476_parse_* parser tests to test/frontend (#1152 batch2)

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -31,7 +31,7 @@ CI now rejects newly added top-level `test/prNNN_*.test.ts` files unless you exp
 
 Representative files:
 
-- `pr476_parse_*.test.ts` for parser helpers
+- `frontend/pr476_parse_*.test.ts` for parser helpers
 - `backend/pr477_encode_*.test.ts` for encoder families
 - `lowering/pr509_*.test.ts`, `lowering/pr510_*.test.ts`, `lowering/pr528_*.test.ts`, `lowering/pr529_*.test.ts`, `lowering/pr530_*.test.ts`, `lowering/pr531_*.test.ts`, and `lowering/pr532_asm_instruction_lowering_integration.test.ts` for lowering helper seams
 
@@ -43,7 +43,7 @@ Representative files:
 
 Representative files:
 
-- `pr468_parser_dispatch_integration.test.ts` for top-level parser dispatch
+- `frontend/pr468_parser_dispatch_integration.test.ts` for top-level parser dispatch
 - `lowering/pr543_function_lowering_integration.test.ts` and `lowering/pr544_program_lowering_integration.test.ts` for lowering seams
 - `lowering/pr511_asm_range_lowering_integration.test.ts` for structured-control lowering
 - `pr582_named_section_*integration.test.ts` and `pr585_named_section_layout_integration.test.ts` for named-section routing/layout
@@ -67,7 +67,7 @@ Representative files:
 | Area                                       | Start with                                                                                                                                                                                                                                                           | Notes                                                                                                                                  |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | CLI behavior and artifact selection        | `cli/cli_contract_matrix.test.ts`, `cli/cli_failure_contract_matrix.test.ts`, `cli/cli_artifacts.test.ts`, `cli/cli_zax_smoke.test.ts`                                                                                                                               | Use `test/helpers/cli.ts` for end-to-end CLI execution.                                                                                |
-| Parser dispatch and recovery               | `pr468_parser_dispatch_integration.test.ts`, `pr227_parser_toplevel_malformed_spans.test.ts`, `pr238_parser_malformed_decl_header_spans_matrix.test.ts`                                                                                                              | Use helper-level `pr476_parse_*.test.ts` files for isolated parser seams.                                                              |
+| Parser dispatch and recovery               | `frontend/pr468_parser_dispatch_integration.test.ts`, `frontend/pr798_addr_expr_parser.test.ts`, `pr227_parser_toplevel_malformed_spans.test.ts`, `pr238_parser_malformed_decl_header_spans_matrix.test.ts`                                                                                                              | Use helper-level `frontend/pr476_parse_*.test.ts` files for isolated parser seams.                                                              |
 | Grammar and token tables                   | `frontend/pr762_grammar_data_conformance.test.ts`, `frontend/pr808_grammar_drift.test.ts`, `frontend/pr250_parser_instruction_head_casing.test.ts`, `frontend/pr252_parser_register_token_canonicalization.test.ts`, `frontend/pr253_parser_control_cc_canonicalization.test.ts`, `frontend/pr578_legacy_syntax_warnings.test.ts`                                                                    | Good home for reserved-word and canonicalization changes.                                                                              |
 | Semantics and layout                       | `semantics/semantics_layout.test.ts`, `semantics/semantics_layout_extra.test.ts`, `pr285_alias_init_parser_semantics_matrix.test.ts`, `pr980_local_alias_legality.test.ts`                                                                                           | Use these when type size, offsets, alias legality, or compile-time rules change.                                                       |
 | Lowering frame and control-flow invariants | `pr102_lowering_frame_invariants.test.ts`, `pr103_lowering_mixed_return_paths.test.ts`, `pr555_function_sp_state_integration.test.ts`, `pr848_break_continue_integration.test.ts`                                                                                    | Covers epilogue cleanup, SP tracking, and structured control lowering.                                                                 |
@@ -83,6 +83,7 @@ Representative files:
 
 - Add the test next to the nearest existing feature cluster instead of creating a new naming family unless the behavior is genuinely new.
 - New tests for lowering seams: prefer `test/lowering/` with the same `prNNN_*.test.ts` naming pattern when adding alongside migrated files.
+- New parser helper or frontend-parser integration tests: prefer `test/frontend/` with the same `prNNN_*.test.ts` naming pattern when adding alongside migrated files.
 - Keep CLI tests under `test/cli/` (`cli_*.test.ts` filenames). Do not bury CLI behavior in a lower-level integration file.
 - Prefer helper-level files when a single extracted module owns the behavior.
 - Prefer `compile(...)` integration coverage when the interaction between phases is the real risk.

--- a/test/frontend/pr468_parser_dispatch_integration.test.ts
+++ b/test/frontend/pr468_parser_dispatch_integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnosticTypes.js';
-import { parseProgram } from '../src/frontend/parser.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { parseProgram } from '../../src/frontend/parser.js';
 
 describe('PR468 parser dispatcher integration coverage', () => {
   it('keeps the split top-level dispatcher wired across extracted declaration families', () => {

--- a/test/frontend/pr476_parse_asm_statements_helpers.test.ts
+++ b/test/frontend/pr476_parse_asm_statements_helpers.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnosticTypes.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import {
   appendParsedAsmStatement,
   isRecoverOnlyControlFrame,
   parseAsmStatement,
   type AsmControlFrame,
-} from '../src/frontend/parseAsmStatements.js';
-import { makeSourceFile, span } from '../src/frontend/source.js';
+} from '../../src/frontend/parseAsmStatements.js';
+import { makeSourceFile, span } from '../../src/frontend/source.js';
 
 describe('PR476 asm statement parsing extraction', () => {
   const file = makeSourceFile('pr476_parse_asm_statements_helpers.zax', '');

--- a/test/frontend/pr476_parse_data_helpers.test.ts
+++ b/test/frontend/pr476_parse_data_helpers.test.ts
@@ -1,16 +1,21 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnosticTypes.js';
-import { parseGlobalsBlock } from '../src/frontend/parseGlobals.js';
-import { parseProgram } from '../src/frontend/parser.js';
-import { makeSourceFile } from '../src/frontend/source.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { parseDataBlock } from '../../src/frontend/parseData.js';
+import { parseProgram } from '../../src/frontend/parser.js';
+import { makeSourceFile } from '../../src/frontend/source.js';
 
-describe('PR476 globals parser extraction', () => {
-  it('keeps globals block parsing intact', () => {
-    const sourceText = ['globals', 'foo: byte', 'bar: word = $1234', 'func main()', 'end'].join(
-      '\n',
-    );
-    const file = makeSourceFile('pr476_parse_globals_helpers.zax', sourceText);
+describe('PR476 data parser extraction', () => {
+  it('keeps data block parsing intact', () => {
+    const sourceText = [
+      'data',
+      'greeting: byte[] = "hi"',
+      'coords: word[2] = [1, 2]',
+      'func main()',
+      'end',
+      '',
+    ].join('\n');
+    const file = makeSourceFile('pr476_parse_data_helpers.zax', sourceText);
     const diagnostics: Diagnostic[] = [];
 
     function getRawLine(lineIndex: number): {
@@ -34,42 +39,52 @@ describe('PR476 globals parser extraction', () => {
       };
     }
 
-    const parsed = parseGlobalsBlock('globals', 0, 1, {
+    const parsed = parseDataBlock(0, {
       file,
       lineCount: file.lineStarts.length,
       diagnostics,
       modulePath: file.path,
       getRawLine,
-      isReservedTopLevelName: () => false,
     });
 
     expect(diagnostics).toEqual([
       expect.objectContaining({
         severity: 'error',
         message:
-          'Legacy "globals ... end" storage blocks are removed; use direct declarations inside named data sections.',
+          'Legacy top-level "data ... end" blocks are removed; use direct declarations inside named data sections.',
       }),
     ]);
     expect(parsed.nextIndex).toBe(3);
-    expect(parsed.varBlock).toMatchObject({
-      kind: 'VarBlock',
-      scope: 'module',
+    expect(parsed.node).toMatchObject({
+      kind: 'DataBlock',
       decls: [
-        { name: 'foo', typeExpr: { kind: 'TypeName', name: 'byte' } },
+        { name: 'greeting', initializer: { kind: 'InitString', value: 'hi' } },
         {
-          name: 'bar',
-          typeExpr: { kind: 'TypeName', name: 'word' },
-          initializer: { kind: 'VarInitValue', expr: { kind: 'ImmLiteral', value: 0x1234 } },
+          name: 'coords',
+          initializer: {
+            kind: 'InitArray',
+            elements: [
+              { kind: 'ImmLiteral', value: 1 },
+              { kind: 'ImmLiteral', value: 2 },
+            ],
+          },
         },
       ],
     });
   });
 
-  it('preserves globals parsing through parser.ts', () => {
+  it('preserves data parsing through parser.ts', () => {
     const diagnostics: Diagnostic[] = [];
     const program = parseProgram(
-      'pr476_parse_globals_helpers.zax',
-      ['globals', 'foo: byte', 'bar: word = $1234', 'func main()', 'end', ''].join('\n'),
+      'pr476_parse_data_helpers.zax',
+      [
+        'data',
+        'greeting: byte[] = "hi"',
+        'coords: word[2] = [1, 2]',
+        'func main()',
+        'end',
+        '',
+      ].join('\n'),
       diagnostics,
     );
 
@@ -77,7 +92,7 @@ describe('PR476 globals parser extraction', () => {
       expect.objectContaining({
         severity: 'error',
         message:
-          'Legacy "globals ... end" storage blocks are removed; use direct declarations inside named data sections.',
+          'Legacy top-level "data ... end" blocks are removed; use direct declarations inside named data sections.',
       }),
     ]);
     expect(program.files[0]?.items).toHaveLength(1);

--- a/test/frontend/pr476_parse_enum_helpers.test.ts
+++ b/test/frontend/pr476_parse_enum_helpers.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnosticTypes.js';
-import { parseEnumDecl } from '../src/frontend/parseEnum.js';
-import { makeSourceFile, span } from '../src/frontend/source.js';
-import { parseProgram } from '../src/frontend/parser.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { parseEnumDecl } from '../../src/frontend/parseEnum.js';
+import { makeSourceFile, span } from '../../src/frontend/source.js';
+import { parseProgram } from '../../src/frontend/parser.js';
 
 describe('PR476 enum parser extraction', () => {
   const file = makeSourceFile('pr476_parse_enum_helpers.zax', '');

--- a/test/frontend/pr476_parse_extern_block_helpers.test.ts
+++ b/test/frontend/pr476_parse_extern_block_helpers.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnosticTypes.js';
-import { parseTopLevelExternDecl } from '../src/frontend/parseExternBlock.js';
-import { parseParamsFromText } from '../src/frontend/parseParams.js';
-import { parseProgram } from '../src/frontend/parser.js';
-import { makeSourceFile, span } from '../src/frontend/source.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { parseTopLevelExternDecl } from '../../src/frontend/parseExternBlock.js';
+import { parseParamsFromText } from '../../src/frontend/parseParams.js';
+import { parseProgram } from '../../src/frontend/parser.js';
+import { makeSourceFile, span } from '../../src/frontend/source.js';
 
 describe('PR476 extern block parser extraction', () => {
   it('keeps extern block parsing intact', () => {

--- a/test/frontend/pr476_parse_extern_helpers.test.ts
+++ b/test/frontend/pr476_parse_extern_helpers.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnosticTypes.js';
-import { parseExternFuncFromTail } from '../src/frontend/parseExtern.js';
-import { makeSourceFile, span } from '../src/frontend/source.js';
-import { parseProgram } from '../src/frontend/parser.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { parseExternFuncFromTail } from '../../src/frontend/parseExtern.js';
+import { makeSourceFile, span } from '../../src/frontend/source.js';
+import { parseProgram } from '../../src/frontend/parser.js';
 
 describe('PR476 extern parser extraction', () => {
   const file = makeSourceFile('pr476_parse_extern_helpers.zax', '');

--- a/test/frontend/pr476_parse_func_helpers.test.ts
+++ b/test/frontend/pr476_parse_func_helpers.test.ts
@@ -1,22 +1,25 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnosticTypes.js';
-import { parseTopLevelOpDecl } from '../src/frontend/parseOp.js';
-import { parseOpParamsFromText } from '../src/frontend/parseParams.js';
-import { parseProgram } from '../src/frontend/parser.js';
-import { makeSourceFile, span } from '../src/frontend/source.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { parseTopLevelFuncDecl } from '../../src/frontend/parseFunc.js';
+import { parseParamsFromText } from '../../src/frontend/parseParams.js';
+import { parseProgram } from '../../src/frontend/parser.js';
+import { makeSourceFile, span } from '../../src/frontend/source.js';
 
-describe('PR476 op parser extraction', () => {
-  it('keeps top-level op parsing intact', () => {
+describe('PR476 func parser extraction', () => {
+  it('keeps top-level func parsing intact', () => {
     const sourceText = [
-      'op add(lhs: word, rhs: word)',
+      'func add(lhs: word, rhs: word): HL',
+      'var',
+      'temp: word = $1234',
+      'end',
       'ld hl, lhs',
       'add hl, rhs',
       'end',
       'const DONE = 1',
       '',
     ].join('\n');
-    const file = makeSourceFile('pr476_parse_op_helpers.zax', sourceText);
+    const file = makeSourceFile('pr476_parse_func_helpers.zax', sourceText);
     const diagnostics: Diagnostic[] = [];
 
     function getRawLine(lineIndex: number): {
@@ -40,10 +43,10 @@ describe('PR476 op parser extraction', () => {
       };
     }
 
-    const parsed = parseTopLevelOpDecl(
-      'add(lhs: word, rhs: word)',
-      'op add(lhs: word, rhs: word)',
-      span(file, 0, 27),
+    const parsed = parseTopLevelFuncDecl(
+      'add(lhs: word, rhs: word): HL',
+      'func add(lhs: word, rhs: word): HL',
+      span(file, 0, 31),
       1,
       0,
       false,
@@ -54,33 +57,49 @@ describe('PR476 op parser extraction', () => {
         modulePath: file.path,
         getRawLine,
         isReservedTopLevelName: () => false,
-        parseOpParamsFromText,
+        parseParamsFromText,
       },
     );
 
     expect(diagnostics).toEqual([]);
-    expect(parsed?.nextIndex).toBe(4);
-    expect(parsed?.node).toMatchObject({
-      kind: 'OpDecl',
+    expect(parsed.nextIndex).toBe(7);
+    expect(parsed.node).toMatchObject({
+      kind: 'FuncDecl',
       name: 'add',
+      returnRegs: ['HL'],
       params: [{ name: 'lhs' }, { name: 'rhs' }],
-      body: { kind: 'AsmBlock' },
+      locals: {
+        kind: 'VarBlock',
+        decls: [{ name: 'temp' }],
+      },
+      asm: { kind: 'AsmBlock' },
     });
   });
 
-  it('preserves op parsing through parser.ts', () => {
+  it('preserves func parsing through parser.ts', () => {
     const diagnostics: Diagnostic[] = [];
     const program = parseProgram(
-      'pr476_parse_op_helpers.zax',
-      ['op add(lhs: word, rhs: word)', 'ld hl, lhs', 'add hl, rhs', 'end', ''].join('\n'),
+      'pr476_parse_func_helpers.zax',
+      [
+        'func add(lhs: word, rhs: word): HL',
+        'var',
+        'temp: word = $1234',
+        'end',
+        'ld hl, lhs',
+        'add hl, rhs',
+        'end',
+        '',
+      ].join('\n'),
       diagnostics,
     );
 
     expect(diagnostics).toEqual([]);
     expect(program.files[0]?.items[0]).toMatchObject({
-      kind: 'OpDecl',
+      kind: 'FuncDecl',
       name: 'add',
+      returnRegs: ['HL'],
       params: [{ name: 'lhs' }, { name: 'rhs' }],
+      locals: { kind: 'VarBlock', decls: [{ name: 'temp' }] },
     });
   });
 });

--- a/test/frontend/pr476_parse_globals_helpers.test.ts
+++ b/test/frontend/pr476_parse_globals_helpers.test.ts
@@ -1,21 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnosticTypes.js';
-import { parseDataBlock } from '../src/frontend/parseData.js';
-import { parseProgram } from '../src/frontend/parser.js';
-import { makeSourceFile } from '../src/frontend/source.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { parseGlobalsBlock } from '../../src/frontend/parseGlobals.js';
+import { parseProgram } from '../../src/frontend/parser.js';
+import { makeSourceFile } from '../../src/frontend/source.js';
 
-describe('PR476 data parser extraction', () => {
-  it('keeps data block parsing intact', () => {
-    const sourceText = [
-      'data',
-      'greeting: byte[] = "hi"',
-      'coords: word[2] = [1, 2]',
-      'func main()',
-      'end',
-      '',
-    ].join('\n');
-    const file = makeSourceFile('pr476_parse_data_helpers.zax', sourceText);
+describe('PR476 globals parser extraction', () => {
+  it('keeps globals block parsing intact', () => {
+    const sourceText = ['globals', 'foo: byte', 'bar: word = $1234', 'func main()', 'end'].join(
+      '\n',
+    );
+    const file = makeSourceFile('pr476_parse_globals_helpers.zax', sourceText);
     const diagnostics: Diagnostic[] = [];
 
     function getRawLine(lineIndex: number): {
@@ -39,52 +34,42 @@ describe('PR476 data parser extraction', () => {
       };
     }
 
-    const parsed = parseDataBlock(0, {
+    const parsed = parseGlobalsBlock('globals', 0, 1, {
       file,
       lineCount: file.lineStarts.length,
       diagnostics,
       modulePath: file.path,
       getRawLine,
+      isReservedTopLevelName: () => false,
     });
 
     expect(diagnostics).toEqual([
       expect.objectContaining({
         severity: 'error',
         message:
-          'Legacy top-level "data ... end" blocks are removed; use direct declarations inside named data sections.',
+          'Legacy "globals ... end" storage blocks are removed; use direct declarations inside named data sections.',
       }),
     ]);
     expect(parsed.nextIndex).toBe(3);
-    expect(parsed.node).toMatchObject({
-      kind: 'DataBlock',
+    expect(parsed.varBlock).toMatchObject({
+      kind: 'VarBlock',
+      scope: 'module',
       decls: [
-        { name: 'greeting', initializer: { kind: 'InitString', value: 'hi' } },
+        { name: 'foo', typeExpr: { kind: 'TypeName', name: 'byte' } },
         {
-          name: 'coords',
-          initializer: {
-            kind: 'InitArray',
-            elements: [
-              { kind: 'ImmLiteral', value: 1 },
-              { kind: 'ImmLiteral', value: 2 },
-            ],
-          },
+          name: 'bar',
+          typeExpr: { kind: 'TypeName', name: 'word' },
+          initializer: { kind: 'VarInitValue', expr: { kind: 'ImmLiteral', value: 0x1234 } },
         },
       ],
     });
   });
 
-  it('preserves data parsing through parser.ts', () => {
+  it('preserves globals parsing through parser.ts', () => {
     const diagnostics: Diagnostic[] = [];
     const program = parseProgram(
-      'pr476_parse_data_helpers.zax',
-      [
-        'data',
-        'greeting: byte[] = "hi"',
-        'coords: word[2] = [1, 2]',
-        'func main()',
-        'end',
-        '',
-      ].join('\n'),
+      'pr476_parse_globals_helpers.zax',
+      ['globals', 'foo: byte', 'bar: word = $1234', 'func main()', 'end', ''].join('\n'),
       diagnostics,
     );
 
@@ -92,7 +77,7 @@ describe('PR476 data parser extraction', () => {
       expect.objectContaining({
         severity: 'error',
         message:
-          'Legacy top-level "data ... end" blocks are removed; use direct declarations inside named data sections.',
+          'Legacy "globals ... end" storage blocks are removed; use direct declarations inside named data sections.',
       }),
     ]);
     expect(program.files[0]?.items).toHaveLength(1);

--- a/test/frontend/pr476_parse_imm_helpers.test.ts
+++ b/test/frontend/pr476_parse_imm_helpers.test.ts
@@ -4,9 +4,9 @@ import {
   parseImmExprFromText,
   parseNumberLiteral,
   parseTypeExprFromText,
-} from '../src/frontend/parseImm.js';
-import { makeSourceFile, span } from '../src/frontend/source.js';
-import type { Diagnostic } from '../src/diagnosticTypes.js';
+} from '../../src/frontend/parseImm.js';
+import { makeSourceFile, span } from '../../src/frontend/source.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
 
 describe('PR476 immediate-expression parsing extraction', () => {
   const file = makeSourceFile('pr476_parse_imm_helpers.zax', '');

--- a/test/frontend/pr476_parse_module_common_helpers.test.ts
+++ b/test/frontend/pr476_parse_module_common_helpers.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnosticTypes.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import {
   consumeKeywordPrefix,
   parseReturnRegsFromText,
   parseVarDeclLine,
   topLevelStartKeyword,
-} from '../src/frontend/parseModuleCommon.js';
-import { makeSourceFile, span } from '../src/frontend/source.js';
+} from '../../src/frontend/parseModuleCommon.js';
+import { makeSourceFile, span } from '../../src/frontend/source.js';
 
 describe('PR476 module helper extraction', () => {
   const file = makeSourceFile('pr476_parse_module_common_helpers.zax', '');

--- a/test/frontend/pr476_parse_op_helpers.test.ts
+++ b/test/frontend/pr476_parse_op_helpers.test.ts
@@ -1,25 +1,22 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnosticTypes.js';
-import { parseTopLevelFuncDecl } from '../src/frontend/parseFunc.js';
-import { parseParamsFromText } from '../src/frontend/parseParams.js';
-import { parseProgram } from '../src/frontend/parser.js';
-import { makeSourceFile, span } from '../src/frontend/source.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { parseTopLevelOpDecl } from '../../src/frontend/parseOp.js';
+import { parseOpParamsFromText } from '../../src/frontend/parseParams.js';
+import { parseProgram } from '../../src/frontend/parser.js';
+import { makeSourceFile, span } from '../../src/frontend/source.js';
 
-describe('PR476 func parser extraction', () => {
-  it('keeps top-level func parsing intact', () => {
+describe('PR476 op parser extraction', () => {
+  it('keeps top-level op parsing intact', () => {
     const sourceText = [
-      'func add(lhs: word, rhs: word): HL',
-      'var',
-      'temp: word = $1234',
-      'end',
+      'op add(lhs: word, rhs: word)',
       'ld hl, lhs',
       'add hl, rhs',
       'end',
       'const DONE = 1',
       '',
     ].join('\n');
-    const file = makeSourceFile('pr476_parse_func_helpers.zax', sourceText);
+    const file = makeSourceFile('pr476_parse_op_helpers.zax', sourceText);
     const diagnostics: Diagnostic[] = [];
 
     function getRawLine(lineIndex: number): {
@@ -43,10 +40,10 @@ describe('PR476 func parser extraction', () => {
       };
     }
 
-    const parsed = parseTopLevelFuncDecl(
-      'add(lhs: word, rhs: word): HL',
-      'func add(lhs: word, rhs: word): HL',
-      span(file, 0, 31),
+    const parsed = parseTopLevelOpDecl(
+      'add(lhs: word, rhs: word)',
+      'op add(lhs: word, rhs: word)',
+      span(file, 0, 27),
       1,
       0,
       false,
@@ -57,49 +54,33 @@ describe('PR476 func parser extraction', () => {
         modulePath: file.path,
         getRawLine,
         isReservedTopLevelName: () => false,
-        parseParamsFromText,
+        parseOpParamsFromText,
       },
     );
 
     expect(diagnostics).toEqual([]);
-    expect(parsed.nextIndex).toBe(7);
-    expect(parsed.node).toMatchObject({
-      kind: 'FuncDecl',
+    expect(parsed?.nextIndex).toBe(4);
+    expect(parsed?.node).toMatchObject({
+      kind: 'OpDecl',
       name: 'add',
-      returnRegs: ['HL'],
       params: [{ name: 'lhs' }, { name: 'rhs' }],
-      locals: {
-        kind: 'VarBlock',
-        decls: [{ name: 'temp' }],
-      },
-      asm: { kind: 'AsmBlock' },
+      body: { kind: 'AsmBlock' },
     });
   });
 
-  it('preserves func parsing through parser.ts', () => {
+  it('preserves op parsing through parser.ts', () => {
     const diagnostics: Diagnostic[] = [];
     const program = parseProgram(
-      'pr476_parse_func_helpers.zax',
-      [
-        'func add(lhs: word, rhs: word): HL',
-        'var',
-        'temp: word = $1234',
-        'end',
-        'ld hl, lhs',
-        'add hl, rhs',
-        'end',
-        '',
-      ].join('\n'),
+      'pr476_parse_op_helpers.zax',
+      ['op add(lhs: word, rhs: word)', 'ld hl, lhs', 'add hl, rhs', 'end', ''].join('\n'),
       diagnostics,
     );
 
     expect(diagnostics).toEqual([]);
     expect(program.files[0]?.items[0]).toMatchObject({
-      kind: 'FuncDecl',
+      kind: 'OpDecl',
       name: 'add',
-      returnRegs: ['HL'],
       params: [{ name: 'lhs' }, { name: 'rhs' }],
-      locals: { kind: 'VarBlock', decls: [{ name: 'temp' }] },
     });
   });
 });

--- a/test/frontend/pr476_parse_operands_helpers.test.ts
+++ b/test/frontend/pr476_parse_operands_helpers.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnosticTypes.js';
-import { parseAsmInstruction } from '../src/frontend/parseAsmInstruction.js';
-import { makeSourceFile, span } from '../src/frontend/source.js';
-import { parseAsmOperand, parseEaExprFromText } from '../src/frontend/parseOperands.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { parseAsmInstruction } from '../../src/frontend/parseAsmInstruction.js';
+import { makeSourceFile, span } from '../../src/frontend/source.js';
+import { parseAsmOperand, parseEaExprFromText } from '../../src/frontend/parseOperands.js';
 
 describe('PR476 operand parsing extraction', () => {
   const file = makeSourceFile('pr476_parse_operands_helpers.zax', '');

--- a/test/frontend/pr476_parse_params_helpers.test.ts
+++ b/test/frontend/pr476_parse_params_helpers.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnosticTypes.js';
-import { parseOpParamsFromText, parseParamsFromText } from '../src/frontend/parseParams.js';
-import { makeSourceFile, span } from '../src/frontend/source.js';
-import { parseProgram } from '../src/frontend/parser.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { parseOpParamsFromText, parseParamsFromText } from '../../src/frontend/parseParams.js';
+import { makeSourceFile, span } from '../../src/frontend/source.js';
+import { parseProgram } from '../../src/frontend/parser.js';
 
 describe('PR476 parameter parser extraction', () => {
   const file = makeSourceFile('pr476_parse_params_helpers.zax', '');

--- a/test/frontend/pr476_parse_top_level_simple_helpers.test.ts
+++ b/test/frontend/pr476_parse_top_level_simple_helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnosticTypes.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import {
   parseAlignDirectiveDecl,
   parseBinDecl,
@@ -8,9 +8,9 @@ import {
   parseHexDecl,
   parseImportDecl,
   parseSectionDirectiveDecl,
-} from '../src/frontend/parseTopLevelSimple.js';
-import { makeSourceFile, span } from '../src/frontend/source.js';
-import { parseProgram } from '../src/frontend/parser.js';
+} from '../../src/frontend/parseTopLevelSimple.js';
+import { makeSourceFile, span } from '../../src/frontend/source.js';
+import { parseProgram } from '../../src/frontend/parser.js';
 
 describe('PR476 simple top-level parser extraction', () => {
   const file = makeSourceFile('pr476_parse_top_level_simple_helpers.zax', '');

--- a/test/frontend/pr476_parse_types_helpers.test.ts
+++ b/test/frontend/pr476_parse_types_helpers.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnosticTypes.js';
-import { parseTypeDecl, parseUnionDecl } from '../src/frontend/parseTypes.js';
-import { parseProgram } from '../src/frontend/parser.js';
-import { makeSourceFile, span } from '../src/frontend/source.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { parseTypeDecl, parseUnionDecl } from '../../src/frontend/parseTypes.js';
+import { parseProgram } from '../../src/frontend/parser.js';
+import { makeSourceFile, span } from '../../src/frontend/source.js';
 
 describe('PR476 type and union parser extraction', () => {
   it('keeps type helper parsing intact', () => {

--- a/test/frontend/pr798_addr_expr_parser.test.ts
+++ b/test/frontend/pr798_addr_expr_parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseProgram } from '../src/frontend/parser.js';
+import { parseProgram } from '../../src/frontend/parser.js';
 
 const parse = (text: string) => {
   const diagnostics: Array<{ message: string }> = [];


### PR DESCRIPTION
## Summary

Migrate **16** frontend/parser-focused tests into `test/frontend/`:

- `pr468_parser_dispatch_integration.test.ts` — top-level parser dispatch
- `pr798_addr_expr_parser.test.ts` — address expression parsing
- All **14** `pr476_parse_*_helpers.test.ts` files (isolated parser seam helpers)

Import updates only: `../src/` → `../../src/`.

`test/README.md`: representative bullets and the Parser dispatch row now use `frontend/...` paths; added guidance under “Where to put new tests” for parser tests.

Continues [#1152](https://github.com/jhlagado/ZAX/issues/1152) (many parser-related root tests remain).

Refs #1152

Made with [Cursor](https://cursor.com)