### PR TITLE
docs(ch7): replace negation opener with positive concrete statement

### DIFF
--- a/learning/part1/07-stack-and-subroutines.md
+++ b/learning/part1/07-stack-and-subroutines.md
@@ -157,8 +157,9 @@ describes exactly what happens.
 `pop hl` is the inverse: virtually `ld hl, (sp)` happens first — two bytes are
 read from SP into HL — then SP is incremented by two.
 
-The operand can be any of AF, BC, DE, HL, IX, or IY. The stack does not know
-whose value it is holding. All register pairs are saved to the same area of
+The operand can be any of AF, BC, DE, HL, IX, or IY. Every push writes two
+bytes to RAM at SP; every pop reads them back. The stack tracks only position —
+not what the bytes mean or where they came from. All register pairs are saved to the same area of
 memory — the bytes at and below SP. The stack is the same RAM where your
 program and variables reside.
 


### PR DESCRIPTION
Fixes #1233.

## Change

One-sentence replacement in the push/pop paragraph of Ch7.

**Before:** `The stack does not know whose value it is holding.`

**After:** `Every push writes two bytes to RAM at SP; every pop reads them back. The stack tracks only position — not what the bytes mean or where they came from.`

The replacement opens on a concrete positive action (writes/reads) before naming the abstraction (tracks position). The negation is retained as a subordinate clause, not an opener. The surrounding sentences are untouched.

## Diff size

2 lines changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)