### PR TITLE
CI: tighten test layout guardrail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
             fi
             base_sha="$before_sha"
           fi
+          export TEST_GUARDRAIL_BASE_SHA="$base_sha"
+          export TEST_GUARDRAIL_HEAD_SHA="$head_sha"
           git diff --name-status "$base_sha" "$head_sha" | node ./scripts/ci/test-layout-guardrail.js
 
       - name: Classify change set

--- a/scripts/ci/test-layout-guardrail.js
+++ b/scripts/ci/test-layout-guardrail.js
@@ -1,6 +1,9 @@
 import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
 
 const TOP_LEVEL_PR_TEST = /^test\/pr\d+_.*\.test\.ts$/;
+const baseSha = process.env.TEST_GUARDRAIL_BASE_SHA;
+const headSha = process.env.TEST_GUARDRAIL_HEAD_SHA;
 
 function normalizePath(path) {
   return path.replaceAll('\\', '/');
@@ -33,7 +36,33 @@ for (const rawLine of input.split(/\r?\n/)) {
 }
 
 if (violations.length === 0) {
-  process.stdout.write('test layout guardrail: no new top-level PR tests\n');
+  let countWarning = '';
+  if (baseSha && headSha) {
+    try {
+      const baseList = execSync(`git ls-tree -r --name-only ${baseSha} -- test`, {
+        encoding: 'utf8',
+      });
+      const headList = execSync(`git ls-tree -r --name-only ${headSha} -- test`, {
+        encoding: 'utf8',
+      });
+      const baseCount = baseList
+        .split(/\r?\n/)
+        .filter((entry) => TOP_LEVEL_PR_TEST.test(normalizePath(entry))).length;
+      const headCount = headList
+        .split(/\r?\n/)
+        .filter((entry) => TOP_LEVEL_PR_TEST.test(normalizePath(entry))).length;
+      if (headCount > baseCount) {
+        process.stderr.write(
+          `test layout guardrail: root PR test count increased (${baseCount} -> ${headCount})\n`,
+        );
+        process.exit(1);
+      }
+      countWarning = ` (root count ${baseCount} -> ${headCount})`;
+    } catch (err) {
+      process.stderr.write(`test layout guardrail: count check skipped (${err})\n`);
+    }
+  }
+  process.stdout.write(`test layout guardrail: no new top-level PR tests${countWarning}\n`);
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary
- Extend test layout guardrail to enforce non-increasing root `test/pr*.test.ts` count
- Pass base/head SHAs into the guardrail for monotonic count checks

## Issue
- Closes #1161

## Files
- .github/workflows/ci.yml
- scripts/ci/test-layout-guardrail.js

## Commands
- npm ci
- npm run typecheck
- npm run lint
- TEST_GUARDRAIL_BASE_SHA=origin/main TEST_GUARDRAIL_HEAD_SHA=HEAD git diff --name-status origin/main HEAD | node ./scripts/ci/test-layout-guardrail.js
