### PR TITLE
docs(ch5): fix intro/section redundancy — closes #1207

### DIFF
--- a/learning/part1/05-counting-loops-and-djnz.md
+++ b/learning/part1/05-counting-loops-and-djnz.md
@@ -2,12 +2,9 @@
 
 # Chapter 5 — Counting Loops and DJNZ
 
-The `dec b / jp nz` loop from Chapter 4 uses two instructions to do one
-conceptual thing: decrement-the-counter-and-loop-if-not-done. The Z80 has a
-single instruction that fuses them.
-
-This chapter introduces `djnz` and the three loop forms that cover most of what
-you will write: counted, sentinel, and flag-exit.
+The `dec b / jp nz` loop from Chapter 4 uses two instructions where one would do.
+This chapter shows the single-instruction replacement, and the three loop forms
+you will reach for most often: counted, sentinel, and flag-exit.
 
 ---
 
@@ -24,8 +21,7 @@ loop_top:
 ```
 
 `dec b` decrements B and sets the Z flag when B reaches zero. `jp nz` branches
-back while B is non-zero. The pattern works, but it takes two instructions to
-perform one conceptual operation: decrement-the-counter-and-loop-if-not-done.
+back while B is non-zero. Two instructions for one conceptual operation.
 
 The Z80 has a single instruction that fuses those two operations.
 


### PR DESCRIPTION
## Summary

- The chapter intro announced `djnz` as the solution before the first section had shown any code, inverting the required problem-first/solution-second order.
- The phrase *"The Z80 has a single instruction that fuses them"* and the label *"decrement-the-counter-and-loop-if-not-done"* each appeared twice within eight lines — once in the intro, once in the section body — with no additional teaching value on the second occurrence.

**Edit 1 — Intro:** Replaced with a two-sentence scope statement that names the problem and previews the chapter without revealing the solution or naming `djnz`.

**Edit 2 — Section body:** Replaced the verbose repeated phrase with `"Two instructions for one conceptual operation."` The code directly above already shows the two instructions; restating them in prose taught nothing new.

All other sections (zero-count semantic, sentinel, flag-exit, summary) are untouched.

## Test plan

- [ ] Read lines 1–27 aloud: intro and section now do different jobs (setup vs. earned solution)
- [ ] Confirm "The Z80 has a single instruction that fuses those two operations." appears exactly once — in the section, after the code
- [ ] Pass 3 AI tic check: no dead openers, minimisers, hedges, or blacklist words in edited sentences
- [ ] Final gate: the chapter can be shortened nowhere without losing real teaching value

Closes #1207

🤖 Generated with [Claude Code](https://claude.com/claude-code)