### PR TITLE
Tighten emit pipeline phase contracts

### DIFF
--- a/src/lowering/emitPipeline.ts
+++ b/src/lowering/emitPipeline.ts
@@ -32,9 +32,25 @@ import {
   preScanProgramDeclarations,
   type Context as ProgramLoweringContext,
   type LoweringResult,
+  type ProgramPrescanContext,
 } from './programLowering.js';
 
-export type { LoweringResult, PrescanResult };
+export type EmitPrescanPhaseContext = ProgramPrescanContext;
+export type EmitPrescanPhaseResult = PrescanResult;
+export type EmitLoweringPhaseContext = ProgramLoweringContext;
+
+export interface EmitLoweringPhaseResult {
+  readonly codeOffset: LoweringResult['codeOffset'];
+  readonly dataOffset: LoweringResult['dataOffset'];
+  readonly varOffset: LoweringResult['varOffset'];
+  readonly pending: LoweringResult['pending'];
+  readonly symbols: LoweringResult['symbols'];
+  readonly absoluteSymbols: LoweringResult['absoluteSymbols'];
+  readonly deferredExterns: LoweringResult['deferredExterns'];
+  readonly codeBytes: LoweringResult['codeBytes'];
+  readonly dataBytes: LoweringResult['dataBytes'];
+  readonly hexBytes: LoweringResult['hexBytes'];
+}
 
 /** Options for `emitProgram` (include paths, policy flags, listing sources). */
 export type EmitProgramOptions = {
@@ -55,8 +71,30 @@ export type EmitProgramResult = {
   placedLoweredAsmProgram: LoweredAsmProgram;
 };
 
-/** Environment for finalization that is *not* part of {@link LoweringResult}. */
-export type EmitFinalizationPhaseEnv = Omit<EmitFinalizationContext, keyof LoweringResult>;
+/** Finalization inputs that come from phase-1 wiring rather than phase-3 lowering. */
+export interface EmitFinalizationPhaseEnv {
+  readonly namedSectionSinks: EmitFinalizationContext['namedSectionSinks'];
+  readonly diagnostics: EmitFinalizationContext['diagnostics'];
+  readonly diag: EmitFinalizationContext['diag'];
+  readonly diagAt: EmitFinalizationContext['diagAt'];
+  readonly primaryFile: EmitFinalizationContext['primaryFile'];
+  readonly baseExprs: EmitFinalizationContext['baseExprs'];
+  readonly evalImmExpr: EmitFinalizationContext['evalImmExpr'];
+  readonly env: EmitFinalizationContext['env'];
+  readonly loweredAsmStream: EmitFinalizationContext['loweredAsmStream'];
+  readonly fixups: EmitFinalizationContext['fixups'];
+  readonly rel8Fixups: EmitFinalizationContext['rel8Fixups'];
+  readonly bytes: EmitFinalizationContext['bytes'];
+  readonly codeSourceSegments: EmitFinalizationContext['codeSourceSegments'];
+  readonly alignTo: EmitFinalizationContext['alignTo'];
+  readonly writeSection: EmitFinalizationContext['writeSection'];
+  readonly computeWrittenRange: EmitFinalizationContext['computeWrittenRange'];
+  readonly rebaseCodeSourceSegments: EmitFinalizationContext['rebaseCodeSourceSegments'];
+  readonly defaultCodeBase?: number;
+}
+
+export type EmitPlacementPhaseContext = EmitLoweringPhaseResult & EmitFinalizationPhaseEnv;
+export type EmitPlacementPhaseResult = Omit<EmitProgramResult, 'loweredAsmStream'>;
 
 // --- Phase handoff: merge lowering output with finalization inputs ---
 /**
@@ -64,9 +102,9 @@ export type EmitFinalizationPhaseEnv = Omit<EmitFinalizationContext, keyof Lower
  * the lowering phase; `env` holds shared refs (maps, diagnostics, helpers) held across phases.
  */
 export function mergeEmitFinalizationContext(
-  lowered: LoweringResult,
+  lowered: EmitLoweringPhaseResult,
   env: EmitFinalizationPhaseEnv,
-): EmitFinalizationContext {
+): EmitPlacementPhaseContext {
   return { ...lowered, ...env };
 }
 
@@ -82,23 +120,23 @@ export function emitProgramEmptyResult(): EmitProgramResult {
 
 // --- Phase 2: prescan (callables, ops, storage aliases) ---
 /** Phase 2 — prescan: build visibility maps and alias metadata before emission. */
-export function runEmitPrescanPhase(ctx: ProgramLoweringContext): PrescanResult {
+export function runEmitPrescanPhase(ctx: EmitPrescanPhaseContext): EmitPrescanPhaseResult {
   return preScanProgramDeclarations(ctx);
 }
 
 // --- Phase 3: lowering (emit bytes, fixups, lowered ASM stream) ---
 /** Phase 3 — lowering: emit declarations and functions into section bytes and fixup queues. */
 export function runEmitLoweringPhase(
-  ctx: ProgramLoweringContext,
-  prescan: PrescanResult,
-): LoweringResult {
+  ctx: EmitLoweringPhaseContext,
+  prescan: EmitPrescanPhaseResult,
+): EmitLoweringPhaseResult {
   return lowerProgramDeclarations(ctx, prescan);
 }
 
 // --- Phase 4: finalization (placement, fixups, artifact assembly) ---
 /** Phase 4 — placement, fixups, merged map and placed lowered ASM. */
 export function runEmitPlacementAndArtifactPhase(
-  context: EmitFinalizationContext,
-): Omit<EmitProgramResult, 'loweredAsmStream'> {
+  context: EmitPlacementPhaseContext,
+): EmitPlacementPhaseResult {
   return finalizeEmitProgram(context);
 }

--- a/src/lowering/programLowering.ts
+++ b/src/lowering/programLowering.ts
@@ -88,6 +88,23 @@ export type Context = FunctionLoweringSharedContext & {
   withNamedSectionSink: <T>(sink: NamedSectionContributionSink, fn: () => T) => T;
 };
 
+export type ProgramPrescanContext = Pick<
+  Context,
+  | 'program'
+  | 'env'
+  | 'localCallablesByFile'
+  | 'visibleCallables'
+  | 'localOpsByFile'
+  | 'visibleOpsByName'
+  | 'declaredOpNames'
+  | 'declaredBinNames'
+  | 'storageTypes'
+  | 'moduleAliasTargets'
+  | 'moduleAliasDecls'
+  | 'rawAddressSymbols'
+  | 'resolveScalarKind'
+>;
+
 // --- Phase 2 product: lowered bytes, symbols, and deferred externs ---
 export type LoweringResult = {
   codeOffset: number;
@@ -151,7 +168,7 @@ export type FinalizationContext = {
 };
 
 // --- Phase 1: prescan declarations (callables, ops, storage aliases) ---
-export function preScanProgramDeclarations(ctx: Context): PrescanResult {
+export function preScanProgramDeclarations(ctx: ProgramPrescanContext): PrescanResult {
   return runProgramPrescan(ctx);
 }
 

--- a/src/lowering/programPrescan.ts
+++ b/src/lowering/programPrescan.ts
@@ -13,10 +13,10 @@ import type {
 } from '../frontend/ast.js';
 import type { Callable } from './loweringTypes.js';
 import type { PrescanResult } from './prescanTypes.js';
-import type { Context } from './programLowering.js';
+import type { ProgramPrescanContext } from './programLowering.js';
 
 function getOrCreateFileCallables(
-  ctx: Context,
+  ctx: ProgramPrescanContext,
   file: string,
 ): Map<string, Callable> {
   const existing = ctx.localCallablesByFile.get(file);
@@ -27,7 +27,7 @@ function getOrCreateFileCallables(
 }
 
 function getOrCreateFileOps(
-  ctx: Context,
+  ctx: ProgramPrescanContext,
   file: string,
 ): Map<string, OpDeclNode[]> {
   const existing = ctx.localOpsByFile.get(file);
@@ -38,7 +38,7 @@ function getOrCreateFileOps(
 }
 
 function preScanItem(
-  ctx: Context,
+  ctx: ProgramPrescanContext,
   item: ModuleItemNode | SectionItemNode,
   namedSection?: NamedSectionNode,
 ): void {
@@ -152,7 +152,7 @@ function preScanItem(
   }
 }
 
-export function preScanProgramDeclarations(ctx: Context): PrescanResult {
+export function preScanProgramDeclarations(ctx: ProgramPrescanContext): PrescanResult {
   for (const module of ctx.program.files) {
     for (const item of module.items) preScanItem(ctx, item);
   }


### PR DESCRIPTION
## Summary
- narrow emit-pipeline phase contracts to named phase-facing types instead of broad reuse
- give prescan its own explicit context contract at the program-lowering seam
- replace the finalization `Omit<...>` handoff with an explicit phase env + placement context

## Testing
- npm ci
- npm run typecheck
- npm run lint
- npx vitest run /Users/johnhardy/.codex/worktrees/emit-pipeline-types/ZAX/test/lowering/pr543_function_lowering_integration.test.ts /Users/johnhardy/.codex/worktrees/emit-pipeline-types/ZAX/test/lowering/pr544_program_lowering_integration.test.ts /Users/johnhardy/.codex/worktrees/emit-pipeline-types/ZAX/test/pr330_frames_epilogue_and_access.test.ts /Users/johnhardy/.codex/worktrees/emit-pipeline-types/ZAX/test/pr582_program_prescan_named_section_rules.test.ts /Users/johnhardy/.codex/worktrees/emit-pipeline-types/ZAX/test/pr622_direct_data_decl_prescan.test.ts /Users/johnhardy/.codex/worktrees/emit-pipeline-types/ZAX/test/pr900_step_integration.test.ts /Users/johnhardy/.codex/worktrees/emit-pipeline-types/ZAX/test/pr1050_step_lowering.test.ts

Closes #1129