### PR TITLE
docs(ch3,ch9,ch11): batch fixes #1212, #1216, #1222

### DIFF
--- a/learning/part1/03-assembly-language.md
+++ b/learning/part1/03-assembly-language.md
@@ -151,18 +151,7 @@ Any of A, B, C, D, E, H, L can appear on either side when the other side is
 `ld (de), a`. The standard pattern is: load an address into
 HL, read or write with `(HL)`, increment HL, repeat.
 
-### Indexed memory access through IX and IY
-
-IX and IY support **displaced** addressing. Point IX at the start of a data record and `(IX+0)`, `(IX+1)`, `(IX+2)` address each field directly — no reloading the base address between accesses. That makes IX the natural choice for working with fixed-size records.
-
-`(IX+n)` means "the byte at address IX + n", where n is a signed offset from −128 to +127.
-
-```zax
-ld a, (ix+0)    ; A = byte at address IX
-ld b, (ix+7)    ; B = byte at address IX+7
-ld (iy-2), a    ; byte at address IY-2 = A
-ld (ix+1), $3F  ; byte at address IX+1 = $3F
-```
+IX and IY support displaced addressing — covered in Chapter 6 when the use case makes it concrete.
 
 ### Memory access through BC or DE
 
@@ -221,8 +210,6 @@ complete searchable list.
 | reg8 ← (HL) | `ld c, (hl)` | Read byte at address HL |
 | (HL) ← reg8 | `ld (hl), d` | Write byte to address HL |
 | (HL) ← n | `ld (hl), 0` | Write immediate to address HL |
-| reg8 ← (IX+n) | `ld a, (ix+3)` | Read byte at IX + offset (n: −128 to +127) |
-| (IX+n) ← reg8 | `ld (ix+3), a` | Write byte to IX + offset |
 | A ← (BC) | `ld a, (bc)` | Read byte at address BC; A only |
 | (DE) ← A | `ld (de), a` | Write A to address DE; A only |
 | A ← (nn) | `ld a, ($8000)` | Read byte from fixed address |

--- a/learning/part1/09-a-phase-a-program.md
+++ b/learning/part1/09-a-phase-a-program.md
@@ -2,11 +2,13 @@
 
 # Chapter 9 — A Complete Program
 
-This chapter builds a complete program using everything from Chapters 3–7:
+This chapter builds a complete program using the techniques from Chapters 3–7:
 a data table, a DJNZ loop, subroutines called from the loop, conditional
-branches, and push/pop register preservation. The two subroutines that result
-expose every friction point in raw Z80 programming — the exact problems
-Chapters 10–13 address.
+branches, and push/pop register preservation. Chapter 8 covered I/O and ports —
+a separate hardware concern. This capstone focuses on data operations in memory,
+which is where the friction points in raw Z80 programming are most visible.
+The two subroutines that result expose exactly those friction points — the
+problems Chapters 10–13 address.
 
 ---
 

--- a/learning/part1/11-structured-control-flow.md
+++ b/learning/part1/11-structured-control-flow.md
@@ -427,6 +427,16 @@ jump. In the structured version, each is expressed by the keyword that carries i
 
 ---
 
+## When to use `if`/`while`/`select` vs raw labels
+
+Use structured control flow when the branch or loop has a single entry and a single exit. `if`/`else`/`end` and `while`/`end` each map to exactly that shape — one way in, one way out. The compiler manages the labels; you name only the condition.
+
+Use raw labels and jumps when the control flow does not fit that shape: multiple exit points mid-loop, a branch that jumps into the middle of another block, or an interrupt handler that must jump to a specific address. Some Z80 programs genuinely need them. `jr`, `jp`, and `djnz` are always available alongside the structured keywords.
+
+Both are always available. Use whichever matches the shape of the logic.
+
+---
+
 ## Summary
 
 - `if <cc> ... end` tests the current flags at `if`. If the condition is true,


### PR DESCRIPTION
Closes #1212. Closes #1216. Closes #1222.

## #1212 — Ch3: remove IX/IY displaced-addressing subsection

Removed the `### Indexed memory access through IX and IY` subsection (header, three paragraphs, one code block) and the two corresponding reference table rows (`reg8 ← (IX+n)` and `(IX+n) ← reg8`). Replaced the subsection with one inline sentence forwarding the reader to Ch6 where the use case is concrete.

## #1216 — Ch9: bridge Ch8 I/O in intro

The intro previously said "everything from Chapters 3–7", skipping Ch8. Replaced with a version that acknowledges Ch8 as a separate hardware concern and names why this capstone focuses on memory data operations — where the friction in raw Z80 programming is most visible.

## #1222 — Ch11: add "when to use" guidance section

Added `## When to use if/while/select vs raw labels` between the example section and Summary, following the same three-paragraph structure as Ch12's `## When to use := vs raw IX access`: use structured when (single-entry/single-exit), use raw when (multiple exits, interrupt handlers, non-fitting shapes), both always available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)