### PR TITLE
test: use toContainEqual for diagnostics (#1132)

### DIFF
--- a/test/backend/pr477_encode_alu_family.test.ts
+++ b/test/backend/pr477_encode_alu_family.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
+import { expectDiagnostic } from '../helpers/diagnostics/index.js';
 import type { AsmInstructionNode, AsmOperandNode, SourceSpan } from '../../src/frontend/ast.js';
 import { encodeInstruction } from '../../src/z80/encode.js';
 
@@ -70,6 +72,10 @@ describe('PR477 alu encoder family extraction', () => {
 
     expect(encoded).toBeUndefined();
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]?.message).toContain('destination A or HL');
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.EncodeError,
+      severity: 'error',
+      messageIncludes: 'destination A or HL',
+    });
   });
 });

--- a/test/backend/pr477_encode_bitops_family.test.ts
+++ b/test/backend/pr477_encode_bitops_family.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
+import { expectDiagnostic } from '../helpers/diagnostics/index.js';
 import type { AsmInstructionNode, AsmOperandNode, SourceSpan } from '../../src/frontend/ast.js';
 import { encodeInstruction } from '../../src/z80/encode.js';
 
@@ -61,6 +63,10 @@ describe('PR477 bit/rotate encoder family extraction', () => {
 
     expect(encoded).toBeUndefined();
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]?.message).toContain('bit index 0..7');
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.EncodeError,
+      severity: 'error',
+      messageIncludes: 'bit index 0..7',
+    });
   });
 });

--- a/test/backend/pr477_encode_control_family.test.ts
+++ b/test/backend/pr477_encode_control_family.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
+import { expectDiagnostic } from '../helpers/diagnostics/index.js';
 import type { AsmInstructionNode, AsmOperandNode, SourceSpan } from '../../src/frontend/ast.js';
 import { encodeInstruction } from '../../src/z80/encode.js';
 
@@ -61,6 +63,10 @@ describe('PR477 control encoder family extraction', () => {
 
     expect(encoded).toBeUndefined();
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]!.message).toContain('requires parentheses');
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.EncodeError,
+      severity: 'error',
+      messageIncludes: 'requires parentheses',
+    });
   });
 });

--- a/test/backend/pr477_encode_core_ops_family.test.ts
+++ b/test/backend/pr477_encode_core_ops_family.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
+import { expectDiagnostic } from '../helpers/diagnostics/index.js';
 import type { AsmInstructionNode, AsmOperandNode, SourceSpan } from '../../src/frontend/ast.js';
 import { encodeInstruction } from '../../src/z80/encode.js';
 
@@ -60,6 +62,10 @@ describe('PR477 core-ops encoder family extraction', () => {
 
     expect(encoded).toBeUndefined();
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]?.message).toContain('push expects reg16');
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.EncodeError,
+      severity: 'error',
+      messageIncludes: 'push expects reg16',
+    });
   });
 });

--- a/test/backend/pr477_encode_io_family.test.ts
+++ b/test/backend/pr477_encode_io_family.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
+import { expectDiagnostic } from '../helpers/diagnostics/index.js';
 import type { AsmInstructionNode, AsmOperandNode, SourceSpan } from '../../src/frontend/ast.js';
 import { encodeInstruction } from '../../src/z80/encode.js';
 
@@ -71,6 +73,10 @@ describe('PR477 io encoder family extraction', () => {
 
     expect(encoded).toBeUndefined();
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]?.message).toContain('requires source A');
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.EncodeError,
+      severity: 'error',
+      messageIncludes: 'requires source A',
+    });
   });
 });

--- a/test/backend/pr477_encode_ld_family.test.ts
+++ b/test/backend/pr477_encode_ld_family.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
+import { expectDiagnostic } from '../helpers/diagnostics/index.js';
 import type { AsmInstructionNode, AsmOperandNode, SourceSpan } from '../../src/frontend/ast.js';
 import { encodeInstruction } from '../../src/z80/encode.js';
 
@@ -70,6 +72,10 @@ describe('PR477 ld encoder family extraction', () => {
 
     expect(encoded).toBeUndefined();
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]?.message).toContain('memory-to-memory');
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.EncodeError,
+      severity: 'error',
+      messageIncludes: 'memory-to-memory',
+    });
   });
 });

--- a/test/parser_nested_index.test.ts
+++ b/test/parser_nested_index.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import { parseProgram } from '../src/frontend/parser.js';
 import type { AsmInstructionNode, FuncDeclNode } from '../src/frontend/ast.js';
-import type { Diagnostic } from '../src/diagnosticTypes.js';
+import { DiagnosticIds, type Diagnostic } from '../src/diagnosticTypes.js';
+import { expectDiagnostic } from './helpers/diagnostics/index.js';
 
 describe('parser nested EA index expressions', () => {
   it('parses arr[table[0]] without spurious imm diagnostics', () => {
@@ -37,7 +38,11 @@ end
     const diagnostics: Diagnostic[] = [];
     parseProgram('broken.zax', source, diagnostics);
     expect(diagnostics.length).toBeGreaterThan(0);
-    expect(diagnostics[0]!.message).toContain('Invalid imm expression');
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      messageIncludes: 'Invalid imm expression',
+    });
   });
 
   it('distinguishes arr[HL] (reg16 index) from arr[(HL)] (indirect byte index)', () => {


### PR DESCRIPTION
Part of #1132

Replaces fragile `diagnostics[0].message` / `toContain` checks with `expectDiagnostic` (`toContainEqual(expect.objectContaining(...))`) using `DiagnosticIds`, `severity`, and `messageIncludes` where the message is not fixed.

**Files**
- `test/backend/pr477_encode_{core_ops,ld,control,alu,bitops,io}_family.test.ts` — encoder error paths (`EncodeError`)
- `test/parser_nested_index.test.ts` — parse diagnostic (`ParseError`)

Made with [Cursor](https://cursor.com)