### PR TITLE
test: diagnostic assertions batch 2 (parser, select, ISA) — #1132

### DIFF
--- a/test/pr113_isa_indexed_bit_setres_dst.test.ts
+++ b/test/pr113_isa_indexed_bit_setres_dst.test.ts
@@ -4,7 +4,9 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -29,9 +31,15 @@ describe('PR113 ISA: indexed set/res with destination register', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     await rm(entry, { force: true });
 
-    expect(
-      res.diagnostics.some((d) => d.message.includes('requires an indexed memory source')),
-    ).toBe(true);
-    expect(res.diagnostics.some((d) => d.message.includes('expects reg8 destination'))).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EncodeError,
+      severity: 'error',
+      messageIncludes: 'requires an indexed memory source',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EncodeError,
+      severity: 'error',
+      messageIncludes: 'expects reg8 destination',
+    });
   });
 });

--- a/test/pr193_asm_marker_diagnostics.test.ts
+++ b/test/pr193_asm_marker_diagnostics.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 
+import { DiagnosticIds, type Diagnostic } from '../src/diagnosticTypes.js';
 import { parseProgram } from '../src/frontend/parser.js';
-import type { Diagnostic } from '../src/diagnosticTypes.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 describe('PR193 parser: explicit asm marker diagnostics', () => {
   it('diagnoses explicit asm marker in function bodies', () => {
@@ -14,11 +15,11 @@ end
     const diagnostics: Diagnostic[] = [];
     parseProgram('func_asm.zax', source, diagnostics);
 
-    expect(
-      diagnostics.some((d) =>
-        d.message.includes('Unexpected "asm" in function body (function bodies are implicit)'),
-      ),
-    ).toBe(true);
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      messageIncludes: 'Unexpected "asm" in function body (function bodies are implicit)',
+    });
   });
 
   it('diagnoses explicit asm marker in op bodies', () => {
@@ -31,11 +32,11 @@ end
     const diagnostics: Diagnostic[] = [];
     parseProgram('op_asm.zax', source, diagnostics);
 
-    expect(
-      diagnostics.some((d) =>
-        d.message.includes('Unexpected "asm" in op body (op bodies are implicit)'),
-      ),
-    ).toBe(true);
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      messageIncludes: 'Unexpected "asm" in op body (op bodies are implicit)',
+    });
   });
 
   it('diagnoses top-level asm marker usage', () => {
@@ -45,13 +46,12 @@ asm
     const diagnostics: Diagnostic[] = [];
     parseProgram('top_level_asm.zax', source, diagnostics);
 
-    expect(
-      diagnostics.some((d) =>
-        d.message.includes(
-          '"asm" is not a top-level construct (function and op bodies are implicit instruction streams)',
-        ),
-      ),
-    ).toBe(true);
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      messageIncludes:
+        '"asm" is not a top-level construct (function and op bodies are implicit instruction streams)',
+    });
   });
 
   it('diagnoses top-level export asm marker usage', () => {
@@ -61,13 +61,12 @@ export asm
     const diagnostics: Diagnostic[] = [];
     parseProgram('top_level_export_asm.zax', source, diagnostics);
 
-    expect(
-      diagnostics.some((d) =>
-        d.message.includes(
-          '"asm" is not a top-level construct (function and op bodies are implicit instruction streams)',
-        ),
-      ),
-    ).toBe(true);
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      messageIncludes:
+        '"asm" is not a top-level construct (function and op bodies are implicit instruction streams)',
+    });
   });
 
   it('diagnoses asm marker used to terminate function-local var block', () => {
@@ -82,10 +81,10 @@ end
     const diagnostics: Diagnostic[] = [];
     parseProgram('func_var_asm_terminator.zax', source, diagnostics);
 
-    expect(
-      diagnostics.some((d) =>
-        d.message.includes('Function-local var block must end with "end" before function body'),
-      ),
-    ).toBe(true);
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      messageIncludes: 'Function-local var block must end with "end" before function body',
+    });
   });
 });

--- a/test/pr24_isa_core.test.ts
+++ b/test/pr24_isa_core.test.ts
@@ -3,7 +3,9 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -19,9 +21,11 @@ describe('PR24 ISA core tranche', () => {
     const entry = join(__dirname, 'fixtures', 'pr24_jr_label_out_of_range.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(res.diagnostics.some((d) => d.message.includes('out of range for rel8 branch'))).toBe(
-      true,
-    );
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      messageIncludes: 'out of range for rel8 branch',
+    });
   });
 
   it('encodes backwards rel8 branch displacements', async () => {

--- a/test/pr26_rotate_retcc.test.ts
+++ b/test/pr26_rotate_retcc.test.ts
@@ -3,8 +3,10 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import type { BinArtifact } from '../src/formats/types.js';
+import { expectDiagnostic, expectNoDiagnostics, expectNoErrors } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,22 +15,24 @@ describe('PR26 rotate and ret cc tranche', () => {
   it('encodes rlca/rrca/rla/rra and ret cc', async () => {
     const entry = join(__dirname, 'fixtures', 'pr26_rotate_retcc.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(false);
+    expectNoErrors(res.diagnostics);
   });
 
   it('diagnoses invalid ret condition codes', async () => {
     const entry = join(__dirname, 'fixtures', 'pr26_retcc_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(
-      res.diagnostics.some((d) => d.message.includes('ret cc expects a valid condition code')),
-    ).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      messageIncludes: 'ret cc expects a valid condition code',
+    });
   });
 
   it('emits direct ret cc in frameless functions', async () => {
     const entry = join(__dirname, 'fixtures', 'pr433_frameless_retcc.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics).toEqual([]);
+    expectNoDiagnostics(res.diagnostics);
 
     const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
     expect(bin).toBeDefined();

--- a/test/pr48_ld_mem_imm16.test.ts
+++ b/test/pr48_ld_mem_imm16.test.ts
@@ -3,7 +3,9 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoErrors } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,19 +14,23 @@ describe('PR48: lower ld (ea), imm16 for word/addr destinations', () => {
   it('lowers ld (abs-word), imm16 via ld (nn),hl', async () => {
     const entry = join(__dirname, 'fixtures', 'pr48_ld_mem_imm16_abs.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(false);
+    expectNoErrors(res.diagnostics);
   });
 
   it('lowers ld (stack-word), imm16 with frame + epilogue', async () => {
     const entry = join(__dirname, 'fixtures', 'pr48_ld_mem_imm16_stack.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(false);
+    expectNoErrors(res.diagnostics);
   });
 
   it('diagnoses imm16 into byte destination', async () => {
     const entry = join(__dirname, 'fixtures', 'pr48_ld_mem_imm16_invalid_byte.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(res.diagnostics.some((d) => d.message.includes('expects imm8'))).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      message: 'ld (ea), imm expects imm8.',
+    });
   });
 });

--- a/test/pr738_select_case_ranges.test.ts
+++ b/test/pr738_select_case_ranges.test.ts
@@ -3,8 +3,10 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import type { BinArtifact } from '../src/formats/types.js';
+import { expectDiagnostic, expectNoDiagnostics, expectNoErrors } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,7 +15,7 @@ describe('#738 select case ranges/groups', () => {
   it('supports grouped case ranges for reg8 selector dispatch', async () => {
     const entry = join(__dirname, 'fixtures', 'pr738_select_case_range_group_reg8.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics).toEqual([]);
+    expectNoDiagnostics(res.diagnostics);
     const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
     expect(bin).toBeDefined();
 
@@ -28,8 +30,8 @@ describe('#738 select case ranges/groups', () => {
     const runtimeEntry = join(__dirname, 'fixtures', 'pr738_select_case_range_group_reg8.zax');
     const constRes = await compile(constEntry, {}, { formats: defaultFormatWriters });
     const runtimeRes = await compile(runtimeEntry, {}, { formats: defaultFormatWriters });
-    expect(constRes.diagnostics).toEqual([]);
-    expect(runtimeRes.diagnostics).toEqual([]);
+    expectNoDiagnostics(constRes.diagnostics);
+    expectNoDiagnostics(runtimeRes.diagnostics);
 
     const constBin = constRes.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
     const runtimeBin = runtimeRes.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
@@ -45,19 +47,22 @@ describe('#738 select case ranges/groups', () => {
     const entry = join(__dirname, 'fixtures', 'pr738_select_case_range_overlap.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(res.diagnostics.some((d) => d.message.includes('Duplicate case value 3.'))).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      messageIncludes: 'Duplicate case value 3.',
+    });
   });
 
   it('warns and clips partially unreachable reg8 case ranges', async () => {
     const entry = join(__dirname, 'fixtures', 'pr738_select_reg8_range_clip_warning.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
-    const warnings = res.diagnostics.filter(
-      (d) =>
-        d.severity === 'warning' &&
-        d.message.includes('reachable portion 250..255 is used'),
-    );
-    expect(warnings).toHaveLength(1);
+    expectNoErrors(res.diagnostics);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitWarning,
+      severity: 'warning',
+      messageIncludes: 'reachable portion 250..255 is used',
+    });
 
     const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
     expect(bin).toBeDefined();
@@ -69,7 +74,7 @@ describe('#738 select case ranges/groups', () => {
   it('supports 16-bit selector range dispatch', async () => {
     const entry = join(__dirname, 'fixtures', 'pr738_select_reg16_range_dispatch.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics).toEqual([]);
+    expectNoDiagnostics(res.diagnostics);
     const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
     expect(bin).toBeDefined();
 


### PR DESCRIPTION
## Summary
Replaces weak `.some() / .includes()` diagnostic checks with `expectDiagnostic`, `expectNoDiagnostics`, and `expectNoErrors` (stable `id` + `severity`).

**Refs #1132** — does not close; global weak-pattern sweep remains.

## Files
- `test/pr193_asm_marker_diagnostics.test.ts` — ParseError asm markers
- `test/pr738_select_case_ranges.test.ts` — EmitError duplicate case; EmitWarning range clip; empty diagnostics
- `test/pr26_rotate_retcc.test.ts`, `test/pr24_isa_core.test.ts`, `test/pr48_ld_mem_imm16.test.ts` — ret cc / rel8 / ld imm (EmitError where lowering emits)
- `test/pr113_isa_indexed_bit_setres_dst.test.ts` — EncodeError bit op forms

## Verify
```sh
npm run typecheck
npm run lint
npx vitest run test/pr193_asm_marker_diagnostics.test.ts test/pr738_select_case_ranges.test.ts test/pr26_rotate_retcc.test.ts test/pr24_isa_core.test.ts test/pr48_ld_mem_imm16.test.ts test/pr113_isa_indexed_bit_setres_dst.test.ts
npx vitest run
```


Made with [Cursor](https://cursor.com)