### PR TITLE
Extract prescan result type

### DIFF
--- a/src/lowering/emitPipeline.ts
+++ b/src/lowering/emitPipeline.ts
@@ -26,12 +26,12 @@ import type { NonBankedSectionKeyCollection } from '../sectionKeys.js';
 import type { OpStackPolicyMode } from '../pipeline.js';
 import { finalizeEmitProgram, type EmitFinalizationContext } from './emitFinalization.js';
 import type { LoweredAsmProgram, LoweredAsmStream } from './loweredAsmTypes.js';
+import type { PrescanResult } from './prescanTypes.js';
 import {
   lowerProgramDeclarations,
   preScanProgramDeclarations,
   type Context as ProgramLoweringContext,
   type LoweringResult,
-  type PrescanResult,
 } from './programLowering.js';
 
 export type { LoweringResult, PrescanResult };

--- a/src/lowering/prescanTypes.ts
+++ b/src/lowering/prescanTypes.ts
@@ -1,0 +1,15 @@
+import type { EaExprNode, OpDeclNode, TypeExprNode, VarDeclNode } from '../frontend/ast.js';
+import type { Callable } from './loweringTypes.js';
+
+export interface PrescanResult {
+  localCallablesByFile: Map<string, Map<string, Callable>>;
+  visibleCallables: Map<string, Callable>;
+  localOpsByFile: Map<string, Map<string, OpDeclNode[]>>;
+  visibleOpsByName: Map<string, OpDeclNode[]>;
+  declaredOpNames: Set<string>;
+  declaredBinNames: Set<string>;
+  storageTypes: Map<string, TypeExprNode>;
+  moduleAliasTargets: Map<string, EaExprNode>;
+  moduleAliasDecls: Map<string, VarDeclNode>;
+  rawAddressSymbols: Set<string>;
+}

--- a/src/lowering/programLowering.ts
+++ b/src/lowering/programLowering.ts
@@ -23,6 +23,7 @@ import type {
   SectionKind,
 } from './loweringTypes.js';
 import type { LoweredAsmItem, LoweredImmExpr } from './loweredAsmTypes.js';
+import type { PrescanResult } from './prescanTypes.js';
 import type { AggregateType } from './typeResolution.js';
 import { preScanProgramDeclarations as runProgramPrescan } from './programPrescan.js';
 import { lowerProgramDeclarations as runProgramLoweringTraversal } from './programLoweringTraversal.js';
@@ -85,20 +86,6 @@ export type Context = FunctionLoweringSharedContext & {
   lowerImmExprForLoweredAsm: (expr: ImmExprNode) => LoweredImmExpr;
   namedSectionSinksByNode: Map<NamedSectionNode, NamedSectionContributionSink>;
   withNamedSectionSink: <T>(sink: NamedSectionContributionSink, fn: () => T) => T;
-};
-
-// --- Phase 1 product: prescan metadata for lowering ---
-export type PrescanResult = {
-  localCallablesByFile: Context['localCallablesByFile'];
-  visibleCallables: Context['visibleCallables'];
-  localOpsByFile: Context['localOpsByFile'];
-  visibleOpsByName: Context['visibleOpsByName'];
-  declaredOpNames: Context['declaredOpNames'];
-  declaredBinNames: Context['declaredBinNames'];
-  storageTypes: Context['storageTypes'];
-  moduleAliasTargets: Context['moduleAliasTargets'];
-  moduleAliasDecls: Context['moduleAliasDecls'];
-  rawAddressSymbols: Context['rawAddressSymbols'];
 };
 
 // --- Phase 2 product: lowered bytes, symbols, and deferred externs ---

--- a/src/lowering/programLoweringTraversal.ts
+++ b/src/lowering/programLoweringTraversal.ts
@@ -14,7 +14,8 @@ import type {
   VarBlockNode,
 } from '../frontend/ast.js';
 import type { NamedSectionContributionSink } from './sectionContributions.js';
-import type { Context, LoweringResult, PrescanResult } from './programLowering.js';
+import type { PrescanResult } from './prescanTypes.js';
+import type { Context, LoweringResult } from './programLowering.js';
 import { sizeOfTypeExpr } from '../semantics/layout.js';
 import { lowerDataBlock } from './programLoweringData.js';
 import { createProgramLoweringDeclarationHelpers } from './programLoweringDeclarations.js';

--- a/src/lowering/programPrescan.ts
+++ b/src/lowering/programPrescan.ts
@@ -12,7 +12,8 @@ import type {
   VarBlockNode,
 } from '../frontend/ast.js';
 import type { Callable } from './loweringTypes.js';
-import type { Context, PrescanResult } from './programLowering.js';
+import type { PrescanResult } from './prescanTypes.js';
+import type { Context } from './programLowering.js';
 
 function getOrCreateFileCallables(
   ctx: Context,


### PR DESCRIPTION
Continues #1126.

This moves `PrescanResult` into a dedicated lowering type module so prescan metadata has a single explicit owner without changing prescan or lowering behavior.