### PR TITLE
Test: migrate lowering helper batch

### DIFF
--- a/test/lowering/pr504_op_matching_helpers.test.ts
+++ b/test/lowering/pr504_op_matching_helpers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import type { AsmOperandNode, OpDeclNode, SourceSpan } from '../src/frontend/ast.js';
-import { createOpMatchingHelpers } from '../src/lowering/opMatching.js';
+import type { AsmOperandNode, OpDeclNode, SourceSpan } from '../../src/frontend/ast.js';
+import { createOpMatchingHelpers } from '../../src/lowering/opMatching.js';
 
 const span: SourceSpan = {
   file: 'test.zax',

--- a/test/lowering/pr506_runtime_atom_budget_helpers.test.ts
+++ b/test/lowering/pr506_runtime_atom_budget_helpers.test.ts
@@ -2,16 +2,16 @@ import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
-import { expectDiagnostic } from './helpers/diagnostics.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectDiagnostic } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR506: extracted runtime-atom budget helpers', () => {
   it('preserves source ea runtime-atom budget diagnostics', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr264_runtime_atom_budget_invalid.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr264_runtime_atom_budget_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expectDiagnostic(res.diagnostics, {
       message: 'Source ea expression exceeds runtime-atom budget (max 1; found 2).',
@@ -19,7 +19,7 @@ describe('PR506: extracted runtime-atom budget helpers', () => {
   });
 
   it('preserves direct call-site ea runtime-atom budget diagnostics', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr273_call_address_runtime_index_reject.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr273_call_address_runtime_index_reject.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expectDiagnostic(res.diagnostics, {
       messageIncludes: 'Direct call-site ea argument for "takeAddr"',

--- a/test/lowering/pr507_ea_resolution_helpers.test.ts
+++ b/test/lowering/pr507_ea_resolution_helpers.test.ts
@@ -2,24 +2,24 @@ import { describe, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { DiagnosticIds } from '../src/diagnosticTypes.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
-import { expectDiagnostic, expectNoDiagnostics } from './helpers/diagnostics.js';
+import { compile } from '../../src/compile.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectDiagnostic, expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR507: extracted EA resolution helpers', () => {
   it('preserves scalar index value semantics for nested EA resolution', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr260_value_semantics_scalar_index.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr260_value_semantics_scalar_index.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
     expectNoDiagnostics(res.diagnostics);
   });
 
   it('preserves runtime-affine unsupported-shape diagnostics', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr272_runtime_affine_invalid.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr272_runtime_affine_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expectDiagnostic(res.diagnostics, {
       id: DiagnosticIds.EmitError,

--- a/test/lowering/pr508_runtime_immediates_helpers.test.ts
+++ b/test/lowering/pr508_runtime_immediates_helpers.test.ts
@@ -2,23 +2,23 @@ import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
-import { compilePlacedProgram, formatLoweredInstructions } from './helpers/lowered_program.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import { compilePlacedProgram, formatLoweredInstructions } from '../helpers/lowered_program.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR508: extracted runtime-immediate helpers', () => {
   it('preserves runtime-affine scaling and immediate materialization in lowering', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr272_runtime_affine_valid.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr272_runtime_affine_valid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
     expect(res.diagnostics).toEqual([]);
   });
 
   it('preserves byte call-arg zero-extension materialization', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr405_byte_call_scalar_arg.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr405_byte_call_scalar_arg.zax');
     const { program, diagnostics } = await compilePlacedProgram(entry);
     expect(diagnostics).toEqual([]);
     const lines = formatLoweredInstructions(program).map((line) => line.toUpperCase());


### PR DESCRIPTION
## Summary
- Move a small lowering helper batch into test/lowering
- Update imports and fixture paths for the moved tests

## Issue
- Closes #1153

## Moved tests
- test/lowering/pr504_op_matching_helpers.test.ts
- test/lowering/pr506_runtime_atom_budget_helpers.test.ts
- test/lowering/pr507_ea_resolution_helpers.test.ts
- test/lowering/pr508_runtime_immediates_helpers.test.ts

## Commands
- npm ci
- npm run typecheck
- npm run lint
- npm test -- --run test/lowering/pr504_op_matching_helpers.test.ts test/lowering/pr506_runtime_atom_budget_helpers.test.ts test/lowering/pr507_ea_resolution_helpers.test.ts test/lowering/pr508_runtime_immediates_helpers.test.ts
