### PR TITLE
test: strengthen assignment parser diagnostics

### DIFF
--- a/test/frontend/pr862_assignment_parser.test.ts
+++ b/test/frontend/pr862_assignment_parser.test.ts
@@ -76,7 +76,7 @@ describe('PR862 := assignment parser/AST support', () => {
     });
 
     parsed = parse('hl := de');
-    expect(parsed.diagnostics).toEqual([]);
+    expectNoDiagnostics(parsed.diagnostics);
     expect(parsed.instr).toMatchObject({
       kind: 'AsmInstruction',
       head: ':=',
@@ -84,7 +84,7 @@ describe('PR862 := assignment parser/AST support', () => {
     });
 
     parsed = parse('de := a');
-    expect(parsed.diagnostics).toEqual([]);
+    expectNoDiagnostics(parsed.diagnostics);
     expect(parsed.instr).toMatchObject({
       kind: 'AsmInstruction',
       head: ':=',
@@ -92,7 +92,7 @@ describe('PR862 := assignment parser/AST support', () => {
     });
 
     parsed = parse('hl := @node.next');
-    expect(parsed.diagnostics).toEqual([]);
+    expectNoDiagnostics(parsed.diagnostics);
     expect(parsed.instr).toMatchObject({
       kind: 'AsmInstruction',
       head: ':=',

--- a/test/frontend/pr868_assignment_reg8_parser.test.ts
+++ b/test/frontend/pr868_assignment_reg8_parser.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import { parseAsmInstruction } from '../../src/frontend/parseAsmInstruction.js';
 import { makeSourceFile, span } from '../../src/frontend/source.js';
+import { expectDiagnostic, expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 describe('PR868 := reg8 parser support', () => {
   const file = makeSourceFile('pr868_assignment_reg8_parser.zax', '');
@@ -19,7 +20,7 @@ describe('PR868 := reg8 parser support', () => {
   it('accepts reg8 typed storage loads and stores', () => {
     for (const text of ['b := count', 'l := idx', 'b := arr[idx]', 'flags := b']) {
       const parsed = parse(text);
-      expect(parsed.diagnostics).toEqual([]);
+      expectNoDiagnostics(parsed.diagnostics);
       expect(parsed.instr?.head).toBe(':=');
     }
   });
@@ -27,7 +28,7 @@ describe('PR868 := reg8 parser support', () => {
   it('accepts reg8 immediate assignments', () => {
     for (const text of ['l := 0', 'b := 1', 'h := 2', 'e := 3']) {
       const parsed = parse(text);
-      expect(parsed.diagnostics).toEqual([]);
+      expectNoDiagnostics(parsed.diagnostics);
       expect(parsed.instr).toMatchObject({
         kind: 'AsmInstruction',
         head: ':=',
@@ -40,15 +41,14 @@ describe('PR868 := reg8 parser support', () => {
     for (const text of ['a := (hl)', '(hl) := a', '(ix+4) := a']) {
       const parsed = parse(text);
       expect(parsed.instr).toBeUndefined();
-      expect(parsed.diagnostics.length).toBeGreaterThan(0);
-      expect(parsed.diagnostics[0]?.message).toContain(':=');
+      expectDiagnostic(parsed.diagnostics, { messageIncludes: ':=' });
     }
   });
 
   it('keeps existing stage 1 pair forms accepted', () => {
     for (const text of ['hl := de', 'hl := 0', 'de := a', 'hl := @x']) {
       const parsed = parse(text);
-      expect(parsed.diagnostics).toEqual([]);
+      expectNoDiagnostics(parsed.diagnostics);
       expect(parsed.instr?.head).toBe(':=');
     }
   });

--- a/test/frontend/pr874_assignment_ixiy_parser.test.ts
+++ b/test/frontend/pr874_assignment_ixiy_parser.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import { parseAsmInstruction } from '../../src/frontend/parseAsmInstruction.js';
 import { makeSourceFile, span } from '../../src/frontend/source.js';
+import { expectDiagnostic, expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 describe('PR874 := IX/IY parser support', () => {
   const file = makeSourceFile('pr874_assignment_ixiy_parser.zax', '');
@@ -19,7 +20,7 @@ describe('PR874 := IX/IY parser support', () => {
   it('accepts IX and IY whole-register assignment forms', () => {
     for (const text of ['ix := word_var', 'iy := @node.next', 'ix := arr_w[idx + 1]', 'ix := 0', 'iy := hl']) {
       const parsed = parse(text);
-      expect(parsed.diagnostics).toEqual([]);
+      expectNoDiagnostics(parsed.diagnostics);
       expect(parsed.instr?.kind).toBe('AsmInstruction');
       expect(parsed.instr?.head).toBe(':=');
       expect(parsed.instr?.operands[0]).toMatchObject({ kind: 'Reg' });
@@ -30,15 +31,14 @@ describe('PR874 := IX/IY parser support', () => {
     for (const text of ['a := (ix+4)', '(ix+4) := a']) {
       const parsed = parse(text);
       expect(parsed.instr).toBeUndefined();
-      expect(parsed.diagnostics.length).toBeGreaterThan(0);
-      expect(parsed.diagnostics[0]?.message).toContain(':=');
+      expectDiagnostic(parsed.diagnostics, { messageIncludes: ':=' });
     }
   });
 
   it('keeps existing reg8 and pair forms accepted', () => {
     for (const text of ['b := count', 'flags := b', 'hl := de', 'hl := @x']) {
       const parsed = parse(text);
-      expect(parsed.diagnostics).toEqual([]);
+      expectNoDiagnostics(parsed.diagnostics);
       expect(parsed.instr?.head).toBe(':=');
     }
   });

--- a/test/frontend/pr887_assignment_half_index_parser.test.ts
+++ b/test/frontend/pr887_assignment_half_index_parser.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import { parseAsmInstruction } from '../../src/frontend/parseAsmInstruction.js';
 import { makeSourceFile, span } from '../../src/frontend/source.js';
+import { expectDiagnostic, expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 describe('PR887 := half-index parser support', () => {
   const file = makeSourceFile('pr887_assignment_half_index_parser.zax', '');
@@ -19,7 +20,7 @@ describe('PR887 := half-index parser support', () => {
   it('accepts typed byte transfer forms for IXH/IXL/IYH/IYL', () => {
     for (const text of ['ixh := count', 'ixl := arr[idx]', 'flags := iyh', 'iyl := flag_byte']) {
       const parsed = parse(text);
-      expect(parsed.diagnostics).toEqual([]);
+      expectNoDiagnostics(parsed.diagnostics);
       expect(parsed.instr?.head).toBe(':=');
     }
   });
@@ -27,7 +28,7 @@ describe('PR887 := half-index parser support', () => {
   it('accepts byte immediates for half-index registers', () => {
     for (const text of ['ixh := 0', 'ixl := 1', 'iyh := 2', 'iyl := 3']) {
       const parsed = parse(text);
-      expect(parsed.diagnostics).toEqual([]);
+      expectNoDiagnostics(parsed.diagnostics);
       expect(parsed.instr).toMatchObject({
         kind: 'AsmInstruction',
         head: ':=',
@@ -40,8 +41,7 @@ describe('PR887 := half-index parser support', () => {
     for (const text of ['ixh := (hl)', '(ix+4) := iyl', 'i := count', 'r := count']) {
       const parsed = parse(text);
       expect(parsed.instr).toBeUndefined();
-      expect(parsed.diagnostics.length).toBeGreaterThan(0);
-      expect(parsed.diagnostics[0]?.message).toContain(':=');
+      expectDiagnostic(parsed.diagnostics, { messageIncludes: ':=' });
     }
   });
 });

--- a/test/frontend/pr895_assignment_ea_ea_parser.test.ts
+++ b/test/frontend/pr895_assignment_ea_ea_parser.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import { parseAsmInstruction } from '../../src/frontend/parseAsmInstruction.js';
 import { makeSourceFile, span } from '../../src/frontend/source.js';
+import { expectDiagnostic, expectNoDiagnostics } from '../helpers/diagnostics.js';
 
 describe('PR895 := scalar path-to-path parser support', () => {
   const file = makeSourceFile('pr895_assignment_ea_ea_parser.zax', '');
@@ -19,7 +20,7 @@ describe('PR895 := scalar path-to-path parser support', () => {
   it('accepts path-to-path and address-of storage assignment forms', () => {
     for (const text of ['arr2[0] := arr1[1]', 'dst := src_word', 'ptr := @arr1[1]']) {
       const parsed = parse(text);
-      expect(parsed.diagnostics).toEqual([]);
+      expectNoDiagnostics(parsed.diagnostics);
       expect(parsed.instr?.kind).toBe('AsmInstruction');
       expect(parsed.instr?.head).toBe(':=');
     }
@@ -29,8 +30,7 @@ describe('PR895 := scalar path-to-path parser support', () => {
     for (const text of ['dst := src_word + 1', 'arr2[0] := arr1[1] + 1']) {
       const parsed = parse(text);
       expect(parsed.instr).toBeUndefined();
-      expect(parsed.diagnostics.length).toBeGreaterThan(0);
-      expect(parsed.diagnostics[0]?.message).toContain(':=');
+      expectDiagnostic(parsed.diagnostics, { messageIncludes: ':=' });
     }
   });
 });


### PR DESCRIPTION
Part of #1132

## Summary
- strengthen a narrow assignment-parser assertion slice
- replace raw diagnostics empties and first-message checks with helper assertions
- keep compiler code untouched