### PR TITLE
test: strengthen runtime semantics diagnostics

### DIFF
--- a/test/pr264_runtime_atom_budget_matrix.test.ts
+++ b/test/pr264_runtime_atom_budget_matrix.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import type { BinArtifact } from '../src/formats/types.js';
+import { expectDiagnostic, expectNoDiagnostics } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -14,7 +15,7 @@ describe('PR264: ea runtime-atom budget matrix', () => {
     const entry = join(__dirname, 'fixtures', 'pr264_runtime_atom_budget_valid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    expect(res.diagnostics).toEqual([]);
+    expectNoDiagnostics(res.diagnostics);
     const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
     expect(bin).toBeDefined();
   });
@@ -24,23 +25,15 @@ describe('PR264: ea runtime-atom budget matrix', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
     expect(res.artifacts).toEqual([]);
-    expect(
-      res.diagnostics.map((d) => ({
-        message: d.message,
-        line: d.line,
-        column: d.column,
-      })),
-    ).toEqual([
-      {
-        message: 'Source ea expression exceeds runtime-atom budget (max 1; found 2).',
-        line: 9,
-        column: 3,
-      },
-      {
-        message: 'Source ea expression exceeds runtime-atom budget (max 1; found 2).',
-        line: 10,
-        column: 3,
-      },
-    ]);
+    expect(res.diagnostics).toHaveLength(2);
+    expectDiagnostic(res.diagnostics, {
+      message: 'Source ea expression exceeds runtime-atom budget (max 1; found 2).',
+      line: 9,
+    });
+    expectDiagnostic(res.diagnostics, {
+      message: 'Source ea expression exceeds runtime-atom budget (max 1; found 2).',
+      line: 10,
+    });
+    expect(res.diagnostics.every((d) => d.column === 3)).toBe(true);
   });
 });

--- a/test/pr273_call_scalar_value_runtime_index.test.ts
+++ b/test/pr273_call_scalar_value_runtime_index.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -15,9 +16,10 @@ describe('PR273: typed call arg value semantics vs direct ea budget', () => {
 
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toContain(
-      'Direct call-site ea argument for "sink" must be runtime-atom-free in v0.2',
-    );
+    expectDiagnostic(res.diagnostics, {
+      messageIncludes:
+        'Direct call-site ea argument for "sink" must be runtime-atom-free in v0.2',
+    });
   });
 
   it('still rejects runtime call-site address ea args that must remain atom-free in v0.2', async () => {
@@ -26,8 +28,9 @@ describe('PR273: typed call arg value semantics vs direct ea budget', () => {
 
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toContain(
-      'Direct call-site ea argument for "takeAddr" must be runtime-atom-free in v0.2',
-    );
+    expectDiagnostic(res.diagnostics, {
+      messageIncludes:
+        'Direct call-site ea argument for "takeAddr" must be runtime-atom-free in v0.2',
+    });
   });
 });

--- a/test/pr278_nested_runtime_store_matrix.test.ts
+++ b/test/pr278_nested_runtime_store_matrix.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 import { compile } from '../src/compile.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import type { BinArtifact } from '../src/formats/types.js';
+import { expectNoDiagnostics } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -14,7 +15,7 @@ describe('PR278: nested runtime-index store matrix (one atom)', () => {
     const entry = join(__dirname, 'fixtures', 'pr278_nested_runtime_store_matrix.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
-    expect(res.diagnostics).toEqual([]);
+    expectNoDiagnostics(res.diagnostics);
     const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
     expect(bin).toBeDefined();
     expect(bin!.bytes.length).toBeGreaterThan(0);

--- a/test/semantics/pr260_value_semantics_scalar_index.test.ts
+++ b/test/semantics/pr260_value_semantics_scalar_index.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 import { compile } from '../../src/compile.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
 import type { BinArtifact } from '../../src/formats/types.js';
+import { expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,7 +14,7 @@ describe('PR260: scalar variable indices in array access', () => {
   it('lowers byte/word scalar indices in ld array forms', async () => {
     const entry = join(__dirname, '..', 'fixtures', 'pr260_value_semantics_scalar_index.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expect(res.diagnostics).toEqual([]);
+    expectNoDiagnostics(res.diagnostics);
 
     const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
     expect(bin).toBeDefined();


### PR DESCRIPTION
Part of #1132

## Summary
- strengthen a small runtime semantics/env assertion slice
- replace raw diagnostics array checks with explicit helper assertions
- keep compiler code untouched