### PR TITLE
Share type and union field block parsing

### DIFF
--- a/src/frontend/parseRecordFieldDecl.ts
+++ b/src/frontend/parseRecordFieldDecl.ts
@@ -4,7 +4,13 @@ import type { SourceFile } from './source.js';
 import { span } from './source.js';
 import { parseDiag as diag } from './parseDiagnostics.js';
 import { diagIfInferredArrayLengthNotAllowed, parseTypeExprFromText } from './parseImm.js';
-import { diagInvalidBlockLine, formatIdentifierToken } from './parseModuleCommon.js';
+import {
+  diagInvalidBlockLine,
+  formatIdentifierToken,
+  looksLikeKeywordBodyDeclLine,
+  topLevelStartKeyword,
+} from './parseModuleCommon.js';
+import { stripLineComment as stripComment } from './parseParserShared.js';
 
 export type RecordFieldLine = {
   raw: string;
@@ -19,6 +25,27 @@ export type RecordFieldValidationContext = {
   diagnostics: Diagnostic[];
   modulePath: string;
   isReservedTopLevelName: (name: string) => boolean;
+};
+
+export type RecordFieldBlockContext = RecordFieldValidationContext & {
+  lineCount: number;
+  getRawLine: (lineIndex: number) => RecordFieldLine;
+};
+
+type ParsedRecordFields = {
+  fields: RecordFieldNode[];
+  nextIndex: number;
+  terminated: boolean;
+  endOffset: number;
+  interruptedByKeyword?: string;
+  interruptedByLine?: number;
+  interruptedByFilePath?: string;
+};
+
+export type ParsedFieldBlock = {
+  fields: RecordFieldNode[];
+  nextIndex: number;
+  endOffset: number;
 };
 
 export function parseRecordFieldDecl(
@@ -103,5 +130,141 @@ export function parseRecordFieldDecl(
     span: fieldSpan,
     name: fieldName,
     typeExpr,
+  };
+}
+
+function parseRecordFields(
+  fieldKind: string,
+  allowFuncKeywordStart: boolean,
+  startIndex: number,
+  ctx: RecordFieldBlockContext,
+): ParsedRecordFields {
+  const { file, lineCount, diagnostics, modulePath, getRawLine, isReservedTopLevelName } = ctx;
+  const fields: RecordFieldNode[] = [];
+  const fieldNamesLower = new Set<string>();
+  let terminated = false;
+  let interruptedByKeyword: string | undefined;
+  let interruptedByLine: number | undefined;
+  let interruptedByFilePath: string | undefined;
+  let endOffset = file.text.length;
+  let index = startIndex;
+
+  while (index < lineCount) {
+    const fieldLine = getRawLine(index);
+    const { endOffset: lineEndOffset, lineNo, filePath } = fieldLine;
+    const fieldText = stripComment(fieldLine.raw).trim();
+    const fieldTextLower = fieldText.toLowerCase();
+    if (fieldText.length === 0) {
+      index++;
+      continue;
+    }
+    if (fieldTextLower === 'end') {
+      terminated = true;
+      endOffset = lineEndOffset;
+      index++;
+      break;
+    }
+    const topKeyword = topLevelStartKeyword(fieldText);
+    if (topKeyword !== undefined) {
+      if (allowFuncKeywordStart && topKeyword === 'func') {
+        // func field forms are allowed inside unions in current parser behavior.
+      } else {
+        if (looksLikeKeywordBodyDeclLine(fieldText)) {
+          diagInvalidBlockLine(
+            diagnostics,
+            filePath,
+            `${fieldKind} field declaration`,
+            fieldText,
+            '<name>: <type>',
+            lineNo,
+          );
+          index++;
+          continue;
+        }
+        interruptedByKeyword = topKeyword;
+        interruptedByLine = lineNo;
+        interruptedByFilePath = filePath;
+        break;
+      }
+    }
+
+    const field = parseRecordFieldDecl(fieldKind, fieldText, fieldLine, fieldNamesLower, {
+      file,
+      diagnostics,
+      modulePath,
+      isReservedTopLevelName,
+    });
+    if (field) fields.push(field);
+    index++;
+  }
+
+  return {
+    fields,
+    nextIndex: index,
+    terminated,
+    endOffset,
+    ...(interruptedByKeyword !== undefined ? { interruptedByKeyword } : {}),
+    ...(interruptedByLine !== undefined ? { interruptedByLine } : {}),
+    ...(interruptedByFilePath !== undefined ? { interruptedByFilePath } : {}),
+  };
+}
+
+export function parseRecordFieldBlock(params: {
+  declarationKind: 'type' | 'union';
+  declarationName: string;
+  fieldKind: 'record' | 'union';
+  allowFuncKeywordStart: boolean;
+  declarationLineNo: number;
+  startIndex: number;
+  ctx: RecordFieldBlockContext;
+}): ParsedFieldBlock {
+  const {
+    declarationKind,
+    declarationName,
+    fieldKind,
+    allowFuncKeywordStart,
+    declarationLineNo,
+    startIndex,
+    ctx,
+  } = params;
+  const { file, diagnostics, modulePath } = ctx;
+  const parsed = parseRecordFields(fieldKind, allowFuncKeywordStart, startIndex, ctx);
+
+  if (!parsed.terminated) {
+    if (
+      parsed.interruptedByKeyword !== undefined &&
+      parsed.interruptedByLine !== undefined &&
+      parsed.interruptedByFilePath !== undefined
+    ) {
+      diag(
+        diagnostics,
+        parsed.interruptedByFilePath,
+        `Unterminated ${declarationKind} "${declarationName}": expected "end" before "${parsed.interruptedByKeyword}"`,
+        { line: parsed.interruptedByLine, column: 1 },
+      );
+    } else {
+      diag(
+        diagnostics,
+        modulePath,
+        `Unterminated ${declarationKind} "${declarationName}": missing "end"`,
+        { line: declarationLineNo, column: 1 },
+      );
+    }
+  }
+
+  if (parsed.fields.length === 0) {
+    const declarationLabel = declarationKind === 'type' ? 'Type' : 'Union';
+    diag(
+      diagnostics,
+      modulePath,
+      `${declarationLabel} "${declarationName}" must contain at least one field`,
+      { line: declarationLineNo, column: 1 },
+    );
+  }
+
+  return {
+    fields: parsed.fields,
+    nextIndex: parsed.nextIndex,
+    endOffset: parsed.terminated ? parsed.endOffset : file.text.length,
   };
 }

--- a/src/frontend/parseTypes.ts
+++ b/src/frontend/parseTypes.ts
@@ -1,26 +1,16 @@
-import type { RecordFieldNode, SourceSpan, TypeDeclNode, UnionDeclNode } from './ast.js';
+import type { SourceSpan, TypeDeclNode, UnionDeclNode } from './ast.js';
 import type { SourceFile } from './source.js';
 import { span } from './source.js';
 import type { Diagnostic } from '../diagnosticTypes.js';
 import { parseDiag as diag } from './parseDiagnostics.js';
 import { diagIfInferredArrayLengthNotAllowed, parseTypeExprFromText } from './parseImm.js';
 import {
-  diagInvalidBlockLine,
   diagInvalidHeaderLine,
   formatIdentifierToken,
-  looksLikeKeywordBodyDeclLine,
-  topLevelStartKeyword,
 } from './parseModuleCommon.js';
-import { stripLineComment as stripComment } from './parseParserShared.js';
-import { parseRecordFieldDecl } from './parseRecordFieldDecl.js';
+import { parseRecordFieldBlock, type RecordFieldLine } from './parseRecordFieldDecl.js';
 
-type RawLine = {
-  raw: string;
-  startOffset: number;
-  endOffset: number;
-  lineNo: number;
-  filePath: string;
-};
+type RawLine = RecordFieldLine;
 
 type ParseTypeContext = {
   file: SourceFile;
@@ -40,90 +30,6 @@ type ParsedUnionDecl = {
   node: UnionDeclNode;
   nextIndex: number;
 };
-
-function parseRecordFields(
-  name: string,
-  allowFuncKeywordStart: boolean,
-  startIndex: number,
-  ctx: ParseTypeContext,
-): {
-  fields: RecordFieldNode[];
-  nextIndex: number;
-  terminated: boolean;
-  endOffset: number;
-  interruptedByKeyword?: string;
-  interruptedByLine?: number;
-  interruptedByFilePath?: string;
-} {
-  const { file, lineCount, diagnostics, modulePath, getRawLine, isReservedTopLevelName } = ctx;
-  const fields: RecordFieldNode[] = [];
-  const fieldNamesLower = new Set<string>();
-  let terminated = false;
-  let interruptedByKeyword: string | undefined;
-  let interruptedByLine: number | undefined;
-  let interruptedByFilePath: string | undefined;
-  let endOffset = file.text.length;
-  let index = startIndex;
-
-  while (index < lineCount) {
-    const fieldLine = getRawLine(index);
-    const { endOffset: eo, lineNo: fieldLineNo, filePath: fieldFilePath } = fieldLine;
-    const t = stripComment(fieldLine.raw).trim();
-    const tLower = t.toLowerCase();
-    if (t.length === 0) {
-      index++;
-      continue;
-    }
-    if (tLower === 'end') {
-      terminated = true;
-      endOffset = eo;
-      index++;
-      break;
-    }
-    const topKeyword = topLevelStartKeyword(t);
-    if (topKeyword !== undefined) {
-      if (allowFuncKeywordStart && topKeyword === 'func') {
-        // func field forms are allowed inside unions in current parser behavior.
-      } else {
-        if (looksLikeKeywordBodyDeclLine(t)) {
-          diagInvalidBlockLine(
-            diagnostics,
-            fieldFilePath,
-            `${name} field declaration`,
-            t,
-            '<name>: <type>',
-            fieldLineNo,
-          );
-          index++;
-          continue;
-        }
-        interruptedByKeyword = topKeyword;
-        interruptedByLine = fieldLineNo;
-        interruptedByFilePath = fieldFilePath;
-        break;
-      }
-    }
-
-    const field = parseRecordFieldDecl(name, t, fieldLine, fieldNamesLower, {
-      file,
-      diagnostics,
-      modulePath,
-      isReservedTopLevelName,
-    });
-    if (field) fields.push(field);
-    index++;
-  }
-
-  return {
-    fields,
-    nextIndex: index,
-    terminated,
-    endOffset,
-    ...(interruptedByKeyword !== undefined ? { interruptedByKeyword } : {}),
-    ...(interruptedByLine !== undefined ? { interruptedByLine } : {}),
-    ...(interruptedByFilePath !== undefined ? { interruptedByFilePath } : {}),
-  };
-}
 
 export function parseTypeDecl(
   typeTail: string,
@@ -196,35 +102,17 @@ export function parseTypeDecl(
     };
   }
 
-  const record = parseRecordFields('record', false, startIndex + 1, ctx);
-  if (!record.terminated) {
-    if (
-      record.interruptedByKeyword !== undefined &&
-      record.interruptedByLine !== undefined &&
-      record.interruptedByFilePath !== undefined
-    ) {
-      diag(
-        diagnostics,
-        record.interruptedByFilePath,
-        `Unterminated type "${name}": expected "end" before "${record.interruptedByKeyword}"`,
-        { line: record.interruptedByLine, column: 1 },
-      );
-    } else {
-      diag(diagnostics, modulePath, `Unterminated type "${name}": missing "end"`, {
-        line: lineNo,
-        column: 1,
-      });
-    }
-  }
+  const record = parseRecordFieldBlock({
+    declarationKind: 'type',
+    declarationName: name,
+    fieldKind: 'record',
+    allowFuncKeywordStart: false,
+    declarationLineNo: lineNo,
+    startIndex: startIndex + 1,
+    ctx,
+  });
 
-  if (record.fields.length === 0) {
-    diag(diagnostics, modulePath, `Type "${name}" must contain at least one field`, {
-      line: lineNo,
-      column: 1,
-    });
-  }
-
-  const typeEnd = record.terminated ? record.endOffset : file.text.length;
+  const typeEnd = record.endOffset;
   const typeSpan = span(file, stmtSpan.start.offset, typeEnd);
   return {
     node: {
@@ -279,36 +167,17 @@ export function parseUnionDecl(
     return undefined;
   }
 
-  const record = parseRecordFields('union', true, startIndex + 1, ctx);
+  const record = parseRecordFieldBlock({
+    declarationKind: 'union',
+    declarationName: name,
+    fieldKind: 'union',
+    allowFuncKeywordStart: true,
+    declarationLineNo: lineNo,
+    startIndex: startIndex + 1,
+    ctx,
+  });
 
-  if (!record.terminated) {
-    if (
-      record.interruptedByKeyword !== undefined &&
-      record.interruptedByLine !== undefined &&
-      record.interruptedByFilePath !== undefined
-    ) {
-      diag(
-        diagnostics,
-        record.interruptedByFilePath,
-        `Unterminated union "${name}": expected "end" before "${record.interruptedByKeyword}"`,
-        { line: record.interruptedByLine, column: 1 },
-      );
-    } else {
-      diag(diagnostics, modulePath, `Unterminated union "${name}": missing "end"`, {
-        line: lineNo,
-        column: 1,
-      });
-    }
-  }
-
-  if (record.fields.length === 0) {
-    diag(diagnostics, modulePath, `Union "${name}" must contain at least one field`, {
-      line: lineNo,
-      column: 1,
-    });
-  }
-
-  const unionEnd = record.terminated ? record.endOffset : file.text.length;
+  const unionEnd = record.endOffset;
   return {
     node: {
       kind: 'UnionDecl',


### PR DESCRIPTION
Implements #1117.

## What changed
- extracted shared type/union field-block parsing into `parseRecordFieldBlock(...)`
- moved the shared field loop, `end` detection, interruption handling, and unterminated/empty-block diagnostics out of `parseTypes.ts`
- kept declaration-specific type vs union semantics in `parseTypeDecl(...)` and `parseUnionDecl(...)`

## Verification
- `npm ci`
- `npm run typecheck`
- `npm run lint`
- `npx vitest run /Users/johnhardy/.codex/worktrees/parse-type-union-shared/ZAX/test/semantics/semantics_layout.test.ts /Users/johnhardy/.codex/worktrees/parse-type-union-shared/ZAX/test/pr160_type_union_missing_end_recovery.test.ts /Users/johnhardy/.codex/worktrees/parse-type-union-shared/ZAX/test/pr168_declaration_duplicate_matrix.test.ts /Users/johnhardy/.codex/worktrees/parse-type-union-shared/ZAX/test/pr181_top_level_malformed_header_canonical_matrix.test.ts`
- `npx vitest run /Users/johnhardy/.codex/worktrees/parse-type-union-shared/ZAX/test/pr179_type_union_var_data_malformed_header_matrix.test.ts /Users/johnhardy/.codex/worktrees/parse-type-union-shared/ZAX/test/pr183_block_invalid_type_shape_matrix.test.ts`

Note: the brief referenced `test/pr476_parse_types_helpers.test.ts`, but that file does not exist on current `main`.