### PR TITLE
docs(ch8,ch9,ch11,ch13): batch fixes #1209, #1199, #1218

### DIFF
--- a/learning/part1/08-io-and-ports.md
+++ b/learning/part1/08-io-and-ports.md
@@ -106,14 +106,14 @@ func read_when_ready(): AF
 wait:
   in a, (C)         ; read status into A, flags set
   and $01           ; test bit 0 (ready flag)
-  jr Z, wait        ; Z set means bit 0 was 0 — not ready yet; loop
+  jr z, wait        ; Z set means bit 0 was 0 — not ready yet; loop
   in a, (DATA_PORT) ; bit 0 is 1 — device is ready; read data into A
   ; A holds the received byte; return it
 end
 ```
 
 `and $01` masks all bits except bit 0 and sets Z if the result is zero.
-`jr Z, wait` loops back while Z is set (bit 0 still clear). When bit 0
+`jr z, wait` loops back while Z is set (bit 0 still clear). When bit 0
 becomes 1, the loop exits and the data read follows.
 
 `in a, (DATA_PORT)` uses the immediate form because the port number is a
@@ -181,7 +181,7 @@ func poll_and_recv(): AF
 poll_loop:
   in a, (C)            ; read status; flags set by in r,(C)
   and $01              ; test bit 0
-  jr Z, poll_loop      ; Z set: not ready; keep polling
+  jr z, poll_loop      ; Z set: not ready; keep polling
   in a, (IN_PORT)      ; ready: read data into A
 end
 

--- a/learning/part1/09-a-phase-a-program.md
+++ b/learning/part1/09-a-phase-a-program.md
@@ -118,6 +118,8 @@ modified by the time the function returns.
 
 ## `count_above`: the cost of manual register discipline
 
+`count_above` works, but it contains a push/pop pair that does no useful work — the explanation is below the code.
+
 ```zax
 func count_above(): AF
   push bc

--- a/learning/part1/11-structured-control-flow.md
+++ b/learning/part1/11-structured-control-flow.md
@@ -212,7 +212,7 @@ of `case` constants, and runs the matching body. If no case matches and an
 `else` arm is present, the `else` body runs. After any arm finishes, control
 transfers to after the enclosing `end`. There is no fallthrough between cases.
 
-The same logic written in raw Z80, using `cp` + `jp Z`:
+The same logic written in raw Z80, using `cp` + `jp z`:
 
 ```zax
 ; raw: test A against three operator characters

--- a/learning/part1/13-op-macros-and-pseudo-opcodes.md
+++ b/learning/part1/13-op-macros-and-pseudo-opcodes.md
@@ -112,14 +112,9 @@ You have completed Volume 1.
 
 By this point you can:
 
-- explain bytes, words, addresses, the Z80 registers, and the hardware stack
-- write raw Z80 instructions: `ld`, `add`, `sub`, `cp`, `and`, `or`, `jp`, `jr`, `djnz`, `call`, `ret`, `push`, `pop`
-- use `section data` to declare named module storage
-- write a ZAX `func` with typed parameters and locals, accessed through raw IX-relative offsets
-- use `if`/`else` and `while` loops with `break` and `continue`
-- use `:=` for typed assignment and `step` for typed scalar mutation
-- write an `op` for inline named instruction sequences
-- use IXH/IXL/IYH/IYL and the ZAX pseudo-opcodes for 16-bit register moves
+- write a complete function that scans a table of bytes, makes comparisons, and returns a result — with typed parameters, a counting loop, and a frame-managed local for the running total
+- write a hardware polling routine that reads a status port, waits on a specific bit, and acts when the device signals ready
+- structure a multi-function program with named data sections, typed storage, and control flow that reads like the algorithm it implements
 
 **Volume 2: `learning/part2/`**
 


### PR DESCRIPTION
Closes #1209. Closes #1199. Closes #1218.

## #1209 — Condition code casing (ch8, ch11)

Four occurrences of `Z` capitalised in condition codes, inconsistent with the rest of the course:

- `08-io-and-ports.md`: `jr Z, wait` → `jr z, wait` (code block + prose inline, ×2); `jr Z, poll_loop` → `jr z, poll_loop`
- `11-structured-control-flow.md`: `jp Z` → `jp z` (prose sentence)

Remaining uppercase hits in `grep -r` output are in `.zax` example source files under `examples/` — not markdown prose, out of scope.

## #1199 — Dead push/pop framed before the code (ch9)

One sentence added immediately before the `count_above` code block:

> `count_above` works, but it contains a push/pop pair that does no useful work — the explanation is below the code.

The existing "Actually…" explanation after the block is unchanged.

## #1218 — Ch13 capability list describes programs, not features

Replaced eight syntax-inventory bullets with three program-capability statements. Each names something the reader can build, not a language feature they have learned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)