### PR TITLE
ci: gate fixture coverage-map drift (#1281)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,10 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Fixture coverage map (no drift vs generator)
+        if: runner.os == 'Linux'
+        run: npm run check:fixture-coverage
+
       - name: Test (coverage core)
         id: coverage_core_tests
         run: npm run test:ci:coverage-core

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "format:check": "prettier -c .",
     "check:source-file-sizes": "node scripts/check-source-file-sizes.mjs",
     "check:source-file-sizes:enforce": "node scripts/check-source-file-sizes.mjs --enforce-hard-cap",
+    "check:fixture-coverage": "node scripts/dev/fixture-coverage.js --check",
     "zax": "npm run build && node dist/src/cli.js",
     "regen:language-tour": "bash scripts/regenerate-language-tour.sh",
     "regen:codegen-corpus": "node scripts/regenerate-codegen-corpus.mjs",

--- a/scripts/dev/fixture-coverage.js
+++ b/scripts/dev/fixture-coverage.js
@@ -15,6 +15,9 @@ import { basename, dirname, join, relative, resolve, sep } from 'node:path';
  * "Potentially unreferenced" means: not reachable from any test string reference to
  * test/fixtures/... via transitive include/import edges using the rules above — not a
  * safe deletion list when limits apply.
+ *
+ * CLI: `--check` compares generated Markdown to test/fixtures/coverage-map.md (exit 1 on drift).
+ * Regenerate: `node scripts/dev/fixture-coverage.js > test/fixtures/coverage-map.md`
  */
 
 const repoRoot = process.cwd();
@@ -420,7 +423,42 @@ function formatMarkdown(summary, fixtureMap) {
   return lines.join('\n');
 }
 
+/** Stable comparison: LF-only, single trailing newline (matches typical editor + CI checkout). */
+function normalizeGeneratedDoc(text) {
+  return `${text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trimEnd()}\n`;
+}
+
+const coverageMapRel = join('test', 'fixtures', 'coverage-map.md');
+const coverageMapAbs = join(repoRoot, coverageMapRel);
+
+function runCheck() {
+  const fixtureMap = buildFixtureMap();
+  const summary = summarizeMap(fixtureMap);
+  const generated = normalizeGeneratedDoc(formatMarkdown(summary, fixtureMap));
+
+  if (!existsSync(coverageMapAbs)) {
+    console.error(`fixture-coverage --check: missing ${coverageMapRel}`);
+    console.error(`Regenerate: node scripts/dev/fixture-coverage.js > ${coverageMapRel}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const onDisk = normalizeGeneratedDoc(readFileSync(coverageMapAbs, 'utf8'));
+  if (generated === onDisk) {
+    return;
+  }
+
+  console.error(`fixture-coverage --check: ${coverageMapRel} is out of date (differs from generator output).`);
+  console.error(`Regenerate from repo root: node scripts/dev/fixture-coverage.js > ${coverageMapRel}`);
+  process.exitCode = 1;
+}
+
 function main() {
+  if (process.argv.includes('--check')) {
+    runCheck();
+    return;
+  }
+
   const format = process.argv.includes('--format=json') ? 'json' : 'md';
   const fixtureMap = buildFixtureMap();
   const summary = summarizeMap(fixtureMap);

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -55,3 +55,11 @@ Example cluster:
 - Tests moved into subsystem folders should reference fixtures via:
   `join(__dirname, '..', 'fixtures', '<name>.zax')`
 - This keeps fixture access stable even as tests migrate into `test/backend`, `test/semantics`, etc.
+
+## Coverage map (`coverage-map.md`)
+
+- `coverage-map.md` is **generated** by `scripts/dev/fixture-coverage.js` (static test references plus
+  fixture `include` / `import` edges; assumptions match the banner in that file).
+- After changing fixtures or tests that affect the map, regenerate from the repo root:
+  `node scripts/dev/fixture-coverage.js > test/fixtures/coverage-map.md`
+- CI runs `npm run check:fixture-coverage` (fails if the committed map drifts from the generator).


### PR DESCRIPTION
## Summary

- `scripts/dev/fixture-coverage.js --check`: normalize output and compare to `test/fixtures/coverage-map.md`
- `npm run check:fixture-coverage` in `package.json`
- Linux-only CI step after lint (same pattern as other checks)
- `test/fixtures/README.md`: Coverage map section (regen + assumptions)

Fixes #1281

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CI gate that can fail PRs when `test/fixtures/coverage-map.md` isn’t regenerated, which may introduce unexpected build failures for fixture/test-only changes. Runtime impact is limited to CI/dev tooling.
> 
> **Overview**
> Adds a drift-check workflow to keep `test/fixtures/coverage-map.md` in sync with the output of `scripts/dev/fixture-coverage.js`.
> 
> Introduces `fixture-coverage.js --check` (normalized, stable doc comparison), wires it as `npm run check:fixture-coverage`, and runs it as a Linux-only step in CI. Updates `test/fixtures/README.md` with regeneration instructions and notes that the map is generated and enforced by CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 666c6739c5e7c266db97a08a3312e0836d2a390f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->