### PR TITLE
test: strengthen parser helper diagnostics

### DIFF
--- a/test/frontend/pr476_parse_func_helpers.test.ts
+++ b/test/frontend/pr476_parse_func_helpers.test.ts
@@ -5,6 +5,7 @@ import { parseTopLevelFuncDecl } from '../../src/frontend/parseFunc.js';
 import { parseParamsFromText } from '../../src/frontend/parseParams.js';
 import { parseProgram } from '../../src/frontend/parser.js';
 import { makeSourceFile, span } from '../../src/frontend/source.js';
+import { expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 describe('PR476 func parser extraction', () => {
   it('keeps top-level func parsing intact', () => {
@@ -61,7 +62,7 @@ describe('PR476 func parser extraction', () => {
       },
     );
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(parsed.nextIndex).toBe(7);
     expect(parsed.node).toMatchObject({
       kind: 'FuncDecl',
@@ -93,7 +94,7 @@ describe('PR476 func parser extraction', () => {
       diagnostics,
     );
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(program.files[0]?.items[0]).toMatchObject({
       kind: 'FuncDecl',
       name: 'add',

--- a/test/frontend/pr476_parse_imm_helpers.test.ts
+++ b/test/frontend/pr476_parse_imm_helpers.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../src/frontend/parseImm.js';
 import { makeSourceFile, span } from '../../src/frontend/source.js';
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 describe('PR476 immediate-expression parsing extraction', () => {
   const file = makeSourceFile('pr476_parse_imm_helpers.zax', '');
@@ -43,7 +44,7 @@ describe('PR476 immediate-expression parsing extraction', () => {
       diagnostics,
     );
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(expr).toMatchObject({
       kind: 'ImmBinary',
       op: '-',

--- a/test/frontend/pr476_parse_module_common_helpers.test.ts
+++ b/test/frontend/pr476_parse_module_common_helpers.test.ts
@@ -8,6 +8,7 @@ import {
   topLevelStartKeyword,
 } from '../../src/frontend/parseModuleCommon.js';
 import { makeSourceFile, span } from '../../src/frontend/source.js';
+import { expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 describe('PR476 module helper extraction', () => {
   const file = makeSourceFile('pr476_parse_module_common_helpers.zax', '');
@@ -24,7 +25,7 @@ describe('PR476 module helper extraction', () => {
     expect(parseReturnRegsFromText('HL, de', zeroSpan, 1, diagnostics, file.path)).toEqual({
       regs: ['HL', 'DE'],
     });
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
   });
 
   it('keeps var declaration parsing intact', () => {
@@ -35,7 +36,7 @@ describe('PR476 module helper extraction', () => {
       isReservedTopLevelName: () => false,
     });
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(decl).toMatchObject({
       kind: 'VarDecl',
       name: 'value',
@@ -55,7 +56,7 @@ describe('PR476 module helper extraction', () => {
       isReservedTopLevelName: () => false,
     });
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(decl).toMatchObject({
       kind: 'VarDecl',
       name: 'value',

--- a/test/frontend/pr476_parse_op_helpers.test.ts
+++ b/test/frontend/pr476_parse_op_helpers.test.ts
@@ -5,6 +5,7 @@ import { parseTopLevelOpDecl } from '../../src/frontend/parseOp.js';
 import { parseOpParamsFromText } from '../../src/frontend/parseParams.js';
 import { parseProgram } from '../../src/frontend/parser.js';
 import { makeSourceFile, span } from '../../src/frontend/source.js';
+import { expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 describe('PR476 op parser extraction', () => {
   it('keeps top-level op parsing intact', () => {
@@ -58,7 +59,7 @@ describe('PR476 op parser extraction', () => {
       },
     );
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(parsed?.nextIndex).toBe(4);
     expect(parsed?.node).toMatchObject({
       kind: 'OpDecl',
@@ -76,7 +77,7 @@ describe('PR476 op parser extraction', () => {
       diagnostics,
     );
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(program.files[0]?.items[0]).toMatchObject({
       kind: 'OpDecl',
       name: 'add',

--- a/test/frontend/pr476_parse_params_helpers.test.ts
+++ b/test/frontend/pr476_parse_params_helpers.test.ts
@@ -4,6 +4,7 @@ import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import { parseOpParamsFromText, parseParamsFromText } from '../../src/frontend/parseParams.js';
 import { makeSourceFile, span } from '../../src/frontend/source.js';
 import { parseProgram } from '../../src/frontend/parser.js';
+import { expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 describe('PR476 parameter parser extraction', () => {
   const file = makeSourceFile('pr476_parse_params_helpers.zax', '');
@@ -20,7 +21,7 @@ describe('PR476 parameter parser extraction', () => {
       ctx,
     );
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(params).toEqual([
       {
         kind: 'Param',
@@ -52,7 +53,7 @@ describe('PR476 parameter parser extraction', () => {
       ctx,
     );
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(params).toEqual([
       {
         kind: 'OpParam',
@@ -77,7 +78,7 @@ describe('PR476 parameter parser extraction', () => {
       diagnostics,
     );
 
-    expect(diagnostics).toEqual([]);
+    expectNoDiagnostics(diagnostics);
     expect(program.files[0]?.items[0]).toMatchObject({ kind: 'FuncDecl', name: 'add' });
     expect(program.files[0]?.items[1]).toMatchObject({ kind: 'OpDecl', name: 'copy16' });
   });


### PR DESCRIPTION
Part of #1132

## Summary
- strengthen another narrow PR476 frontend helper slice
- replace raw empty diagnostics assertions with explicit helper assertions
- keep compiler code untouched