### PR TITLE
Test: add diagnostics matcher setup

### DIFF
--- a/test/helpers/diagnostics.test.ts
+++ b/test/helpers/diagnostics.test.ts
@@ -42,6 +42,11 @@ describe('test/helpers/diagnostics', () => {
       severity: 'warning',
       message: 'Raw call targets typed callable "callee_typed".',
     });
+    expect(sampleDiagnostics).toHaveDiagnostic({
+      id: DiagnosticIds.RawCallTypedTargetWarning,
+      severity: 'warning',
+      message: 'Raw call targets typed callable "callee_typed".',
+    });
     expectNoDiagnostic(sampleDiagnostics, {
       id: DiagnosticIds.RawCallTypedTargetWarning,
       severity: 'error',

--- a/test/helpers/diagnostics/index.ts
+++ b/test/helpers/diagnostics/index.ts
@@ -15,7 +15,7 @@ export type DiagnosticExpectation = {
   line?: number;
 };
 
-function makeDiagnosticMatcher(expected: DiagnosticExpectation) {
+export function makeDiagnosticMatcher(expected: DiagnosticExpectation) {
   if (expected.message !== undefined && expected.messageIncludes !== undefined) {
     throw new Error('DiagnosticExpectation cannot specify both message and messageIncludes.');
   }

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -2,3 +2,4 @@ export * from './diagnostics.js';
 export * from './cli.js';
 export * from './cliBuild.js';
 export * from './lowered_program.js';
+export * from './setup.js';

--- a/test/helpers/setup.ts
+++ b/test/helpers/setup.ts
@@ -1,0 +1,19 @@
+import { expect } from 'vitest';
+
+import type { DiagnosticExpectation } from './diagnostics/index.js';
+import { makeDiagnosticMatcher } from './diagnostics/index.js';
+
+expect.extend({
+  toHaveDiagnostic(received: unknown, expected: DiagnosticExpectation) {
+    const diagnostics = Array.isArray(received) ? received : [];
+    const matcher = makeDiagnosticMatcher(expected);
+    const pass = diagnostics.some((diag) => matcher.asymmetricMatch(diag));
+    return {
+      pass,
+      message: () =>
+        pass
+          ? 'Expected diagnostics not to contain a matching diagnostic.'
+          : 'Expected diagnostics to contain a matching diagnostic.',
+    };
+  },
+});

--- a/test/helpers/vitest.d.ts
+++ b/test/helpers/vitest.d.ts
@@ -1,0 +1,10 @@
+import type { DiagnosticExpectation } from './diagnostics/index.js';
+
+declare module 'vitest' {
+  interface Assertion<T = unknown> {
+    toHaveDiagnostic(expected: DiagnosticExpectation): T;
+  }
+  interface AsymmetricMatchersContaining {
+    toHaveDiagnostic(expected: DiagnosticExpectation): unknown;
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['test/**/*.test.ts'],
+    setupFiles: ['test/helpers/setup.ts'],
   },
   coverage: {
     provider: 'v8',


### PR DESCRIPTION
## Summary
- Register a shared `toHaveDiagnostic` matcher via Vitest setup
- Expose the matcher from test/helpers and reuse existing diagnostic matching logic
- Add matcher typing for TS

## Issue
- Closes #1157

## Files
- test/helpers/setup.ts
- test/helpers/vitest.d.ts
- test/helpers/diagnostics/index.ts
- test/helpers/index.ts
- test/helpers/diagnostics.test.ts
- vitest.config.ts

## Commands
- npm ci
- npm run typecheck
- npm run lint
- npm test -- --run test/helpers/diagnostics.test.ts
