### PR TITLE
test: strengthen severity diagnostic assertions

### DIFF
--- a/test/pr221_lowering_op_expansion_retcc_interactions.test.ts
+++ b/test/pr221_lowering_op_expansion_retcc_interactions.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,24 +13,32 @@ describe('PR221 lowering: op-expansion and ret cc interaction invariants', () =>
   it('diagnoses exact unknown-stack ret cc + fallthrough contract after inline op expansion', async () => {
     const entry = join(__dirname, 'fixtures', 'pr221_lowering_op_unknown_retcc_fallthrough.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.length).toBeGreaterThanOrEqual(0);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+    });
   });
 
   it('diagnoses exact if/else join unknown-state contract with ret cc after op expansion', async () => {
     const entry = join(__dirname, 'fixtures', 'pr221_lowering_op_unknown_if_else_retcc.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+    });
   });
 
   it('diagnoses exact while back-edge unknown-state contract with ret cc after op expansion', async () => {
     const entry = join(__dirname, 'fixtures', 'pr221_lowering_op_unknown_while_retcc.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.some((d) => d.severity === 'error')).toBe(true);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+    });
   });
 
   it('diagnoses both return sites in multi-return functions after untrackable op expansion', async () => {
     const entry = join(__dirname, 'fixtures', 'pr221_lowering_op_unknown_multi_return.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics.length).toBeGreaterThanOrEqual(0);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'error',
+    });
   });
 });

--- a/test/pr263_case_style_lint.test.ts
+++ b/test/pr263_case_style_lint.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import type { BinArtifact } from '../src/formats/types.js';
+import { expectDiagnostic, expectNoDiagnostic, expectNoErrors, expectNoDiagnostics } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -14,7 +15,7 @@ describe('PR263: case-style linting', () => {
     const entry = join(__dirname, 'fixtures', 'pr263_case_style_lint.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    expect(res.diagnostics).toEqual([]);
+    expectNoDiagnostics(res.diagnostics);
     const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
     expect(bin).toBeDefined();
   });
@@ -23,39 +24,59 @@ describe('PR263: case-style linting', () => {
     const entry = join(__dirname, 'fixtures', 'pr263_case_style_lint.zax');
     const res = await compile(entry, { caseStyle: 'upper' }, { formats: defaultFormatWriters });
 
-    const errors = res.diagnostics.filter((d) => d.severity === 'error');
     const warnings = res.diagnostics.filter((d) => d.severity === 'warning');
 
-    expect(errors).toEqual([]);
+    expectNoErrors(res.diagnostics);
     expect(warnings).toHaveLength(5);
-    expect(warnings.map((d) => d.message)).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining('mnemonic "ld" should be uppercase'),
-        expect.stringContaining('register "a" should be uppercase'),
-        expect.stringContaining('keyword "If" should be uppercase'),
-        expect.stringContaining('mnemonic "nop" should be uppercase'),
-        expect.stringContaining('keyword "End" should be uppercase'),
-      ]),
-    );
+    expectDiagnostic(res.diagnostics, {
+      severity: 'warning',
+      messageIncludes: 'mnemonic "ld" should be uppercase',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'warning',
+      messageIncludes: 'register "a" should be uppercase',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'warning',
+      messageIncludes: 'keyword "If" should be uppercase',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'warning',
+      messageIncludes: 'mnemonic "nop" should be uppercase',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'warning',
+      messageIncludes: 'keyword "End" should be uppercase',
+    });
   });
 
   it('ignores label prefixes and hex immediates when linting registers/mnemonics', async () => {
     const entry = join(__dirname, 'fixtures', 'pr264_case_style_label_hex_literal.zax');
     const res = await compile(entry, { caseStyle: 'upper' }, { formats: defaultFormatWriters });
 
-    const errors = res.diagnostics.filter((d) => d.severity === 'error');
     const warnings = res.diagnostics.filter((d) => d.severity === 'warning');
-    const messages = warnings.map((d) => d.message);
 
-    expect(errors).toEqual([]);
-    expect(messages).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining('mnemonic "ld" should be uppercase'),
-        expect.stringContaining('register "a" should be uppercase'),
-        expect.stringContaining('mnemonic "ret" should be uppercase'),
-      ]),
-    );
-    expect(messages.join('\n')).not.toContain('mnemonic "loop:" should be uppercase');
-    expect(messages.join('\n')).not.toContain('register "af" should be uppercase');
+    expectNoErrors(res.diagnostics);
+    expect(warnings).toHaveLength(3);
+    expectDiagnostic(res.diagnostics, {
+      severity: 'warning',
+      messageIncludes: 'mnemonic "ld" should be uppercase',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'warning',
+      messageIncludes: 'register "a" should be uppercase',
+    });
+    expectDiagnostic(res.diagnostics, {
+      severity: 'warning',
+      messageIncludes: 'mnemonic "ret" should be uppercase',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      severity: 'warning',
+      messageIncludes: 'mnemonic "loop:" should be uppercase',
+    });
+    expectNoDiagnostic(res.diagnostics, {
+      severity: 'warning',
+      messageIncludes: 'register "af" should be uppercase',
+    });
   });
 });


### PR DESCRIPTION
Part of #1132

## Summary
- replace remaining severity-oriented weak diagnostic assertions with helper-based checks
- strengthen frontend case-style warning checks and lowering ret-cc invariant checks
- keep compiler behavior unchanged and limit the change to tests only