### PR TITLE
docs(ch6): put problem before mechanism in intro and IX section

### DIFF
--- a/learning/part1/06-data-tables-and-indexed-access.md
+++ b/learning/part1/06-data-tables-and-indexed-access.md
@@ -2,9 +2,10 @@
 
 # Chapter 6 — Data Tables and Indexed Access
 
-This chapter shows how to lay out a byte or word table in memory and read
-entries from it — using HL as a sequential pointer and IX as a displaced-access
-pointer.
+Once your data lives in a table, you need two things: a way to process every
+entry in order, and a way to reach one specific entry directly. HL handles the
+first — load the base, read, advance, repeat. IX handles the second — load the
+base once and name any entry by its offset from there.
 
 ---
 
@@ -113,6 +114,9 @@ space, and it is your job to keep them organised.
 
 ## IX-based displaced access
 
+With HL you would increment between each read. With IX you load the base once
+and name each field by its offset.
+
 IX is a 16-bit index register. Its specific capability is the `(ix+d)`
 addressing mode: `d` is a signed byte offset, any value from -128 to +127, and
 `ld a, (ix+d)` reads the byte at address IX + d without touching IX itself.
@@ -128,9 +132,6 @@ ld b, (ix+1)         ; B = high byte field
 ld c, (ix+2)         ; C = low byte field
 ; IX is unchanged throughout — all three fields read from one base address
 ```
-
-With HL you would increment between each read. With IX you load the base once
-and name each field by its offset.
 
 The displacement `d` is a byte-sized signed offset. Offsets larger than 127 or
 smaller than -128 are not encodable and will cause an assembler error.


### PR DESCRIPTION
Fixes #1211.

## Changes

**Edit 1 — Chapter intro (lines 5–7)**

Replaced the mechanism-first opener ("This chapter shows how to lay out…using HL as a sequential pointer and IX as a displaced-access pointer") with a situation-first opener. The new intro names the two needs a reader with table data faces — process every entry, or reach one entry directly — then maps HL and IX to those needs. Tools are introduced after need.

**Edit 2 — IX section opener (lines 116–133)**

Moved the contrast sentence ("With HL you would increment between each read. With IX you load the base once and name each field by its offset.") from after the code block to the top of the section. The section now reads: HL limitation → IX as answer → `(ix+d)` syntax definition → code example → displacement range constraint. No new content written; existing sentence repositioned.

## Diff size

7 insertions, 6 deletions. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)