### PR TITLE
Strengthen op diagnostics assertions

### DIFF
--- a/test/pr136_bit_indexed_dest_invalid.test.ts
+++ b/test/pr136_bit_indexed_dest_invalid.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,7 +14,6 @@ describe('PR136: bit indexed-destination invalid form', () => {
     const entry = join(__dirname, 'fixtures', 'pr136_bit_indexed_dest_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('bit expects two operands');
+    expectDiagnostic(res.diagnostics, { message: 'bit expects two operands' });
   });
 });

--- a/test/pr146_known_head_no_unsupported.test.ts
+++ b/test/pr146_known_head_no_unsupported.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,15 +13,20 @@ describe('PR146: known-head diagnostics avoid unsupported fallback', () => {
   it('uses specific diagnostics for malformed known instruction heads', async () => {
     const entry = join(__dirname, 'fixtures', 'pr146_known_head_no_unsupported.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const messages = res.diagnostics.map((d) => d.message);
 
-    expect(messages).toContain('ld IXH, source expects (ix+disp)');
-    expect(messages).toContain(
-      `ex supports "AF, AF'", "DE, HL", "(SP), HL", "(SP), IX", and "(SP), IY" only`,
-    );
-    expect(messages).toContain('jp indirect form supports (hl), (ix), or (iy) only');
-    expect(messages).toContain('in (c) is the only one-operand in form');
-    expect(messages).toContain('out expects two operands');
-    expect(messages.some((m) => m.startsWith('Unsupported instruction:'))).toBe(false);
+    expectDiagnostic(res.diagnostics, { message: 'ld IXH, source expects (ix+disp)' });
+    expectDiagnostic(res.diagnostics, {
+      message: `ex supports "AF, AF'", "DE, HL", "(SP), HL", "(SP), IX", and "(SP), IY" only`,
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'jp indirect form supports (hl), (ix), or (iy) only',
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'in (c) is the only one-operand in form',
+    });
+    expectDiagnostic(res.diagnostics, { message: 'out expects two operands' });
+    expectNoDiagnostic(res.diagnostics, {
+      messageIncludes: 'Unsupported instruction:',
+    });
   });
 });

--- a/test/pr268_op_diagnostics_matrix.test.ts
+++ b/test/pr268_op_diagnostics_matrix.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 import { compile } from '../src/compile.js';
 import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,96 +14,123 @@ describe('PR268: op diagnostics matrix', () => {
   it('reports no-match diagnostics with operand summary and overload list', async () => {
     const entry = join(__dirname, 'fixtures', 'pr268_op_no_match_diagnostics.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const ids = res.diagnostics.map((d) => d.id);
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(ids).toContain(DiagnosticIds.OpNoMatchingOverload);
-    expect(messages.some((m) => m.includes('No matching op overload for "add16"'))).toBe(true);
-    expect(messages.some((m) => m.includes('call-site operands: (IX, DE)'))).toBe(true);
-    expect(messages.some((m) => m.includes('available overloads:'))).toBe(true);
-    expect(messages.some((m) => m.includes('dst: expects HL, got IX'))).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpNoMatchingOverload,
+      messageIncludes: 'No matching op overload for "add16"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpNoMatchingOverload,
+      messageIncludes: 'call-site operands: (IX, DE)',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpNoMatchingOverload,
+      messageIncludes: 'available overloads:',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpNoMatchingOverload,
+      messageIncludes: 'dst: expects HL, got IX',
+    });
   });
 
   it('reports arity mismatch diagnostics with available signatures', async () => {
     const entry = join(__dirname, 'fixtures', 'pr268_op_arity_mismatch_diagnostics.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const ids = res.diagnostics.map((d) => d.id);
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(ids).toContain(DiagnosticIds.OpArityMismatch);
-    expect(
-      messages.some((m) => m.includes('No op overload of "add16" accepts 3 operand(s).')),
-    ).toBe(true);
-    expect(messages.some((m) => m.includes('available overloads:'))).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpArityMismatch,
+      messageIncludes: 'No op overload of "add16" accepts 3 operand(s).',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpArityMismatch,
+      messageIncludes: 'available overloads:',
+    });
   });
 
   it('reports ambiguous candidate signatures for incomparable matches', async () => {
     const entry = join(__dirname, 'fixtures', 'pr267_op_ambiguous_incomparable.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const ids = res.diagnostics.map((d) => d.id);
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(ids).toContain(DiagnosticIds.OpAmbiguousOverload);
-    expect(messages.some((m) => m.includes('Ambiguous op overload for "choose"'))).toBe(true);
-    expect(messages.some((m) => m.includes('equally specific candidates:'))).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpAmbiguousOverload,
+      messageIncludes: 'Ambiguous op overload for "choose"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpAmbiguousOverload,
+      messageIncludes: 'equally specific candidates:',
+    });
   });
 
   it('reports cyclic op expansion chain context', async () => {
     const entry = join(__dirname, 'fixtures', 'pr16_op_cycle.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const ids = res.diagnostics.map((d) => d.id);
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(ids).toContain(DiagnosticIds.OpExpansionCycle);
-    expect(messages.some((m) => m.includes('Cyclic op expansion detected for "first".'))).toBe(
-      true,
-    );
-    expect(messages.some((m) => m.includes('expansion chain: first'))).toBe(true);
-    expect(messages.some((m) => m.includes('-> second'))).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpExpansionCycle,
+      messageIncludes: 'Cyclic op expansion detected for "first".',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpExpansionCycle,
+      messageIncludes: 'expansion chain: first',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpExpansionCycle,
+      messageIncludes: '-> second',
+    });
   });
 
   it('reports invalid op expansion diagnostics with expanded instruction context', async () => {
     const entry = join(__dirname, 'fixtures', 'pr270_op_invalid_expansion_diagnostics.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const ids = res.diagnostics.map((d) => d.id);
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(ids).toContain(DiagnosticIds.OpInvalidExpansion);
-    expect(messages.some((m) => m.includes('Invalid op expansion in "clobber_a_with"'))).toBe(true);
-    expect(messages.some((m) => m.includes('expanded instruction: ld A, SP'))).toBe(true);
-    expect(messages.some((m) => m.includes('op definition:'))).toBe(true);
-    expect(messages.some((m) => m.includes('expansion chain: clobber_a_with'))).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpInvalidExpansion,
+      messageIncludes: 'Invalid op expansion in "clobber_a_with"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpInvalidExpansion,
+      messageIncludes: 'expanded instruction: ld A, SP',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpInvalidExpansion,
+      messageIncludes: 'op definition:',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpInvalidExpansion,
+      messageIncludes: 'expansion chain: clobber_a_with',
+    });
   });
 
   it('reports nested invalid expansion diagnostics with full expansion chain', async () => {
     const entry = join(__dirname, 'fixtures', 'pr270_op_invalid_expansion_nested_chain.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const ids = res.diagnostics.map((d) => d.id);
-    const messages = res.diagnostics.map((d) => d.message);
-
-    expect(ids).toContain(DiagnosticIds.OpInvalidExpansion);
-    expect(messages.some((m) => m.includes('Invalid op expansion in "bad_inner"'))).toBe(true);
-    expect(messages.some((m) => m.includes('expansion chain: mid'))).toBe(true);
-    expect(messages.some((m) => m.includes('-> bad_inner'))).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpInvalidExpansion,
+      messageIncludes: 'Invalid op expansion in "bad_inner"',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpInvalidExpansion,
+      messageIncludes: 'expansion chain: mid',
+    });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.OpInvalidExpansion,
+      messageIncludes: '-> bad_inner',
+    });
   });
 
   it('reports one invalid-expansion diagnostic per failing expanded instruction', async () => {
     const entry = join(__dirname, 'fixtures', 'pr270_op_invalid_expansion_multi_failure.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     const invalids = res.diagnostics.filter((d) => d.id === DiagnosticIds.OpInvalidExpansion);
-    const messages = invalids.map((d) => d.message);
 
     expect(invalids).toHaveLength(2);
-    expect(messages.some((m) => m.includes('expanded instruction: ld A, SP'))).toBe(true);
-    expect(messages.some((m) => m.includes('expanded instruction: ld C, SP'))).toBe(true);
+    expectDiagnostic(invalids, {
+      messageIncludes: 'expanded instruction: ld A, SP',
+    });
+    expectDiagnostic(invalids, {
+      messageIncludes: 'expanded instruction: ld C, SP',
+    });
   });
 
   it('does not emit invalid-expansion diagnostics for non-op instruction failures', async () => {
     const entry = join(__dirname, 'fixtures', 'pr270_nonop_invalid_instruction_baseline.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const ids = res.diagnostics.map((d) => d.id);
-
-    expect(ids).not.toContain(DiagnosticIds.OpInvalidExpansion);
-    expect(ids).toContain(DiagnosticIds.EncodeError);
+    expectNoDiagnostic(res.diagnostics, { id: DiagnosticIds.OpInvalidExpansion });
+    expectDiagnostic(res.diagnostics, { id: DiagnosticIds.EncodeError });
   });
 });


### PR DESCRIPTION
Continues #1132.

Focused batch:
- op overload diagnostics
- known-head diagnostics
- indexed bit diagnostics

This replaces weak diagnostic assertions with helper-backed expectations without changing compiler code.