### PR TITLE
docs(ch3,ch6): relocate EX DE,HL to ch6 where use case exists

### DIFF
--- a/learning/part1/03-assembly-language.md
+++ b/learning/part1/03-assembly-language.md
@@ -316,42 +316,6 @@ The parentheses mean the same thing everywhere:
 
 ---
 
-## EX DE, HL
-
-`EX DE, HL` swaps DE and HL in a single instruction. Afterward, DE holds what HL had and HL holds what DE had.
-
-Copying HL into DE without caring about DE's old value takes two instructions:
-
-```zax
-ld d, h
-ld e, l        ; DE = old HL; HL unchanged
-```
-
-But if you need a genuine exchange — each pair receiving the other's value — you would need six instructions and a scratch register:
-
-```zax
-ld a, h
-ld h, d
-ld d, a        ; D = old H
-ld a, l
-ld l, e
-ld e, a        ; E = old L — swap complete, A clobbered
-```
-
-`EX DE, HL` replaces all six with one instruction and leaves A untouched:
-
-```zax
-ld hl, $1234
-ld de, $5678
-ex de, hl      ; HL = $5678, DE = $1234
-```
-
-You will reach for it whenever you need to hand an address between these two pairs — after building a result in HL and needing it in DE for the next step, for instance.
-
-Two other exchange instructions exist: `EX AF, AF'` swaps AF with its shadow counterpart, and `EXX` swaps BC, DE, and HL all at once with their shadow counterparts. Both rely on the shadow registers, which are covered in Chapter 7. For now, `EX DE, HL` is the one you will use.
-
----
-
 ## ADD, INC, and DEC
 
 `ADD A, B` adds B to A and **writes the result back into A**. The original
@@ -438,7 +402,7 @@ declaring it as `word` instead of `byte` does.
 - Two memory locations cannot appear in a single `LD`; you must go through a register
 - Unsigned bytes hold 0–255; signed bytes use two's complement (bit 7 = sign, range −128 to +127)
 - `const` names a fixed value substituted at assembly time; it produces no output bytes
-- `EX DE, HL` swaps the two register pairs in one instruction
+- `EX DE, HL` swaps the two register pairs in one instruction — introduced in Chapter 6 when both HL and DE are in use as pointers
 - `ADD A, B` writes the result back into A, destroying its previous value; copy A to another register first if you need it later
 - `INC r` and `DEC r` add or subtract 1 in place and update the flags; `DEC` sets the Zero flag at zero, making it useful as a loop counter
 

--- a/learning/part1/06-data-tables-and-indexed-access.md
+++ b/learning/part1/06-data-tables-and-indexed-access.md
@@ -298,6 +298,16 @@ the same scan in the decrementing direction.
 `ldir`, `lddr`, `cpir`, and `cpdr` are raw Z80 mnemonics used directly in ZAX,
 exactly like `djnz` — the assembler emits them as-is.
 
+When both HL and DE are live pointers — as they are during any `ldir` sequence — you sometimes need to exchange them. After a copy, the destination you wrote may become the source for the next pass, or you need to hand that address to a routine that expects it in HL. Without a swap instruction, exchanging the two pairs takes six instructions and clobbers A. `EX DE, HL` does it in one: afterward, DE holds what HL had and HL holds what DE had, and nothing else changes.
+
+```zax
+ld hl, source
+ld de, dest
+ld bc, 64
+ldir              ; copy 64 bytes; HL and DE now point past the copied region
+ex de, hl         ; HL now points past dest; DE points past source
+```
+
 ---
 
 ## Summary


### PR DESCRIPTION
Fixes #1203.

## Changes

**Ch3 — remove**
- Deleted the `## EX DE, HL` section (header, four paragraphs, three code blocks, leading `---` separator).
- Updated the summary bullet: now reads "introduced in Chapter 6 when both HL and DE are in use as pointers" so the concept is still signposted.
- `EX DE` now appears exactly once in Ch3.

**Ch6 — add**
- New paragraph immediately after "the assembler emits them as-is." Names the situation (both HL and DE live after `ldir`), states the cost without EX (six instructions, A clobbered), then introduces `EX DE, HL` as the one-instruction solution.
- Code example uses `ldir` as the motivating context — not a contrived standalone exchange.

## Why this order

In Ch3 the reader has no reason to need EX DE,HL — they have not yet seen `ldir` or any scenario where both registers hold live pointers simultaneously. In Ch6 after the `ldir` explanation, the need is immediate and concrete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)