### PR TITLE
Test: migrate ISA/ASM80 backend tests

### DIFF
--- a/test/backend/pr1048_write_asm80_unit.test.ts
+++ b/test/backend/pr1048_write_asm80_unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { writeAsm80 } from '../src/formats/writeAsm80.js';
-import type { LoweredAsmProgram, LoweredEaExpr } from '../src/lowering/loweredAsmTypes.js';
+import { writeAsm80 } from '../../src/formats/writeAsm80.js';
+import type { LoweredAsmProgram, LoweredEaExpr } from '../../src/lowering/loweredAsmTypes.js';
 
 describe('writeAsm80', () => {
   it('formats lowered asm programs across expression and item variants', () => {

--- a/test/backend/pr113_isa_indexed_bit_setres_dst.test.ts
+++ b/test/backend/pr113_isa_indexed_bit_setres_dst.test.ts
@@ -3,23 +3,23 @@ import { rm, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { DiagnosticIds } from '../src/diagnosticTypes.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
-import { expectDiagnostic } from './helpers/diagnostics.js';
+import { compile } from '../../src/compile.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectDiagnostic } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR113 ISA: indexed set/res with destination register', () => {
   it('encodes set/res b,(ix/iy+disp),r forms', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr113_isa_indexed_bit_setres_dst.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr113_isa_indexed_bit_setres_dst.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics.length).toBeGreaterThanOrEqual(0);
   });
 
   it('diagnoses invalid 3-operand source/destination forms', async () => {
-    const entry = join(__dirname, 'fixtures', 'tmp-pr113-indexed-setres-invalid.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'tmp-pr113-indexed-setres-invalid.zax');
     const source = [
       'export func main()',
       '    set 1, (hl), a',

--- a/test/backend/pr123_isa_alu_a_core.test.ts
+++ b/test/backend/pr123_isa_alu_a_core.test.ts
@@ -2,21 +2,21 @@ import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR123 ISA: core ALU-A matrix', () => {
   it('encodes add/adc/sub/sbc/and/or/xor/cp across reg8, (hl), and imm8', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr123_isa_alu_a_core.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr123_isa_alu_a_core.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics.length).toBeGreaterThanOrEqual(0);
   });
 
   it('diagnoses imm8 out-of-range ALU immediates', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr123_isa_alu_a_core_invalid.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr123_isa_alu_a_core_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics.some((d) => d.message.includes('expects imm8'))).toBe(true);

--- a/test/backend/pr129_isa_ed_zero_operand_diag.test.ts
+++ b/test/backend/pr129_isa_ed_zero_operand_diag.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR129: ED zero-operand diagnostics', () => {
   it('reports explicit diagnostics when ED zero-operand mnemonics are given operands', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr129_isa_ed_zero_operand_invalid.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr129_isa_ed_zero_operand_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
     const messages = res.diagnostics.map((d) => d.message);

--- a/test/backend/pr130_isa_inout_im_rst_arity_diag.test.ts
+++ b/test/backend/pr130_isa_inout_im_rst_arity_diag.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR130: in/out/im/rst operand-count diagnostics', () => {
   it('reports explicit arity diagnostics for malformed instruction forms', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr130_isa_inout_im_rst_arity_invalid.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr130_isa_inout_im_rst_arity_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
     const messages = res.diagnostics.map((d) => d.message);

--- a/test/backend/pr131_isa_zero_operand_core_diag.test.ts
+++ b/test/backend/pr131_isa_zero_operand_core_diag.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR131: core zero-operand diagnostics', () => {
   it('reports explicit no-operand diagnostics for malformed core forms', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr131_isa_zero_operand_core_invalid.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr131_isa_zero_operand_core_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
     const messages = res.diagnostics.map((d) => d.message);

--- a/test/backend/pr144_isa_ed_cb_diag_matrix.test.ts
+++ b/test/backend/pr144_isa_ed_cb_diag_matrix.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR144: ED/CB diagnostics parity matrix', () => {
   it('reports explicit diagnostics for malformed ED/CB forms', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr144_isa_ed_cb_diag_matrix_invalid.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr144_isa_ed_cb_diag_matrix_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
     const messages = res.diagnostics.map((d) => d.message);

--- a/test/backend/pr240_isa_register_target_diag_matrix.test.ts
+++ b/test/backend/pr240_isa_register_target_diag_matrix.test.ts
@@ -2,16 +2,16 @@ import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
-import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR240: ISA register-target diagnostics parity', () => {
   it('emits explicit diagnostics for register-target misuse in call/jp/jr/djnz', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr240_isa_register_target_diag_matrix_invalid.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr240_isa_register_target_diag_matrix_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expectDiagnostic(res.diagnostics, {
       severity: 'error',

--- a/test/backend/pr24_isa_core.test.ts
+++ b/test/backend/pr24_isa_core.test.ts
@@ -2,23 +2,23 @@ import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { DiagnosticIds } from '../src/diagnosticTypes.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
-import { expectDiagnostic } from './helpers/diagnostics.js';
+import { compile } from '../../src/compile.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectDiagnostic } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR24 ISA core tranche', () => {
   it('encodes sub/cp/and/or/xor and rel8 branches', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr24_isa_core.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr24_isa_core.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics.length).toBeGreaterThanOrEqual(0);
   });
 
   it('diagnoses rel8 out-of-range label branches', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr24_jr_label_out_of_range.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr24_jr_label_out_of_range.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expectDiagnostic(res.diagnostics, {
@@ -29,7 +29,7 @@ describe('PR24 ISA core tranche', () => {
   });
 
   it('encodes backwards rel8 branch displacements', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr24_rel8_backward.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr24_rel8_backward.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics.length).toBeGreaterThanOrEqual(0);
   });

--- a/test/backend/pr56_isa_misc.test.ts
+++ b/test/backend/pr56_isa_misc.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR56: ISA misc single-byte ops', () => {
   it('encodes common misc ops', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr56_isa_misc.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr56_isa_misc.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics.length).toBeGreaterThanOrEqual(0);
   });

--- a/test/backend/pr57_isa_im_rst.test.ts
+++ b/test/backend/pr57_isa_im_rst.test.ts
@@ -2,16 +2,16 @@ import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
-import type { BinArtifact } from '../src/formats/types.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import type { BinArtifact } from '../../src/formats/types.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR57: ISA im/rst/reti/retn', () => {
   it('encodes im, rst, reti, and retn', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr57_isa_im_rst.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr57_isa_im_rst.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts.find((a): a is BinArtifact => a.kind === 'bin')).toBeUndefined();
     expect(res.diagnostics.map((d) => d.message)).toEqual(

--- a/test/backend/pr91_isa_hl16_adc_sbc.test.ts
+++ b/test/backend/pr91_isa_hl16_adc_sbc.test.ts
@@ -2,21 +2,21 @@ import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR91: ISA adc/sbc HL,rr', () => {
   it('encodes adc/sbc HL,BC/DE/HL/SP (ED forms)', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr91_isa_hl16_adc_sbc.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr91_isa_hl16_adc_sbc.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics.length).toBeGreaterThanOrEqual(0);
   });
 
   it('diagnoses unsupported rr in adc HL,rr', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr91_isa_hl16_adc_sbc_invalid.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr91_isa_hl16_adc_sbc_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics.some((d) => d.message.includes('adc HL, rr expects BC/DE/HL/SP'))).toBe(

--- a/test/backend/pr991_asm80_comment_preservation.test.ts
+++ b/test/backend/pr991_asm80_comment_preservation.test.ts
@@ -2,16 +2,16 @@ import { describe, expect, it } from 'vitest';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
-import type { Asm80Artifact } from '../src/formats/types.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import type { Asm80Artifact } from '../../src/formats/types.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('ASM80 comment preservation', () => {
   it('keeps user comments distinct from generated comments', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr991_comment_preservation.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr991_comment_preservation.zax');
     const res = await compile(
       entry,
       {


### PR DESCRIPTION
## Summary
- Migrate an ISA/ASM80 backend batch from root test/ into test/backend
- Update imports and fixture paths for the moved tests

## Issue
- Closes #1155

## Moved tests
- test/backend/pr24_isa_core.test.ts
- test/backend/pr56_isa_misc.test.ts
- test/backend/pr57_isa_im_rst.test.ts
- test/backend/pr91_isa_hl16_adc_sbc.test.ts
- test/backend/pr113_isa_indexed_bit_setres_dst.test.ts
- test/backend/pr123_isa_alu_a_core.test.ts
- test/backend/pr129_isa_ed_zero_operand_diag.test.ts
- test/backend/pr130_isa_inout_im_rst_arity_diag.test.ts
- test/backend/pr131_isa_zero_operand_core_diag.test.ts
- test/backend/pr144_isa_ed_cb_diag_matrix.test.ts
- test/backend/pr240_isa_register_target_diag_matrix.test.ts
- test/backend/pr991_asm80_comment_preservation.test.ts
- test/backend/pr1048_write_asm80_unit.test.ts

## Commands
- npm ci
- npm run typecheck
- npm run lint
- npm test -- --run test/backend/pr24_isa_core.test.ts test/backend/pr56_isa_misc.test.ts test/backend/pr57_isa_im_rst.test.ts test/backend/pr91_isa_hl16_adc_sbc.test.ts test/backend/pr113_isa_indexed_bit_setres_dst.test.ts test/backend/pr123_isa_alu_a_core.test.ts test/backend/pr129_isa_ed_zero_operand_diag.test.ts test/backend/pr130_isa_inout_im_rst_arity_diag.test.ts test/backend/pr131_isa_zero_operand_core_diag.test.ts test/backend/pr144_isa_ed_cb_diag_matrix.test.ts test/backend/pr240_isa_register_target_diag_matrix.test.ts test/backend/pr991_asm80_comment_preservation.test.ts test/backend/pr1048_write_asm80_unit.test.ts
