### PR TITLE
Strengthen return diagnostics assertions

### DIFF
--- a/test/frontend/pr184_func_extern_param_return_diag_matrix.test.ts
+++ b/test/frontend/pr184_func_extern_param_return_diag_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../../src/compile.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,18 +14,40 @@ describe('PR184 parser: func/extern parameter and return diagnostics matrix', ()
     const entry = join(__dirname, '..', 'fixtures', 'pr184_func_extern_param_return_diag_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      line: 1,
+      message: 'Invalid parameter declaration: expected <name>: <type>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      line: 5,
+      message: 'Invalid parameter type "[byte]": expected <type>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      line: 9,
+      message: 'Invalid return register "[word]": expected HL, DE, BC, or AF.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      line: 13,
+      message: 'Invalid op parameter declaration: expected <name>: <matcher>',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      line: 19,
+      message: 'Invalid return register "[word]": expected HL, DE, BC, or AF.',
+    });
 
-    expect(messages).toContain('Invalid parameter declaration: expected <name>: <type>');
-    expect(messages).toContain('Invalid parameter type "[byte]": expected <type>');
-    expect(messages).toContain('Invalid return register "[word]": expected HL, DE, BC, or AF.');
-    expect(messages).toContain('Invalid op parameter declaration: expected <name>: <matcher>');
-    expect(messages).toContain('Invalid return register "[word]": expected HL, DE, BC, or AF.');
-
-    expect(messages.some((m) => m.includes('Unsupported type in parameter declaration'))).toBe(
-      false,
-    );
-    expect(messages.some((m) => m.includes('Unsupported return type'))).toBe(false);
-    expect(messages.some((m) => m.includes('Unsupported extern func return type'))).toBe(false);
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported type in parameter declaration',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported return type',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported extern func return type',
+    });
   });
 });

--- a/test/pr322_return_flags_parser.test.ts
+++ b/test/pr322_return_flags_parser.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { join } from 'node:path';
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const flagsFixture = join(__dirname, 'fixtures', 'pr322_return_flags_positive.zax');
 
@@ -13,8 +14,15 @@ describe('PR322: return flags modifier removed', () => {
       { formats: defaultFormatWriters },
     );
 
-    const errors = res.diagnostics.filter((d) => d.severity === 'error');
-    expect(errors.length).toBeGreaterThan(0);
-    expect(errors.some((d) => d.message.includes('Invalid return register'))).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      line: 4,
+      message: 'Invalid return register "HL flags": expected HL, DE, BC, or AF.',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      line: 9,
+      message: 'Invalid return register "HL flags": expected HL, DE, BC, or AF.',
+    });
   });
 });

--- a/test/pr354_register_list_only_surface.test.ts
+++ b/test/pr354_register_list_only_surface.test.ts
@@ -3,15 +3,24 @@ import { join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const fixture = join(__dirname, 'fixtures', 'pr354_return_keyword_rejection.zax');
 
 describe('PR354: register-list only return surface', () => {
   it('rejects legacy return keywords (void/long)', async () => {
     const res = await compile(fixture, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
 
-    expect(messages.some((m) => m.includes('Legacy return keyword \"void\"'))).toBe(true);
-    expect(messages.some((m) => m.includes('Legacy return keyword \"long\"'))).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      line: 1,
+      messageIncludes: 'Legacy return keyword "void"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      line: 4,
+      messageIncludes: 'Legacy return keyword "long"',
+    });
+    expect(res.diagnostics).toHaveLength(4);
   });
 });


### PR DESCRIPTION
Continues #1132.

Focused batch:
- return-surface diagnostics
- return-flag/parser diagnostics
- func/extern parameter+return parser diagnostics

This replaces weak message-fragment assertions with diagnostic helpers without changing compiler code.