### PR TITLE
docs(ch4): name unsigned failure mode of cp $80 technique — closes #1220

### DIFF
--- a/learning/part1/04-flags-comparisons-jumps.md
+++ b/learning/part1/04-flags-comparisons-jumps.md
@@ -304,7 +304,9 @@ flips the sign, leaving A with the absolute value.
 This pattern works because signed and unsigned representations share the same
 bits — the only difference is how you interpret bit 7. Comparing against `$80`
 is the dividing line between the two halves: 0–127 (non-negative) and 128–255
-(negative when read as signed).
+(negative when read as signed). If A holds an unsigned value, this test gives
+the wrong answer — 128 through 255 are valid positive results in unsigned
+arithmetic, and `cp $80` will treat them all as negative.
 
 `neg` applied to −128 gives −128 — the mathematical result (+128) does not fit
 in a signed byte, so the bit pattern (`$80`) is unchanged.


### PR DESCRIPTION
## Summary

One sentence appended to the closing paragraph of the "Detecting a negative number: the `cp $80` technique" section.

The section explained the dual interpretation of bit 7 but never stated the consequence of applying the technique to an unsigned byte. Added:

> If A holds an unsigned value, this test gives the wrong answer — 128 through 255 are valid positive results in unsigned arithmetic, and `cp $80` will treat them all as negative.

The sentence flows directly from "the only difference is how you interpret bit 7" and gives the reader a specific failure mode to point to if they misapply the technique.

Nothing else in the section or chapter changed.

## Test plan

- [ ] Reader who applies `cp $80` to an unsigned byte can point to a sentence naming the wrong result
- [ ] Pass 3: no dead openers, minimisers, hedges, or blacklist words in the new sentence

Closes #1220

🤖 Generated with [Claude Code](https://claude.com/claude-code)