### PR TITLE
refactor(lowering): program-lowering PrescanContext / LoweringContext / FinalizationContext (#1124)

### DIFF
--- a/src/lowering/emitFinalization.ts
+++ b/src/lowering/emitFinalization.ts
@@ -8,7 +8,7 @@ import type { SourceSpan } from '../frontend/ast.js';
 import type { CompileEnv } from '../semantics/env.js';
 import {
   finalizeProgramEmission,
-  type FinalizationContext,
+  type ProgramEmissionFinalizeContext,
 } from './programLowering.js';
 import { computeSectionBases } from './programLoweringFinalize.js';
 import type { NamedSectionContributionSink } from './sectionContributions.js';
@@ -38,28 +38,28 @@ export type EmitFinalizationContext = {
   diag: (diagnostics: Diagnostic[], file: string, message: string) => void;
   diagAt: (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
   primaryFile: string;
-  baseExprs: FinalizationContext['baseExprs'];
-  evalImmExpr: FinalizationContext['evalImmExpr'];
+  baseExprs: ProgramEmissionFinalizeContext['baseExprs'];
+  evalImmExpr: ProgramEmissionFinalizeContext['evalImmExpr'];
   env: CompileEnv;
   loweredAsmStream: LoweredAsmStream;
   codeOffset: number;
   dataOffset: number;
   varOffset: number;
-  pending: FinalizationContext['pending'];
+  pending: ProgramEmissionFinalizeContext['pending'];
   symbols: SymbolEntry[];
-  absoluteSymbols: FinalizationContext['absoluteSymbols'];
-  deferredExterns: FinalizationContext['deferredExterns'];
-  fixups: FinalizationContext['fixups'];
-  rel8Fixups: FinalizationContext['rel8Fixups'];
-  codeBytes: FinalizationContext['codeBytes'];
-  dataBytes: FinalizationContext['dataBytes'];
-  hexBytes: FinalizationContext['hexBytes'];
+  absoluteSymbols: ProgramEmissionFinalizeContext['absoluteSymbols'];
+  deferredExterns: ProgramEmissionFinalizeContext['deferredExterns'];
+  fixups: ProgramEmissionFinalizeContext['fixups'];
+  rel8Fixups: ProgramEmissionFinalizeContext['rel8Fixups'];
+  codeBytes: ProgramEmissionFinalizeContext['codeBytes'];
+  dataBytes: ProgramEmissionFinalizeContext['dataBytes'];
+  hexBytes: ProgramEmissionFinalizeContext['hexBytes'];
   bytes: Map<number, number>;
   codeSourceSegments: EmittedSourceSegment[];
-  alignTo: FinalizationContext['alignTo'];
-  writeSection: FinalizationContext['writeSection'];
-  computeWrittenRange: FinalizationContext['computeWrittenRange'];
-  rebaseCodeSourceSegments: FinalizationContext['rebaseCodeSourceSegments'];
+  alignTo: ProgramEmissionFinalizeContext['alignTo'];
+  writeSection: ProgramEmissionFinalizeContext['writeSection'];
+  computeWrittenRange: ProgramEmissionFinalizeContext['computeWrittenRange'];
+  rebaseCodeSourceSegments: ProgramEmissionFinalizeContext['rebaseCodeSourceSegments'];
   defaultCodeBase?: number;
 };
 

--- a/src/lowering/emitPipeline.ts
+++ b/src/lowering/emitPipeline.ts
@@ -32,10 +32,10 @@ import {
   preScanProgramDeclarations,
   type Context as ProgramLoweringContext,
   type LoweringResult,
-  type ProgramPrescanContext,
+  type PrescanContext,
 } from './programLowering.js';
 
-export type EmitPrescanPhaseContext = ProgramPrescanContext;
+export type EmitPrescanPhaseContext = PrescanContext;
 export type EmitPrescanPhaseResult = PrescanResult;
 export type EmitLoweringPhaseContext = ProgramLoweringContext;
 
@@ -130,7 +130,7 @@ export function runEmitLoweringPhase(
   ctx: EmitLoweringPhaseContext,
   prescan: EmitPrescanPhaseResult,
 ): EmitLoweringPhaseResult {
-  return lowerProgramDeclarations(ctx, prescan);
+  return lowerProgramDeclarations({ ...ctx, prescan });
 }
 
 // --- Phase 4: finalization (placement, fixups, artifact assembly) ---

--- a/src/lowering/programLowering.ts
+++ b/src/lowering/programLowering.ts
@@ -88,10 +88,12 @@ export type Context = FunctionLoweringSharedContext & {
   withNamedSectionSink: <T>(sink: NamedSectionContributionSink, fn: () => T) => T;
 };
 
-export type ProgramPrescanContext = Pick<
+/** Phase 1 — inputs mutated while discovering callables, ops, and module-scope metadata. */
+export type PrescanContext = Pick<
   Context,
   | 'program'
   | 'env'
+  | 'diagnostics'
   | 'localCallablesByFile'
   | 'visibleCallables'
   | 'localOpsByFile'
@@ -104,6 +106,17 @@ export type ProgramPrescanContext = Pick<
   | 'rawAddressSymbols'
   | 'resolveScalarKind'
 >;
+
+/** @deprecated Use {@link PrescanContext} */
+export type ProgramPrescanContext = PrescanContext;
+
+/**
+ * Phase 2 — full program-lowering context after prescan. Prescan outputs are frozen in
+ * {@link PrescanResult}; the same map instances remain on `ctx` for lowering (shared refs).
+ */
+export type LoweringContext = Context & {
+  readonly prescan: PrescanResult;
+};
 
 // --- Phase 2 product: lowered bytes, symbols, and deferred externs ---
 export type LoweringResult = {
@@ -119,8 +132,11 @@ export type LoweringResult = {
   hexBytes: Context['hexBytes'];
 };
 
-// --- Phase 3 context: finalization inputs (placement, fixups, artifacts) ---
-export type FinalizationContext = {
+/**
+ * Phase 3 — inputs for section placement, fixup resolution, and merged byte emission
+ * (`finalizeProgramEmission`).
+ */
+export type ProgramEmissionFinalizeContext = {
   diagnostics: Diagnostic[];
   diag: (diagnostics: Diagnostic[], file: string, message: string) => void;
   primaryFile: string;
@@ -167,14 +183,22 @@ export type FinalizationContext = {
   ) => EmittedSourceSegment[];
 };
 
+/**
+ * Phase 3 — conceptual bundle: lowering context plus the lowering-phase product (#1124).
+ * (Runtime placement still uses {@link ProgramEmissionFinalizeContext} + merged env.)
+ */
+export interface FinalizationContext extends LoweringContext {
+  readonly lowered: LoweringResult;
+}
+
 // --- Phase 1: prescan declarations (callables, ops, storage aliases) ---
-export function preScanProgramDeclarations(ctx: ProgramPrescanContext): PrescanResult {
+export function preScanProgramDeclarations(ctx: PrescanContext): PrescanResult {
   return runProgramPrescan(ctx);
 }
 
 // --- Phase 2: lower declarations and functions into section bytes ---
-export function lowerProgramDeclarations(ctx: Context, _prescan: PrescanResult): LoweringResult {
-  return runProgramLoweringTraversal(ctx, _prescan);
+export function lowerProgramDeclarations(ctx: LoweringContext): LoweringResult {
+  return runProgramLoweringTraversal(ctx);
 }
 
 // --- Phase 3: finalization (placement, fixups, emission) ---

--- a/src/lowering/programLoweringFinalize.ts
+++ b/src/lowering/programLoweringFinalize.ts
@@ -3,11 +3,11 @@ import type {
   EmittedSourceSegment,
 } from '../formats/types.js';
 import type { SectionKind } from './loweringTypes.js';
-import type { FinalizationContext } from './programLowering.js';
+import type { ProgramEmissionFinalizeContext } from './programLowering.js';
 import { parseNumberLiteral } from '../frontend/parseImm.js';
 
 export function computeSectionBases(
-  ctx: Pick<FinalizationContext, 'baseExprs' | 'evalImmExpr' | 'env' | 'diagnostics' | 'diag' | 'primaryFile' | 'alignTo' | 'codeOffset' | 'dataOffset'>,
+  ctx: Pick<ProgramEmissionFinalizeContext, 'baseExprs' | 'evalImmExpr' | 'env' | 'diagnostics' | 'diag' | 'primaryFile' | 'alignTo' | 'codeOffset' | 'dataOffset'>,
   defaultCodeBase?: number,
   options?: { quiet?: boolean },
 ): {
@@ -66,7 +66,7 @@ export function computeSectionBases(
   return { codeBase, dataBase, varBase, codeOk, dataOk, varOk };
 }
 
-export function finalizeProgramEmission(ctx: FinalizationContext): {
+export function finalizeProgramEmission(ctx: ProgramEmissionFinalizeContext): {
   codeBase: number;
   dataBase: number;
   varBase: number;

--- a/src/lowering/programLoweringTraversal.ts
+++ b/src/lowering/programLoweringTraversal.ts
@@ -14,8 +14,7 @@ import type {
   VarBlockNode,
 } from '../frontend/ast.js';
 import type { NamedSectionContributionSink } from './sectionContributions.js';
-import type { PrescanResult } from './prescanTypes.js';
-import type { Context, LoweringResult } from './programLowering.js';
+import type { LoweringContext, LoweringResult } from './programLowering.js';
 import { sizeOfTypeExpr } from '../semantics/layout.js';
 import { lowerDataBlock } from './programLoweringData.js';
 import { createProgramLoweringDeclarationHelpers } from './programLoweringDeclarations.js';
@@ -32,14 +31,14 @@ function sinkOffsetRef(sink: NamedSectionContributionSink) {
 }
 
 function alignNamedSection(
-  ctx: Context,
+  ctx: LoweringContext,
   sink: NamedSectionContributionSink,
   value: number,
 ): void {
   sink.offset = ctx.alignTo(sink.offset, value);
 }
 
-function lowerVarBlock(ctx: Context, varBlock: VarBlockNode): void {
+function lowerVarBlock(ctx: LoweringContext, varBlock: VarBlockNode): void {
   for (const decl of varBlock.decls) {
     if (decl.form !== 'typed') continue;
     const size = sizeOfTypeExpr(decl.typeExpr, ctx.env, ctx.diagnostics);
@@ -79,7 +78,7 @@ function lowerVarBlock(ctx: Context, varBlock: VarBlockNode): void {
   }
 }
 
-function lowerExternDecl(ctx: Context, externDecl: ExternDeclNode): void {
+function lowerExternDecl(ctx: LoweringContext, externDecl: ExternDeclNode): void {
   const baseLower = externDecl.base?.toLowerCase();
   if (baseLower !== undefined && !ctx.declaredBinNames.has(baseLower)) {
     ctx.diag(
@@ -135,7 +134,7 @@ function lowerExternDecl(ctx: Context, externDecl: ExternDeclNode): void {
 }
 
 function lowerItem(
-  ctx: Context,
+  ctx: LoweringContext,
   lowerBinDecl: ReturnType<typeof createProgramLoweringDeclarationHelpers>['lowerBinDecl'],
   lowerRawDataDecl: ReturnType<typeof createProgramLoweringDeclarationHelpers>['lowerRawDataDecl'],
   item: ModuleItemNode | SectionItemNode,
@@ -382,8 +381,7 @@ function lowerItem(
 }
 
 export function lowerProgramDeclarations(
-  ctx: Context,
-  _prescan: PrescanResult,
+  ctx: LoweringContext,
 ): LoweringResult {
   const { lowerBinDecl, lowerRawDataDecl } = createProgramLoweringDeclarationHelpers(ctx);
 

--- a/src/lowering/programPrescan.ts
+++ b/src/lowering/programPrescan.ts
@@ -13,10 +13,10 @@ import type {
 } from '../frontend/ast.js';
 import type { Callable } from './loweringTypes.js';
 import type { PrescanResult } from './prescanTypes.js';
-import type { ProgramPrescanContext } from './programLowering.js';
+import type { PrescanContext } from './programLowering.js';
 
 function getOrCreateFileCallables(
-  ctx: ProgramPrescanContext,
+  ctx: PrescanContext,
   file: string,
 ): Map<string, Callable> {
   const existing = ctx.localCallablesByFile.get(file);
@@ -27,7 +27,7 @@ function getOrCreateFileCallables(
 }
 
 function getOrCreateFileOps(
-  ctx: ProgramPrescanContext,
+  ctx: PrescanContext,
   file: string,
 ): Map<string, OpDeclNode[]> {
   const existing = ctx.localOpsByFile.get(file);
@@ -38,7 +38,7 @@ function getOrCreateFileOps(
 }
 
 function preScanItem(
-  ctx: ProgramPrescanContext,
+  ctx: PrescanContext,
   item: ModuleItemNode | SectionItemNode,
   namedSection?: NamedSectionNode,
 ): void {
@@ -152,7 +152,7 @@ function preScanItem(
   }
 }
 
-export function preScanProgramDeclarations(ctx: ProgramPrescanContext): PrescanResult {
+export function preScanProgramDeclarations(ctx: PrescanContext): PrescanResult {
   for (const module of ctx.program.files) {
     for (const item of module.items) preScanItem(ctx, item);
   }


### PR DESCRIPTION
## Summary

Implements [#1124](https://github.com/jhlagado/ZAX/issues/1124): explicit phase-owned types at the **program-lowering** layer.

### Types

- **`PrescanContext`** — `Pick<Context, …>` including `env`, `diagnostics`, `program`, visibility maps, alias/raw-address state, `resolveScalarKind`. Used by `preScanProgramDeclarations`.
- **`LoweringContext`** — `Context & { readonly prescan: PrescanResult }`. `lowerProgramDeclarations` takes a single argument; emit pipeline passes `{ ...ctx, prescan }`.
- **`FinalizationContext`** — `extends LoweringContext` with `readonly lowered: LoweringResult` (conceptual bundle per issue). Placement/emission still uses the renamed **`ProgramEmissionFinalizeContext`** for `finalizeProgramEmission` (former `FinalizationContext`).

### Renames

- Previous placement-only `FinalizationContext` → **`ProgramEmissionFinalizeContext`** in `programLowering.ts`, `programLoweringFinalize.ts`, `emitFinalization.ts`.

### Behaviour

No intentional changes to traversal, diagnostics, or emitted bytes.

### Deferred

- Per-function / function-level context splits (out of scope for #1124).

Fixes #1124

Made with [Cursor](https://cursor.com)