### PR TITLE
test: strengthen conformance diagnostic assertions

### DIFF
--- a/test/frontend/pr762_grammar_data_conformance.test.ts
+++ b/test/frontend/pr762_grammar_data_conformance.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { expectDiagnostic, expectNoDiagnostic, expectNoDiagnostics } from '../helpers/diagnostics.js';
 import {
   ASM_CONTROL_KEYWORD_LIST,
   ASM_CONTROL_KEYWORDS,
@@ -103,13 +104,10 @@ describe('PR762 grammar-data conformance', () => {
     for (const [keyword, source] of Object.entries(samples)) {
       const diagnostics: Diagnostic[] = [];
       parseProgram(`pr762_${keyword}.zax`, source, diagnostics);
-      expect(
-        diagnostics.some(
-          (diagnostic) =>
-            diagnostic.message.startsWith('Unsupported top-level construct:') ||
-            diagnostic.message.startsWith('Unsupported section-contained construct:'),
-        ),
-      ).toBe(false);
+      expectNoDiagnostic(diagnostics, { messageIncludes: 'Unsupported top-level construct:' });
+      expectNoDiagnostic(diagnostics, {
+        messageIncludes: 'Unsupported section-contained construct:',
+      });
     }
   });
 
@@ -124,7 +122,7 @@ describe('PR762 grammar-data conformance', () => {
         diagnostics,
       );
 
-      expect(diagnostics).toEqual([]);
+      expectNoDiagnostics(diagnostics);
     }
 
     for (const sectionKind of LEGACY_SECTION_DIRECTIVE_KIND_LIST) {
@@ -136,9 +134,10 @@ describe('PR762 grammar-data conformance', () => {
         diagnostics,
       );
       expect(diagnostics).toHaveLength(1);
-      expect(diagnostics[0]?.message).toContain(
-        `Legacy active-counter section directive "section ${sectionKind}" is removed`,
-      );
+      expectDiagnostic(diagnostics, {
+        messageIncludes:
+          `Legacy active-counter section directive "section ${sectionKind}" is removed`,
+      });
     }
   });
   it('routes every asm control keyword from the grammar baseline through the structured-control parser', () => {
@@ -190,7 +189,7 @@ describe('PR762 grammar-data conformance', () => {
       const out: Array<{ kind: string }> = [];
       appendParsedAsmStatement(out as any[], parsed);
 
-      expect(diagnostics).toEqual([]);
+      expectNoDiagnostics(diagnostics);
       expect(parsed).toBeDefined();
       expect(out.length > 0 || (parsed && !Array.isArray(parsed))).toBe(true);
 

--- a/test/pr447_direct_index_high_low.test.ts
+++ b/test/pr447_direct_index_high_low.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import type { BinArtifact } from '../src/formats/types.js';
+import { expectDiagnostic, expectNoDiagnostics } from './helpers/diagnostics.js';
 import {
   compilePlacedProgram,
   flattenLoweredInstructions,
@@ -79,7 +80,7 @@ describe('PR447: direct IXH/IXL/IYH/IYL forms', () => {
     expected.push(0xc9);
 
     const { entry, res } = await compileSource(buildProgram(lines));
-    expect(res.diagnostics).toEqual([]);
+    expectNoDiagnostics(res.diagnostics);
 
     const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
     expect(bin).toBeDefined();
@@ -115,10 +116,12 @@ describe('PR447: direct IXH/IXL/IYH/IYL forms', () => {
     ];
 
     const { res } = await compileSource(buildProgram(lines));
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(messages).toContain('ld with IX*/IY* does not support legacy H/L counterpart operands');
-    expect(messages).toContain('ld between IX* and IY* byte registers is not supported');
-    expect(messages).toHaveLength(lines.length);
+    expectDiagnostic(res.diagnostics, {
+      message: 'ld with IX*/IY* does not support legacy H/L counterpart operands',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'ld between IX* and IY* byte registers is not supported',
+    });
+    expect(res.diagnostics).toHaveLength(lines.length);
   });
 });

--- a/test/pr9_sections_align.test.ts
+++ b/test/pr9_sections_align.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { DiagnosticIds } from '../src/diagnosticTypes.js';
+import { expectDiagnostic, expectNoDiagnostic, expectNoErrors } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,7 +14,7 @@ describe('PR9 sections + align', () => {
   it('applies align to the active section counter', async () => {
     const entry = join(__dirname, 'fixtures', 'pr9_align_between_funcs.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(false);
+    expectNoErrors(res.diagnostics);
   });
 
   it('rejects legacy active-counter section base directives', async () => {
@@ -33,33 +34,21 @@ describe('PR9 sections + align', () => {
     const entry = join(__dirname, 'fixtures', 'pr9_overlap_code_data.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(res.diagnostics.map((d) => d.id)).toEqual(
-      expect.arrayContaining([DiagnosticIds.ParseError]),
-    );
-    expect(res.diagnostics.map((d) => d.message)).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining('Legacy active-counter section directive "section data at ..." is removed'),
-      ]),
-    );
-    expect(res.diagnostics.map((d) => d.message)).toEqual(
-      expect.not.arrayContaining([expect.stringContaining('Byte overlap')]),
-    );
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      messageIncludes: 'Legacy active-counter section directive "section data at ..." is removed',
+    });
+    expectNoDiagnostic(res.diagnostics, { messageIncludes: 'Byte overlap' });
   });
 
   it('rejects legacy section bases before range validation runs', async () => {
     const entry = join(__dirname, 'fixtures', 'pr9_invalid_code_base_no_overlap.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
-    expect(res.diagnostics.map((d) => d.id)).toEqual(
-      expect.arrayContaining([DiagnosticIds.ParseError]),
-    );
-    expect(res.diagnostics.map((d) => d.message)).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining('Legacy active-counter section directive "section code at ..." is removed'),
-      ]),
-    );
-    expect(res.diagnostics.map((d) => d.message)).toEqual(
-      expect.not.arrayContaining([expect.stringContaining('base address out of range')]),
-    );
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      messageIncludes: 'Legacy active-counter section directive "section code at ..." is removed',
+    });
+    expectNoDiagnostic(res.diagnostics, { messageIncludes: 'base address out of range' });
   });
 });


### PR DESCRIPTION
Part of #1132

## Summary
- replace weak conformance/layout diagnostic assertions with helper-based checks
- strengthen section-align, indexed byte-register legality, grammar-data, and nonscalar param compatibility tests
- keep compiler behavior unchanged and limit the change to tests only