### PR TITLE
test: strengthen frontend helper diagnostics

### DIFF
--- a/test/frontend/pr184_func_extern_param_return_diag_matrix.test.ts
+++ b/test/frontend/pr184_func_extern_param_return_diag_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../../src/compile.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,18 +14,40 @@ describe('PR184 parser: func/extern parameter and return diagnostics matrix', ()
     const entry = join(__dirname, '..', 'fixtures', 'pr184_func_extern_param_return_diag_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      line: 1,
+      message: 'Invalid parameter declaration: expected <name>: <type>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      line: 5,
+      message: 'Invalid parameter type "[byte]": expected <type>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      line: 9,
+      message: 'Invalid return register "[word]": expected HL, DE, BC, or AF.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      line: 13,
+      message: 'Invalid op parameter declaration: expected <name>: <matcher>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      line: 19,
+      message: 'Invalid return register "[word]": expected HL, DE, BC, or AF.',
+    });
 
-    expect(messages).toContain('Invalid parameter declaration: expected <name>: <type>');
-    expect(messages).toContain('Invalid parameter type "[byte]": expected <type>');
-    expect(messages).toContain('Invalid return register "[word]": expected HL, DE, BC, or AF.');
-    expect(messages).toContain('Invalid op parameter declaration: expected <name>: <matcher>');
-    expect(messages).toContain('Invalid return register "[word]": expected HL, DE, BC, or AF.');
-
-    expect(messages.some((m) => m.includes('Unsupported type in parameter declaration'))).toBe(
-      false,
-    );
-    expect(messages.some((m) => m.includes('Unsupported return type'))).toBe(false);
-    expect(messages.some((m) => m.includes('Unsupported extern func return type'))).toBe(false);
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported type in parameter declaration',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported return type',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported extern func return type',
+    });
   });
 });

--- a/test/frontend/pr476_parse_asm_statements_helpers.test.ts
+++ b/test/frontend/pr476_parse_asm_statements_helpers.test.ts
@@ -8,6 +8,7 @@ import {
   type AsmControlFrame,
 } from '../../src/frontend/parseAsmStatements.js';
 import { makeSourceFile, span } from '../../src/frontend/source.js';
+import { expectDiagnostic, expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 describe('PR476 asm statement parsing extraction', () => {
   const file = makeSourceFile('pr476_parse_asm_statements_helpers.zax', '');
@@ -33,7 +34,7 @@ describe('PR476 asm statement parsing extraction', () => {
       { kind: 'Case', span: zeroSpan, value: { kind: 'ImmLiteral', span: zeroSpan, value: 1 } },
       { kind: 'Case', span: zeroSpan, value: { kind: 'ImmLiteral', span: zeroSpan, value: 2 } },
     ]);
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
   });
 
   it('parses grouped range case items without flattening the ranges away', () => {
@@ -53,7 +54,7 @@ describe('PR476 asm statement parsing extraction', () => {
       },
       { kind: 'Case', span: zeroSpan, value: { kind: 'ImmLiteral', span: zeroSpan, value: 95 } },
     ]);
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
   });
 
   it('keeps recovery markers intact', () => {
@@ -70,7 +71,7 @@ describe('PR476 asm statement parsing extraction', () => {
     expect(parsed).toMatchObject({ kind: 'If', cc: '__missing__' });
     expect(controlStack).toHaveLength(1);
     expect(isRecoverOnlyControlFrame(controlStack[0]!)).toBe(true);
-    expect(diagnostics[0]?.message).toContain('"if" expects a condition code');
+    expectDiagnostic(diagnostics, { messageIncludes: '"if" expects a condition code' });
   });
 
   it('validates structured-control condition codes at parse time', () => {
@@ -94,11 +95,16 @@ describe('PR476 asm statement parsing extraction', () => {
       cc: '__missing__',
     });
     expect(repeatStack).toHaveLength(0);
-    expect(diagnostics.map((d) => d.message)).toEqual([
-      'Invalid if condition code "nope": expected z, nz, c, nc, pe, po, m, p.',
-      'Invalid while condition code "nope": expected z, nz, c, nc, pe, po, m, p.',
-      'Invalid until condition code "nope": expected z, nz, c, nc, pe, po, m, p.',
-    ]);
+    expect(diagnostics).toHaveLength(3);
+    expectDiagnostic(diagnostics, {
+      message: 'Invalid if condition code "nope": expected z, nz, c, nc, pe, po, m, p.',
+    });
+    expectDiagnostic(diagnostics, {
+      message: 'Invalid while condition code "nope": expected z, nz, c, nc, pe, po, m, p.',
+    });
+    expectDiagnostic(diagnostics, {
+      message: 'Invalid until condition code "nope": expected z, nz, c, nc, pe, po, m, p.',
+    });
   });
 
   it('allows symbolic condition placeholders when explicitly permitted', () => {
@@ -110,7 +116,7 @@ describe('PR476 asm statement parsing extraction', () => {
     });
 
     expect(parsed).toMatchObject({ kind: 'If', cc: 'cond' });
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
   });
 
   it('falls back to instruction parsing for plain asm lines', () => {
@@ -126,7 +132,7 @@ describe('PR476 asm statement parsing extraction', () => {
         { kind: 'Imm', span: zeroSpan, expr: { kind: 'ImmLiteral', span: zeroSpan, value: 18 } },
       ],
     });
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
   });
 
   it('parses break and continue only when enclosed by a loop', () => {
@@ -150,7 +156,7 @@ describe('PR476 asm statement parsing extraction', () => {
         [{ kind: 'Repeat', openSpan: zeroSpan }],
       ),
     ).toEqual({ kind: 'Continue', span: zeroSpan });
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
   });
 
   it('diagnoses out-of-loop or malformed break and continue', () => {
@@ -158,9 +164,12 @@ describe('PR476 asm statement parsing extraction', () => {
 
     expect(parseAsmStatement(file.path, 'break', zeroSpan, diagnostics, [])).toBeUndefined();
     expect(parseAsmStatement(file.path, 'continue extra', zeroSpan, diagnostics, [])).toBeUndefined();
-    expect(diagnostics.map((d) => d.message)).toEqual([
-      '"break" is only valid inside "while" or "repeat"',
-      '"continue" does not take operands',
-    ]);
+    expect(diagnostics).toHaveLength(2);
+    expectDiagnostic(diagnostics, {
+      message: '"break" is only valid inside "while" or "repeat"',
+    });
+    expectDiagnostic(diagnostics, {
+      message: '"continue" does not take operands',
+    });
   });
 });

--- a/test/frontend/pr785_raw_data_parser.test.ts
+++ b/test/frontend/pr785_raw_data_parser.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import type { NamedSectionNode, RawDataDeclNode } from '../../src/frontend/ast.js';
 import { parseModuleFile } from '../../src/frontend/parser.js';
+import { expectDiagnostic, expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 function parse(source: string): { diagnostics: Diagnostic[]; module: ReturnType<typeof parseModuleFile> } {
   const diagnostics: Diagnostic[] = [];
@@ -38,7 +39,7 @@ func handler_b()
 end
     `);
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     const section = getFirstSection(module);
     const rawItems = section.items.filter(
       (item): item is RawDataDeclNode => item.kind === 'RawDataDecl',
@@ -87,8 +88,7 @@ end
     const { diagnostics } = parse(`
 db 1, 2, 3
     `);
-    expect(diagnostics.length).toBeGreaterThan(0);
-    expect(diagnostics[0]?.message).toContain('Raw data directives');
+    expectDiagnostic(diagnostics, { messageIncludes: 'Raw data directives' });
   });
 
   it('rejects raw directives inside code sections', () => {
@@ -99,7 +99,7 @@ section code text at $0000
 end
     `);
     expect(diagnostics.length).toBeGreaterThan(0);
-    expect(diagnostics.some((d) => d.message.includes('Raw data'))).toBe(true);
+    expectDiagnostic(diagnostics, { messageIncludes: 'Raw data' });
   });
 
   it('rejects malformed db/dw/ds directives', () => {
@@ -135,7 +135,8 @@ section code text at $0000
   nop
 end
     `);
-    expect(diagnostics.length).toBeGreaterThan(0);
-    expect(diagnostics[0]?.message).toContain('Unsupported section-contained construct');
+    expectDiagnostic(diagnostics, {
+      messageIncludes: 'Unsupported section-contained construct',
+    });
   });
 });

--- a/test/frontend/pr798_addr_expr_parser.test.ts
+++ b/test/frontend/pr798_addr_expr_parser.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import { parseProgram } from '../../src/frontend/parser.js';
+import { expectDiagnostic, expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 const parse = (text: string) => {
-  const diagnostics: Array<{ message: string }> = [];
-  const program = parseProgram('pr798_addr_expr.zax', text, diagnostics as any);
+  const diagnostics: Diagnostic[] = [];
+  const program = parseProgram('pr798_addr_expr.zax', text, diagnostics);
   return { program, diagnostics };
 };
 
@@ -21,7 +23,7 @@ export func main()
 end
 end
     `);
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
 
     const section = program.files[0]?.items.find((i: any) => i.kind === 'NamedSection');
     expect(section).toBeDefined();
@@ -36,8 +38,7 @@ export func main()
 end
 end
     `);
-    expect(diagnostics.length).toBeGreaterThan(0);
-    expect(diagnostics[0]?.message).toContain('":="');
+    expectDiagnostic(diagnostics, { messageIncludes: '":="' });
   });
 
   it('rejects nested or parenthesized @ forms', () => {
@@ -53,7 +54,7 @@ end
 end
     `);
     expect(diagnostics.length).toBeGreaterThan(0);
-    expect(diagnostics.some((d) => d.message.includes('address-of'))).toBe(true);
+    expectDiagnostic(diagnostics, { messageIncludes: 'address-of' });
   });
 
   it('rejects ld with @path', () => {
@@ -77,6 +78,6 @@ export func main()
 end
 end
     `);
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
   });
 });

--- a/test/frontend/pr862_assignment_parser.test.ts
+++ b/test/frontend/pr862_assignment_parser.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import { parseAsmInstruction } from '../../src/frontend/parseAsmInstruction.js';
 import { makeSourceFile, span } from '../../src/frontend/source.js';
+import { expectDiagnostic, expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 describe('PR862 := assignment parser/AST support', () => {
   const file = makeSourceFile('pr862_assignment_parser.zax', '');
@@ -18,7 +19,7 @@ describe('PR862 := assignment parser/AST support', () => {
 
   it('parses storage and register assignment forms', () => {
     let parsed = parse('x := a');
-    expect(parsed.diagnostics).toEqual([]);
+    expectNoDiagnostics(parsed.diagnostics);
     expect(parsed.instr).toMatchObject({
       kind: 'AsmInstruction',
       head: ':=',
@@ -29,7 +30,7 @@ describe('PR862 := assignment parser/AST support', () => {
     });
 
     parsed = parse('a := x');
-    expect(parsed.diagnostics).toEqual([]);
+    expectNoDiagnostics(parsed.diagnostics);
     expect(parsed.instr).toMatchObject({
       kind: 'AsmInstruction',
       head: ':=',
@@ -40,7 +41,7 @@ describe('PR862 := assignment parser/AST support', () => {
     });
 
     parsed = parse('words[idx] := hl');
-    expect(parsed.diagnostics).toEqual([]);
+    expectNoDiagnostics(parsed.diagnostics);
     expect(parsed.instr).toMatchObject({
       kind: 'AsmInstruction',
       head: ':=',
@@ -59,7 +60,7 @@ describe('PR862 := assignment parser/AST support', () => {
 
   it('parses whole-register immediate and copy forms', () => {
     let parsed = parse('hl := 0');
-    expect(parsed.diagnostics).toEqual([]);
+    expectNoDiagnostics(parsed.diagnostics);
     expect(parsed.instr).toMatchObject({
       kind: 'AsmInstruction',
       head: ':=',
@@ -67,7 +68,7 @@ describe('PR862 := assignment parser/AST support', () => {
     });
 
     parsed = parse('a := 1');
-    expect(parsed.diagnostics).toEqual([]);
+    expectNoDiagnostics(parsed.diagnostics);
     expect(parsed.instr).toMatchObject({
       kind: 'AsmInstruction',
       head: ':=',
@@ -114,14 +115,15 @@ describe('PR862 := assignment parser/AST support', () => {
     for (const text of ['(hl) := a', 'a := (hl)']) {
       const parsed = parse(text);
       expect(parsed.instr).toBeUndefined();
-      expect(parsed.diagnostics.length).toBeGreaterThan(0);
-      expect(parsed.diagnostics[0]?.message).toContain(':=');
+      expectDiagnostic(parsed.diagnostics, { messageIncludes: ':=' });
     }
   });
 
   it('rejects removed move syntax', () => {
     const parsed = parse('move x, a');
     expect(parsed.instr).toBeUndefined();
-    expect(parsed.diagnostics.map((d) => d.message)).toContain('"move" has been removed; use ":=".');
+    expectDiagnostic(parsed.diagnostics, {
+      message: '"move" has been removed; use ":=".',
+    });
   });
 });

--- a/test/frontend/pr922_paren_imm_backslash_separator.test.ts
+++ b/test/frontend/pr922_paren_imm_backslash_separator.test.ts
@@ -6,6 +6,7 @@ import { defaultFormatWriters } from '../../src/formats/index.js';
 import type { BinArtifact } from '../../src/formats/types.js';
 import { parseProgram } from '../../src/frontend/parser.js';
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { expectDiagnostic, expectNoErrors } from '../helpers/diagnostics.js';
 
 const indexOfSubarray = (haystack: number[], needle: number[]): number => {
   if (needle.length === 0) return 0;
@@ -30,7 +31,7 @@ describe('PR922: parenthesized imm indirection and backslash separators', () => 
       { emitAsm80: true, emitBin: true, emitHex: false, emitListing: false, emitD8m: false },
       { formats: defaultFormatWriters },
     );
-    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    expectNoErrors(res.diagnostics);
 
     const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
     expect(bin).toBeDefined();
@@ -47,7 +48,7 @@ describe('PR922: parenthesized imm indirection and backslash separators', () => 
       { emitAsm80: false, emitBin: true, emitHex: false, emitListing: false, emitD8m: false },
       { formats: defaultFormatWriters },
     );
-    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    expectNoErrors(res.diagnostics);
 
     const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
     expect(bin).toBeDefined();
@@ -63,7 +64,9 @@ describe('PR922: parenthesized imm indirection and backslash separators', () => 
       ['export func main()', '  ld a, 1 \\', 'end', ''].join('\n'),
       diagnostics,
     );
-    expect(diagnostics.some((d) => d.message.includes('Trailing backslash must be followed'))).toBe(true);
+    expectDiagnostic(diagnostics, {
+      messageIncludes: 'Trailing backslash must be followed',
+    });
   });
 
   it('keeps physical line numbers for diagnostics after backslash separators', () => {
@@ -73,8 +76,7 @@ describe('PR922: parenthesized imm indirection and backslash separators', () => 
       ['export func main()', '  ld a, 1 \\ ld a, ?', 'end', ''].join('\n'),
       diagnostics,
     );
-    const bad = diagnostics.find((d) => d.message.includes('Unsupported operand'));
-    expect(bad?.line).toBe(2);
+    expectDiagnostic(diagnostics, { messageIncludes: 'Unsupported operand', line: 2 });
   });
 
   it('does not treat a tight backslash as a separator', () => {

--- a/test/pr322_return_flags_parser.test.ts
+++ b/test/pr322_return_flags_parser.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { join } from 'node:path';
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const flagsFixture = join(__dirname, 'fixtures', 'pr322_return_flags_positive.zax');
 
@@ -13,8 +14,15 @@ describe('PR322: return flags modifier removed', () => {
       { formats: defaultFormatWriters },
     );
 
-    const errors = res.diagnostics.filter((d) => d.severity === 'error');
-    expect(errors.length).toBeGreaterThan(0);
-    expect(errors.some((d) => d.message.includes('Invalid return register'))).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      line: 4,
+      message: 'Invalid return register "HL flags": expected HL, DE, BC, or AF.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      line: 9,
+      message: 'Invalid return register "HL flags": expected HL, DE, BC, or AF.',
+    });
   });
 });

--- a/test/pr354_register_list_only_surface.test.ts
+++ b/test/pr354_register_list_only_surface.test.ts
@@ -3,15 +3,24 @@ import { join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const fixture = join(__dirname, 'fixtures', 'pr354_return_keyword_rejection.zax');
 
 describe('PR354: register-list only return surface', () => {
   it('rejects legacy return keywords (void/long)', async () => {
     const res = await compile(fixture, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
 
-    expect(messages.some((m) => m.includes('Legacy return keyword \"void\"'))).toBe(true);
-    expect(messages.some((m) => m.includes('Legacy return keyword \"long\"'))).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      line: 1,
+      messageIncludes: 'Legacy return keyword "void"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      line: 4,
+      messageIncludes: 'Legacy return keyword "long"',
+    });
+    expect(res.diagnostics).toHaveLength(4);
   });
 });


### PR DESCRIPTION
## Summary
- replace remaining weak diagnostic assertions in a focused frontend helper/parser diagnostics batch
- cover asm-statement helpers, raw-data parsing, address-of path parsing, assignment parsing, backslash separators, and nearby return-surface diagnostics
- preserve compiler behavior and keep the slice limited to helper-based assertion migration

## Testing
- npm ci
- npm run typecheck
- npm run lint
- npm test -- --run test/frontend/pr184_func_extern_param_return_diag_matrix.test.ts test/frontend/pr476_parse_asm_statements_helpers.test.ts test/frontend/pr785_raw_data_parser.test.ts test/frontend/pr798_addr_expr_parser.test.ts test/frontend/pr862_assignment_parser.test.ts test/frontend/pr922_paren_imm_backslash_separator.test.ts test/pr322_return_flags_parser.test.ts test/pr354_register_list_only_surface.test.ts

Part of #1132