### PR TITLE
refactor(lowering): EAResolutionContext, EAMaterializationContext (#1127)

### DIFF
--- a/src/lowering/eaMaterialization.ts
+++ b/src/lowering/eaMaterialization.ts
@@ -1,7 +1,8 @@
 import type { AsmOperandNode, EaExprNode, SourceSpan } from '../frontend/ast.js';
 import type { EaResolution } from './eaResolution.js';
 
-type EaMaterializationContext = {
+/** Inputs for {@link createEaMaterializationHelpers} — emission hooks plus `resolveEa`, not the EA type-resolution bag (`EAResolutionContext`). */
+export type EAMaterializationContext = {
   resolveEa: (ea: EaExprNode, span: SourceSpan) => EaResolution | undefined;
   pushEaAddress: (ea: EaExprNode, span: SourceSpan) => boolean;
   emitInstr: (head: string, operands: AsmOperandNode[], span: SourceSpan) => boolean;
@@ -9,7 +10,7 @@ type EaMaterializationContext = {
   loadImm16ToDE: (value: number, span: SourceSpan) => boolean;
 };
 
-export function createEaMaterializationHelpers(ctx: EaMaterializationContext) {
+export function createEaMaterializationHelpers(ctx: EAMaterializationContext) {
   const materializeEaAddressToHL = (ea: EaExprNode, span: SourceSpan): boolean => {
     const resolved = ctx.resolveEa(ea, span);
     if (!resolved) {

--- a/src/lowering/eaResolution.ts
+++ b/src/lowering/eaResolution.ts
@@ -1,6 +1,6 @@
 import type { Diagnostic } from '../diagnosticTypes.js';
 import type { EaExprNode, SourceSpan, TypeExprNode } from '../frontend/ast.js';
-import type { CompileEnv } from '../semantics/env.js';
+import { evalImmExpr, type CompileEnv } from '../semantics/env.js';
 import { sizeOfTypeExpr } from '../semantics/layout.js';
 
 export type EaResolution =
@@ -8,7 +8,8 @@ export type EaResolution =
   | { kind: 'stack'; ixDisp: number; typeExpr?: TypeExprNode }
   | { kind: 'indirect'; ixDisp: number; addend: number; typeExpr?: TypeExprNode };
 
-type EaResolutionContext = {
+/** Maps, env, and type hooks used by {@link createEaResolutionHelpers} — not the full function-lowering context. */
+export type EAResolutionContext = {
   env: CompileEnv;
   diagnostics: Diagnostic[];
   diagAt: (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
@@ -27,7 +28,46 @@ type EaResolutionContext = {
   sizeOfTypeExpr: (te: TypeExprNode) => number | undefined;
 };
 
-export function createEaResolutionHelpers(ctx: EaResolutionContext) {
+/** Workspace fields that feed EA resolution (emit phase 1 `EmitPhase1Workspace` slice). */
+export type EaResolutionWorkspaceSlice = {
+  stackSlotOffsets: Map<string, number>;
+  stackSlotTypes: Map<string, TypeExprNode>;
+  storageTypes: Map<string, TypeExprNode>;
+  moduleAliasTargets: Map<string, EaExprNode>;
+  localAliasTargets: Map<string, EaExprNode>;
+};
+
+/** Builds {@link EAResolutionContext} from emit-phase env/workspace plus type-resolution hooks. */
+export function buildEaResolutionContext(params: {
+  env: CompileEnv;
+  diagnostics: Diagnostic[];
+  diagAt: EAResolutionContext['diagAt'];
+  workspace: EaResolutionWorkspaceSlice;
+  resolveScalarKind: EAResolutionContext['resolveScalarKind'];
+  resolveAggregateType: EAResolutionContext['resolveAggregateType'];
+  resolveEaTypeExpr: EAResolutionContext['resolveEaTypeExpr'];
+  evalImmNoDiag: EAResolutionContext['evalImmNoDiag'];
+}): EAResolutionContext {
+  const { env, diagnostics, diagAt, workspace } = params;
+  return {
+    env,
+    diagnostics,
+    diagAt,
+    stackSlotOffsets: workspace.stackSlotOffsets,
+    stackSlotTypes: workspace.stackSlotTypes,
+    storageTypes: workspace.storageTypes,
+    moduleAliasTargets: workspace.moduleAliasTargets,
+    getLocalAliasTargets: () => workspace.localAliasTargets,
+    evalImmExpr: (expr) => evalImmExpr(expr, env, diagnostics),
+    evalImmNoDiag: params.evalImmNoDiag,
+    resolveScalarKind: params.resolveScalarKind,
+    resolveAggregateType: params.resolveAggregateType,
+    resolveEaTypeExpr: params.resolveEaTypeExpr,
+    sizeOfTypeExpr: (te) => sizeOfTypeExpr(te, env, diagnostics),
+  };
+}
+
+export function createEaResolutionHelpers(ctx: EAResolutionContext) {
   const resolveAliasTarget = (nameLower: string): EaExprNode | undefined =>
     ctx.getLocalAliasTargets().get(nameLower) ?? ctx.moduleAliasTargets.get(nameLower);
 

--- a/src/lowering/emitPhase1Helpers.ts
+++ b/src/lowering/emitPhase1Helpers.ts
@@ -29,7 +29,7 @@ import type { CompileEnv } from '../semantics/env.js';
 import { evalImmExpr } from '../semantics/env.js';
 import { sizeOfTypeExpr } from '../semantics/layout.js';
 import { encodeInstruction } from '../z80/encode.js';
-import { createEaResolutionHelpers } from './eaResolution.js';
+import { buildEaResolutionContext, createEaResolutionHelpers } from './eaResolution.js';
 import { createEaMaterializationHelpers } from './eaMaterialization.js';
 import { createAddressingPipelineBuilders } from './addressingPipelines.js';
 import { createRuntimeImmediateHelpers } from './runtimeImmediates.js';
@@ -246,22 +246,24 @@ export function createEmitPhase1Helpers(ctx: Context): EmitPhase1Helpers {
     isEnumName: (name) => ctx.env.enums.has(name),
   });
 
-  const { resolveEa } = createEaResolutionHelpers({
-    env: ctx.env,
-    diagnostics: ctx.diagnostics,
-    diagAt,
-    stackSlotOffsets: ctx.workspace.stackSlotOffsets,
-    stackSlotTypes: ctx.workspace.stackSlotTypes,
-    storageTypes: ctx.workspace.storageTypes,
-    moduleAliasTargets: ctx.workspace.moduleAliasTargets,
-    getLocalAliasTargets: () => ctx.workspace.localAliasTargets,
-    evalImmExpr: (expr) => evalImmExpr(expr, ctx.env, ctx.diagnostics),
-    evalImmNoDiag,
-    resolveScalarKind,
-    resolveAggregateType,
-    resolveEaTypeExpr,
-    sizeOfTypeExpr: (te) => sizeOfTypeExpr(te, ctx.env, ctx.diagnostics),
-  });
+  const { resolveEa } = createEaResolutionHelpers(
+    buildEaResolutionContext({
+      env: ctx.env,
+      diagnostics: ctx.diagnostics,
+      diagAt,
+      workspace: {
+        stackSlotOffsets: ctx.workspace.stackSlotOffsets,
+        stackSlotTypes: ctx.workspace.stackSlotTypes,
+        storageTypes: ctx.workspace.storageTypes,
+        moduleAliasTargets: ctx.workspace.moduleAliasTargets,
+        localAliasTargets: ctx.workspace.localAliasTargets,
+      },
+      resolveScalarKind,
+      resolveAggregateType,
+      resolveEaTypeExpr,
+      evalImmNoDiag,
+    }),
+  );
 
   const isIxIyIndexedMem = (op: AsmOperandNode): boolean =>
     op.kind === 'Mem' &&

--- a/test/lowering/pr509_ea_materialization_helpers.test.ts
+++ b/test/lowering/pr509_ea_materialization_helpers.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import type { AsmOperandNode, EaExprNode, SourceSpan } from '../../src/frontend/ast.js';
-import { createEaMaterializationHelpers } from '../../src/lowering/eaMaterialization.js';
+import {
+  createEaMaterializationHelpers,
+  type EAMaterializationContext,
+} from '../../src/lowering/eaMaterialization.js';
 import type { EaResolution } from '../../src/lowering/eaResolution.js';
 
 const span: SourceSpan = {
@@ -33,7 +36,7 @@ describe('#509 ea materialization helpers', () => {
       return true;
     };
 
-    const helpers = createEaMaterializationHelpers({
+    const materializationCtx: EAMaterializationContext = {
       resolveEa: (ea) => (ea.kind === 'EaName' ? resolutions.get(ea.name.toLowerCase()) : undefined),
       pushEaAddress: () => {
         emitted.push('pushEaAddress');
@@ -47,7 +50,8 @@ describe('#509 ea materialization helpers', () => {
         emitted.push(`loadImm16ToDE ${value}`);
         return true;
       },
-    });
+    };
+    const helpers = createEaMaterializationHelpers(materializationCtx);
 
     expect(helpers.materializeEaAddressToHL(eaName('globw'), span)).toBe(true);
     expect(helpers.materializeEaAddressToHL(eaName('slotw'), span)).toBe(true);

--- a/test/pr709_ea_resolution_indirect.test.ts
+++ b/test/pr709_ea_resolution_indirect.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import type { Diagnostic } from '../src/diagnosticTypes.js';
 import type { EaExprNode, RecordFieldNode, SourceSpan, TypeExprNode } from '../src/frontend/ast.js';
-import { createEaResolutionHelpers } from '../src/lowering/eaResolution.js';
+import { buildEaResolutionContext, createEaResolutionHelpers } from '../src/lowering/eaResolution.js';
 
 const span: SourceSpan = {
   file: 'pr709.zax',
@@ -52,45 +52,40 @@ function makeHelpers() {
   ]);
   const localAliasTargets = new Map<string, EaExprNode>([['alias_table', eaName('table')]]);
 
-  const helpers = createEaResolutionHelpers({
-    env: { consts: new Map(), enums: new Map(), types: new Map() },
-    diagnostics,
-    diagAt: (diags, s, message) => {
-      diags.push({
-        id: DiagnosticIds.TypeError,
-        severity: 'error',
-        message,
-        file: s.file,
-        line: s.start.line,
-        column: s.start.column,
-      });
-    },
-    stackSlotOffsets,
-    stackSlotTypes,
-    storageTypes: new Map(),
-    moduleAliasTargets: new Map(),
-    getLocalAliasTargets: () => localAliasTargets,
-    evalImmExpr: (expr) => (expr.kind === 'ImmLiteral' ? expr.value : undefined),
-    evalImmNoDiag: (expr) => (expr.kind === 'ImmLiteral' ? expr.value : undefined),
-    resolveScalarKind: (typeExpr) => {
-      if (typeExpr.kind !== 'TypeName') return undefined;
-      const lower = typeExpr.name.toLowerCase();
-      return lower === 'byte' || lower === 'word' || lower === 'addr' ? lower : undefined;
-    },
-    resolveAggregateType: (typeExpr) => {
-      if (typeExpr.kind === 'RecordType') return { kind: 'record', fields: typeExpr.fields };
-      return undefined;
-    },
-    resolveEaTypeExpr: () => undefined,
-    sizeOfTypeExpr: (typeExpr) => {
-      if (typeExpr.kind === 'TypeName') {
-        if (typeExpr.name === 'byte') return 1;
-        if (typeExpr.name === 'word') return 2;
-      }
-      if (typeExpr.kind === 'RecordType') return 4;
-      return undefined;
-    },
-  });
+  const helpers = createEaResolutionHelpers(
+    buildEaResolutionContext({
+      env: { consts: new Map(), enums: new Map(), types: new Map() },
+      diagnostics,
+      diagAt: (diags, s, message) => {
+        diags.push({
+          id: DiagnosticIds.TypeError,
+          severity: 'error',
+          message,
+          file: s.file,
+          line: s.start.line,
+          column: s.start.column,
+        });
+      },
+      workspace: {
+        stackSlotOffsets,
+        stackSlotTypes,
+        storageTypes: new Map(),
+        moduleAliasTargets: new Map(),
+        localAliasTargets,
+      },
+      evalImmNoDiag: (expr) => (expr.kind === 'ImmLiteral' ? expr.value : undefined),
+      resolveScalarKind: (typeExpr) => {
+        if (typeExpr.kind !== 'TypeName') return undefined;
+        const lower = typeExpr.name.toLowerCase();
+        return lower === 'byte' || lower === 'word' || lower === 'addr' ? lower : undefined;
+      },
+      resolveAggregateType: (typeExpr) => {
+        if (typeExpr.kind === 'RecordType') return { kind: 'record', fields: typeExpr.fields };
+        return undefined;
+      },
+      resolveEaTypeExpr: () => undefined,
+    }),
+  );
 
   return { diagnostics, resolveEa: helpers.resolveEa };
 }


### PR DESCRIPTION
## Summary

Isolate EA resolution wiring from ad-hoc object construction by exporting a minimal `EAResolutionContext` and `buildEaResolutionContext` in `eaResolution.ts`, and using it from emit phase 1 and EA tests.

Export `EAMaterializationContext` for `createEaMaterializationHelpers` (materialization remains callback-based; it does not take the resolution bag).

## Testing

- `npm run typecheck`
- `npm run lint`
- `npx vitest run`

Fixes #1127

Made with [Cursor](https://cursor.com)