### PR TITLE
Strengthen nonscalar param diagnostics assertions

### DIFF
--- a/test/semantics/pr286_nonscalar_param_compat_matrix.test.ts
+++ b/test/semantics/pr286_nonscalar_param_compat_matrix.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../../src/compile.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,19 +13,22 @@ describe('PR286: non-scalar typed-call parameter compatibility', () => {
   it('accepts T[N] -> T[] and exact T[N] -> T[N] non-scalar arguments', async () => {
     const entry = join(__dirname, '..', 'fixtures', 'pr286_nonscalar_param_compat_positive.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics).toEqual([]);
+    expectNoDiagnostics(res.diagnostics);
   });
 
   it('rejects T[] -> T[N] without proof and rejects element-type mismatches', async () => {
     const entry = join(__dirname, '..', 'fixtures', 'pr286_nonscalar_param_compat_negative.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
 
-    expect(messages).toContain(
-      'Incompatible non-scalar argument for parameter "values": expected byte[10], got byte[] (exact length proof required).',
-    );
-    expect(messages).toContain(
-      'Incompatible non-scalar argument for parameter "values": expected element type byte, got word.',
-    );
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message:
+        'Incompatible non-scalar argument for parameter "values": expected byte[10], got byte[] (exact length proof required).',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+      message:
+        'Incompatible non-scalar argument for parameter "values": expected element type byte, got word.',
+    });
   });
 });


### PR DESCRIPTION
Continues #1132.

Focused batch:
- semantics/env non-scalar parameter compatibility diagnostics

This replaces weak diagnostic assertions with helper-backed expectations without changing compiler code.