### PR TITLE
test: strengthen ed zero-operand diagnostics

### DIFF
--- a/test/backend/pr129_isa_ed_zero_operand_diag.test.ts
+++ b/test/backend/pr129_isa_ed_zero_operand_diag.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../../src/compile.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectDiagnostic } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,14 +14,13 @@ describe('PR129: ED zero-operand diagnostics', () => {
     const entry = join(__dirname, '..', 'fixtures', 'pr129_isa_ed_zero_operand_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    const messages = res.diagnostics.map((d) => d.message);
-    expect(messages).toContain('reti expects no operands');
-    expect(messages).toContain('retn expects no operands');
-    expect(messages).toContain('ldi expects no operands');
-    expect(messages).toContain('ldir expects no operands');
-    expect(messages).toContain('cpi expects no operands');
-    expect(messages).toContain('cpdr expects no operands');
-    expect(messages).toContain('ini expects no operands');
-    expect(messages).toContain('otdr expects no operands');
+    expectDiagnostic(res.diagnostics, { message: 'reti expects no operands' });
+    expectDiagnostic(res.diagnostics, { message: 'retn expects no operands' });
+    expectDiagnostic(res.diagnostics, { message: 'ldi expects no operands' });
+    expectDiagnostic(res.diagnostics, { message: 'ldir expects no operands' });
+    expectDiagnostic(res.diagnostics, { message: 'cpi expects no operands' });
+    expectDiagnostic(res.diagnostics, { message: 'cpdr expects no operands' });
+    expectDiagnostic(res.diagnostics, { message: 'ini expects no operands' });
+    expectDiagnostic(res.diagnostics, { message: 'otdr expects no operands' });
   });
 });


### PR DESCRIPTION
Part of #1132

## Summary
- replace the remaining backend weak message-array assertion in the ED zero-operand diagnostics test
- use explicit diagnostic helper assertions only
- keep compiler behavior unchanged and limit the change to tests only