### PR TITLE
refactor(lowering): FrameContext, BodyContext, RewriteContext (#1123)

### DIFF
--- a/src/lowering/functionLowering.ts
+++ b/src/lowering/functionLowering.ts
@@ -280,11 +280,17 @@ export type FunctionLoweringSharedContext = FunctionLoweringDiagnosticsContext &
   FunctionLoweringAstUtilityContext &
   FunctionLoweringRegisterContext;
 
+/**
+ * Entry context for lowering a whole function. Narrower phase views are
+ * {@link FrameContext}, {@link BodyContext}, and {@link RewriteContext} (#1123).
+ */
 export type FunctionLoweringContext = FunctionLoweringItemContext & FunctionLoweringSharedContext;
+
+export type { BodyContext, FrameContext, RewriteContext } from './functionLoweringPhases.js';
 
 export function lowerFunctionDecl(ctx: FunctionLoweringContext): void {
   const setup = prepareFunctionLoweringSetupPhase(ctx);
   const frame = runFunctionFrameSetupPhase(setup);
-  const body = prepareFunctionBodyLoweringPhase(setup, frame);
-  finalizeFunctionLoweringPhase(setup, body);
+  const body = prepareFunctionBodyLoweringPhase({ ...setup, frame });
+  finalizeFunctionLoweringPhase({ ...setup, frame, body });
 }

--- a/src/lowering/functionLoweringPhases.ts
+++ b/src/lowering/functionLoweringPhases.ts
@@ -9,8 +9,12 @@ import {
 } from './functionBodySetup.js';
 import { createFunctionAsmRewritingHelpers } from './functionAsmRewriting.js';
 import { createFunctionCallLoweringHelpers } from './functionCallLowering.js';
+import type { FunctionFrameSetupContext } from './functionFrameSetup.js';
 import { initializeFunctionFrame } from './functionFrameSetup.js';
 import type { FunctionLoweringContext } from './functionLowering.js';
+
+/** #1123 — inputs to {@link initializeFunctionFrame} (alias of {@link FunctionFrameSetupContext}). */
+export type FrameContext = FunctionFrameSetupContext;
 
 export interface FunctionLoweringSetupPhase {
   readonly ctx: FunctionLoweringContext;
@@ -63,6 +67,16 @@ export interface FunctionFramePhase {
 }
 
 export type FunctionBodyPhase = Readonly<ReturnType<typeof createAsmBodyOrchestrationHelpers>>;
+
+/** #1123 — setup bundle plus frame phase result (before body lowering). */
+export type BodyContext = FunctionLoweringSetupPhase & {
+  readonly frame: FunctionFramePhase;
+};
+
+/** #1123 — frame + body orchestration product for finalization. */
+export type RewriteContext = BodyContext & {
+  readonly body: FunctionBodyPhase;
+};
 
 function buildFrameSetupContext(ctx: FunctionLoweringContext, currentCodeSegmentTagRef: { current: SourceSegmentTag | undefined }) {
   const {
@@ -201,9 +215,7 @@ export function prepareFunctionLoweringSetupPhase(ctx: FunctionLoweringContext):
   };
 }
 
-export function runFunctionFrameSetupPhase(
-  setup: ReturnType<typeof prepareFunctionLoweringSetupPhase>,
-): FunctionFramePhase {
+export function runFunctionFrameSetupPhase(setup: FunctionLoweringSetupPhase): FunctionFramePhase {
   const {
     ctx: {
       diagnostics,
@@ -346,10 +358,8 @@ export function runFunctionFrameSetupPhase(
   };
 }
 
-export function prepareFunctionBodyLoweringPhase(
-  setup: ReturnType<typeof prepareFunctionLoweringSetupPhase>,
-  frame: ReturnType<typeof runFunctionFrameSetupPhase>,
-) {
+export function prepareFunctionBodyLoweringPhase(ctx: BodyContext): FunctionBodyPhase {
+  const { frame, ...setup } = ctx;
   const {
     ctx: {
       item,
@@ -662,10 +672,9 @@ export function prepareFunctionBodyLoweringPhase(
   });
 }
 
-export function finalizeFunctionLoweringPhase(
-  setup: ReturnType<typeof prepareFunctionLoweringSetupPhase>,
-  body: ReturnType<typeof prepareFunctionBodyLoweringPhase>,
-): void {
+export function finalizeFunctionLoweringPhase(ctx: RewriteContext): void {
+  const { body, frame, ...setup } = ctx;
+  void frame;
   body.lowerAndFinalizeFunctionBody();
   setup.bindSpTracking(undefined);
   setup.setCurrentCodeSegmentTag(setup.getCurrentCodeSegmentTag());


### PR DESCRIPTION
## Summary

Implements [#1123](https://github.com/jhlagado/ZAX/issues/1123): explicit **function-lowering** phase contexts without behavior changes.

### Types

| Type | Role |
|------|------|
| **`FrameContext`** | Alias of `FunctionFrameSetupContext` — inputs to `initializeFunctionFrame`. |
| **`BodyContext`** | `FunctionLoweringSetupPhase` & `{ frame: FunctionFramePhase }` — body lowering after frame setup. |
| **`RewriteContext`** | `BodyContext` & `{ body: FunctionBodyPhase }` — finalization pass. |

### API

- `prepareFunctionBodyLoweringPhase(ctx: BodyContext)` (was `(setup, frame)`).
- `finalizeFunctionLoweringPhase(ctx: RewriteContext)` (was `(setup, body)`).
- `lowerFunctionDecl` builds `BodyContext` / `RewriteContext` via object spread.
- `FunctionLoweringContext` remains the **entry** context (`item` + shared emit/resolve state); JSDoc points to phase types.

### Deferred

- Further narrowing `runFunctionFrameSetupPhase` to a slimmer pick (optional).
- Program-level `FinalizationContext` vs `ProgramEmissionFinalizeContext` follow-up (per review notes).

Fixes #1123

Made with [Cursor](https://cursor.com)