### PR TITLE
docs(ch10): explain why byte parameters occupy a 16-bit stack slot — closes #1206

### DIFF
--- a/learning/part1/10-functions-and-the-ix-frame.md
+++ b/learning/part1/10-functions-and-the-ix-frame.md
@@ -98,7 +98,7 @@ The comment block is gone — the parameter names `tbl` and `len` say what the f
 
 `tbl: addr` is a 16-bit address parameter — it occupies a two-byte frame slot. To load it into HL you need two byte-wide loads: `(ix+tbl+0)` for the low byte into L, `(ix+tbl+1)` for the high byte into H.
 
-`len: byte` is a one-byte parameter. It still occupies a 16-bit slot on the stack (everything is pushed as a word), but only the low byte matters: `(ix+len+0)` is all you need.
+`len: byte` is a one-byte parameter, but it still occupies a 16-bit slot on the stack. The Z80's `push` instruction always writes a full register pair — there is no single-byte push — so every argument takes two bytes of stack space regardless of its declared type. Only the low byte carries the value: `(ix+len+0)` is all you need.
 
 `running_max: byte = 0` is a local variable initialized to zero. It sits at a negative offset from IX. You read it with `ld a, (ix+running_max+0)` and write it with `ld (ix+running_max+0), a`.
 


### PR DESCRIPTION
## Summary

One sentence replaced with two. The parenthetical `"(everything is pushed as a word)"` stated the rule without explaining it.

**Before:**
> `` `len: byte` is a one-byte parameter. It still occupies a 16-bit slot on the stack (everything is pushed as a word), but only the low byte matters: `(ix+len+0)` is all you need. ``

**After:**
> `` `len: byte` is a one-byte parameter, but it still occupies a 16-bit slot on the stack. The Z80's `push` instruction always writes a full register pair — there is no single-byte push — so every argument takes two bytes of stack space regardless of its declared type. Only the low byte carries the value: `(ix+len+0)` is all you need. ``

Three requirements in order: name the constraint (`push` always writes 16 bits), name the consequence (byte parameter occupies a word-sized slot), name what the reader does about it (`+0` to access the low byte).

Nothing else in the file changed.

## Test plan

- [ ] Reader asking "why does a byte parameter take two bytes of stack space?" finds the answer in the paragraph
- [ ] Pass 3: no dead openers, minimisers, hedges, or blacklist words in new sentences
- [ ] `tbl: addr` sentence before and `running_max` sentence after untouched

Closes #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)