### PR TITLE
Test: migrate semantics tests to test/semantics

### DIFF
--- a/test/semantics/pr286_nonscalar_param_compat_matrix.test.ts
+++ b/test/semantics/pr286_nonscalar_param_compat_matrix.test.ts
@@ -2,21 +2,21 @@ import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR286: non-scalar typed-call parameter compatibility', () => {
   it('accepts T[N] -> T[] and exact T[N] -> T[N] non-scalar arguments', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr286_nonscalar_param_compat_positive.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr286_nonscalar_param_compat_positive.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics).toEqual([]);
   });
 
   it('rejects T[] -> T[N] without proof and rejects element-type mismatches', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr286_nonscalar_param_compat_negative.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr286_nonscalar_param_compat_negative.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     const messages = res.diagnostics.map((d) => d.message);
 

--- a/test/semantics/pr287_address_of_operator.test.ts
+++ b/test/semantics/pr287_address_of_operator.test.ts
@@ -2,16 +2,16 @@ import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
-import { expectDiagnostic } from './helpers/diagnostics.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectDiagnostic } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR287 explicit address-of operator (@place)', () => {
   it('rejects @place outside := with a stable diagnostic', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr287_address_of_positive.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr287_address_of_positive.zax');
     const res = await compile(
       entry,
       { emitBin: false, emitHex: false, emitD8m: false, emitListing: false },
@@ -25,7 +25,7 @@ describe('PR287 explicit address-of operator (@place)', () => {
   });
 
   it('rejects invalid @ targets with stable diagnostics', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr287_address_of_invalid_targets_negative.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr287_address_of_invalid_targets_negative.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(
       res.diagnostics.filter((d) => d.message.startsWith('Invalid address-of target ')).length,

--- a/test/semantics/pr849_local_init_consts.test.ts
+++ b/test/semantics/pr849_local_init_consts.test.ts
@@ -2,23 +2,23 @@ import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
-import { expectDiagnostic, expectNoErrors, expectNoDiagnostic } from './helpers/diagnostics.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectDiagnostic, expectNoErrors, expectNoDiagnostic } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('GitHub issue #849 local constant initializers', () => {
   it('accepts named constants and simple const-evaluable expressions in typed local initializers', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr849_local_init_consts_positive.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr849_local_init_consts_positive.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
     expectNoErrors(res.diagnostics);
   });
 
   it('diagnoses unknown compile-time names in typed local initializers', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr849_local_init_unknown_name_negative.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr849_local_init_unknown_name_negative.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expectDiagnostic(res.diagnostics, {
       severity: 'error',
@@ -27,7 +27,7 @@ describe('GitHub issue #849 local constant initializers', () => {
   });
 
   it('diagnoses non-constant names in typed local initializers', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr849_local_init_nonconstant_negative.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr849_local_init_nonconstant_negative.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expectDiagnostic(res.diagnostics, {
       severity: 'error',
@@ -37,7 +37,7 @@ describe('GitHub issue #849 local constant initializers', () => {
   });
 
   it('diagnoses EA-shaped local initializer expressions as invalid local constant initializers', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr849_local_init_ea_shape_negative.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr849_local_init_ea_shape_negative.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expectDiagnostic(res.diagnostics, {
       severity: 'error',
@@ -50,7 +50,7 @@ describe('GitHub issue #849 local constant initializers', () => {
   });
 
   it('diagnoses type-fit failures with existing immediate ranges', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr849_local_init_type_fit_negative.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr849_local_init_type_fit_negative.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expectDiagnostic(res.diagnostics, {
       severity: 'error',

--- a/test/semantics/pr895_assignment_acceptance.test.ts
+++ b/test/semantics/pr895_assignment_acceptance.test.ts
@@ -1,11 +1,11 @@
 import { describe, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnosticTypes.js';
-import type { ProgramNode } from '../src/frontend/ast.js';
-import { parseModuleFile } from '../src/frontend/parser.js';
-import { validateAssignmentAcceptance } from '../src/semantics/assignmentAcceptance.js';
-import { buildEnv } from '../src/semantics/env.js';
-import { expectDiagnostic, expectNoDiagnostics } from './helpers/diagnostics.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import type { ProgramNode } from '../../src/frontend/ast.js';
+import { parseModuleFile } from '../../src/frontend/parser.js';
+import { validateAssignmentAcceptance } from '../../src/semantics/assignmentAcceptance.js';
+import { buildEnv } from '../../src/semantics/env.js';
+import { expectDiagnostic, expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 function parseProgram(modulePath: string, source: string): { program: ProgramNode; diagnostics: Diagnostic[] } {
   const diagnostics: Diagnostic[] = [];

--- a/test/semantics/pr899_step_acceptance.test.ts
+++ b/test/semantics/pr899_step_acceptance.test.ts
@@ -1,11 +1,11 @@
 import { describe, it } from 'vitest';
 
-import type { Diagnostic } from '../src/diagnosticTypes.js';
-import type { ProgramNode } from '../src/frontend/ast.js';
-import { parseModuleFile } from '../src/frontend/parser.js';
-import { validateStepAcceptance } from '../src/semantics/stepAcceptance.js';
-import { buildEnv } from '../src/semantics/env.js';
-import { expectDiagnostic, expectNoDiagnostics } from './helpers/diagnostics.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import type { ProgramNode } from '../../src/frontend/ast.js';
+import { parseModuleFile } from '../../src/frontend/parser.js';
+import { validateStepAcceptance } from '../../src/semantics/stepAcceptance.js';
+import { buildEnv } from '../../src/semantics/env.js';
+import { expectDiagnostic, expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 function parseProgram(modulePath: string, source: string): { program: ProgramNode; diagnostics: Diagnostic[] } {
   const diagnostics: Diagnostic[] = [];

--- a/test/semantics/pr980_local_alias_legality.test.ts
+++ b/test/semantics/pr980_local_alias_legality.test.ts
@@ -2,15 +2,15 @@ import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
-import { expectDiagnostic, expectNoDiagnostics } from './helpers/diagnostics.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const compileFixture = async (name: string) => {
-  const entry = join(__dirname, 'fixtures', name);
+  const entry = join(__dirname, '..', 'fixtures', name);
   return compile(entry, {}, { formats: defaultFormatWriters });
 };
 


### PR DESCRIPTION
## Summary
- Migrate a semantics-focused batch from root test/ into test/semantics
- Update imports and fixture paths for the moved tests

## Issue
- Closes #1154

## Moved tests
- test/semantics/pr286_nonscalar_param_compat_matrix.test.ts
- test/semantics/pr287_address_of_operator.test.ts
- test/semantics/pr849_local_init_consts.test.ts
- test/semantics/pr895_assignment_acceptance.test.ts
- test/semantics/pr899_step_acceptance.test.ts
- test/semantics/pr980_local_alias_legality.test.ts

## Commands
- npm ci
- npm run typecheck
- npm run lint
- npm test -- --run test/semantics/pr286_nonscalar_param_compat_matrix.test.ts test/semantics/pr287_address_of_operator.test.ts test/semantics/pr849_local_init_consts.test.ts test/semantics/pr895_assignment_acceptance.test.ts test/semantics/pr899_step_acceptance.test.ts test/semantics/pr980_local_alias_legality.test.ts
