### PR TITLE
test: use expectDiagnostic for diagnostics batch 2 (#1132)

### DIFF
--- a/test/frontend/pr899_step_parser.test.ts
+++ b/test/frontend/pr899_step_parser.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { expectDiagnostic } from '../helpers/diagnostics/index.js';
 import { parseAsmInstruction } from '../../src/frontend/parseAsmInstruction.js';
 import { makeSourceFile, span } from '../../src/frontend/source.js';
 
@@ -77,7 +79,11 @@ describe('PR899 step parser support', () => {
       const parsed = parse(text);
       expect(parsed.instr).toBeUndefined();
       expect(parsed.diagnostics.length).toBeGreaterThan(0);
-      expect(parsed.diagnostics[0]?.message.toLowerCase()).toContain('step');
+      expectDiagnostic(parsed.diagnostics, {
+        id: DiagnosticIds.ParseError,
+        severity: 'error',
+        messageIncludes: 'step',
+      });
     }
   });
 });

--- a/test/lowering/pr510_op_expansion_orchestration_helpers.test.ts
+++ b/test/lowering/pr510_op_expansion_orchestration_helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { DiagnosticIds, type Diagnostic } from '../../src/diagnosticTypes.js';
 import type { AsmInstructionNode, AsmOperandNode, OpDeclNode, SourceSpan } from '../../src/frontend/ast.js';
 import { createOpExpansionOrchestrationHelpers } from '../../src/lowering/opExpansionOrchestration.js';
+import { expectDiagnostic } from '../helpers/diagnostics/index.js';
 
 const span: SourceSpan = {
   file: 'test.zax',
@@ -68,11 +69,11 @@ describe('#510 op expansion orchestration helpers', () => {
 
     expect(helpers.tryHandleOpExpansion(asmItem)).toBe(true);
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]).toMatchObject({
+    expectDiagnostic(diagnostics, {
       id: DiagnosticIds.OpArityMismatch,
       severity: 'error',
       file: 'test.zax',
+      messageIncludes: 'No op overload of "my_op" accepts 0 operand(s).',
     });
-    expect(diagnostics[0]!.message).toContain('No op overload of "my_op" accepts 0 operand(s).');
   });
 });

--- a/test/pr50_union_field_access.test.ts
+++ b/test/pr50_union_field_access.test.ts
@@ -3,7 +3,9 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -14,8 +16,11 @@ describe('PR50: union declarations + union field EA access', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toContain(
-      'Unsupported data type for "v" (expected byte/word/addr/ptr or fixed-length arrays of those).',
-    );
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      message:
+        'Unsupported data type for "v" (expected byte/word/addr/ptr or fixed-length arrays of those).',
+    });
   });
 });

--- a/test/pr583_section_placement_helpers.test.ts
+++ b/test/pr583_section_placement_helpers.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import type { Diagnostic } from '../src/diagnosticTypes.js';
+import { expectDiagnostic } from './helpers/diagnostics/index.js';
 import type { AnchorBoundNode, NamedSectionNode } from '../src/frontend/ast.js';
 import { parseProgram } from '../src/frontend/parser.js';
 import { emitProgram } from '../src/lowering/emit.js';
@@ -163,10 +165,10 @@ describe('PR583 section placement helpers', () => {
     });
 
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]).toMatchObject({
-      id: 'ZAX300',
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.EmitError,
       severity: 'error',
+      messageIncludes: 'Section "code boot" exceeds its anchored capacity',
     });
-    expect(diagnostics[0]?.message).toContain('Section "code boot" exceeds its anchored capacity');
   });
 });

--- a/test/pr781_ld_typed_storage_migration_diag.test.ts
+++ b/test/pr781_ld_typed_storage_migration_diag.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import type { Diagnostic } from '../src/diagnosticTypes.js';
 import { createAsmInstructionLoweringHelpers } from '../src/lowering/asmInstructionLowering.js';
+import { expectDiagnostic } from './helpers/diagnostics/index.js';
 import type { AsmInstructionNode, AsmOperandNode, SourceSpan } from '../src/frontend/ast.js';
 
 const span: SourceSpan = {
@@ -88,7 +89,11 @@ describe('PR781 ld typed-storage migration diagnostics', () => {
     ctx.helper.lowerAsmInstructionDispatcher(ldItem);
 
     expect(ctx.diagnostics.length).toBeGreaterThan(0);
-    expect(ctx.diagnostics[0]?.message).toContain(':=');
+    expectDiagnostic(ctx.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      messageIncludes: ':=',
+    });
     expect(ctx.ldCalled).toBe(false);
   });
 
@@ -107,7 +112,11 @@ describe('PR781 ld typed-storage migration diagnostics', () => {
     ctx.helper.lowerAsmInstructionDispatcher(ldItem);
 
     expect(ctx.diagnostics.length).toBeGreaterThan(0);
-    expect(ctx.diagnostics[0]?.message).toContain(':=');
+    expectDiagnostic(ctx.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      messageIncludes: ':=',
+    });
     expect(ctx.ldCalled).toBe(false);
   });
 });


### PR DESCRIPTION
Part of #1132

Replaces `diagnostics[0]` + `toContain` / `toMatchObject` + message substring checks with `expectDiagnostic` (`toContainEqual` + `DiagnosticIds` + `severity`).

**Areas**
- `test/pr50_union_field_access.test.ts` — `EmitError`, exact stable message for union data decl
- `test/pr781_ld_typed_storage_migration_diag.test.ts` — `EmitError`, `messageIncludes: ':='`
- `test/lowering/pr510_op_expansion_orchestration_helpers.test.ts` — `OpArityMismatch` + file + message
- `test/pr583_section_placement_helpers.test.ts` — `EmitError` (was raw `ZAX300`) + anchored capacity message
- `test/frontend/pr899_step_parser.test.ts` — `ParseError`, `messageIncludes: 'step'` for negative `step` forms

Made with [Cursor](https://cursor.com)