### PR TITLE
test: strengthen resolution diagnostics

### DIFF
--- a/test/pr1049_record_named_init_data_lowering.test.ts
+++ b/test/pr1049_record_named_init_data_lowering.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import type { D8mArtifact, HexArtifact } from '../src/formats/types.js';
+import { expectDiagnostic, expectNoDiagnostics } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -43,7 +44,7 @@ describe('PR1049 record data lowering', () => {
       { formats: defaultFormatWriters },
     );
 
-    expect(result.diagnostics).toEqual([]);
+    expectNoDiagnostics(result.diagnostics);
 
     const hex = result.artifacts.find((artifact): artifact is HexArtifact => artifact.kind === 'hex');
     const d8m = result.artifacts.find((artifact): artifact is D8mArtifact => artifact.kind === 'd8m');
@@ -64,28 +65,38 @@ describe('PR1049 record data lowering', () => {
   it('diagnoses invalid record initializer shapes and duplicate taken symbols', async () => {
     const entry = join(__dirname, 'fixtures', 'pr286_record_named_init_negative.zax');
     const result = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = result.diagnostics.map((diagnostic) => diagnostic.message);
-
-    expect(messages).toContain('Unknown record field "xx" in initializer for "bad_unknown".');
-    expect(messages).toContain('Duplicate record field "lo" in initializer for "bad_duplicate".');
-    expect(messages).toContain('Missing record field "hi" in initializer for "bad_missing".');
-    expect(messages).toContain(
-      'Named-field aggregate initializer requires a record type for "bad_shape".',
-    );
-    expect(messages).toContain('Record initializer field count mismatch for "bad_positional".');
-    expect(messages).toContain('Record initializer for "bad_record_string" must use aggregate form.');
-    expect(messages).toContain(
-      'Unsupported record field type "pair" in initializer for "bad_nested" (expected byte/word/addr/ptr).',
-    );
-    expect(messages).toContain('Duplicate symbol name "dup".');
+    expectDiagnostic(result.diagnostics, {
+      message: 'Unknown record field "xx" in initializer for "bad_unknown".',
+    });
+    expectDiagnostic(result.diagnostics, {
+      message: 'Duplicate record field "lo" in initializer for "bad_duplicate".',
+    });
+    expectDiagnostic(result.diagnostics, {
+      message: 'Missing record field "hi" in initializer for "bad_missing".',
+    });
+    expectDiagnostic(result.diagnostics, {
+      message: 'Named-field aggregate initializer requires a record type for "bad_shape".',
+    });
+    expectDiagnostic(result.diagnostics, {
+      message: 'Record initializer field count mismatch for "bad_positional".',
+    });
+    expectDiagnostic(result.diagnostics, {
+      message: 'Record initializer for "bad_record_string" must use aggregate form.',
+    });
+    expectDiagnostic(result.diagnostics, {
+      message:
+        'Unsupported record field type "pair" in initializer for "bad_nested" (expected byte/word/addr/ptr).',
+    });
+    expectDiagnostic(result.diagnostics, { message: 'Duplicate symbol name "dup".' });
   });
 
   it('rejects mixed positional and named aggregate entries before lowering', async () => {
     const entry = join(__dirname, 'fixtures', 'pr286_record_named_init_mixed_negative.zax');
     const result = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    expect(result.diagnostics.map((diagnostic) => diagnostic.message)).toContain(
-      'Mixed positional and named aggregate initializer entries are not allowed for "bad_mixed".',
-    );
+    expectDiagnostic(result.diagnostics, {
+      message:
+        'Mixed positional and named aggregate initializer entries are not allowed for "bad_mixed".',
+    });
   });
 });

--- a/test/pr272_runtime_affine_index_offset.test.ts
+++ b/test/pr272_runtime_affine_index_offset.test.ts
@@ -5,6 +5,10 @@ import { dirname, join } from 'node:path';
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import type { BinArtifact } from '../src/formats/types.js';
+import {
+  expectDiagnostic,
+  expectNoDiagnostics,
+} from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -14,7 +18,7 @@ describe('PR272: runtime affine index/offset lowering', () => {
     const entry = join(__dirname, 'fixtures', 'pr272_runtime_affine_valid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    expect(res.diagnostics).toEqual([]);
+    expectNoDiagnostics(res.diagnostics);
     const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
     expect(bin).toBeDefined();
   });
@@ -24,12 +28,12 @@ describe('PR272: runtime affine index/offset lowering', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
     expect(res.artifacts).toEqual([]);
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages.some((m) => m.includes('runtime multiplier must be a power-of-2'))).toBe(true);
-    expect(
-      messages.some((m) =>
-        m.includes('is unsupported. Use a single scalar runtime atom with +, -, *, <<'),
-      ),
-    ).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      messageIncludes: 'runtime multiplier must be a power-of-2',
+    });
+    expectDiagnostic(res.diagnostics, {
+      messageIncludes:
+        'is unsupported. Use a single scalar runtime atom with +, -, *, <<',
+    });
   });
 });

--- a/test/pr37_fixup_negative.test.ts
+++ b/test/pr37_fixup_negative.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,45 +14,45 @@ describe('PR37 fixup negatives', () => {
     const entry = join(__dirname, 'fixtures', 'pr37_unresolved_symbol_abs16.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(
-      res.diagnostics.some((d) => d.message.includes('Unresolved symbol "missing_label"')),
-    ).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unresolved symbol "missing_label"',
+    });
   });
 
   it('diagnoses unresolved rel8 fixup symbols', async () => {
     const entry = join(__dirname, 'fixtures', 'pr37_unresolved_symbol_rel8.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(
-      res.diagnostics.some((d) => d.message.includes('Unresolved symbol "missing_label"')),
-    ).toBe(true);
-    expect(res.diagnostics.some((d) => d.message.includes('rel8 jr fixup'))).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unresolved symbol "missing_label"',
+    });
+    expectDiagnostic(res.diagnostics, { messageIncludes: 'rel8 jr fixup' });
   });
 
   it('diagnoses rel8 out-of-range fixups', async () => {
     const entry = join(__dirname, 'fixtures', 'pr37_rel8_out_of_range.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(
-      res.diagnostics.some((d) => d.message.includes('jr target out of range for rel8 branch')),
-    ).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      messageIncludes: 'jr target out of range for rel8 branch',
+    });
   });
 
   it('diagnoses conditional jr rel8 out-of-range fixups', async () => {
     const entry = join(__dirname, 'fixtures', 'pr37_rel8_out_of_range_jr_cond.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(
-      res.diagnostics.some((d) => d.message.includes('jr nz target out of range for rel8 branch')),
-    ).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      messageIncludes: 'jr nz target out of range for rel8 branch',
+    });
   });
 
   it('diagnoses djnz rel8 out-of-range fixups', async () => {
     const entry = join(__dirname, 'fixtures', 'pr37_rel8_out_of_range_djnz.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(
-      res.diagnostics.some((d) => d.message.includes('djnz target out of range for rel8 branch')),
-    ).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      messageIncludes: 'djnz target out of range for rel8 branch',
+    });
   });
 });

--- a/test/pr506_runtime_atom_budget_helpers.test.ts
+++ b/test/pr506_runtime_atom_budget_helpers.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,18 +13,16 @@ describe('PR506: extracted runtime-atom budget helpers', () => {
   it('preserves source ea runtime-atom budget diagnostics', async () => {
     const entry = join(__dirname, 'fixtures', 'pr264_runtime_atom_budget_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain('Source ea expression exceeds runtime-atom budget (max 1; found 2).');
+    expectDiagnostic(res.diagnostics, {
+      message: 'Source ea expression exceeds runtime-atom budget (max 1; found 2).',
+    });
   });
 
   it('preserves direct call-site ea runtime-atom budget diagnostics', async () => {
     const entry = join(__dirname, 'fixtures', 'pr273_call_address_runtime_index_reject.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages.some((m) => m.includes('Direct call-site ea argument for "takeAddr"'))).toBe(
-      true,
-    );
+    expectDiagnostic(res.diagnostics, {
+      messageIncludes: 'Direct call-site ea argument for "takeAddr"',
+    });
   });
 });

--- a/test/pr895_assignment_acceptance.test.ts
+++ b/test/pr895_assignment_acceptance.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 
 import type { Diagnostic } from '../src/diagnosticTypes.js';
 import type { ProgramNode } from '../src/frontend/ast.js';
 import { parseModuleFile } from '../src/frontend/parser.js';
 import { validateAssignmentAcceptance } from '../src/semantics/assignmentAcceptance.js';
 import { buildEnv } from '../src/semantics/env.js';
+import { expectDiagnostic, expectNoDiagnostics } from './helpers/diagnostics.js';
 
 function parseProgram(modulePath: string, source: string): { program: ProgramNode; diagnostics: Diagnostic[] } {
   const diagnostics: Diagnostic[] = [];
@@ -50,7 +51,7 @@ end
     const env = buildEnv(program, diagnostics);
     validateAssignmentAcceptance(program, env, diagnostics);
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
   });
 
   it('rejects composite decay and composite-to-composite assignment', () => {
@@ -84,9 +85,12 @@ end
     const env = buildEnv(program, diagnostics);
     validateAssignmentAcceptance(program, env, diagnostics);
 
-    const messages = diagnostics.map((d) => d.message);
-    expect(messages).toContain('":=" path source must resolve to scalar storage; got byte[4]. Use "@path" for addresses.');
-    expect(messages).toContain('":=" path target must resolve to scalar storage; got Rec.');
+    expectDiagnostic(diagnostics, {
+      message: '":=" path source must resolve to scalar storage; got byte[4]. Use "@path" for addresses.',
+    });
+    expectDiagnostic(diagnostics, {
+      message: '":=" path target must resolve to scalar storage; got Rec.',
+    });
   });
 
   it('rejects storage-target path forms inside ops in this slice', () => {
@@ -106,8 +110,11 @@ end
     const env = buildEnv(program, diagnostics);
     validateAssignmentAcceptance(program, env, diagnostics);
 
-    const messages = diagnostics.map((d) => d.message);
-    expect(messages).toContain('":=" path-to-path storage-target forms are not supported inside ops in this slice.');
-    expect(messages).toContain('":=" address-of storage-target forms are not supported inside ops in this slice.');
+    expectDiagnostic(diagnostics, {
+      message: '":=" path-to-path storage-target forms are not supported inside ops in this slice.',
+    });
+    expectDiagnostic(diagnostics, {
+      message: '":=" address-of storage-target forms are not supported inside ops in this slice.',
+    });
   });
 });

--- a/test/pr899_step_acceptance.test.ts
+++ b/test/pr899_step_acceptance.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 
 import type { Diagnostic } from '../src/diagnosticTypes.js';
 import type { ProgramNode } from '../src/frontend/ast.js';
 import { parseModuleFile } from '../src/frontend/parser.js';
 import { validateStepAcceptance } from '../src/semantics/stepAcceptance.js';
 import { buildEnv } from '../src/semantics/env.js';
+import { expectDiagnostic, expectNoDiagnostics } from './helpers/diagnostics.js';
 
 function parseProgram(modulePath: string, source: string): { program: ProgramNode; diagnostics: Diagnostic[] } {
   const diagnostics: Diagnostic[] = [];
@@ -51,7 +52,7 @@ end
     const env = buildEnv(program, diagnostics);
     validateStepAcceptance(program, env, diagnostics);
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
   });
 
   it('rejects composite and address-typed operands', () => {
@@ -83,10 +84,11 @@ end
     const env = buildEnv(program, diagnostics);
     validateStepAcceptance(program, env, diagnostics);
 
-    const messages = diagnostics.map((d) => d.message);
-    expect(messages).toContain('"step" requires scalar storage; got Rec.');
-    expect(messages).toContain('"step" only supports byte and word scalar paths in this slice.');
-    expect(messages).toContain('"step" requires scalar storage; got unknown.');
+    expectDiagnostic(diagnostics, { message: '"step" requires scalar storage; got Rec.' });
+    expectDiagnostic(diagnostics, {
+      message: '"step" only supports byte and word scalar paths in this slice.',
+    });
+    expectDiagnostic(diagnostics, { message: '"step" requires scalar storage; got unknown.' });
   });
 
   it('rejects step amounts that are not compile-time integer expressions', () => {
@@ -110,8 +112,9 @@ end
     const env = buildEnv(program, diagnostics);
     validateStepAcceptance(program, env, diagnostics);
 
-    const messages = diagnostics.map((d) => d.message);
-    expect(messages).toContain('"step" amount must be a compile-time integer expression.');
+    expectDiagnostic(diagnostics, {
+      message: '"step" amount must be a compile-time integer expression.',
+    });
   });
 
   it('rejects typed-path forms inside ops in this slice', () => {
@@ -127,7 +130,8 @@ end
     const env = buildEnv(program, diagnostics);
     validateStepAcceptance(program, env, diagnostics);
 
-    const messages = diagnostics.map((d) => d.message);
-    expect(messages).toContain('"step" typed-path forms are not supported inside ops in this slice.');
+    expectDiagnostic(diagnostics, {
+      message: '"step" typed-path forms are not supported inside ops in this slice.',
+    });
   });
 });

--- a/test/pr950_include_text_only.test.ts
+++ b/test/pr950_include_text_only.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import type { Asm80Artifact } from '../src/formats/types.js';
+import { expectDiagnostic, expectNoErrors } from './helpers/diagnostics.js';
 
 describe('PR950: text-only include directive', () => {
   it('inlines included text before parsing', async () => {
@@ -13,7 +14,7 @@ describe('PR950: text-only include directive', () => {
       { emitAsm80: true, emitBin: false, emitHex: false, emitListing: false, emitD8m: false },
       { formats: defaultFormatWriters },
     );
-    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    expectNoErrors(res.diagnostics);
     const asm = res.artifacts.find((a): a is Asm80Artifact => a.kind === 'asm80');
     expect(asm).toBeDefined();
     expect(asm!.text.toUpperCase()).toMatch(/LD A, \$0*1/);
@@ -26,7 +27,7 @@ describe('PR950: text-only include directive', () => {
       { emitBin: false, emitHex: false, emitListing: false, emitD8m: false },
       { formats: defaultFormatWriters },
     );
-    expect(res.diagnostics.some((d) => d.message.includes('Failed to resolve include'))).toBe(true);
+    expectDiagnostic(res.diagnostics, { messageIncludes: 'Failed to resolve include' });
   });
 
   it('resolves includes via -I search paths', async () => {
@@ -37,7 +38,7 @@ describe('PR950: text-only include directive', () => {
       { includeDirs: [includeDir], emitAsm80: true, emitBin: false, emitHex: false, emitListing: false, emitD8m: false },
       { formats: defaultFormatWriters },
     );
-    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    expectNoErrors(res.diagnostics);
     const asm = res.artifacts.find((a): a is Asm80Artifact => a.kind === 'asm80');
     expect(asm).toBeDefined();
     expect(asm!.text.toUpperCase()).toMatch(/LD A, \$0*2/);
@@ -50,7 +51,9 @@ describe('PR950: text-only include directive', () => {
       { emitBin: false, emitHex: false, emitListing: false, emitD8m: false },
       { formats: defaultFormatWriters },
     );
-    const bad = res.diagnostics.find((d) => d.message.includes('Unsupported operand'));
-    expect(bad?.file).toContain('pr950_bad_include.inc');
+    expectDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported operand',
+      file: join(__dirname, 'fixtures', 'pr950_bad_include.inc'),
+    });
   });
 });


### PR DESCRIPTION
## Summary
- replace remaining weak diagnostic assertions in a compile-time expression and resolution batch
- cover assignment and step acceptance, record initializer diagnostics, include resolution, fixup symbol resolution, and runtime ea-budget diagnostics
- preserve existing compiler behavior and keep the slice focused on helper-based assertion migration

## Testing
- npm ci
- npm run typecheck
- npm run lint
- npm test -- --run test/pr895_assignment_acceptance.test.ts test/pr899_step_acceptance.test.ts test/pr1049_record_named_init_data_lowering.test.ts test/pr950_include_text_only.test.ts test/pr37_fixup_negative.test.ts test/pr506_runtime_atom_budget_helpers.test.ts test/pr272_runtime_affine_index_offset.test.ts

Part of #1132