### PR TITLE
docs(lowering): JSDoc on context and result fields (#1130)

### DIFF
--- a/src/lowering/asmUtils.ts
+++ b/src/lowering/asmUtils.ts
@@ -1,6 +1,7 @@
 import type { AsmOperandNode, EaExprNode, ImmExprNode, OffsetofPathNode } from '../frontend/ast.js';
 
 type Context = {
+  /** Returns true when `name` matches a declared enum (used to normalize asm tokens); callback must stay pure. */
   isEnumName: (name: string) => boolean;
 };
 

--- a/src/lowering/capabilities.ts
+++ b/src/lowering/capabilities.ts
@@ -12,11 +12,14 @@ import type { OpOverloadSelection } from './opMatching.js';
 import type { OpStackSummary } from './opStackAnalysis.js';
 
 export interface LoweringDiagnosticsCapability {
+  /** Mutable diagnostic list. */
   diagnostics: Diagnostic[];
+  /** Span-attached diagnostic. */
   diagAt: (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
 }
 
 export interface LoweringDiagnosticsWithIdCapability extends LoweringDiagnosticsCapability {
+  /** Diagnostic with stable id. */
   diagAtWithId: (
     diagnostics: Diagnostic[],
     span: SourceSpan,
@@ -26,6 +29,7 @@ export interface LoweringDiagnosticsWithIdCapability extends LoweringDiagnostics
 }
 
 export interface LoweringDiagnosticsWithSeverityCapability extends LoweringDiagnosticsWithIdCapability {
+  /** Diagnostic with id and severity. */
   diagAtWithSeverityAndId: (
     diagnostics: Diagnostic[],
     span: SourceSpan,
@@ -36,51 +40,65 @@ export interface LoweringDiagnosticsWithSeverityCapability extends LoweringDiagn
 }
 
 export interface CompileEnvCapability {
+  /** Compile environment (module ids, consts, types). */
   env: CompileEnv;
 }
 
 export interface AstCloneCapability {
+  /** Deep-clone an imm AST node. */
   cloneImmExpr: (expr: ImmExprNode) => ImmExprNode;
+  /** Deep-clone an EA AST node. */
   cloneEaExpr: (ea: EaExprNode) => EaExprNode;
+  /** Deep-clone an asm operand. */
   cloneOperand: (operand: AsmOperandNode) => AsmOperandNode;
 }
 
 export interface DottedEaNameCapability {
+  /** Flattens dotted EA to a single string; `undefined` if not a simple dotted path. */
   flattenEaDottedName: (ea: EaExprNode) => string | undefined;
 }
 
 export interface FixedTokenNormalizationCapability {
+  /** Normalizes fixed tokens for op matching; `undefined` if not applicable. */
   normalizeFixedToken: (operand: AsmOperandNode) => string | undefined;
 }
 
 export interface InverseConditionCapability {
+  /** Inverts a condition name for opposite branch; `undefined` if unknown. */
   inverseConditionName: (name: string) => string | undefined;
 }
 
 export interface HiddenLabelCapability {
+  /** Allocates a unique hidden label with `prefix`. */
   newHiddenLabel: (prefix: string) => string;
 }
 
 export interface AsmRangeLoweringCapability {
+  /** Lowers a contiguous asm range until `stopKinds`; returns next index. */
   lowerAsmRange: (items: readonly AsmItemNode[], startIndex: number, stopKinds: Set<string>) => number;
 }
 
 export interface FlowSyncCapability {
+  /** Persists structured-control state into the flow ref. */
   syncToFlow: () => void;
 }
 
 export interface OpCandidateResolverCapability {
+  /** Resolves op overloads; `undefined` if none. */
   resolveOpCandidates: (name: string, file: string) => OpDeclNode[] | undefined;
 }
 
 export interface OpOperandFormattingCapability {
+  /** Renders an operand for diagnostic text. */
   formatAsmOperandForOpDiag: (operand: AsmOperandNode) => string;
 }
 
 export interface OpOverloadSelectionCapability {
+  /** Picks overload from operands; returns selection metadata. */
   selectOpOverload: (overloads: OpDeclNode[], operands: AsmOperandNode[]) => OpOverloadSelection;
 }
 
 export interface OpStackSummaryCapability {
+  /** Summarizes stack delta for an op body. */
   summarizeOpStackEffect: (opDecl: OpDeclNode) => OpStackSummary;
 }

--- a/src/lowering/eaMaterialization.ts
+++ b/src/lowering/eaMaterialization.ts
@@ -3,10 +3,15 @@ import type { EaResolution } from './eaResolution.js';
 
 /** Inputs for {@link createEaMaterializationHelpers} — emission hooks plus `resolveEa`, not the EA type-resolution bag (`EAResolutionContext`). */
 export type EAMaterializationContext = {
+  /** Resolves an EA to storage/abs form; `undefined` means unresolved (caller may use push path). */
   resolveEa: (ea: EaExprNode, span: SourceSpan) => EaResolution | undefined;
+  /** Materializes unresolved EA via push sequence; `false` on failure. */
   pushEaAddress: (ea: EaExprNode, span: SourceSpan) => boolean;
+  /** Emits one encoded instruction; `false` if encoding failed. */
   emitInstr: (head: string, operands: AsmOperandNode[], span: SourceSpan) => boolean;
+  /** Queues a 16-bit absolute fixup (e.g. LD HL, sym+off). */
   emitAbs16Fixup: (opcode: number, target: string, addend: number, span: SourceSpan) => void;
+  /** Loads a 16-bit immediate into DE; `false` if emission failed. */
   loadImm16ToDE: (value: number, span: SourceSpan) => boolean;
 };
 

--- a/src/lowering/eaResolution.ts
+++ b/src/lowering/eaResolution.ts
@@ -4,48 +4,100 @@ import { evalImmExpr, type CompileEnv } from '../semantics/env.js';
 import { sizeOfTypeExpr } from '../semantics/layout.js';
 
 export type EaResolution =
-  | { kind: 'abs'; baseLower: string; addend: number; typeExpr?: TypeExprNode }
-  | { kind: 'stack'; ixDisp: number; typeExpr?: TypeExprNode }
-  | { kind: 'indirect'; ixDisp: number; addend: number; typeExpr?: TypeExprNode };
+  | {
+      /** Resolved global/absolute label or numeric base. */
+      kind: 'abs';
+      /** Lowercased symbol name or stringified numeric base for fixups. */
+      baseLower: string;
+      /** Byte offset added to the base symbol. */
+      addend: number;
+      /** Optional inferred type at this address; omit when unknown. */
+      typeExpr?: TypeExprNode;
+    }
+  | {
+      /** IX/IY-relative stack or direct stack slot. */
+      kind: 'stack';
+      /** Displacement in bytes from the frame base register. */
+      ixDisp: number;
+      /** Optional slot/aggregate type when known. */
+      typeExpr?: TypeExprNode;
+    }
+  | {
+      /** Stack slot holds an address; access is indirect with offset. */
+      kind: 'indirect';
+      /** Frame displacement of the pointer slot. */
+      ixDisp: number;
+      /** Byte offset applied after loading the pointer. */
+      addend: number;
+      /** Optional pointee type when known. */
+      typeExpr?: TypeExprNode;
+    };
 
 /** Maps, env, and type hooks used by {@link createEaResolutionHelpers} — not the full function-lowering context. */
 export type EAResolutionContext = {
+  /** Compile-time const/enum/type environment for imm evaluation. */
   env: CompileEnv;
+  /** Mutable diagnostic list for resolution errors. */
   diagnostics: Diagnostic[];
+  /** Appends a span-attached diagnostic. */
   diagAt: (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
+  /** Lowercased stack slot name → IX/IY displacement (bytes). */
   stackSlotOffsets: Map<string, number>;
+  /** Lowercased stack slot name → declared slot type, when known. */
   stackSlotTypes: Map<string, TypeExprNode>;
+  /** Lowercased symbol → global/storage type expression. */
   storageTypes: Map<string, TypeExprNode>;
+  /** Cross-module alias name → target EA expression. */
   moduleAliasTargets: Map<string, EaExprNode>;
+  /** Current function’s local alias map (fresh each function). */
   getLocalAliasTargets: () => Map<string, EaExprNode>;
+  /** Evaluates immediates with diagnostics; `undefined` if ill-typed or non-const. */
   evalImmExpr: (expr: import('../frontend/ast.js').ImmExprNode) => number | undefined;
+  /** Evaluates immediates without recording diagnostics (best-effort). */
   evalImmNoDiag: (expr: import('../frontend/ast.js').ImmExprNode) => number | undefined;
+  /** Classifies scalar kinds for layout; `undefined` if not a scalar shape. */
   resolveScalarKind: (typeExpr: TypeExprNode) => 'byte' | 'word' | 'addr' | undefined;
+  /** Unwraps record/union for field walk; `undefined` if not aggregate. */
   resolveAggregateType: (
     te: TypeExprNode,
   ) => { kind: 'record' | 'union'; fields: import('../frontend/ast.js').RecordFieldNode[] } | undefined;
+  /** Infers a type for an EA subexpression when possible; `undefined` if unknown. */
   resolveEaTypeExpr: (ea: EaExprNode) => TypeExprNode | undefined;
+  /** Storage size in bytes; `undefined` if layout cannot be computed. */
   sizeOfTypeExpr: (te: TypeExprNode) => number | undefined;
 };
 
 /** Workspace fields that feed EA resolution (emit phase 1 `EmitPhase1Workspace` slice). */
 export type EaResolutionWorkspaceSlice = {
+  /** See {@link EAResolutionContext.stackSlotOffsets}. */
   stackSlotOffsets: Map<string, number>;
+  /** See {@link EAResolutionContext.stackSlotTypes}. */
   stackSlotTypes: Map<string, TypeExprNode>;
+  /** See {@link EAResolutionContext.storageTypes}. */
   storageTypes: Map<string, TypeExprNode>;
+  /** See {@link EAResolutionContext.moduleAliasTargets}. */
   moduleAliasTargets: Map<string, EaExprNode>;
+  /** Snapshot of local aliases (not a getter); paired with `getLocalAliasTargets` in builders. */
   localAliasTargets: Map<string, EaExprNode>;
 };
 
 /** Builds {@link EAResolutionContext} from emit-phase env/workspace plus type-resolution hooks. */
 export function buildEaResolutionContext(params: {
+  /** See {@link EAResolutionContext.env}. */
   env: CompileEnv;
+  /** See {@link EAResolutionContext.diagnostics}. */
   diagnostics: Diagnostic[];
+  /** See {@link EAResolutionContext.diagAt}. */
   diagAt: EAResolutionContext['diagAt'];
+  /** Workspace maps aliasing the fields on {@link EAResolutionContext}. */
   workspace: EaResolutionWorkspaceSlice;
+  /** See {@link EAResolutionContext.resolveScalarKind}. */
   resolveScalarKind: EAResolutionContext['resolveScalarKind'];
+  /** See {@link EAResolutionContext.resolveAggregateType}. */
   resolveAggregateType: EAResolutionContext['resolveAggregateType'];
+  /** See {@link EAResolutionContext.resolveEaTypeExpr}. */
   resolveEaTypeExpr: EAResolutionContext['resolveEaTypeExpr'];
+  /** See {@link EAResolutionContext.evalImmNoDiag}. */
   evalImmNoDiag: EAResolutionContext['evalImmNoDiag'];
 }): EAResolutionContext {
   const { env, diagnostics, diagAt, workspace } = params;

--- a/src/lowering/emissionCore.ts
+++ b/src/lowering/emissionCore.ts
@@ -2,14 +2,23 @@ import type { AsmOperandNode, ImmExprNode, SourceSpan } from '../frontend/ast.js
 import { renderStepInstr, type StepInstr, type StepPipeline } from './steps.js';
 
 type Context = {
+  /** Current code emission offset. */
   getCodeOffset: () => number;
+  /** Sets absolute code offset cursor. */
   setCodeOffset: (value: number) => void;
+  /** Writes one byte into the code map. */
   setCodeByte: (offset: number, value: number) => void;
+  /** Extends source range map for listings. */
   recordCodeSourceRange: (start: number, end: number) => void;
+  /** Optional trace hook for emitted bytes. */
   traceInstruction: (start: number, bytes: Uint8Array, traceText: string) => void;
+  /** Encodes one asm instruction. */
   emitInstr: (head: string, operands: AsmOperandNode[], span: SourceSpan) => boolean;
+  /** Loads imm16 to DE. */
   loadImm16ToDE: (value: number, span: SourceSpan) => boolean;
+  /** Loads imm16 to HL. */
   loadImm16ToHL: (value: number, span: SourceSpan) => boolean;
+  /** Queues standard abs16 fixup. */
   emitAbs16Fixup: (
     opcode: number,
     baseLower: string,
@@ -17,6 +26,7 @@ type Context = {
     span: SourceSpan,
     asmText?: string,
   ) => void;
+  /** Queues ED-prefixed abs16 fixup. */
   emitAbs16FixupEd: (
     opcode2: number,
     baseLower: string,

--- a/src/lowering/emitContextBuilder.ts
+++ b/src/lowering/emitContextBuilder.ts
@@ -18,121 +18,233 @@ import type {
 } from './programLowering.js';
 import type { NamedSectionContributionSink } from './sectionContributions.js';
 
-/** Flat field bag passed into {@link createEmitLoweringContexts} for function-body lowering. */
+/**
+ * Flat field bag passed into {@link createEmitLoweringContexts} for function-body lowering.
+ * Each field matches the same-named member on {@link import('./functionLowering.js').FunctionLoweringContext}.
+ */
 export type EmitFunctionLoweringContextInputs = {
+  /** @inheritdoc FunctionLoweringDiagnosticsContext */
   diagnostics: FunctionLoweringDiagnosticsContext['diagnostics'];
+  /** @inheritdoc FunctionLoweringDiagnosticsContext */
   diag: FunctionLoweringDiagnosticsContext['diag'];
+  /** @inheritdoc FunctionLoweringDiagnosticsContext */
   diagAt: FunctionLoweringDiagnosticsContext['diagAt'];
+  /** @inheritdoc FunctionLoweringDiagnosticsContext */
   diagAtWithId: FunctionLoweringDiagnosticsContext['diagAtWithId'];
+  /** @inheritdoc FunctionLoweringDiagnosticsContext */
   diagAtWithSeverityAndId: FunctionLoweringDiagnosticsContext['diagAtWithSeverityAndId'];
+  /** @inheritdoc FunctionLoweringDiagnosticsContext */
   warnAt: FunctionLoweringDiagnosticsContext['warnAt'];
+  /** @inheritdoc FunctionLoweringSymbolContext */
   taken: FunctionLoweringSymbolContext['taken'];
+  /** @inheritdoc FunctionLoweringSymbolContext */
   pending: FunctionLoweringSymbolContext['pending'];
+  /** @inheritdoc FunctionLoweringSymbolContext */
   traceComment: FunctionLoweringSymbolContext['traceComment'];
+  /** @inheritdoc FunctionLoweringSymbolContext */
   traceLabel: FunctionLoweringSymbolContext['traceLabel'];
+  /** @inheritdoc FunctionLoweringSymbolContext */
   currentCodeSegmentTagRef: FunctionLoweringSymbolContext['currentCodeSegmentTagRef'];
+  /** @inheritdoc FunctionLoweringSymbolContext */
   generatedLabelCounterRef: FunctionLoweringSymbolContext['generatedLabelCounterRef'];
+  /** @inheritdoc FunctionLoweringSpTrackingContext */
   bindSpTracking: FunctionLoweringSpTrackingContext['bindSpTracking'];
+  /** @inheritdoc FunctionLoweringEmissionContext */
   getCodeOffset: FunctionLoweringEmissionContext['getCodeOffset'];
+  /** @inheritdoc FunctionLoweringEmissionContext */
   emitInstr: FunctionLoweringEmissionContext['emitInstr'];
+  /** @inheritdoc FunctionLoweringEmissionContext */
   emitRawCodeBytes: FunctionLoweringEmissionContext['emitRawCodeBytes'];
+  /** @inheritdoc FunctionLoweringEmissionContext */
   emitAbs16Fixup: FunctionLoweringEmissionContext['emitAbs16Fixup'];
+  /** @inheritdoc FunctionLoweringEmissionContext */
   emitAbs16FixupPrefixed: FunctionLoweringEmissionContext['emitAbs16FixupPrefixed'];
+  /** @inheritdoc FunctionLoweringEmissionContext */
   emitRel8Fixup: FunctionLoweringEmissionContext['emitRel8Fixup'];
+  /** @inheritdoc FunctionLoweringConditionContext */
   conditionOpcodeFromName: FunctionLoweringConditionContext['conditionOpcodeFromName'];
+  /** @inheritdoc FunctionLoweringConditionContext */
   conditionNameFromOpcode: FunctionLoweringConditionContext['conditionNameFromOpcode'];
+  /** @inheritdoc FunctionLoweringConditionContext */
   callConditionOpcodeFromName: FunctionLoweringConditionContext['callConditionOpcodeFromName'];
+  /** @inheritdoc FunctionLoweringConditionContext */
   jrConditionOpcodeFromName: FunctionLoweringConditionContext['jrConditionOpcodeFromName'];
+  /** @inheritdoc FunctionLoweringConditionContext */
   conditionOpcode: FunctionLoweringConditionContext['conditionOpcode'];
+  /** @inheritdoc FunctionLoweringConditionContext */
   inverseConditionName: FunctionLoweringConditionContext['inverseConditionName'];
+  /** @inheritdoc FunctionLoweringConditionContext */
   symbolicTargetFromExpr: FunctionLoweringConditionContext['symbolicTargetFromExpr'];
+  /** @inheritdoc FunctionLoweringTypeContext */
   evalImmExpr: FunctionLoweringTypeContext['evalImmExpr'];
+  /** @inheritdoc FunctionLoweringTypeContext */
   env: FunctionLoweringTypeContext['env'];
+  /** @inheritdoc FunctionLoweringTypeContext */
   resolveScalarBinding: FunctionLoweringTypeContext['resolveScalarBinding'];
+  /** @inheritdoc FunctionLoweringTypeContext */
   resolveScalarKind: FunctionLoweringTypeContext['resolveScalarKind'];
+  /** @inheritdoc FunctionLoweringTypeContext */
   resolveEaTypeExpr: FunctionLoweringTypeContext['resolveEaTypeExpr'];
+  /** @inheritdoc FunctionLoweringTypeContext */
   resolveScalarTypeForEa: FunctionLoweringTypeContext['resolveScalarTypeForEa'];
+  /** @inheritdoc FunctionLoweringTypeContext */
   resolveScalarTypeForLd: FunctionLoweringTypeContext['resolveScalarTypeForLd'];
+  /** @inheritdoc FunctionLoweringTypeContext */
   resolveArrayType: FunctionLoweringTypeContext['resolveArrayType'];
+  /** @inheritdoc FunctionLoweringTypeContext */
   typeDisplay: FunctionLoweringTypeContext['typeDisplay'];
+  /** @inheritdoc FunctionLoweringTypeContext */
   sameTypeShape: FunctionLoweringTypeContext['sameTypeShape'];
+  /** @inheritdoc FunctionLoweringMaterializationContext */
   resolveEa: FunctionLoweringMaterializationContext['resolveEa'];
+  /** @inheritdoc FunctionLoweringMaterializationContext */
   buildEaWordPipeline: FunctionLoweringMaterializationContext['buildEaWordPipeline'];
+  /** @inheritdoc FunctionLoweringMaterializationContext */
   enforceEaRuntimeAtomBudget: FunctionLoweringMaterializationContext['enforceEaRuntimeAtomBudget'];
+  /** @inheritdoc FunctionLoweringMaterializationContext */
   enforceDirectCallSiteEaBudget:
     FunctionLoweringMaterializationContext['enforceDirectCallSiteEaBudget'];
+  /** @inheritdoc FunctionLoweringMaterializationContext */
   pushEaAddress: FunctionLoweringMaterializationContext['pushEaAddress'];
+  /** @inheritdoc FunctionLoweringMaterializationContext */
   materializeEaAddressToHL: FunctionLoweringMaterializationContext['materializeEaAddressToHL'];
+  /** @inheritdoc FunctionLoweringMaterializationContext */
   pushMemValue: FunctionLoweringMaterializationContext['pushMemValue'];
+  /** @inheritdoc FunctionLoweringMaterializationContext */
   pushImm16: FunctionLoweringMaterializationContext['pushImm16'];
+  /** @inheritdoc FunctionLoweringMaterializationContext */
   pushZeroExtendedReg8: FunctionLoweringMaterializationContext['pushZeroExtendedReg8'];
+  /** @inheritdoc FunctionLoweringMaterializationContext */
   loadImm16ToHL: FunctionLoweringMaterializationContext['loadImm16ToHL'];
+  /** @inheritdoc FunctionLoweringMaterializationContext */
   emitStepPipeline: FunctionLoweringMaterializationContext['emitStepPipeline'];
+  /** @inheritdoc FunctionLoweringMaterializationContext */
   emitScalarWordLoad: FunctionLoweringMaterializationContext['emitScalarWordLoad'];
+  /** @inheritdoc FunctionLoweringMaterializationContext */
   emitScalarWordStore: FunctionLoweringMaterializationContext['emitScalarWordStore'];
+  /** @inheritdoc FunctionLoweringMaterializationContext */
   lowerLdWithEa: FunctionLoweringMaterializationContext['lowerLdWithEa'];
+  /** @inheritdoc FunctionLoweringStorageContext */
   stackSlotOffsets: FunctionLoweringStorageContext['stackSlotOffsets'];
+  /** @inheritdoc FunctionLoweringStorageContext */
   stackSlotTypes: FunctionLoweringStorageContext['stackSlotTypes'];
+  /** @inheritdoc FunctionLoweringStorageContext */
   localAliasTargets: FunctionLoweringStorageContext['localAliasTargets'];
+  /** @inheritdoc FunctionLoweringStorageContext */
   storageTypes: FunctionLoweringStorageContext['storageTypes'];
+  /** @inheritdoc FunctionLoweringStorageContext */
   moduleAliasTargets: FunctionLoweringStorageContext['moduleAliasTargets'];
+  /** @inheritdoc FunctionLoweringStorageContext */
   rawTypedCallWarningsEnabled: FunctionLoweringStorageContext['rawTypedCallWarningsEnabled'];
+  /** @inheritdoc FunctionLoweringCallableResolutionContext */
   resolveCallable: FunctionLoweringCallableResolutionContext['resolveCallable'];
+  /** @inheritdoc FunctionLoweringCallableResolutionContext */
   resolveOpCandidates: FunctionLoweringCallableResolutionContext['resolveOpCandidates'];
+  /** @inheritdoc FunctionLoweringCallableResolutionContext */
   opStackPolicyMode: FunctionLoweringCallableResolutionContext['opStackPolicyMode'];
+  /** @inheritdoc FunctionLoweringOpOverloadContext */
   formatAsmOperandForOpDiag: FunctionLoweringOpOverloadContext['formatAsmOperandForOpDiag'];
+  /** @inheritdoc FunctionLoweringOpOverloadContext */
   selectOpOverload: FunctionLoweringOpOverloadContext['selectOpOverload'];
+  /** @inheritdoc FunctionLoweringOpOverloadContext */
   summarizeOpStackEffect: FunctionLoweringOpOverloadContext['summarizeOpStackEffect'];
+  /** @inheritdoc FunctionLoweringAstUtilityContext */
   cloneImmExpr: FunctionLoweringAstUtilityContext['cloneImmExpr'];
+  /** @inheritdoc FunctionLoweringAstUtilityContext */
   cloneEaExpr: FunctionLoweringAstUtilityContext['cloneEaExpr'];
+  /** @inheritdoc FunctionLoweringAstUtilityContext */
   cloneOperand: FunctionLoweringAstUtilityContext['cloneOperand'];
+  /** @inheritdoc FunctionLoweringAstUtilityContext */
   flattenEaDottedName: FunctionLoweringAstUtilityContext['flattenEaDottedName'];
+  /** @inheritdoc FunctionLoweringAstUtilityContext */
   normalizeFixedToken: FunctionLoweringAstUtilityContext['normalizeFixedToken'];
+  /** @inheritdoc FunctionLoweringRegisterContext */
   reg8: FunctionLoweringRegisterContext['reg8'];
+  /** @inheritdoc FunctionLoweringRegisterContext */
   reg16: FunctionLoweringRegisterContext['reg16'];
 };
 
-/** Flat field bag for program-level lowering (merged with shared function-lowering fields in the builder). */
+/**
+ * Flat field bag for program-level lowering (merged with shared function-lowering fields in the builder).
+ * Each field matches the same-named member on {@link import('./programLowering.js').Context}.
+ */
 export type EmitProgramLoweringContextInputs = {
+  /** @inheritdoc ProgramLoweringContext */
   program: ProgramLoweringContext['program'];
+  /** @inheritdoc ProgramLoweringContext */
   includeDirs: ProgramLoweringContext['includeDirs'];
+  /** @inheritdoc ProgramLoweringContext */
   localCallablesByFile: ProgramLoweringContext['localCallablesByFile'];
+  /** @inheritdoc ProgramLoweringContext */
   visibleCallables: ProgramLoweringContext['visibleCallables'];
+  /** @inheritdoc ProgramLoweringContext */
   localOpsByFile: ProgramLoweringContext['localOpsByFile'];
+  /** @inheritdoc ProgramLoweringContext */
   visibleOpsByName: ProgramLoweringContext['visibleOpsByName'];
+  /** @inheritdoc ProgramLoweringContext */
   declaredOpNames: ProgramLoweringContext['declaredOpNames'];
+  /** @inheritdoc ProgramLoweringContext */
   declaredBinNames: ProgramLoweringContext['declaredBinNames'];
+  /** @inheritdoc ProgramLoweringContext */
   deferredExterns: ProgramLoweringContext['deferredExterns'];
+  /** @inheritdoc ProgramLoweringContext */
   storageTypes: ProgramLoweringContext['storageTypes'];
+  /** @inheritdoc ProgramLoweringContext */
   moduleAliasTargets: ProgramLoweringContext['moduleAliasTargets'];
+  /** @inheritdoc ProgramLoweringContext */
   moduleAliasDecls: ProgramLoweringContext['moduleAliasDecls'];
+  /** @inheritdoc ProgramLoweringContext */
   rawAddressSymbols: ProgramLoweringContext['rawAddressSymbols'];
+  /** @inheritdoc ProgramLoweringContext */
   absoluteSymbols: ProgramLoweringContext['absoluteSymbols'];
+  /** @inheritdoc ProgramLoweringContext */
   symbols: ProgramLoweringContext['symbols'];
+  /** @inheritdoc ProgramLoweringContext */
   dataBytes: ProgramLoweringContext['dataBytes'];
+  /** @inheritdoc ProgramLoweringContext */
   codeBytes: ProgramLoweringContext['codeBytes'];
+  /** @inheritdoc ProgramLoweringContext */
   hexBytes: ProgramLoweringContext['hexBytes'];
+  /** @inheritdoc ProgramLoweringContext */
   activeSectionRef: ProgramLoweringContext['activeSectionRef'];
+  /** @inheritdoc ProgramLoweringContext */
   codeOffsetRef: ProgramLoweringContext['codeOffsetRef'];
+  /** @inheritdoc ProgramLoweringContext */
   dataOffsetRef: ProgramLoweringContext['dataOffsetRef'];
+  /** @inheritdoc ProgramLoweringContext */
   varOffsetRef: ProgramLoweringContext['varOffsetRef'];
+  /** @inheritdoc ProgramLoweringContext */
   baseExprs: ProgramLoweringContext['baseExprs'];
+  /** @inheritdoc ProgramLoweringContext */
   advanceAlign: ProgramLoweringContext['advanceAlign'];
+  /** @inheritdoc ProgramLoweringContext */
   alignTo: ProgramLoweringContext['alignTo'];
+  /** @inheritdoc ProgramLoweringContext */
   loadBinInput: ProgramLoweringContext['loadBinInput'];
+  /** @inheritdoc ProgramLoweringContext */
   loadHexInput: ProgramLoweringContext['loadHexInput'];
+  /** @inheritdoc ProgramLoweringContext */
   resolveAggregateType: ProgramLoweringContext['resolveAggregateType'];
+  /** @inheritdoc ProgramLoweringContext */
   sizeOfTypeExpr: ProgramLoweringContext['sizeOfTypeExpr'];
+  /** @inheritdoc ProgramLoweringContext */
   lowerFunctionDecl: ProgramLoweringContext['lowerFunctionDecl'];
+  /** @inheritdoc ProgramLoweringContext */
   recordLoweredAsmItem: ProgramLoweringContext['recordLoweredAsmItem'];
+  /** @inheritdoc ProgramLoweringContext */
   lowerImmExprForLoweredAsm: ProgramLoweringContext['lowerImmExprForLoweredAsm'];
+  /** @inheritdoc ProgramLoweringContext */
   namedSectionSinksByNode: ProgramLoweringContext['namedSectionSinksByNode'];
+  /** Current sink for the active named section contribution; `undefined` when not in a named block. */
   currentNamedSectionSinkRef: { current: NamedSectionContributionSink | undefined };
+  /** @inheritdoc FunctionLoweringSymbolContext */
   currentCodeSegmentTagRef: FunctionLoweringSymbolContext['currentCodeSegmentTagRef'];
 };
 
 export type EmitLoweringContextBuilderInput = {
+  /** Flattened function-lowering inputs (see {@link EmitFunctionLoweringContextInputs}). */
   readonly functionLowering: Readonly<EmitFunctionLoweringContextInputs>;
+  /** Flattened program-lowering inputs (see {@link EmitProgramLoweringContextInputs}). */
   readonly programLowering: Readonly<EmitProgramLoweringContextInputs>;
 };
 

--- a/src/lowering/emitFinalization.ts
+++ b/src/lowering/emitFinalization.ts
@@ -33,33 +33,61 @@ import {
 import type { LoweredAsmProgram, LoweredAsmStream } from './loweredAsmTypes.js';
 
 export type EmitFinalizationContext = {
+  /** Sinks carrying named section bytes/fixups from lowering. */
   namedSectionSinks: NamedSectionContributionSink[];
+  /** Mutable diagnostics for placement and emission. */
   diagnostics: Diagnostic[];
+  /** File-scoped diagnostic helper. */
   diag: (diagnostics: Diagnostic[], file: string, message: string) => void;
+  /** Span-scoped diagnostic helper. */
   diagAt: (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
+  /** Entry file path for diagnostics. */
   primaryFile: string;
+  /** Optional section base expressions. */
   baseExprs: ProgramEmissionFinalizeContext['baseExprs'];
+  /** Imm evaluator for bases and fixups. */
   evalImmExpr: ProgramEmissionFinalizeContext['evalImmExpr'];
+  /** Compile environment. */
   env: CompileEnv;
+  /** Lowered asm stream before placement. */
   loweredAsmStream: LoweredAsmStream;
+  /** Current code section size cursor after lowering. */
   codeOffset: number;
+  /** Current data section size cursor. */
   dataOffset: number;
+  /** Current var section size cursor. */
   varOffset: number;
+  /** Pending forward symbols from lowering. */
   pending: ProgramEmissionFinalizeContext['pending'];
+  /** Symbol table (mutated when placing named sections). */
   symbols: SymbolEntry[];
+  /** Absolute symbols from lowering. */
   absoluteSymbols: ProgramEmissionFinalizeContext['absoluteSymbols'];
+  /** Deferred extern metadata. */
   deferredExterns: ProgramEmissionFinalizeContext['deferredExterns'];
+  /** Absolute fixup queue. */
   fixups: ProgramEmissionFinalizeContext['fixups'];
+  /** Relative fixup queue. */
   rel8Fixups: ProgramEmissionFinalizeContext['rel8Fixups'];
+  /** Code section bytes. */
   codeBytes: ProgramEmissionFinalizeContext['codeBytes'];
+  /** Data section bytes. */
   dataBytes: ProgramEmissionFinalizeContext['dataBytes'];
+  /** Hex-ingested bytes. */
   hexBytes: ProgramEmissionFinalizeContext['hexBytes'];
+  /** Merged working byte map across sections. */
   bytes: Map<number, number>;
+  /** Code source segment map for listings. */
   codeSourceSegments: EmittedSourceSegment[];
+  /** Align helper (section padding). */
   alignTo: ProgramEmissionFinalizeContext['alignTo'];
+  /** Writes a section range into `bytes`. */
   writeSection: ProgramEmissionFinalizeContext['writeSection'];
+  /** Computes min/max written for overlap detection. */
   computeWrittenRange: ProgramEmissionFinalizeContext['computeWrittenRange'];
+  /** Rebases source segments after moves. */
   rebaseCodeSourceSegments: ProgramEmissionFinalizeContext['rebaseCodeSourceSegments'];
+  /** Optional default code base when not inferred. */
   defaultCodeBase?: number;
 };
 

--- a/src/lowering/emitFinalizationSetup.ts
+++ b/src/lowering/emitFinalizationSetup.ts
@@ -9,10 +9,15 @@ import type { EmitPhase1Workspace } from './emitPhase1Workspace.js';
 import type { EmitPhase1Helpers } from './emitPhase1Helpers.js';
 
 type Context = {
+  /** Semantic environment for imm evaluation during finalization. */
   env: CompileEnv;
+  /** Mutable diagnostic sink for placement and fixup phases. */
   diagnostics: Diagnostic[];
+  /** Optional emit knobs (code base, etc.); omit when defaults apply. */
   options?: EmitProgramOptions;
+  /** Phase-1 workspace carrying bytes, fixups, and lowered asm stream. */
   workspace: EmitPhase1Workspace;
+  /** Phase-1 helpers (named section sinks, lowered asm) wired into finalization. */
   helpers: EmitPhase1Helpers;
 };
 

--- a/src/lowering/emitPhase1Helpers.ts
+++ b/src/lowering/emitPhase1Helpers.ts
@@ -76,17 +76,26 @@ const REG8_CODES = new Map([
 ]);
 
 export type EmitPhase1Helpers = {
+  /** Flushes trailing user comments from the lowered asm recording buffer. */
   flushTrailingUserComments: () => void;
+  /** Live lowered asm stream (same ref as workspace). */
   loweredAsmStream: EmitPhase1Workspace['loweredAsmStream'];
+  /** Program-level lowering context (symbols, traversal, function lowerer). */
   programLoweringContext: ReturnType<typeof createEmitProgramContext>['programLoweringContext'];
+  /** Sinks for named section contributions during emit. */
   namedSectionSinks: ReturnType<typeof createEmitStateHelpers>['namedSectionSinks'];
 };
 
 type Context = {
+  /** Whole program AST. */
   program: ProgramNode;
+  /** Compile environment (consts, types, modules). */
   env: CompileEnv;
+  /** Shared diagnostic sink for emit phase 1. */
   diagnostics: Diagnostic[];
+  /** Optional emit options (listing sources, section keys, etc.). */
   options?: EmitProgramOptions;
+  /** Mutable workspace shared with program lowering. */
   workspace: EmitPhase1Workspace;
 };
 

--- a/src/lowering/emitPhase1Workspace.ts
+++ b/src/lowering/emitPhase1Workspace.ts
@@ -9,53 +9,108 @@ import { createEmitVisibilityHelpers } from './emitVisibility.js';
 import { createOpStackAnalysisHelpers } from './opStackAnalysis.js';
 
 export type EmitPhase1Workspace = {
+  /** Merged map of all emitted bytes across sections (code/data/var/hex). */
   bytes: Map<number, number>;
+  /** Code section bytes only (before merge into `bytes` for some paths). */
   codeBytes: Map<number, number>;
+  /** Data section bytes. */
   dataBytes: Map<number, number>;
+  /** Intel HEX–sourced bytes. */
   hexBytes: Map<number, number>;
+  /** Source ranges for emitted code bytes (listing/debug). */
   codeSourceSegments: EmittedSourceSegment[];
+  /** Stream of lowered asm blocks for tracing. */
   loweredAsmStream: LoweredAsmStream;
+  /** Lookup of lowered asm blocks by stable key (named sections, etc.). */
   loweredAsmBlocksByKey: Map<string, LoweredAsmStreamBlock>;
+  /** Symbols with absolute addresses after prescan/lowering. */
   absoluteSymbols: SymbolEntry[];
+  /** All collected symbol table entries. */
   symbols: SymbolEntry[];
+  /** Pending forward references not yet bound. */
   pending: PendingSymbol[];
+  /** Lowercased names already claimed (labels, locals). */
   taken: Set<string>;
-  fixups: { offset: number; baseLower: string; addend: number; file: string }[];
-  rel8Fixups: {
+  /** Absolute 16-bit fixups pending placement (offset in output, symbol, addend). */
+  fixups: {
+    /** Byte offset where the fixup applies. */
     offset: number;
-    origin: number;
+    /** Target symbol (lowercased). */
     baseLower: string;
+    /** Addend in bytes. */
     addend: number;
+    /** Source file owning the emission site. */
     file: string;
+  }[];
+  /** Relative 8-bit PC-relative fixups. */
+  rel8Fixups: {
+    /** Patch offset. */
+    offset: number;
+    /** Instruction origin for range checks. */
+    origin: number;
+    /** Target symbol (lowercased). */
+    baseLower: string;
+    /** Addend to target. */
+    addend: number;
+    /** Source file. */
+    file: string;
+    /** Mnemonic for diagnostics. */
     mnemonic: string;
   }[];
+  /** Extern symbols deferred until link/finalize. */
   deferredExterns: {
+    /** Declared extern name. */
     name: string;
+    /** Resolved base symbol when known. */
     baseLower: string;
+    /** Offset addend. */
     addend: number;
+    /** Referencing file. */
     file: string;
+    /** Source line of reference. */
     line: number;
   }[];
+  /** Per compilation unit: local callable map by lowercased name. */
   localCallablesByFile: Map<string, Map<string, Callable>>;
+  /** Globally visible callables after imports. */
   visibleCallables: Map<string, Callable>;
+  /** Per-file op overload lists. */
   localOpsByFile: Map<string, Map<string, OpDeclNode[]>>;
+  /** Visible ops merged by name. */
   visibleOpsByName: Map<string, OpDeclNode[]>;
+  /** User-selected op stack policy (`off` when unset in options). */
   opStackPolicyMode: NonNullable<EmitProgramOptions['opStackPolicy']>;
+  /** When true, emit extra warnings for raw typed calls. */
   rawTypedCallWarningsEnabled: boolean;
+  /** All declared `op` names (lowercased) for diagnostics. */
   declaredOpNames: Set<string>;
+  /** Declared `bin` resource names. */
   declaredBinNames: Set<string>;
+  /** Global/storage type map from prescan. */
   storageTypes: Map<string, TypeExprNode>;
+  /** Module-level alias targets. */
   moduleAliasTargets: Map<string, EaExprNode>;
+  /** Alias declarations for diagnostics. */
   moduleAliasDecls: Map<string, VarDeclNode>;
+  /** Names used as raw addresses (no typed storage). */
   rawAddressSymbols: Set<string>;
+  /** Current function stack slot types (mutable during lowering). */
   stackSlotTypes: Map<string, TypeExprNode>;
+  /** Current function stack displacements. */
   stackSlotOffsets: Map<string, number>;
+  /** Function-local alias targets. */
   localAliasTargets: Map<string, EaExprNode>;
+  /** Optional base imm expressions per section for placement. */
   baseExprs: Partial<Record<'code' | 'data' | 'var', import('../frontend/ast.js').ImmExprNode>>;
+  /** Entry / primary source file path. */
   primaryFile: string;
+  /** Resolved include directories for asset loads. */
   includeDirs: string[];
+  /** Resolves callables visible from a file. */
   resolveVisibleCallable: ReturnType<typeof createEmitVisibilityHelpers>['resolveVisibleCallable'];
+  /** Resolves op candidates visible from a file. */
   resolveVisibleOpCandidates: ReturnType<typeof createEmitVisibilityHelpers>['resolveVisibleOpCandidates'];
+  /** Cached op stack effect summary for overload policy. */
   summarizeOpStackEffect: ReturnType<typeof createOpStackAnalysisHelpers>['summarizeOpStackEffect'];
 };
 

--- a/src/lowering/emitPipeline.ts
+++ b/src/lowering/emitPipeline.ts
@@ -40,56 +40,95 @@ export type EmitPrescanPhaseResult = PrescanResult;
 export type EmitLoweringPhaseContext = ProgramLoweringContext;
 
 export interface EmitLoweringPhaseResult {
+  /** Next code section allocation offset after lowering. */
   readonly codeOffset: LoweringResult['codeOffset'];
+  /** Next data section offset. */
   readonly dataOffset: LoweringResult['dataOffset'];
+  /** Next var section offset. */
   readonly varOffset: LoweringResult['varOffset'];
+  /** Symbols still pending resolution. */
   readonly pending: LoweringResult['pending'];
+  /** Emitted symbol table entries. */
   readonly symbols: LoweringResult['symbols'];
+  /** Absolute-address symbols. */
   readonly absoluteSymbols: LoweringResult['absoluteSymbols'];
+  /** Deferred extern fixup metadata. */
   readonly deferredExterns: LoweringResult['deferredExterns'];
+  /** Emitted code bytes map. */
   readonly codeBytes: LoweringResult['codeBytes'];
+  /** Emitted data bytes map. */
   readonly dataBytes: LoweringResult['dataBytes'];
+  /** Emitted hex-derived bytes map. */
   readonly hexBytes: LoweringResult['hexBytes'];
 }
 
 /** Options for `emitProgram` (include paths, policy flags, listing sources). */
 export type EmitProgramOptions = {
+  /** Extra include directories for `include` / assets; omit for none. */
   includeDirs?: string[];
+  /** Stack policy for op bodies; omit defaults to `off`. */
   opStackPolicy?: OpStackPolicyMode;
+  /** Enable raw typed call warnings when true. */
   rawTypedCallWarnings?: boolean;
+  /** Default code load address for placement; omit uses pipeline default. */
   defaultCodeBase?: number;
+  /** Named section key collection for placement; omit when not used. */
   namedSectionKeys?: NonBankedSectionKeyCollection;
+  /** Optional full source text per file for listings. */
   sourceTexts?: Map<string, string>;
+  /** Optional line-end comments keyed by file and 1-based line. */
   sourceLineComments?: Map<string, Map<number, string>>;
 };
 
 /** In-memory compile products passed to format writers (plus trace stream). */
 export type EmitProgramResult = {
+  /** Final merged address→byte map for writers. */
   map: EmittedByteMap;
+  /** Resolved symbol table. */
   symbols: SymbolEntry[];
+  /** Raw lowered asm trace from phase 1. */
   loweredAsmStream: LoweredAsmStream;
+  /** Lowered asm after placement (named sections applied). */
   placedLoweredAsmProgram: LoweredAsmProgram;
 };
 
 /** Finalization inputs that come from phase-1 wiring rather than phase-3 lowering. */
 export interface EmitFinalizationPhaseEnv {
+  /** Named section sinks from phase 1 helpers. */
   readonly namedSectionSinks: EmitFinalizationContext['namedSectionSinks'];
+  /** Shared diagnostics buffer. */
   readonly diagnostics: EmitFinalizationContext['diagnostics'];
+  /** File-level diagnostic helper. */
   readonly diag: EmitFinalizationContext['diag'];
+  /** Span-level diagnostic helper. */
   readonly diagAt: EmitFinalizationContext['diagAt'];
+  /** Primary source path for diagnostics. */
   readonly primaryFile: EmitFinalizationContext['primaryFile'];
+  /** Section base imm expressions. */
   readonly baseExprs: EmitFinalizationContext['baseExprs'];
+  /** Imm evaluator used during placement. */
   readonly evalImmExpr: EmitFinalizationContext['evalImmExpr'];
+  /** Compile environment. */
   readonly env: EmitFinalizationContext['env'];
+  /** Lowered asm stream to place. */
   readonly loweredAsmStream: EmitFinalizationContext['loweredAsmStream'];
+  /** Pending abs16 fixups. */
   readonly fixups: EmitFinalizationContext['fixups'];
+  /** Pending rel8 fixups. */
   readonly rel8Fixups: EmitFinalizationContext['rel8Fixups'];
+  /** Working byte map before merge. */
   readonly bytes: EmitFinalizationContext['bytes'];
+  /** Code source segments for rebasing. */
   readonly codeSourceSegments: EmitFinalizationContext['codeSourceSegments'];
+  /** Section alignment helper. */
   readonly alignTo: EmitFinalizationContext['alignTo'];
+  /** Writes a section slice into the byte map. */
   readonly writeSection: EmitFinalizationContext['writeSection'];
+  /** Computes written byte ranges for overlap checks. */
   readonly computeWrittenRange: EmitFinalizationContext['computeWrittenRange'];
+  /** Rebases source map after section moves. */
   readonly rebaseCodeSourceSegments: EmitFinalizationContext['rebaseCodeSourceSegments'];
+  /** Optional default code base override. */
   readonly defaultCodeBase?: number;
 }
 

--- a/src/lowering/emitProgramContext.ts
+++ b/src/lowering/emitProgramContext.ts
@@ -131,17 +131,29 @@ export type EmitRegistersBundle = Pick<EmitFunctionLoweringContextInputs, 'reg8'
 
 /** Named bundles passed from `emitProgram` into lowering context construction. */
 export type EmitProgramContextBundles = {
+  /** Diagnostic helpers and mutable sink refs. */
   readonly diagnostics: Readonly<EmitDiagnosticsBundle>;
+  /** Symbol tables, pending, trace hooks. */
   readonly symbolsAndTrace: Readonly<EmitSymbolsAndTraceBundle>;
+  /** SP tracking binder for asm emission. */
   readonly spTracking: Readonly<EmitSpTrackingBundle>;
+  /** Code emission and fixup hooks. */
   readonly emission: Readonly<EmitEmissionBundle>;
+  /** Branch/condition opcode helpers. */
   readonly conditions: Readonly<EmitConditionsBundle>;
+  /** Type and imm evaluation hooks. */
   readonly types: Readonly<EmitTypesBundle>;
+  /** EA / step pipeline materialization. */
   readonly materialization: Readonly<EmitMaterializationBundle>;
+  /** Stack slots, storage maps, alias targets. */
   readonly storage: Readonly<EmitStorageBundle>;
+  /** Callable and op resolution. */
   readonly callableResolution: Readonly<EmitCallableResolutionBundle>;
+  /** Op overload selection and stack summaries. */
   readonly opOverload: Readonly<EmitOpOverloadBundle>;
+  /** AST clone / operand normalization utilities. */
   readonly astUtilities: Readonly<EmitAstUtilitiesBundle>;
+  /** Virtual register sets for lowering. */
   readonly registers: Readonly<EmitRegistersBundle>;
   /** Program-level fields (visibility, sections, placement hooks, …). */
   readonly program: Readonly<EmitProgramLoweringContextInputs>;

--- a/src/lowering/emitState.ts
+++ b/src/lowering/emitState.ts
@@ -10,12 +10,19 @@ import type {
 } from './loweredAsmTypes.js';
 
 type Context = {
+  /** Optional named section metadata for contribution sinks. */
   namedSectionKeys?: NonBankedSectionKeyCollection;
+  /** Full source text per file for listings. */
   sourceTexts?: Map<string, string>;
+  /** Line-end comments keyed by file and line. */
   sourceLineComments?: Map<string, Map<number, string>>;
+  /** Code section byte map. */
   codeBytes: Map<number, number>;
+  /** Source segment ranges for code bytes. */
   codeSourceSegments: EmittedSourceSegment[];
+  /** Pending abs16 fixups. */
   fixups: Array<{ offset: number; baseLower: string; addend: number; file: string }>;
+  /** Pending rel8 fixups. */
   rel8Fixups: Array<{
     offset: number;
     origin: number;
@@ -24,14 +31,21 @@ type Context = {
     file: string;
     mnemonic: string;
   }>;
+  /** Lowered asm trace stream. */
   loweredAsmStream: LoweredAsmStream;
+  /** Lowered asm blocks keyed for random access. */
   loweredAsmBlocksByKey: Map<string, LoweredAsmStreamBlock>;
+  /** Alignment helper. */
   alignTo: (n: number, alignment: number) => number;
+  /** Best-effort imm evaluation. */
   evalImmNoDiag: (expr: ImmExprNode) => number | undefined;
+  /** Parses simple symbolic targets; `undefined` if not symbolic. */
   symbolicTargetFromExpr: (
     expr: ImmExprNode,
   ) => { baseLower: string; addend: number } | undefined;
+  /** Formats an imm for lowered asm text. */
   formatImmExprForAsm: (expr: ImmExprNode) => string;
+  /** Pretty-prints a type for traces. */
   typeDisplay: (typeExpr: import('../frontend/ast.js').TypeExprNode) => string;
 };
 

--- a/src/lowering/emitVisibility.ts
+++ b/src/lowering/emitVisibility.ts
@@ -4,10 +4,15 @@ import type { Callable } from './loweringTypes.js';
 import type { OpDeclNode } from '../frontend/ast.js';
 
 type Context = {
+  /** Compile environment (module ids, imports) used with visibility maps. */
   env: CompileEnv;
+  /** Per-file map of lowered callables keyed by lowercased name. */
   localCallablesByFile: Map<string, Map<string, Callable>>;
+  /** Flat map of visible callables across the program (qualified and unqualified resolution). */
   visibleCallables: Map<string, Callable>;
+  /** Per-file op overload lists keyed by lowercased op name. */
   localOpsByFile: Map<string, Map<string, OpDeclNode[]>>;
+  /** Merged visible op candidates by lowercased name. */
   visibleOpsByName: Map<string, OpDeclNode[]>;
 };
 

--- a/src/lowering/fixupEmission.ts
+++ b/src/lowering/fixupEmission.ts
@@ -6,18 +6,28 @@ import {
 } from './traceFormat.js';
 
 type FixupRecord = {
+  /** Patch offset in code. */
   offset: number;
+  /** Target symbol (lowercased). */
   baseLower: string;
+  /** Byte addend. */
   addend: number;
+  /** Owning file. */
   file: string;
 };
 
 type Rel8FixupRecord = {
+  /** Patch offset. */
   offset: number;
+  /** Branch origin. */
   origin: number;
+  /** Target symbol. */
   baseLower: string;
+  /** Addend. */
   addend: number;
+  /** Owning file. */
   file: string;
+  /** Mnemonic for diagnostics. */
   mnemonic: string;
 };
 
@@ -26,14 +36,23 @@ type EvalImmExpr = (expr: ImmExprNode) => number | undefined;
 type TraceInstruction = (start: number, bytes: Uint8Array, asmText: string) => void;
 
 type Context = {
+  /** Current code offset. */
   getCodeOffset: () => number;
+  /** Sets code offset. */
   setCodeOffset: (value: number) => void;
+  /** Writes a code byte. */
   setCodeByte: (offset: number, value: number) => void;
+  /** Records source range for listing. */
   recordCodeSourceRange: (start: number, end: number) => void;
+  /** Enqueues abs16 fixup. */
   pushFixup: (fixup: FixupRecord) => void;
+  /** Enqueues rel8 fixup. */
   pushRel8Fixup: (fixup: Rel8FixupRecord) => void;
+  /** Trace hook for raw emission. */
   traceInstruction: TraceInstruction;
+  /** Optional lowered-instr recorder for asm trace. */
   recordLoweredInstr?: (bytes: Uint8Array, asmText: string, span: SourceSpan) => void;
+  /** Const imm evaluation. */
   evalImmExpr: EvalImmExpr;
 };
 

--- a/src/lowering/functionLowering.ts
+++ b/src/lowering/functionLowering.ts
@@ -27,7 +27,13 @@ import {
 // This module owns the per-function lowering coordinator. It assembles the
 // function-local helpers, state, and diagnostics around the extracted
 // rewriting, frame-setup, body-setup, and call-lowering submodules.
-type ResolvedArrayType = { element: TypeExprNode; length?: number };
+/** Array shape extracted for lowering; `length` omitted when unknown. */
+type ResolvedArrayType = {
+  /** Element type expression. */
+  element: TypeExprNode;
+  /** Fixed length when statically known. */
+  length?: number;
+};
 export type FunctionLoweringItemContext = {
   /** Set by: program lowering construction. Used by: frame setup, body orchestration. */
   readonly item: FuncDeclNode;

--- a/src/lowering/functionLoweringPhases.ts
+++ b/src/lowering/functionLoweringPhases.ts
@@ -17,52 +17,96 @@ import type { FunctionLoweringContext } from './functionLowering.js';
 export type FrameContext = FunctionFrameSetupContext;
 
 export interface FunctionLoweringSetupPhase {
+  /** Full function-lowering context. */
   readonly ctx: FunctionLoweringContext;
+  /** Function being lowered. */
   readonly item: FunctionLoweringContext['item'];
+  /** Shared diagnostic list. */
   readonly diagnostics: FunctionLoweringContext['diagnostics'];
+  /** Pending forward symbols. */
   readonly pending: FunctionLoweringContext['pending'];
+  /** Trace hook for comments. */
   readonly traceComment: FunctionLoweringContext['traceComment'];
+  /** Trace hook for labels. */
   readonly traceLabel: FunctionLoweringContext['traceLabel'];
+  /** Registers SP tracking callbacks for asm emission. */
   readonly bindSpTracking: FunctionLoweringContext['bindSpTracking'];
+  /** Current emitted code offset. */
   readonly getCodeOffset: FunctionLoweringContext['getCodeOffset'];
+  /** General instruction emitter. */
   readonly emitInstr: FunctionLoweringContext['emitInstr'];
+  /** Active source segment tag for listing, if any. */
   readonly getCurrentCodeSegmentTag: () => SourceSegmentTag | undefined;
+  /** Sets active source segment tag; `undefined` clears. */
   readonly setCurrentCodeSegmentTag: (tag: SourceSegmentTag | undefined) => void;
+  /** Narrow context passed into frame setup. */
   readonly frameSetupContext: ReturnType<typeof buildFrameSetupContext>;
+  /** Resolves a local alias name to its canonical target; `undefined` if not aliased. */
   readonly resolveLocalAliasTargetName: (name: string) => string | undefined;
+  /** Evaluates imms in asm with diagnostics; `undefined` if not const. */
   readonly evalImmExprForAsm: (expr: FunctionLoweringContext['item']['asm']['items'][number]['span'] extends never ? never : import('../frontend/ast.js').ImmExprNode) => number | undefined;
+  /** Symbolic branch target from imm; `undefined` if not a simple symbol+addend. */
   readonly symbolicTargetFromExprForAsm: (expr: import('../frontend/ast.js').ImmExprNode) => { baseLower: string; addend: number } | undefined;
+  /** Instruction emitter bound for asm lowering (same as `emitInstr`). */
   readonly emitInstrForAsm: FunctionLoweringContext['emitInstr'];
 }
 
 export interface FunctionFramePhase {
+  /** True when the frame allocates stack slots. */
   readonly hasStackSlots: boolean;
+  /** Whether a synthetic epilogue must be emitted at exits. */
   readonly emitSyntheticEpilogue: boolean;
+  /** Label name for the shared epilogue target. */
   readonly epilogueLabel: string;
+  /** Callee-saved registers that must be preserved across the body. */
   readonly preserveSet: ReadonlyArray<string>;
+  /** SP tracking summary: `invalid` when analysis cannot trust SP. */
   readonly trackedSp: { valid: boolean; delta: number; invalid: boolean };
+  /** Nested op-expansion frames for structured control. */
   readonly opExpansionStack: OpExpansionFrame[];
+  /** Reads current structured-control flow state. */
   readonly getFlow: () => FlowState;
+  /** Replaces flow state (e.g. after branches). */
   readonly setFlow: (state: FlowState) => void;
+  /** Mutable ref to the active flow state. */
   readonly flowRef: { readonly current: FlowState };
+  /** Pulls frame-local flags from `flowRef` into lowering scratch state. */
   readonly syncFromFlow: () => void;
+  /** Pushes lowering scratch state back into `flowRef`. */
   readonly syncToFlow: () => void;
+  /** Captures flow for nested regions. */
   readonly snapshotFlow: () => FlowState;
+  /** Restores a prior snapshot. */
   readonly restoreFlow: (state: FlowState) => void;
+  /** Emits diagnostic for invalid op expansion in structured control. */
   readonly appendInvalidOpExpansionDiagnostic: ReturnType<typeof createFunctionBodySetupHelpers>['appendInvalidOpExpansionDiagnostic'];
+  /** Maps a source span to a segment tag for tracing. */
   readonly sourceTagForSpan: ReturnType<typeof createFunctionBodySetupHelpers>['sourceTagForSpan'];
+  /** Runs a callback with a bound code-source tag. */
   readonly withCodeSourceTag: ReturnType<typeof createFunctionBodySetupHelpers>['withCodeSourceTag'];
+  /** Allocates a fresh compiler-generated label name. */
   readonly newHiddenLabel: ReturnType<typeof createFunctionBodySetupHelpers>['newHiddenLabel'];
+  /** Defines a code label at the current offset. */
   readonly defineCodeLabel: ReturnType<typeof createFunctionBodySetupHelpers>['defineCodeLabel'];
+  /** Unconditional jump emitter. */
   readonly emitJumpTo: ReturnType<typeof createFunctionBodySetupHelpers>['emitJumpTo'];
+  /** Conditional jump emitter. */
   readonly emitJumpCondTo: ReturnType<typeof createFunctionBodySetupHelpers>['emitJumpCondTo'];
+  /** False-edge jump for structured `if`. */
   readonly emitJumpIfFalse: ReturnType<typeof createFunctionBodySetupHelpers>['emitJumpIfFalse'];
+  /** Virtual 16-bit register move (lowering helper). */
   readonly emitVirtualReg16Transfer: ReturnType<typeof createFunctionBodySetupHelpers>['emitVirtualReg16Transfer'];
+  /** Merges control-flow at join points. */
   readonly joinFlows: ReturnType<typeof createFunctionBodySetupHelpers>['joinFlows'];
+  /** `select` compare to imm16. */
   readonly emitSelectCompareToImm16: ReturnType<typeof createFunctionBodySetupHelpers>['emitSelectCompareToImm16'];
+  /** `select` compare reg8 to imm8. */
   readonly emitSelectCompareReg8ToImm8: ReturnType<typeof createFunctionBodySetupHelpers>['emitSelectCompareReg8ToImm8'];
+  /** `select` compare reg8 range. */
   readonly emitSelectCompareReg8Range: ReturnType<typeof createFunctionBodySetupHelpers>['emitSelectCompareReg8Range'];
+  /** `select` compare imm16 range. */
   readonly emitSelectCompareImm16Range: ReturnType<typeof createFunctionBodySetupHelpers>['emitSelectCompareImm16Range'];
+  /** Loads `select` discriminator into HL. */
   readonly loadSelectorIntoHL: ReturnType<typeof createFunctionBodySetupHelpers>['loadSelectorIntoHL'];
 }
 
@@ -70,11 +114,13 @@ export type FunctionBodyPhase = Readonly<ReturnType<typeof createAsmBodyOrchestr
 
 /** #1123 — setup bundle plus frame phase result (before body lowering). */
 export type BodyContext = FunctionLoweringSetupPhase & {
+  /** Frame layout, flow state, and synthetic prologue/epilogue helpers after frame setup. */
   readonly frame: FunctionFramePhase;
 };
 
 /** #1123 — frame + body orchestration product for finalization. */
 export type RewriteContext = BodyContext & {
+  /** Asm body orchestration helpers (structured control, instruction lowering). */
   readonly body: FunctionBodyPhase;
 };
 

--- a/src/lowering/loweredAsmTypes.ts
+++ b/src/lowering/loweredAsmTypes.ts
@@ -1,77 +1,252 @@
 import type { SectionKind } from './loweringTypes.js';
 
 export type LoweredAsmStream = {
+  /** Ordered blocks as emitted during lowering (pre-placement). */
   blocks: LoweredAsmStreamBlock[];
 };
 
 export type LoweredAsmStreamBlock = {
+  /** Base section chunk vs named contribution block. */
   kind: 'base' | 'named';
+  /** Which logical section this block belongs to. */
   section: SectionKind;
+  /** Named section name when `kind === 'named'`. */
   name?: string;
+  /** Stable ordering among contributions to the same anchor. */
   contributionOrder?: number;
+  /** Lowered items in emission order. */
   items: LoweredAsmItem[];
 };
 
 export type LoweredAsmProgram = {
+  /** Blocks with assigned origins after placement. */
   blocks: LoweredAsmBlock[];
+  /** Optional symbol table snapshot for listings. */
   symbols?: LoweredAsmSymbol[];
 };
 
 export type LoweredAsmBlock = {
+  /** Section-relative block vs absolute-origin blob. */
   kind: 'section' | 'absolute';
+  /** Base address for this block’s bytes. */
   origin: number;
+  /** Section kind when `kind === 'section'`. */
   section?: SectionKind;
+  /** Named section name when applicable. */
   name?: string;
+  /** Contribution ordering within a named anchor. */
   contributionOrder?: number;
+  /** Lowered items. */
   items: LoweredAsmItem[];
 };
 
 export type LoweredAsmSymbol =
-  | { kind: 'constant'; name: string; value: LoweredImmExpr }
-  | { kind: 'label' | 'data' | 'var' | 'unknown'; name: string; address: LoweredImmExpr };
+  | {
+      /** Compile-time named constant. */
+      kind: 'constant';
+      /** Constant identifier text. */
+      name: string;
+      /** Folded imm expression. */
+      value: LoweredImmExpr;
+    }
+  | {
+      /** Runtime label or storage symbol. */
+      kind: 'label' | 'data' | 'var' | 'unknown';
+      /** Symbol name. */
+      name: string;
+      /** Address expression (may reference other symbols). */
+      address: LoweredImmExpr;
+    };
 
 export type LoweredAsmItem =
-  | { kind: 'label'; name: string }
-  | { kind: 'const'; name: string; value: LoweredImmExpr }
-  | { kind: 'db'; values: LoweredImmExpr[] }
-  | { kind: 'dw'; values: LoweredImmExpr[] }
-  | { kind: 'ds'; size: LoweredImmExpr; fill?: LoweredImmExpr }
-  | { kind: 'instr'; head: string; operands: LoweredOperand[]; bytes?: number[] }
-  | { kind: 'comment'; text: string; origin: 'user' | 'zax' };
+  | {
+      kind: 'label';
+      /** Label name for this position. */
+      name: string;
+    }
+  | {
+      kind: 'const';
+      /** Const name. */
+      name: string;
+      /** Const value expression. */
+      value: LoweredImmExpr;
+    }
+  | {
+      kind: 'db';
+      /** Byte values. */
+      values: LoweredImmExpr[];
+    }
+  | {
+      kind: 'dw';
+      /** Word values. */
+      values: LoweredImmExpr[];
+    }
+  | {
+      kind: 'ds';
+      /** Reserve size in bytes. */
+      size: LoweredImmExpr;
+      /** Optional fill byte; omit for undefined fill. */
+      fill?: LoweredImmExpr;
+    }
+  | {
+      kind: 'instr';
+      /** Mnemonic head token. */
+      head: string;
+      /** Rendered operands. */
+      operands: LoweredOperand[];
+      /** Encoded bytes when available; omit before encoding. */
+      bytes?: number[];
+    }
+  | {
+      kind: 'comment';
+      /** Comment text. */
+      text: string;
+      /** User source comment vs compiler-generated trace. */
+      origin: 'user' | 'zax';
+    };
 
 export type LoweredOperand =
-  | { kind: 'reg'; name: string }
-  | { kind: 'imm'; expr: LoweredImmExpr }
-  | { kind: 'mem'; expr: LoweredEaExpr }
-  | { kind: 'ea'; expr: LoweredEaExpr }
-  | { kind: 'portImm8'; expr: LoweredImmExpr }
-  | { kind: 'portC' };
+  | {
+      kind: 'reg';
+      /** Canonical register name. */
+      name: string;
+    }
+  | {
+      kind: 'imm';
+      /** Immediate subexpression. */
+      expr: LoweredImmExpr;
+    }
+  | {
+      kind: 'mem';
+      /** Memory EA expression. */
+      expr: LoweredEaExpr;
+    }
+  | {
+      kind: 'ea';
+      /** Standalone EA operand. */
+      expr: LoweredEaExpr;
+    }
+  | {
+      kind: 'portImm8';
+      /** 8-bit port immediate. */
+      expr: LoweredImmExpr;
+    }
+  | {
+      /** `(C)` port form. */
+      kind: 'portC';
+    };
 
 export type LoweredImmExpr =
-  | { kind: 'literal'; value: number }
-  | { kind: 'symbol'; name: string; addend: number }
-  | { kind: 'unary'; op: '+' | '-' | '~'; expr: LoweredImmExpr }
+  | {
+      kind: 'literal';
+      /** Numeric literal value. */
+      value: number;
+    }
+  | {
+      kind: 'symbol';
+      /** Symbol name (may be address-bearing). */
+      name: string;
+      /** Byte offset added to the symbol’s value. */
+      addend: number;
+    }
+  | {
+      kind: 'unary';
+      /** Unary operator. */
+      op: '+' | '-' | '~';
+      /** Inner expression. */
+      expr: LoweredImmExpr;
+    }
   | {
       kind: 'binary';
+      /** Binary operator. */
       op: '*' | '/' | '%' | '+' | '-' | '&' | '^' | '|' | '<<' | '>>';
+      /** Left operand. */
       left: LoweredImmExpr;
+      /** Right operand. */
       right: LoweredImmExpr;
     }
-  | { kind: 'opaque'; text: string };
+  | {
+      kind: 'opaque';
+      /** Unparsed / passthrough text for listing. */
+      text: string;
+    };
 
 export type LoweredEaExpr =
-  | { kind: 'name'; name: string }
-  | { kind: 'imm'; expr: LoweredImmExpr }
-  | { kind: 'reinterpret'; typeName: string; base: LoweredEaExpr }
-  | { kind: 'field'; base: LoweredEaExpr; field: string }
-  | { kind: 'index'; base: LoweredEaExpr; index: LoweredIndexExpr }
-  | { kind: 'add'; base: LoweredEaExpr; offset: LoweredImmExpr }
-  | { kind: 'sub'; base: LoweredEaExpr; offset: LoweredImmExpr };
+  | {
+      kind: 'name';
+      /** Identifier in an EA. */
+      name: string;
+    }
+  | {
+      kind: 'imm';
+      /** Nested immediate. */
+      expr: LoweredImmExpr;
+    }
+  | {
+      kind: 'reinterpret';
+      /** Target type name for reinterpret. */
+      typeName: string;
+      /** Base EA. */
+      base: LoweredEaExpr;
+    }
+  | {
+      kind: 'field';
+      /** Record/union base. */
+      base: LoweredEaExpr;
+      /** Field name. */
+      field: string;
+    }
+  | {
+      kind: 'index';
+      /** Array base. */
+      base: LoweredEaExpr;
+      /** Index selector. */
+      index: LoweredIndexExpr;
+    }
+  | {
+      kind: 'add';
+      /** Base EA. */
+      base: LoweredEaExpr;
+      /** Positive offset imm. */
+      offset: LoweredImmExpr;
+    }
+  | {
+      kind: 'sub';
+      /** Base EA. */
+      base: LoweredEaExpr;
+      /** Subtracted offset imm. */
+      offset: LoweredImmExpr;
+    };
 
 export type LoweredIndexExpr =
-  | { kind: 'imm'; value: LoweredImmExpr }
-  | { kind: 'reg8'; reg: string }
-  | { kind: 'reg16'; reg: string }
-  | { kind: 'memHL' }
-  | { kind: 'memIxIy'; base: 'IX' | 'IY'; disp?: LoweredImmExpr }
-  | { kind: 'ea'; expr: LoweredEaExpr };
+  | {
+      kind: 'imm';
+      /** Constant index expression. */
+      value: LoweredImmExpr;
+    }
+  | {
+      kind: 'reg8';
+      /** 8-bit index register name. */
+      reg: string;
+    }
+  | {
+      kind: 'reg16';
+      /** 16-bit index register name. */
+      reg: string;
+    }
+  | {
+      /** `(HL)` addressing form. */
+      kind: 'memHL';
+    }
+  | {
+      kind: 'memIxIy';
+      /** Which index register. */
+      base: 'IX' | 'IY';
+      /** Displacement; omit for 0. */
+      disp?: LoweredImmExpr;
+    }
+  | {
+      kind: 'ea';
+      /** General EA used as index. */
+      expr: LoweredEaExpr;
+    };

--- a/src/lowering/loweringTypes.ts
+++ b/src/lowering/loweringTypes.ts
@@ -7,13 +7,21 @@ import type { EmittedSourceSegment } from '../formats/types.js';
 export type SectionKind = 'code' | 'data' | 'var';
 
 export type PendingSymbol = {
+  /** What kind of symbol is pending resolution. */
   kind: 'label' | 'data' | 'var';
+  /** Declared name (not yet bound to an address). */
   name: string;
+  /** Target section for the symbol. */
   section: SectionKind;
+  /** Tentative offset within the section; refined at finalize. */
   offset: number;
+  /** Source file when known; omit for synthetic entries. */
   file?: string;
+  /** 1-based source line when known. */
   line?: number;
+  /** Local vs global visibility when applicable. */
   scope?: 'global' | 'local';
+  /** Byte size for data/var when known. */
   size?: number;
 };
 

--- a/src/lowering/opMatching.ts
+++ b/src/lowering/opMatching.ts
@@ -1,13 +1,21 @@
 import type { AsmOperandNode, EaExprNode, ImmExprNode, OpDeclNode, OpMatcherNode } from '../frontend/ast.js';
 
 type Context = {
+  /** 8-bit register names for matching. */
   reg8: Set<string>;
+  /** True when operand uses IX/IY indexed memory form. */
   isIxIyIndexedMem: (operand: AsmOperandNode) => boolean;
+  /** Flattens dotted EA; `undefined` if not expressible as dotted. */
   flattenEaDottedName: (ea: EaExprNode) => string | undefined;
+  /** True for declared enum names. */
   isEnumName: (name: string) => boolean;
+  /** Normalizes fixed tokens for overload keys. */
   normalizeFixedToken: (operand: AsmOperandNode) => string | undefined;
+  /** Maps condition name to opcode; `undefined` if unknown. */
   conditionOpcodeFromName: (name: string) => number | undefined;
+  /** Best-effort imm evaluation. */
   evalImmNoDiag: (expr: ImmExprNode) => number | undefined;
+  /** Infers memory operand width in bytes; `undefined` if unknown. */
   inferMemWidth: (operand: AsmOperandNode) => number | undefined;
 };
 
@@ -15,10 +23,32 @@ type MatcherSpecificity = 'x_more_specific' | 'y_more_specific' | 'equal';
 type OverloadSpecificity = 'x_wins' | 'y_wins' | 'equal' | 'incomparable';
 
 export type OpOverloadSelection =
-  | { kind: 'arity_mismatch'; overloads: OpDeclNode[]; signatures: string[] }
-  | { kind: 'no_match'; overloads: OpDeclNode[]; mismatchDetails: string[] }
-  | { kind: 'ambiguous'; overloads: OpDeclNode[]; definitions: string[] }
-  | { kind: 'selected'; overload: OpDeclNode };
+  | {
+      kind: 'arity_mismatch';
+      /** Candidate overloads. */
+      overloads: OpDeclNode[];
+      /** Rendered arity signatures for diagnostics. */
+      signatures: string[];
+    }
+  | {
+      kind: 'no_match';
+      /** Candidate overloads. */
+      overloads: OpDeclNode[];
+      /** Per-operand mismatch notes. */
+      mismatchDetails: string[];
+    }
+  | {
+      kind: 'ambiguous';
+      /** Competing overloads. */
+      overloads: OpDeclNode[];
+      /** Rendered definitions for diagnostics. */
+      definitions: string[];
+    }
+  | {
+      kind: 'selected';
+      /** Chosen overload. */
+      overload: OpDeclNode;
+    };
 
 const fitsImm8 = (value: number): boolean => value >= -0x80 && value <= 0xff;
 const fitsImm16 = (value: number): boolean => value >= -0x8000 && value <= 0xffff;

--- a/src/lowering/opStackAnalysis.ts
+++ b/src/lowering/opStackAnalysis.ts
@@ -5,6 +5,7 @@ export type OpStackSummary =
   | { kind: 'complex' };
 
 type Context = {
+  /** Resolves op declarations by name in `file`; `undefined` means no candidates (not an error by itself). */
   resolveOpCandidates: (name: string, file: string) => OpDeclNode[] | undefined;
 };
 

--- a/src/lowering/prescanTypes.ts
+++ b/src/lowering/prescanTypes.ts
@@ -2,14 +2,24 @@ import type { EaExprNode, OpDeclNode, TypeExprNode, VarDeclNode } from '../front
 import type { Callable } from './loweringTypes.js';
 
 export interface PrescanResult {
+  /** Frozen per-file callable maps from prescan. */
   readonly localCallablesByFile: ReadonlyMap<string, ReadonlyMap<string, Callable>>;
+  /** Frozen merged callable visibility. */
   readonly visibleCallables: ReadonlyMap<string, Callable>;
+  /** Frozen per-file op maps. */
   readonly localOpsByFile: ReadonlyMap<string, ReadonlyMap<string, OpDeclNode[]>>;
+  /** Frozen merged op visibility. */
   readonly visibleOpsByName: ReadonlyMap<string, OpDeclNode[]>;
+  /** Declared `op` names (lowercased). */
   readonly declaredOpNames: ReadonlySet<string>;
+  /** Declared `bin` names. */
   readonly declaredBinNames: ReadonlySet<string>;
+  /** Global/storage types discovered in prescan. */
   readonly storageTypes: ReadonlyMap<string, TypeExprNode>;
+  /** Module alias EA targets. */
   readonly moduleAliasTargets: ReadonlyMap<string, EaExprNode>;
+  /** Alias declarations for later diagnostics. */
   readonly moduleAliasDecls: ReadonlyMap<string, VarDeclNode>;
+  /** Raw address symbol names. */
   readonly rawAddressSymbols: ReadonlySet<string>;
 }

--- a/src/lowering/programLowering.ts
+++ b/src/lowering/programLowering.ts
@@ -32,59 +32,98 @@ import { lowerProgramDeclarations as runProgramLoweringTraversal } from './progr
 // emission/fixup passes after all symbols and section bases are known.
 // --- Phase 0: shared context and products ---
 export type Context = FunctionLoweringSharedContext & {
+  /** Full program AST being lowered. */
   program: ProgramNode;
+  /** Resolved include directories for asset loads. */
   includeDirs: string[];
+  /** Per-file callable maps for visibility. */
   localCallablesByFile: Map<string, Map<string, Callable>>;
+  /** Merged callable visibility map. */
   visibleCallables: Map<string, Callable>;
+  /** Per-file op overload maps. */
   localOpsByFile: Map<string, Map<string, OpDeclNode[]>>;
+  /** Merged op visibility map. */
   visibleOpsByName: Map<string, OpDeclNode[]>;
+  /** All declared `op` names (lowercased). */
   declaredOpNames: Set<string>;
+  /** Declared `bin` names. */
   declaredBinNames: Set<string>;
+  /** Extern references deferred to link/finalize. */
   deferredExterns: Array<{
+    /** Referenced extern name. */
     name: string;
+    /** Resolved target symbol when known. */
     baseLower: string;
+    /** Addend bytes. */
     addend: number;
+    /** Referencing file. */
     file: string;
+    /** Source line. */
     line: number;
   }>;
+  /** Global/storage type map (prescan + lowering). */
   storageTypes: Map<string, TypeExprNode>;
+  /** Module alias EA targets. */
   moduleAliasTargets: Map<string, EaExprNode>;
+  /** Alias declarations for diagnostics. */
   moduleAliasDecls: Map<string, VarDeclNode>;
+  /** Names used as raw addresses. */
   rawAddressSymbols: Set<string>;
+  /** Symbols with absolute addresses. */
   absoluteSymbols: SymbolEntry[];
+  /** Running symbol table. */
   symbols: SymbolEntry[];
+  /** Data section byte map. */
   dataBytes: Map<number, number>;
+  /** Code section byte map. */
   codeBytes: Map<number, number>;
+  /** Hex-ingested bytes. */
   hexBytes: Map<number, number>;
+  /** Currently selected section for emission. */
   activeSectionRef: { current: SectionKind };
+  /** Next code allocation offset (mutable cursor). */
   codeOffsetRef: { current: number };
+  /** Next data allocation offset. */
   dataOffsetRef: { current: number };
+  /** Next var allocation offset. */
   varOffsetRef: { current: number };
+  /** Optional base imm per section. */
   baseExprs: Partial<Record<SectionKind, ImmExprNode>>;
+  /** Advances alignment state for `align` directives. */
   advanceAlign: (a: number) => void;
+  /** Rounds `n` up to `alignment` bytes. */
   alignTo: (n: number, alignment: number) => number;
+  /** Loads a binary asset; `undefined` on failure (diagnostics via `diag`). */
   loadBinInput: (
     file: string,
     fromPath: string,
     includeDirs: string[],
     diag: (file: string, message: string) => void,
   ) => Uint8Array | undefined;
+  /** Loads Intel HEX; `undefined` on failure. */
   loadHexInput: (
     file: string,
     fromPath: string,
     includeDirs: string[],
     diag: (file: string, message: string) => void,
   ) => { bytes: Map<number, number>; minAddress: number } | undefined;
+  /** Structural type resolver for records/unions. */
   resolveAggregateType: (type: TypeExprNode) => AggregateType | undefined;
+  /** Layout size helper; `undefined` if type cannot be sized. */
   sizeOfTypeExpr: (
     typeExpr: TypeExprNode,
     env: CompileEnv,
     diagnostics: Diagnostic[],
   ) => number | undefined;
+  /** Lowers one function body using the shared context. */
   lowerFunctionDecl: (ctx: FunctionLoweringContext) => void;
+  /** Records one lowered asm item for tracing; `span` optional for synthetic items. */
   recordLoweredAsmItem: (item: LoweredAsmItem, span?: SourceSpan) => void;
+  /** Lowers an imm AST node to the trace IR. */
   lowerImmExprForLoweredAsm: (expr: ImmExprNode) => LoweredImmExpr;
+  /** Named section AST node → contribution sink. */
   namedSectionSinksByNode: Map<NamedSectionNode, NamedSectionContributionSink>;
+  /** Runs `fn` with the active named-section sink bound for nested lowering. */
   withNamedSectionSink: <T>(sink: NamedSectionContributionSink, fn: () => T) => T;
 };
 
@@ -115,20 +154,31 @@ export type ProgramPrescanContext = PrescanContext;
  * {@link PrescanResult}; the same map instances remain on `ctx` for lowering (shared refs).
  */
 export type LoweringContext = Context & {
+  /** Frozen prescan result; map refs alias `ctx` for shared mutation during lowering. */
   readonly prescan: PrescanResult;
 };
 
 // --- Phase 2 product: lowered bytes, symbols, and deferred externs ---
 export type LoweringResult = {
+  /** Final code section size cursor. */
   codeOffset: number;
+  /** Final data section size cursor. */
   dataOffset: number;
+  /** Final var section size cursor. */
   varOffset: number;
+  /** Still-unresolved symbols after lowering. */
   pending: Context['pending'];
+  /** Emitted symbol table. */
   symbols: Context['symbols'];
+  /** Absolute-address symbols. */
   absoluteSymbols: Context['absoluteSymbols'];
+  /** Deferred extern list (same shape as on `Context`). */
   deferredExterns: Context['deferredExterns'];
+  /** Emitted code bytes. */
   codeBytes: Context['codeBytes'];
+  /** Emitted data bytes. */
   dataBytes: Context['dataBytes'];
+  /** Emitted hex bytes. */
   hexBytes: Context['hexBytes'];
 };
 
@@ -137,24 +187,39 @@ export type LoweringResult = {
  * (`finalizeProgramEmission`).
  */
 export type ProgramEmissionFinalizeContext = {
+  /** Diagnostics for placement and merge. */
   diagnostics: Diagnostic[];
+  /** File-scoped diagnostic helper. */
   diag: (diagnostics: Diagnostic[], file: string, message: string) => void;
+  /** Primary source path. */
   primaryFile: string;
+  /** Section base imm expressions. */
   baseExprs: Partial<Record<SectionKind, ImmExprNode>>;
+  /** Imm evaluator; `undefined` when expression is not const. */
   evalImmExpr: (
     expr: ImmExprNode,
     env: CompileEnv,
     diagnostics: Diagnostic[],
   ) => number | undefined;
+  /** Compile environment. */
   env: CompileEnv;
+  /** Code size after lowering. */
   codeOffset: number;
+  /** Data size after lowering. */
   dataOffset: number;
+  /** Var size after lowering. */
   varOffset: number;
+  /** Pending symbols. */
   pending: PendingSymbol[];
+  /** Symbol table (may grow during placement). */
   symbols: SymbolEntry[];
+  /** Absolute symbols. */
   absoluteSymbols: SymbolEntry[];
+  /** Deferred extern metadata. */
   deferredExterns: Context['deferredExterns'];
+  /** Absolute fixup records. */
   fixups: Array<{ offset: number; baseLower: string; addend: number; file: string }>;
+  /** Relative fixup records. */
   rel8Fixups: Array<{
     offset: number;
     origin: number;
@@ -163,20 +228,30 @@ export type ProgramEmissionFinalizeContext = {
     file: string;
     mnemonic: string;
   }>;
+  /** Code bytes. */
   codeBytes: Map<number, number>;
+  /** Data bytes. */
   dataBytes: Map<number, number>;
+  /** Hex bytes. */
   hexBytes: Map<number, number>;
+  /** Merged working map across sections. */
   bytes: Map<number, number>;
+  /** Code source segments for listing. */
   codeSourceSegments: EmittedSourceSegment[];
+  /** Optional default code load address. */
   defaultCodeBase?: number;
+  /** Alignment helper. */
   alignTo: (n: number, alignment: number) => number;
+  /** Copies one section map into the merged `bytes` map. */
   writeSection: (
     base: number,
     section: Map<number, number>,
     bytes: Map<number, number>,
     report: (message: string) => void,
   ) => void;
+  /** Min/max written addresses for overlap checks. */
   computeWrittenRange: (bytes: Map<number, number>) => AddressRange;
+  /** Rebases listing segments after code base is fixed. */
   rebaseCodeSourceSegments: (
     codeBase: number,
     segments: EmittedSourceSegment[],
@@ -188,6 +263,7 @@ export type ProgramEmissionFinalizeContext = {
  * (Runtime placement still uses {@link ProgramEmissionFinalizeContext} + merged env.)
  */
 export interface FinalizationContext extends LoweringContext {
+  /** Snapshot product of `lowerProgramDeclarations` paired with this context (#1124). */
   readonly lowered: LoweringResult;
 }
 

--- a/src/lowering/sectionContributions.ts
+++ b/src/lowering/sectionContributions.ts
@@ -7,43 +7,69 @@ import type {
 } from '../sectionKeys.js';
 
 export type AbsoluteFixupRecord = {
+  /** Byte offset of the patched word. */
   offset: number;
+  /** Target symbol (lowercased). */
   baseLower: string;
+  /** Addend in bytes. */
   addend: number;
+  /** Owning source file. */
   file: string;
 };
 
 export type Rel8FixupRecord = {
+  /** Patch site offset. */
   offset: number;
+  /** Branch origin for range validation. */
   origin: number;
+  /** Target symbol (lowercased). */
   baseLower: string;
+  /** Addend to target. */
   addend: number;
+  /** Owning source file. */
   file: string;
+  /** Mnemonic for diagnostics. */
   mnemonic: string;
 };
 
 export type StartupInitAction =
   | {
+      /** Copy region into named section bytes. */
       kind: 'copy';
+      /** Destination offset within the section. */
       offset: number;
+      /** Length in bytes. */
       length: number;
     }
   | {
+      /** Zero-fill region. */
       kind: 'zero';
+      /** Destination offset within the section. */
       offset: number;
+      /** Length in bytes. */
       length: number;
     };
 
 export type NamedSectionContributionSink = {
+  /** Contribution metadata (order, key). */
   contribution: SectionContributionRecord;
+  /** Anchor placement record for this section. */
   anchor: SectionAnchorRecord;
+  /** Emitted bytes for this contribution. */
   bytes: Map<number, number>;
+  /** Current write cursor within `bytes`. */
   offset: number;
+  /** Symbols defined in this block not yet finalized. */
   pendingSymbols: PendingSymbol[];
+  /** Queued abs16 fixups for this sink. */
   fixups: AbsoluteFixupRecord[];
+  /** Queued rel8 fixups. */
   rel8Fixups: Rel8FixupRecord[];
+  /** Source segments for listings. */
   sourceSegments: EmittedSourceSegment[];
+  /** Active listing tag; `undefined` when not in a tagged region. */
   currentSourceTag: SourceSegmentTag | undefined;
+  /** Recorded init/copy actions for startup glue. */
   startupInitActions: StartupInitAction[];
 };
 

--- a/src/lowering/sectionPlacement.ts
+++ b/src/lowering/sectionPlacement.ts
@@ -8,23 +8,35 @@ import type { NonBankedSectionKeyId } from '../sectionKeys.js';
 import { formatNonBankedSectionKey } from '../sectionKeys.js';
 
 export type PlacedNamedSectionContribution = {
+  /** Sink carrying bytes/fixups for one contribution. */
   sink: NamedSectionContributionSink;
+  /** Assigned base address for this contribution. */
   baseAddress: number;
 };
 
 export type PlacedNamedSectionRegion = {
+  /** Stable section key id. */
   keyId: NonBankedSectionKeyId;
+  /** Logical section kind. */
   section: 'code' | 'data';
+  /** Section display name. */
   name: string;
+  /** Region base address. */
   baseAddress: number;
+  /** Total span in bytes. */
   totalSize: number;
+  /** Inclusive end address when known; `undefined` while sizing. */
   endAddress: number | undefined;
+  /** Ordered contributions in this region. */
   contributions: PlacedNamedSectionContribution[];
 };
 
 type Context = {
+  /** Diagnostic sink. */
   diagnostics: Diagnostic[];
+  /** Compile environment for imm eval. */
   env: CompileEnv;
+  /** Evaluates imm with env; `undefined` if not const. */
   evalImmExpr: (expr: ImmExprNode, env: CompileEnv, diagnostics: Diagnostic[]) => number | undefined;
 };
 

--- a/src/lowering/startupInit.ts
+++ b/src/lowering/startupInit.ts
@@ -6,22 +6,33 @@ import { encodeInstruction } from '../z80/encode.js';
 import type { PlacedNamedSectionContribution } from './sectionPlacement.js';
 
 export type StartupInitCopyEntry = {
+  /** Copy region descriptor. */
   kind: 'copy';
+  /** Destination address in the final image. */
   destination: number;
+  /** Source offset within the packed blob. */
   sourceOffset: number;
+  /** Byte length. */
   length: number;
 };
 
 export type StartupInitZeroEntry = {
+  /** Zero-fill descriptor. */
   kind: 'zero';
+  /** Destination start address. */
   destination: number;
+  /** Byte length. */
   length: number;
 };
 
 export type StartupInitRegion = {
+  /** Ordered copy operations. */
   copyEntries: StartupInitCopyEntry[];
+  /** Ordered zero-fill operations. */
   zeroEntries: StartupInitZeroEntry[];
+  /** Packed init payload bytes. */
   blob: number[];
+  /** Encoded opcode bytes for the startup routine. */
   encoded: number[];
 };
 

--- a/src/lowering/valueMaterializationContext.ts
+++ b/src/lowering/valueMaterializationContext.ts
@@ -5,23 +5,40 @@ import type { StepPipeline } from './steps.js';
 
 export type DiagAt = (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
 
-/** Shared dependency surface for value / EA materialization helpers. */
+/**
+ * Shared dependency surface for value / EA materialization helpers.
+ * Semantics align with the same-named members on {@link import('./functionLowering.js').FunctionLoweringContext} where applicable.
+ */
 export type ValueMaterializationContext = {
+  /** Mutable diagnostic list. */
   diagnostics: Diagnostic[];
+  /** Span diagnostic helper. */
   diagAt: DiagAt;
+  /** Names treated as 8-bit registers for templates. */
   reg8: Set<string>;
+  /** EA resolution; `undefined` when unresolved. */
   resolveEa: (ea: EaExprNode, span: SourceSpan) => EaResolution | undefined;
+  /** Infers a type for an EA; `undefined` if unknown. */
   resolveEaTypeExpr: (ea: EaExprNode) => TypeExprNode | undefined;
+  /** Unwraps aggregate shape; `undefined` if not aggregate. */
   resolveAggregateType: (
     typeExpr: TypeExprNode,
   ) => { kind: 'record' | 'union'; fields: import('../frontend/ast.js').RecordFieldNode[] } | undefined;
+  /** Scalar class for a binding name. */
   resolveScalarBinding: (name: string) => 'byte' | 'word' | 'addr' | undefined;
+  /** Scalar class for a type expression. */
   resolveScalarKind: (typeExpr: TypeExprNode) => 'byte' | 'word' | 'addr' | undefined;
+  /** Storage size; `undefined` if not computable. */
   sizeOfTypeExpr: (typeExpr: TypeExprNode) => number | undefined;
+  /** Const imm evaluation with diagnostics. */
   evalImmExpr: (expr: ImmExprNode) => number | undefined;
+  /** Best-effort imm evaluation. */
   evalImmNoDiag: (expr: ImmExprNode) => number | undefined;
+  /** Encodes one instruction. */
   emitInstr: (head: string, operands: AsmOperandNode[], span: SourceSpan) => boolean;
+  /** Emits raw bytes with trace text. */
   emitRawCodeBytes: (bytes: Uint8Array, file: string, asmText: string) => void;
+  /** Queues abs16 fixup. */
   emitAbs16Fixup: (
     opcode: number,
     baseLower: string,
@@ -29,17 +46,30 @@ export type ValueMaterializationContext = {
     span: SourceSpan,
     asmText?: string,
   ) => void;
+  /** Load 16-bit imm to DE. */
   loadImm16ToDE: (value: number, span: SourceSpan) => boolean;
+  /** Load 16-bit imm to HL. */
   loadImm16ToHL: (value: number, span: SourceSpan) => boolean;
+  /** Negate HL (two’s complement). */
   negateHL: (span: SourceSpan) => boolean;
+  /** Push 8-bit reg zero-extended to 16 bits. */
   pushZeroExtendedReg8: (reg: string, span: SourceSpan) => boolean;
+  /** Emits a step pipeline. */
   emitStepPipeline: (pipeline: StepPipeline, span: SourceSpan) => boolean;
+  /** Builds byte-oriented EA pipeline; `null` if unsupported. */
   buildEaBytePipeline: (ea: EaExprNode, span: SourceSpan) => StepPipeline | null;
+  /** Builds word-oriented EA pipeline; `null` if unsupported. */
   buildEaWordPipeline: (ea: EaExprNode, span: SourceSpan) => StepPipeline | null;
+  /** Scalar word load helper. */
   emitScalarWordLoad: (target: 'HL' | 'DE' | 'BC', resolved: EaResolution | undefined, span: SourceSpan) => boolean;
+  /** Formats IX/IY displacement for asm text. */
   formatIxDisp: (disp: number) => string;
+  /** Template: load byte ABC form. */
   TEMPLATE_L_ABC: (dest: string, ea: StepPipeline) => StepPipeline;
+  /** Template: load word via DE. */
   TEMPLATE_LW_DE: (ea: StepPipeline) => StepPipeline;
+  /** Template: load register pair from EA pipeline. */
   LOAD_RP_EA: (rp: 'HL' | 'DE' | 'BC') => StepPipeline;
+  /** Template: store register pair to EA pipeline. */
   STORE_RP_EA: (rp: 'DE' | 'BC') => StepPipeline;
 };


### PR DESCRIPTION
## Summary

Adds one-line `/** ... */` documentation on fields of context/result types across `src/lowering/`: emit pipeline and phase-1 workspace, program lowering (`Context`, `LoweringResult`, `ProgramEmissionFinalizeContext`), lowered asm IR unions, EA resolution/materialization, value materialization, section contributions/placement, capabilities, prescan result, and several helper `Context` bags (emit state, fixup emission, op matching, emission core).

`EmitFunctionLoweringContextInputs` / `EmitProgramLoweringContextInputs` use `@inheritdoc` to mirror the split `FunctionLowering*` / program `Context` fields without duplicating prose.

## Testing

- `npm run typecheck`
- `npm run lint`
- `npx vitest run`

Fixes #1130

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes across lowering context/result/type definitions; no functional logic or runtime behavior changes are introduced.
> 
> **Overview**
> Adds extensive one-line JSDoc across `src/lowering/` to clarify the meaning/ownership of fields in context bags, capabilities, phase workspaces/results, fixup records, section contribution/placement types, EA resolution/materialization, and the lowered-asm IR unions.
> 
> Also annotates the emit pipeline/phase handoff types and uses `@inheritdoc` in `EmitFunctionLoweringContextInputs`/`EmitProgramLoweringContextInputs` to mirror existing `FunctionLowering*` and `ProgramLowering` field docs without duplicating text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e2193f0906e7fce91c084e7024b445772eea594. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->