### PR TITLE
docs(ch2,ch3): fix garbled sentence and remove Ch4 deferral — closes #1223 #1219

### DIFF
--- a/learning/part1/02-machine-code.md
+++ b/learning/part1/02-machine-code.md
@@ -88,7 +88,7 @@ Machine code is just bytes. Assembly adds names for addresses.
 
 The program above was ten bytes. Real programs are thousands, and raw hex does not scale. Every address is a bare number — `$8000` could be your result variable, a display buffer, or a lookup table, and nothing in the code says which. Insert one instruction anywhere and every downstream address shifts; miss a single update and you get a silent wrong result with no error to point to. Reading the code directly is no help: `3E 05 47 3E 03 80 32 00 80 76` means nothing until you decode each byte by hand. And there are no structural building blocks — no subroutines, no loops, no conditionals, just bytes and jump targets calculated by hand.
 
-The CPU still sees bytes — the assembler changes what you write and maintain.
+The CPU still sees bytes. The assembler changes what you write — not what it executes.
 
 ---
 

--- a/learning/part1/03-assembly-language.md
+++ b/learning/part1/03-assembly-language.md
@@ -250,8 +250,7 @@ identical whether you treat the inputs as signed or unsigned. Where the differen
 $01` gives `$81`. Read as unsigned that is 128 + 1 = 129. Read as signed that
 is −128 + 1 = −127. Same instruction, same output, two different numbers. The
 bug appears when one part of your program writes a value intending it as signed
-and another reads it as unsigned. Chapter 4 shows how the flags let you select
-which interpretation the CPU acts on. The common landmark values (`$00`, `$7F`,
+and another reads it as unsigned. The common landmark values (`$00`, `$7F`,
 `$80`, `$FF`) and their signed and unsigned meanings are in
 [Appendix 2](../appendices/02-registers-flags-and-conditions.md).
 


### PR DESCRIPTION
## Summary

Two targeted edits in two files. 2 insertions, 3 deletions total.

**Ch2 — #1223** (`02-machine-code.md`):
`"The CPU still sees bytes — the assembler changes what you write and maintain."` was syntactically broken — *maintain* has no object. Rewrote as: `"The CPU still sees bytes. The assembler changes what you write — not what it executes."` The new sentence parses, fits the rhythm of the section close, and adds one thing the paragraph above didn't land: assembly is a human-side transformation only; the CPU sees the same bytes regardless.

**Ch3 — #1219** (`03-assembly-language.md`):
Cut `"Chapter 4 shows how the flags let you select which interpretation the CPU acts on."` — a forward reference that introduced flags (undefined at this point) and loosely implied the CPU can be directed to treat a byte as signed or unsigned (it cannot; the programmer decides what to do with the flag result). The paragraph ends cleanly on the appendix reference.

## Test plan

- [ ] Ch2 closing sentence: reads aloud cleanly, does not restate paragraph above, adds the human-side-only angle
- [ ] Ch3 paragraph: ends on the appendix reference (something the reader can act on now)
- [ ] Grep `"Chapter 4 shows"` in `03-assembly-language.md` — should return nothing
- [ ] Pass 3 on new Ch2 sentence: no dead openers, minimisers, hedges, or blacklist words

Closes #1223, closes #1219

🤖 Generated with [Claude Code](https://claude.com/claude-code)