### PR TITLE
test: expectDiagnostic batch — PR4/PR35/PR97/PR226/PR254/PR694/PR952 (#1132)

### DIFF
--- a/test/backend/pr694_encoder_registry_dispatch.test.ts
+++ b/test/backend/pr694_encoder_registry_dispatch.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { DiagnosticIds, type Diagnostic } from '../../src/diagnosticTypes.js';
+import { expectDiagnostic } from '../helpers/diagnostics/index.js';
 import type { AsmInstructionNode, AsmOperandNode, SourceSpan } from '../../src/frontend/ast.js';
 import { getEncoderRegistryEntry } from '../../src/z80/encoderRegistry.js';
 import { encodeInstruction } from '../../src/z80/encode.js';
@@ -60,7 +61,11 @@ describe('PR694 encoder registry dispatch', () => {
 
     const zeroArityError = encodeInstruction(instruction('ldi', [reg('A')]), env, diagnostics);
     expect(zeroArityError).toBeUndefined();
-    expect(diagnostics[0]?.message).toBe('ldi expects no operands');
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.EncodeError,
+      severity: 'error',
+      message: 'ldi expects no operands',
+    });
 
     const familyArityError = encodeInstruction(
       instruction('add', [reg('A'), reg('B'), reg('C')]),
@@ -68,10 +73,18 @@ describe('PR694 encoder registry dispatch', () => {
       diagnostics,
     );
     expect(familyArityError).toBeUndefined();
-    expect(diagnostics[1]?.message).toBe('add expects two operands');
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.EncodeError,
+      severity: 'error',
+      message: 'add expects two operands',
+    });
 
     const unknown = encodeInstruction(instruction('bogus_op', [imm(1)]), env, diagnostics);
     expect(unknown).toBeUndefined();
-    expect(diagnostics[2]?.message).toBe('Unsupported instruction: bogus_op');
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.EncodeError,
+      severity: 'error',
+      message: 'Unsupported instruction: bogus_op',
+    });
   });
 });

--- a/test/frontend/pr226_parser_decl_control_spans.test.ts
+++ b/test/frontend/pr226_parser_decl_control_spans.test.ts
@@ -3,7 +3,9 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../../src/compile.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectDiagnostic } from '../helpers/diagnostics/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -57,18 +59,24 @@ describe('PR226 parser declaration/control span matrix', () => {
     const funcEntry = join(__dirname, '..', 'fixtures', 'pr217_parser_func_missing_body_eof.zax');
     const funcRes = await compile(funcEntry, {}, { formats: defaultFormatWriters });
     expect(funcRes.diagnostics).toHaveLength(1);
-    expect(funcRes.diagnostics[0]?.message).toBe(
-      'Unterminated func "no_body": expected function body',
-    );
-    expect(funcRes.diagnostics[0]?.line).toBe(1);
-    expect(funcRes.diagnostics[0]?.column).toBe(1);
+    expectDiagnostic(funcRes.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      message: 'Unterminated func "no_body": expected function body',
+      line: 1,
+      column: 1,
+    });
 
     const opEntry = join(__dirname, '..', 'fixtures', 'pr217_parser_op_missing_end_eof.zax');
     const opRes = await compile(opEntry, {}, { formats: defaultFormatWriters });
     expect(opRes.diagnostics).toHaveLength(1);
-    expect(opRes.diagnostics[0]?.message).toBe('Unterminated op "no_end": missing "end"');
-    expect(opRes.diagnostics[0]?.line).toBe(1);
-    expect(opRes.diagnostics[0]?.column).toBe(1);
+    expectDiagnostic(opRes.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      message: 'Unterminated op "no_end": missing "end"',
+      line: 1,
+      column: 1,
+    });
   });
 
   it('pins line/column for explicit asm-marker body diagnostics', async () => {

--- a/test/frontend/pr254_module_var_renamed_globals.test.ts
+++ b/test/frontend/pr254_module_var_renamed_globals.test.ts
@@ -3,7 +3,9 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../../src/compile.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectDiagnostic } from '../helpers/diagnostics/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -14,10 +16,12 @@ describe('PR254 parser: module var removal', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe(
-      `Legacy "var ... end" storage blocks are removed; use direct declarations inside named data sections.`,
-    );
-    expect(res.diagnostics[0]?.line).toBe(1);
-    expect(res.diagnostics[0]?.column).toBe(1);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      message: `Legacy "var ... end" storage blocks are removed; use direct declarations inside named data sections.`,
+      line: 1,
+      column: 1,
+    });
   });
 });

--- a/test/frontend/pr97_parser_span_structured_control.test.ts
+++ b/test/frontend/pr97_parser_span_structured_control.test.ts
@@ -3,7 +3,9 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../../src/compile.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectDiagnostic } from '../helpers/diagnostics/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -14,9 +16,13 @@ describe('PR97 parser spans for structured-control diagnostics', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe('"if" expects a condition code');
-    expect(res.diagnostics[0]?.line).toBe(2);
-    expect(res.diagnostics[0]?.column).toBe(5);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      message: '"if" expects a condition code',
+      line: 2,
+      column: 5,
+    });
   });
 
   it('reports line/column for invalid while condition syntax', async () => {
@@ -24,9 +30,13 @@ describe('PR97 parser spans for structured-control diagnostics', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe('"while" expects a condition code');
-    expect(res.diagnostics[0]?.line).toBe(2);
-    expect(res.diagnostics[0]?.column).toBe(3);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      message: '"while" expects a condition code',
+      line: 2,
+      column: 3,
+    });
   });
 
   it('reports line/column for select without arms', async () => {
@@ -34,11 +44,13 @@ describe('PR97 parser spans for structured-control diagnostics', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe(
-      '"select" must contain at least one arm ("case" or "else")',
-    );
-    expect(res.diagnostics[0]?.line).toBe(3);
-    expect(res.diagnostics[0]?.column).toBe(5);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      message: '"select" must contain at least one arm ("case" or "else")',
+      line: 3,
+      column: 5,
+    });
   });
 
   it('reports line/column for missing until condition', async () => {
@@ -46,9 +58,13 @@ describe('PR97 parser spans for structured-control diagnostics', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe('"until" expects a condition code');
-    expect(res.diagnostics[0]?.line).toBe(4);
-    expect(res.diagnostics[0]?.column).toBe(5);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      message: '"until" expects a condition code',
+      line: 4,
+      column: 5,
+    });
   });
 
   it('reports line/column for invalid until condition syntax', async () => {
@@ -56,9 +72,13 @@ describe('PR97 parser spans for structured-control diagnostics', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe('"until" expects a condition code');
-    expect(res.diagnostics[0]?.line).toBe(4);
-    expect(res.diagnostics[0]?.column).toBe(5);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      message: '"until" expects a condition code',
+      line: 4,
+      column: 5,
+    });
   });
 
   it('reports line/column for case outside select', async () => {
@@ -66,9 +86,13 @@ describe('PR97 parser spans for structured-control diagnostics', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe('"case" without matching "select"');
-    expect(res.diagnostics[0]?.line).toBe(2);
-    expect(res.diagnostics[0]?.column).toBe(5);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      message: '"case" without matching "select"',
+      line: 2,
+      column: 5,
+    });
   });
 
   it('reports line/column for else outside if/select', async () => {
@@ -76,9 +100,13 @@ describe('PR97 parser spans for structured-control diagnostics', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe('"else" without matching "if" or "select"');
-    expect(res.diagnostics[0]?.line).toBe(2);
-    expect(res.diagnostics[0]?.column).toBe(5);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      message: '"else" without matching "if" or "select"',
+      line: 2,
+      column: 5,
+    });
   });
 
   it('reports line/column for missing select selector', async () => {
@@ -86,9 +114,13 @@ describe('PR97 parser spans for structured-control diagnostics', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe('"select" expects a selector');
-    expect(res.diagnostics[0]?.line).toBe(2);
-    expect(res.diagnostics[0]?.column).toBe(5);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      message: '"select" expects a selector',
+      line: 2,
+      column: 5,
+    });
   });
 
   it('reports line/column for case without value', async () => {
@@ -96,9 +128,13 @@ describe('PR97 parser spans for structured-control diagnostics', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe('"case" expects a value');
-    expect(res.diagnostics[0]?.line).toBe(3);
-    expect(res.diagnostics[0]?.column).toBe(7);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      message: '"case" expects a value',
+      line: 3,
+      column: 7,
+    });
   });
 
   it('reports line/column for invalid case value (comma)', async () => {
@@ -106,9 +142,13 @@ describe('PR97 parser spans for structured-control diagnostics', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe('Invalid case value');
-    expect(res.diagnostics[0]?.line).toBe(3);
-    expect(res.diagnostics[0]?.column).toBe(7);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      message: 'Invalid case value',
+      line: 3,
+      column: 7,
+    });
   });
 
   it('reports line/column for invalid case value list', async () => {
@@ -116,8 +156,12 @@ describe('PR97 parser spans for structured-control diagnostics', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe('Invalid case value');
-    expect(res.diagnostics[0]?.line).toBe(3);
-    expect(res.diagnostics[0]?.column).toBe(7);
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      message: 'Invalid case value',
+      line: 3,
+      column: 7,
+    });
   });
 });

--- a/test/helpers/diagnostics/index.ts
+++ b/test/helpers/diagnostics/index.ts
@@ -13,6 +13,7 @@ export type DiagnosticExpectation = {
   messageIncludes?: string;
   file?: string;
   line?: number;
+  column?: number;
 };
 
 export function makeDiagnosticMatcher(expected: DiagnosticExpectation) {
@@ -29,6 +30,7 @@ export function makeDiagnosticMatcher(expected: DiagnosticExpectation) {
   }
   if (expected.file !== undefined) shape.file = expected.file;
   if (expected.line !== undefined) shape.line = expected.line;
+  if (expected.column !== undefined) shape.column = expected.column;
   return expect.objectContaining(shape);
 }
 

--- a/test/pr35_char_literals_invalid.test.ts
+++ b/test/pr35_char_literals_invalid.test.ts
@@ -3,7 +3,9 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -14,6 +16,10 @@ describe('PR35 char literals (invalid)', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe("Invalid imm expression: '\\z'");
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      message: "Invalid imm expression: '\\z'",
+    });
   });
 });

--- a/test/pr4_negative.test.ts
+++ b/test/pr4_negative.test.ts
@@ -3,7 +3,9 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -13,29 +15,44 @@ describe('PR4 negative cases', () => {
     const entry = join(__dirname, 'fixtures', 'pr4_undefined_name.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe('Failed to evaluate const "X".');
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.SemanticsError,
+      severity: 'error',
+      message: 'Failed to evaluate const "X".',
+    });
   });
 
   it('diagnoses forward references in const expressions', async () => {
     const entry = join(__dirname, 'fixtures', 'pr4_forward_ref.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe('Failed to evaluate const "B".');
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.SemanticsError,
+      severity: 'error',
+      message: 'Failed to evaluate const "B".',
+    });
   });
 
   it('diagnoses mismatched string initializer lengths', async () => {
     const entry = join(__dirname, 'fixtures', 'pr4_data_length_mismatch.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe('String length mismatch for "msg".');
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      message: 'String length mismatch for "msg".',
+    });
   });
 
   it('diagnoses unsupported data types', async () => {
     const entry = join(__dirname, 'fixtures', 'pr4_data_unsupported_type.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe(
-      'Unsupported data type for "p" (expected byte/word/addr/ptr or fixed-length arrays of those).',
-    );
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      message:
+        'Unsupported data type for "p" (expected byte/word/addr/ptr or fixed-length arrays of those).',
+    });
   });
 });

--- a/test/pr952_raw_ix_slot_offsets.test.ts
+++ b/test/pr952_raw_ix_slot_offsets.test.ts
@@ -3,7 +3,9 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
+import { expectDiagnostic } from './helpers/diagnostics/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -25,17 +27,21 @@ describe('PR952 raw ix slot offsets', () => {
     const entry = join(__dirname, 'fixtures', 'pr952_raw_ix_slot_offsets_alias.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe(
-      'Alias "alias" has no frame slot; cannot be used as a raw IX offset.',
-    );
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      message: 'Alias "alias" has no frame slot; cannot be used as a raw IX offset.',
+    });
   });
 
   it('diagnoses out-of-range ix displacements', async () => {
     const entry = join(__dirname, 'fixtures', 'pr952_raw_ix_slot_offsets_range.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics).toHaveLength(1);
-    expect(res.diagnostics[0]?.message).toBe(
-      'IX/IY displacement out of range (-128..127): 204.',
-    );
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      message: 'IX/IY displacement out of range (-128..127): 204.',
+    });
   });
 });


### PR DESCRIPTION
Part of #1132

- Extend test diagnostic helper with optional column (with line) for span-pinning.
- PR4: SemanticsError / EmitError with exact messages.
- PR35, PR97, PR226, PR254: ParseError; PR97 adds line/column on 11 cases.
- PR694: EncodeError for encoder diagnostics.
- PR952: EmitError for IX raw offset / displacement range.

Made with [Cursor](https://cursor.com)