### PR TITLE
test: strengthen parser recovery diagnostics

### DIFF
--- a/test/frontend/parser_recovery_quality.test.ts
+++ b/test/frontend/parser_recovery_quality.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from 'vitest';
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import type { ConstDeclNode, ModuleItemNode, TypeDeclNode } from '../../src/frontend/ast.js';
 import { parseModuleFile } from '../../src/frontend/parser.js';
+import { expectDiagnostic } from '../helpers/diagnostics.js';
 
 const FILE = 'test_recovery.zax';
 
@@ -35,8 +36,8 @@ describe('parseModuleFile recovery AST shape', () => {
     const { mod, diagnostics } = parseModule(src);
 
     expect(mod.items).toHaveLength(0);
-    expect(diagnostics.some((d) => d.message.includes('Unterminated func "f"'))).toBe(true);
-    expect(diagnostics.some((d) => d.message.includes('missing "end"'))).toBe(true);
+    expectDiagnostic(diagnostics, { messageIncludes: 'Unterminated func "f"' });
+    expectDiagnostic(diagnostics, { messageIncludes: 'missing "end"' });
   });
 
   it('function body interrupted by next top-level: no FuncDecl; following const is still parsed', () => {
@@ -46,10 +47,10 @@ const After = 1`;
     const { mod, diagnostics } = parseModule(src);
 
     expect(itemKinds(mod.items)).toEqual(['ConstDecl']);
-    expect(diagnostics.some((d) => d.message.includes('Unterminated func "g"'))).toBe(true);
-    expect(diagnostics.some((d) => d.message.includes('expected "end" before "const"'))).toBe(
-      true,
-    );
+    expectDiagnostic(diagnostics, { messageIncludes: 'Unterminated func "g"' });
+    expectDiagnostic(diagnostics, {
+      messageIncludes: 'expected "end" before "const"',
+    });
 
     const c = mod.items[0] as ConstDeclNode;
     expect(c.kind).toBe('ConstDecl');
@@ -62,13 +63,9 @@ const K = 42`;
     const { mod, diagnostics } = parseModule(src);
 
     expect(itemKinds(mod.items)).toEqual(['ConstDecl']);
-    expect(
-      diagnostics.some(
-        (d) =>
-          d.message.includes('Unsupported top-level construct') &&
-          d.message.includes('totally_unknown_construct'),
-      ),
-    ).toBe(true);
+    expectDiagnostic(diagnostics, {
+      messageIncludes: 'Unsupported top-level construct: totally_unknown_construct',
+    });
 
     const c = mod.items[0] as ConstDeclNode;
     expect(c.name).toBe('K');
@@ -84,14 +81,9 @@ end`;
 
     expect(mod.items).toHaveLength(1);
     expect(itemKinds(mod.items)).toEqual(['TypeDecl']);
-    expect(
-      diagnostics.some(
-        (d) =>
-          d.message.includes('record field declaration') &&
-          d.message.includes('not a field') &&
-          d.message.includes('<name>: <type>'),
-      ),
-    ).toBe(true);
+    expectDiagnostic(diagnostics, {
+      messageIncludes: 'record field declaration line "not a field": expected <name>: <type>',
+    });
 
     const t = mod.items[0] as TypeDeclNode;
     expect(t.kind).toBe('TypeDecl');
@@ -117,8 +109,8 @@ end`;
       expect(t.typeExpr.fields).toHaveLength(1);
       expect(t.typeExpr.fields[0]!.name).toBe('a');
     }
-    expect(diagnostics.some((d) => d.message.includes('Unterminated type "T"'))).toBe(true);
-    expect(diagnostics.some((d) => d.message.includes('missing "end"'))).toBe(true);
+    expectDiagnostic(diagnostics, { messageIncludes: 'Unterminated type "T"' });
+    expectDiagnostic(diagnostics, { messageIncludes: 'missing "end"' });
   });
 
   it('top-level asm: skipped with diagnostic; following declaration still parsed', () => {
@@ -127,9 +119,9 @@ const Z = 0`;
     const { mod, diagnostics } = parseModule(src);
 
     expect(itemKinds(mod.items)).toEqual(['ConstDecl']);
-    expect(
-      diagnostics.some((d) => d.message.includes('"asm" is not a top-level construct')),
-    ).toBe(true);
+    expectDiagnostic(diagnostics, {
+      messageIncludes: '"asm" is not a top-level construct',
+    });
     expect((mod.items[0] as ConstDeclNode).name).toBe('Z');
   });
 });

--- a/test/frontend/pr174_mixed_malformed_keyword_ordering.test.ts
+++ b/test/frontend/pr174_mixed_malformed_keyword_ordering.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 
 import { compile } from '../../src/compile.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectNoDiagnostic } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,8 +13,6 @@ describe('PR174 parser: mixed malformed + keyword-collision ordering', () => {
   it('keeps block diagnostics explicit and stable when malformed and keyword-collision lines are mixed', async () => {
     const entry = join(__dirname, '..', 'fixtures', 'pr174_mixed_malformed_keyword_ordering.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-
-    const messages = res.diagnostics.map((d) => d.message);
 
     const expectedOrder = [
       'Invalid record field declaration line "func x: byte": expected <name>: <type>',
@@ -28,8 +27,12 @@ describe('PR174 parser: mixed malformed + keyword-collision ordering', () => {
       'Invalid data declaration name "extern": collides with a top-level keyword.',
     ];
 
-    const actualOrder = messages.filter((m) => expectedOrder.includes(m));
+    const actualOrder = res.diagnostics
+      .map(({ message }) => message)
+      .filter((message) => expectedOrder.includes(message));
     expect(actualOrder).toEqual(expectedOrder);
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/frontend/pr177_parenthesized_keyword_line_recovery_matrix.test.ts
+++ b/test/frontend/pr177_parenthesized_keyword_line_recovery_matrix.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 
 import { compile } from '../../src/compile.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectNoDiagnostic } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -15,7 +16,6 @@ describe('PR177 parser: parenthesized keyword-shaped line recovery matrix', () =
     );
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
     const expectedOrder = [
       'Invalid record field declaration line "op y(a: byte): byte": expected <name>: <type>',
       'Invalid record field name "const": collides with a top-level keyword.',
@@ -31,8 +31,12 @@ describe('PR177 parser: parenthesized keyword-shaped line recovery matrix', () =
       'Invalid var declaration name "extern": collides with a top-level keyword.',
     ];
 
-    const actualOrder = messages.filter((m) => expectedOrder.includes(m));
+    const actualOrder = res.diagnostics
+      .map(({ message }) => message)
+      .filter((message) => expectedOrder.includes(message));
     expect(actualOrder).toEqual(expectedOrder);
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/frontend/pr196_parser_control_interruption_matrix.test.ts
+++ b/test/frontend/pr196_parser_control_interruption_matrix.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 
 import { compile } from '../../src/compile.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectNoDiagnostic } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -14,16 +15,21 @@ describe('PR196 parser: control-stack interruption recovery matrix', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toEqual([
+    const expectedOrder = [
       '"if" without matching "end"',
       'Unterminated func "broken_if": expected "end" before "const"',
       '"select" without matching "end"',
       'Unterminated op "broken_select": expected "end" before "enum"',
       '"repeat" without matching "until <cc>"',
       'Unterminated func "broken_repeat": expected "end" before "type"',
-    ]);
-    expect(messages.some((m) => m.startsWith('Unsupported instruction:'))).toBe(false);
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    ];
+    expect(res.diagnostics).toHaveLength(expectedOrder.length);
+    expect(res.diagnostics).toMatchObject(expectedOrder.map((message) => ({ message })));
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported instruction:',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/frontend/pr216_parser_remaining_decl_control_recovery_matrix.test.ts
+++ b/test/frontend/pr216_parser_remaining_decl_control_recovery_matrix.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 
 import { compile } from '../../src/compile.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectNoDiagnostic } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -14,7 +15,6 @@ describe('PR216 parser: remaining declaration/control recovery matrix', () => {
       'pr216_parser_remaining_decl_control_recovery_matrix.zax',
     );
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
 
     const expectedInOrder = [
       'Unexpected "end" in asm block',
@@ -23,8 +23,12 @@ describe('PR216 parser: remaining declaration/control recovery matrix', () => {
       'Trailing commas are not permitted in enum member lists',
     ];
 
-    const actualInOrder = messages.filter((m) => expectedInOrder.includes(m));
+    const actualInOrder = res.diagnostics
+      .map(({ message }) => message)
+      .filter((message) => expectedInOrder.includes(message));
     expect(actualInOrder).toEqual(expectedInOrder);
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
   });
 });

--- a/test/frontend/pr223_parser_var_and_body_recovery_matrix.test.ts
+++ b/test/frontend/pr223_parser_var_and_body_recovery_matrix.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 
 import { compile } from '../../src/compile.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectNoDiagnostic } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -14,8 +15,7 @@ describe('PR223 parser: var/body interruption and recovery ordering matrix', () 
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toEqual([
+    const expectedOrder = [
       'Unterminated func "missing_var_end_before_top": expected function body before "const"',
       'Invalid var declaration line "notADecl": expected <name>: <type>',
       'Function-local var block must end with "end" before function body',
@@ -23,8 +23,14 @@ describe('PR223 parser: var/body interruption and recovery ordering matrix', () 
       'Unterminated func "missing_end_in_body_if": expected "end" before "enum"',
       '"select" without matching "end"',
       'Unterminated op "missing_end_in_body_select": expected "end" before "type"',
-    ]);
-    expect(messages.some((m) => m.startsWith('Unsupported top-level construct:'))).toBe(false);
-    expect(messages.some((m) => m.startsWith('Unsupported instruction:'))).toBe(false);
+    ];
+    expect(res.diagnostics).toHaveLength(expectedOrder.length);
+    expect(res.diagnostics).toMatchObject(expectedOrder.map((message) => ({ message })));
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported top-level construct:',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported instruction:',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- replace remaining weak diagnostic assertions in a focused parser-recovery diagnostics batch
- cover parser recovery quality plus the remaining frontend recovery/order matrices
- preserve compiler behavior and keep the slice limited to helper-based assertion migration

## Testing
- npm ci
- npm run typecheck
- npm run lint
- npm test -- --run test/frontend/parser_recovery_quality.test.ts test/frontend/pr177_parenthesized_keyword_line_recovery_matrix.test.ts test/frontend/pr174_mixed_malformed_keyword_ordering.test.ts test/frontend/pr196_parser_control_interruption_matrix.test.ts test/frontend/pr216_parser_remaining_decl_control_recovery_matrix.test.ts test/frontend/pr223_parser_var_and_body_recovery_matrix.test.ts

Part of #1132