### PR TITLE
docs(ch11,ch13): fix byte count ambiguity, delete dead ref, add op/func failure cases — closes #1198 #1205 #1224

### DIFF
--- a/learning/part1/11-structured-control-flow.md
+++ b/learning/part1/11-structured-control-flow.md
@@ -260,11 +260,6 @@ dispatch sequence may modify A and flags, so do not rely on A still holding
 the selector value inside a case body. When the selector is any other register,
 that register is preserved across dispatch.
 
-For a real-world example of `select` in a larger program, see
-`learning/part2/examples/unit7/rpn_calculator.zax`. That file (Volume 2 material)
-dispatches on token kind constants using `select A` with three `case` arms,
-one for each operator type. The structure of the dispatch is directly readable
-from the case labels.
 
 ---
 

--- a/learning/part1/13-op-macros-and-pseudo-opcodes.md
+++ b/learning/part1/13-op-macros-and-pseudo-opcodes.md
@@ -60,6 +60,10 @@ Use `func` when:
 - the function is called from many places and you want the compiler to enforce the calling convention
 - a consistent register-preservation boundary at the call site matters
 
+An `op` is pasted at every call site. If your `op` body is ten instructions long and you invoke it eight times, the binary contains eighty instructions — the same ten copied eight times. For a two- or three-instruction op this is correct and desirable; for something longer it is expensive. If you find yourself writing an `op` with more than five instructions, consider whether a `func` call would cost less in binary size than the repeated inlining.
+
+A ZAX `func` with a frame emits six overhead instructions — the prologue and epilogue — before and after the body. If the body itself is two or three instructions, the overhead is two to three times the cost of the work being done. For a short accumulator operation you will call in a tight loop, that overhead compounds. Use `op` when the body is shorter than the frame overhead; use `func` when the body is long enough that the overhead is negligible.
+
 `op` bodies have no preservation boundary of their own. Registers clobbered by an `op` body are clobbered in the caller's instruction stream, exactly as if you had written those instructions there yourself. A `func` call preserves all registers not in the return clause — the compiler generates the save/restore sequence.
 
 ---
@@ -93,7 +97,7 @@ The full set of synthetic 16-bit register transfers:
 | `ld bc, hl` | `ld b, h` / `ld c, l` |
 | `ld bc, de` | `ld b, d` / `ld c, e` |
 
-Each expands to exactly two bytes of machine code. The cost is the same as writing the pair by hand — ZAX adds nothing at run time.
+Each expands to two one-byte instructions — the same two `ld` moves you would write by hand. ZAX adds nothing at run time.
 
 ---
 


### PR DESCRIPTION
## Summary

Three targeted changes across two files.

**#1198 — Ch13 pseudo-opcode table caption** (`13-op-macros-and-pseudo-opcodes.md`):
`"Each expands to exactly two bytes of machine code"` was ambiguous — a reader who just learned that some Z80 instructions are two bytes would read this as a single two-byte instruction. Replaced with: `"Each expands to two one-byte instructions — the same two ld moves you would write by hand."`

**#1205 — Ch11 rpn_calculator forward reference** (`11-structured-control-flow.md`):
Deleted the four-line paragraph referencing `learning/part2/examples/unit7/rpn_calculator.zax`. The file is Volume 2 material; a Part 1 reader cannot open it and the reference adds nothing. `grep -r "rpn_calculator" learning/part1/` now returns nothing.

**#1224 — Ch13 op vs func decision** (`13-op-macros-and-pseudo-opcodes.md`):
Added two paragraphs between the bullet lists and the preservation-boundary paragraph:
- Over-inlining failure: op body × call sites = binary size; >5 instructions is the signal to switch to func
- Over-framing failure: 6-instruction frame overhead vs 2–3 instruction body; overhead compounds in tight loops

Both paragraphs use specific numbers. Bullet lists untouched.

## Test plan

- [ ] `grep "two bytes of machine code" learning/part1/13-op-macros-and-pseudo-opcodes.md` — no results
- [ ] `grep -r "rpn_calculator" learning/part1/` — no results
- [ ] Op/func section: reader can identify the cost of choosing wrong in both directions with a concrete number
- [ ] Pass 3: no dead openers, minimisers, hedges, or blacklist words in new sentences

Closes #1198, closes #1205, closes #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)