### PR TITLE
test: strengthen frontend helper diagnostics

### DIFF
--- a/test/frontend/pr476_parse_enum_helpers.test.ts
+++ b/test/frontend/pr476_parse_enum_helpers.test.ts
@@ -4,6 +4,7 @@ import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import { parseEnumDecl } from '../../src/frontend/parseEnum.js';
 import { makeSourceFile, span } from '../../src/frontend/source.js';
 import { parseProgram } from '../../src/frontend/parser.js';
+import { expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 describe('PR476 enum parser extraction', () => {
   const file = makeSourceFile('pr476_parse_enum_helpers.zax', '');
@@ -19,7 +20,7 @@ describe('PR476 enum parser extraction', () => {
 
   it('keeps enum helper parsing intact', () => {
     const node = parseEnumDecl('Colors Red, Green, Blue', ctx);
-    expect(ctx.diagnostics).toEqual([]);
+    expectNoDiagnostics(ctx.diagnostics);
     expect(node).toEqual({
       kind: 'EnumDecl',
       span: zeroSpan,
@@ -33,7 +34,7 @@ describe('PR476 enum parser extraction', () => {
     const diagnostics: Diagnostic[] = [];
     const program = parseProgram(file.path, 'enum Colors Red, Green, Blue\n', diagnostics);
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(program.files[0]?.items[0]).toMatchObject({
       kind: 'EnumDecl',
       name: 'Colors',

--- a/test/frontend/pr476_parse_extern_block_helpers.test.ts
+++ b/test/frontend/pr476_parse_extern_block_helpers.test.ts
@@ -5,6 +5,7 @@ import { parseTopLevelExternDecl } from '../../src/frontend/parseExternBlock.js'
 import { parseParamsFromText } from '../../src/frontend/parseParams.js';
 import { parseProgram } from '../../src/frontend/parser.js';
 import { makeSourceFile, span } from '../../src/frontend/source.js';
+import { expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 describe('PR476 extern block parser extraction', () => {
   it('keeps extern block parsing intact', () => {
@@ -50,7 +51,7 @@ describe('PR476 extern block parser extraction', () => {
       parseParamsFromText,
     });
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(parsed.nextIndex).toBe(3);
     expect(parsed.node).toMatchObject({
       kind: 'ExternDecl',
@@ -73,7 +74,7 @@ describe('PR476 extern block parser extraction', () => {
       diagnostics,
     );
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(program.files[0]?.items[0]).toMatchObject({
       kind: 'ExternDecl',
       base: 'Math',

--- a/test/frontend/pr476_parse_extern_helpers.test.ts
+++ b/test/frontend/pr476_parse_extern_helpers.test.ts
@@ -4,6 +4,7 @@ import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import { parseExternFuncFromTail } from '../../src/frontend/parseExtern.js';
 import { makeSourceFile, span } from '../../src/frontend/source.js';
 import { parseProgram } from '../../src/frontend/parser.js';
+import { expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 describe('PR476 extern parser extraction', () => {
   const file = makeSourceFile('pr476_parse_extern_helpers.zax', '');
@@ -25,7 +26,7 @@ describe('PR476 extern parser extraction', () => {
       ],
     });
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(parsed).toMatchObject({
       kind: 'ExternFunc',
       name: 'sink',
@@ -42,7 +43,7 @@ describe('PR476 extern parser extraction', () => {
       diagnostics,
     );
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(program.files[0]?.items[0]).toMatchObject({
       kind: 'ExternDecl',
       funcs: [{ kind: 'ExternFunc', name: 'sink', returnRegs: ['HL'] }],

--- a/test/frontend/pr476_parse_types_helpers.test.ts
+++ b/test/frontend/pr476_parse_types_helpers.test.ts
@@ -4,6 +4,7 @@ import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import { parseTypeDecl, parseUnionDecl } from '../../src/frontend/parseTypes.js';
 import { parseProgram } from '../../src/frontend/parser.js';
 import { makeSourceFile, span } from '../../src/frontend/source.js';
+import { expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 describe('PR476 type and union parser extraction', () => {
   it('keeps type helper parsing intact', () => {
@@ -41,7 +42,7 @@ describe('PR476 type and union parser extraction', () => {
       isReservedTopLevelName: () => false,
     });
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(parsed?.nextIndex).toBe(4);
     expect(parsed?.node).toMatchObject({
       kind: 'TypeDecl',
@@ -91,7 +92,7 @@ describe('PR476 type and union parser extraction', () => {
       isReservedTopLevelName: () => false,
     });
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(parsed?.nextIndex).toBe(4);
     expect(parsed?.node).toMatchObject({
       kind: 'UnionDecl',
@@ -111,7 +112,7 @@ describe('PR476 type and union parser extraction', () => {
       diagnostics,
     );
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(program.files[0]?.items[0]).toMatchObject({
       kind: 'TypeDecl',
       name: 'Pair',


### PR DESCRIPTION
Part of #1132

## Summary
- replace raw empty-diagnostics assertions in frontend parser helper tests with expectNoDiagnostics
- keep the batch focused on the PR476 helper extraction suite
- keep compiler behavior unchanged and limit the change to tests only