### PR TITLE
test: diagnostic id, severity, and spans (#1137)

### DIFF
--- a/test/frontend/parser_recovery_quality.test.ts
+++ b/test/frontend/parser_recovery_quality.test.ts
@@ -13,6 +13,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
 import type { ConstDeclNode, ModuleItemNode, TypeDeclNode } from '../../src/frontend/ast.js';
 import { parseModuleFile } from '../../src/frontend/parser.js';
 import { expectDiagnostic } from '../helpers/diagnostics.js';
@@ -36,8 +37,14 @@ describe('parseModuleFile recovery AST shape', () => {
     const { mod, diagnostics } = parseModule(src);
 
     expect(mod.items).toHaveLength(0);
-    expectDiagnostic(diagnostics, { messageIncludes: 'Unterminated func "f"' });
-    expectDiagnostic(diagnostics, { messageIncludes: 'missing "end"' });
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      file: FILE,
+      line: 1,
+      column: 1,
+      messageIncludes: 'Unterminated func "f"',
+    });
   });
 
   it('function body interrupted by next top-level: no FuncDecl; following const is still parsed', () => {
@@ -47,9 +54,13 @@ const After = 1`;
     const { mod, diagnostics } = parseModule(src);
 
     expect(itemKinds(mod.items)).toEqual(['ConstDecl']);
-    expectDiagnostic(diagnostics, { messageIncludes: 'Unterminated func "g"' });
     expectDiagnostic(diagnostics, {
-      messageIncludes: 'expected "end" before "const"',
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      file: FILE,
+      line: 3,
+      column: 1,
+      messageIncludes: 'Unterminated func "g"',
     });
 
     const c = mod.items[0] as ConstDeclNode;
@@ -64,6 +75,11 @@ const K = 42`;
 
     expect(itemKinds(mod.items)).toEqual(['ConstDecl']);
     expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      file: FILE,
+      line: 1,
+      column: 1,
       messageIncludes: 'Unsupported top-level construct: totally_unknown_construct',
     });
 
@@ -82,6 +98,11 @@ end`;
     expect(mod.items).toHaveLength(1);
     expect(itemKinds(mod.items)).toEqual(['TypeDecl']);
     expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      file: FILE,
+      line: 3,
+      column: 1,
       messageIncludes: 'record field declaration line "not a field": expected <name>: <type>',
     });
 
@@ -109,8 +130,14 @@ end`;
       expect(t.typeExpr.fields).toHaveLength(1);
       expect(t.typeExpr.fields[0]!.name).toBe('a');
     }
-    expectDiagnostic(diagnostics, { messageIncludes: 'Unterminated type "T"' });
-    expectDiagnostic(diagnostics, { messageIncludes: 'missing "end"' });
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      file: FILE,
+      line: 1,
+      column: 1,
+      messageIncludes: 'Unterminated type "T"',
+    });
   });
 
   it('top-level asm: skipped with diagnostic; following declaration still parsed', () => {
@@ -120,6 +147,11 @@ const Z = 0`;
 
     expect(itemKinds(mod.items)).toEqual(['ConstDecl']);
     expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      file: FILE,
+      line: 1,
+      column: 1,
       messageIncludes: '"asm" is not a top-level construct',
     });
     expect((mod.items[0] as ConstDeclNode).name).toBe('Z');

--- a/test/frontend/pr176_mixed_keyword_shaped_line_recovery.test.ts
+++ b/test/frontend/pr176_mixed_keyword_shaped_line_recovery.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../../src/compile.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from '../helpers/diagnostics.js';
 
@@ -15,14 +16,20 @@ describe('PR176 parser: mixed keyword-shaped line recovery parity', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
       message:
         'Invalid extern func declaration line "data x: byte": expected func <name>(...): <retType> at <imm16>',
     });
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
       message:
         'Invalid data declaration line "op x: byte = [1]": expected <name>: <type> = <initializer>',
     });
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
       message: 'Invalid var declaration line "extern y: byte": expected <name>: <type>',
     });
     expectNoDiagnostic(res.diagnostics, {

--- a/test/frontend/pr184_func_extern_param_return_diag_matrix.test.ts
+++ b/test/frontend/pr184_func_extern_param_return_diag_matrix.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../../src/compile.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from '../helpers/diagnostics.js';
 
@@ -15,26 +16,31 @@ describe('PR184 parser: func/extern parameter and return diagnostics matrix', ()
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
       severity: 'error',
       line: 1,
       message: 'Invalid parameter declaration: expected <name>: <type>',
     });
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
       severity: 'error',
       line: 5,
       message: 'Invalid parameter type "[byte]": expected <type>',
     });
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
       severity: 'error',
       line: 9,
       message: 'Invalid return register "[word]": expected HL, DE, BC, or AF.',
     });
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
       severity: 'error',
       line: 13,
       message: 'Invalid op parameter declaration: expected <name>: <matcher>',
     });
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.ParseError,
       severity: 'error',
       line: 19,
       message: 'Invalid return register "[word]": expected HL, DE, BC, or AF.',

--- a/test/frontend/pr798_addr_expr_parser.test.ts
+++ b/test/frontend/pr798_addr_expr_parser.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
 import { parseProgram } from '../../src/frontend/parser.js';
 import { expectDiagnostic, expectNoDiagnostics } from '../helpers/diagnostics.js';
 
@@ -38,7 +39,11 @@ export func main()
 end
 end
     `);
-    expectDiagnostic(diagnostics, { messageIncludes: '":="' });
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      messageIncludes: '":="',
+    });
   });
 
   it('rejects nested or parenthesized @ forms', () => {
@@ -54,7 +59,11 @@ end
 end
     `);
     expect(diagnostics.length).toBeGreaterThan(0);
-    expectDiagnostic(diagnostics, { messageIncludes: 'address-of' });
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      messageIncludes: 'address-of',
+    });
   });
 
   it('rejects ld with @path', () => {

--- a/test/helpers/README.md
+++ b/test/helpers/README.md
@@ -42,7 +42,7 @@ Avoid duplicating the same helper import across **three** styles (barrel + shim 
 
 ## Vitest setup (`toHaveDiagnostic`)
 
-`vitest.config.ts` sets `setupFiles: ['test/helpers/setup.ts']`. That file registers the custom matcher **`toHaveDiagnostic`** (see `test/helpers/vitest.d.ts`). Tests that call `expect(diagnostics).toHaveDiagnostic(...)` rely on this global setup; they do not need to import `setup.ts` themselves.
+`vitest.config.ts` sets `setupFiles: ['test/helpers/setup.ts']`. That file registers the custom matcher **`toHaveDiagnostic`** (see `test/helpers/vitest.d.ts`). Use `expect(diagnostics).toHaveDiagnostic({ id, severity, messageIncludes?, line?, column?, file? })` for full control, or the shorthand `expect(diagnostics).toHaveDiagnostic(DiagnosticIds.EmitError, 'error')`. Tests rely on this global setup; they do not need to import `setup.ts` themselves.
 
 ## What the barrel includes
 

--- a/test/helpers/diagnostics.test.ts
+++ b/test/helpers/diagnostics.test.ts
@@ -58,4 +58,9 @@ describe('test/helpers/diagnostics', () => {
     expectNoErrors(sampleDiagnostics.filter((d) => d.severity !== 'error'));
     expectNoDiagnostics([]);
   });
+
+  it('supports positional toHaveDiagnostic(id, severity) from Vitest setup', () => {
+    expect(sampleDiagnostics).toHaveDiagnostic(DiagnosticIds.TypeError, 'error');
+    expect(sampleDiagnostics).toHaveDiagnostic(DiagnosticIds.RawCallTypedTargetWarning, 'warning');
+  });
 });

--- a/test/helpers/diagnostics/index.ts
+++ b/test/helpers/diagnostics/index.ts
@@ -13,6 +13,7 @@ export type DiagnosticExpectation = {
   messageIncludes?: string;
   file?: string;
   line?: number;
+  column?: number;
 };
 
 export function makeDiagnosticMatcher(expected: DiagnosticExpectation) {
@@ -29,6 +30,7 @@ export function makeDiagnosticMatcher(expected: DiagnosticExpectation) {
   }
   if (expected.file !== undefined) shape.file = expected.file;
   if (expected.line !== undefined) shape.line = expected.line;
+  if (expected.column !== undefined) shape.column = expected.column;
   return expect.objectContaining(shape);
 }
 

--- a/test/helpers/setup.ts
+++ b/test/helpers/setup.ts
@@ -1,11 +1,37 @@
 import { expect } from 'vitest';
 
+import type { DiagnosticId, DiagnosticSeverity } from '../../src/diagnosticTypes.js';
 import type { DiagnosticExpectation } from './diagnostics/index.js';
 import { makeDiagnosticMatcher } from './diagnostics/index.js';
 
+function isDiagnosticIdString(value: unknown): value is DiagnosticId {
+  return typeof value === 'string' && /^ZAX\d{3}$/.test(value);
+}
+
+function toHaveDiagnosticArgsToExpectation(args: unknown[]): DiagnosticExpectation {
+  if (args.length === 0) {
+    throw new Error('toHaveDiagnostic: expected at least one argument');
+  }
+  if (args.length === 1) {
+    const a = args[0];
+    if (isDiagnosticIdString(a)) {
+      return { id: a, severity: 'error' };
+    }
+    return a as DiagnosticExpectation;
+  }
+  if (args.length === 2 && isDiagnosticIdString(args[0])) {
+    return {
+      id: args[0] as DiagnosticId,
+      severity: args[1] as DiagnosticSeverity,
+    };
+  }
+  throw new Error('toHaveDiagnostic: use (expectation: object) or (id: DiagnosticId, severity?: ...)');
+}
+
 expect.extend({
-  toHaveDiagnostic(received: unknown, expected: DiagnosticExpectation) {
+  toHaveDiagnostic(received: unknown, ...args: unknown[]) {
     const diagnostics = Array.isArray(received) ? received : [];
+    const expected = toHaveDiagnosticArgsToExpectation(args);
     const matcher = makeDiagnosticMatcher(expected);
     const pass = diagnostics.some((diag) => matcher.asymmetricMatch(diag));
     return {

--- a/test/helpers/vitest.d.ts
+++ b/test/helpers/vitest.d.ts
@@ -1,10 +1,13 @@
+import type { DiagnosticId, DiagnosticSeverity } from '../../src/diagnosticTypes.js';
 import type { DiagnosticExpectation } from './diagnostics/index.js';
 
 declare module 'vitest' {
   interface Assertion<T = unknown> {
     toHaveDiagnostic(expected: DiagnosticExpectation): T;
+    toHaveDiagnostic(id: DiagnosticId, severity?: DiagnosticSeverity): T;
   }
   interface AsymmetricMatchersContaining {
     toHaveDiagnostic(expected: DiagnosticExpectation): unknown;
+    toHaveDiagnostic(id: DiagnosticId, severity?: DiagnosticSeverity): unknown;
   }
 }

--- a/test/lowering/boundary_conditions.test.ts
+++ b/test/lowering/boundary_conditions.test.ts
@@ -12,8 +12,10 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { compile } from '../../src/compile.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
 import { compilePlacedProgram } from '../helpers/lowered_program.js';
+import { expectDiagnostic } from '../helpers/diagnostics.js';
 
 function writeTempEntry(source: string): { entry: string; cleanup: () => void } {
   const dir = mkdtempSync(join(tmpdir(), 'zax-boundary-'));
@@ -23,10 +25,6 @@ function writeTempEntry(source: string): { entry: string; cleanup: () => void } 
     entry,
     cleanup: () => rmSync(dir, { recursive: true, force: true }),
   };
-}
-
-function hasErrorMessage(diagnostics: { severity: string; message: string }[], substr: string): boolean {
-  return diagnostics.some((d) => d.severity === 'error' && d.message.includes(substr));
 }
 
 describe('lowering boundary conditions (#1134)', () => {
@@ -55,9 +53,12 @@ end
     const { entry, cleanup } = writeTempEntry(lines.join('\n'));
     try {
       const res = await compile(entry, {}, { formats: defaultFormatWriters });
-      expect(res.diagnostics.some((d) => d.message.includes('IX/IY displacement out of range'))).toBe(
-        true,
-      );
+      expectDiagnostic(res.diagnostics, {
+        id: DiagnosticIds.EmitError,
+        severity: 'error',
+        messageIncludes: 'IX/IY displacement out of range',
+        line: 69,
+      });
     } finally {
       cleanup();
     }
@@ -243,7 +244,12 @@ end
     );
     try {
       const res = await compile(entry, {}, { formats: defaultFormatWriters });
-      expect(hasErrorMessage(res.diagnostics, 'does not fit')).toBe(true);
+      expectDiagnostic(res.diagnostics, {
+        id: DiagnosticIds.EmitError,
+        severity: 'error',
+        messageIncludes: 'does not fit',
+        line: 3,
+      });
     } finally {
       cleanup();
     }

--- a/test/pr102_lowering_frame_invariants.test.ts
+++ b/test/pr102_lowering_frame_invariants.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { expectDiagnostic } from './helpers/diagnostics.js';
 
@@ -15,6 +16,7 @@ describe('PR102 lowering/frame invariants with locals', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
       severity: 'error',
       messageIncludes: 'Stack depth mismatch at if join',
     });
@@ -25,6 +27,7 @@ describe('PR102 lowering/frame invariants with locals', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
       severity: 'error',
       messageIncludes: 'Stack depth mismatch at while back-edge',
     });
@@ -35,6 +38,7 @@ describe('PR102 lowering/frame invariants with locals', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
       severity: 'error',
       messageIncludes: 'Stack depth mismatch at repeat/until',
     });

--- a/test/pr211_jr_djnz_diag_matrix.test.ts
+++ b/test/pr211_jr_djnz_diag_matrix.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
@@ -14,22 +15,27 @@ describe('PR211: jr/djnz malformed-form diagnostics parity', () => {
     const entry = join(__dirname, 'fixtures', 'pr211_jr_djnz_diag_matrix_invalid.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
       severity: 'error',
       message: 'jr cc expects valid condition code NZ/Z/NC/C',
     });
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
       severity: 'error',
       message: 'jr cc, disp does not support register targets; expects disp8',
     });
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
       severity: 'error',
       message: 'jr cc, disp does not support indirect targets',
     });
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
       severity: 'error',
       message: 'jr does not support indirect targets; expects disp8',
     });
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
       severity: 'error',
       message: 'djnz does not support indirect targets; expects disp8',
     });

--- a/test/pr268_op_diagnostics_matrix.test.ts
+++ b/test/pr268_op_diagnostics_matrix.test.ts
@@ -48,6 +48,7 @@ describe('PR268: op diagnostics matrix', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expectDiagnostic(res.diagnostics, {
       id: row.id,
+      severity: 'error',
       messageIncludes: row.messageIncludes,
     });
   });
@@ -70,6 +71,7 @@ describe('PR268: op diagnostics matrix', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expectDiagnostic(res.diagnostics, {
       id: row.id,
+      severity: 'error',
       messageIncludes: row.messageIncludes,
     });
   });
@@ -92,6 +94,7 @@ describe('PR268: op diagnostics matrix', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expectDiagnostic(res.diagnostics, {
       id: row.id,
+      severity: 'error',
       messageIncludes: row.messageIncludes,
     });
   });
@@ -120,6 +123,7 @@ describe('PR268: op diagnostics matrix', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expectDiagnostic(res.diagnostics, {
       id: row.id,
+      severity: 'error',
       messageIncludes: row.messageIncludes,
     });
   });
@@ -154,6 +158,7 @@ describe('PR268: op diagnostics matrix', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expectDiagnostic(res.diagnostics, {
       id: row.id,
+      severity: 'error',
       messageIncludes: row.messageIncludes,
     });
   });
@@ -182,6 +187,7 @@ describe('PR268: op diagnostics matrix', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expectDiagnostic(res.diagnostics, {
       id: row.id,
+      severity: 'error',
       messageIncludes: row.messageIncludes,
     });
   });
@@ -205,6 +211,7 @@ describe('PR268: op diagnostics matrix', () => {
     expect(invalids).toHaveLength(2);
     expectDiagnostic(invalids, {
       id: DiagnosticIds.OpInvalidExpansion,
+      severity: 'error',
       messageIncludes: row.messageIncludes,
     });
   });
@@ -213,6 +220,6 @@ describe('PR268: op diagnostics matrix', () => {
     const entry = join(__dirname, 'fixtures', 'pr270_nonop_invalid_instruction_baseline.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expectNoDiagnostic(res.diagnostics, { id: DiagnosticIds.OpInvalidExpansion });
-    expectDiagnostic(res.diagnostics, { id: DiagnosticIds.EncodeError });
+    expectDiagnostic(res.diagnostics, { id: DiagnosticIds.EncodeError, severity: 'error' });
   });
 });

--- a/test/pr272_runtime_affine_index_offset.test.ts
+++ b/test/pr272_runtime_affine_index_offset.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import type { BinArtifact } from '../src/formats/types.js';
 import {
@@ -29,9 +30,13 @@ describe('PR272: runtime affine index/offset lowering', () => {
 
     expect(res.artifacts).toEqual([]);
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
       messageIncludes: 'runtime multiplier must be a power-of-2',
     });
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
       messageIncludes:
         'is unsupported. Use a single scalar runtime atom with +, -, *, <<',
     });

--- a/test/pr37_fixup_negative.test.ts
+++ b/test/pr37_fixup_negative.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { expectDiagnostic } from './helpers/diagnostics.js';
 
@@ -15,6 +16,8 @@ describe('PR37 fixup negatives', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
       messageIncludes: 'Unresolved symbol "missing_label"',
     });
   });
@@ -24,9 +27,15 @@ describe('PR37 fixup negatives', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
       messageIncludes: 'Unresolved symbol "missing_label"',
     });
-    expectDiagnostic(res.diagnostics, { messageIncludes: 'rel8 jr fixup' });
+    expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
+      messageIncludes: 'rel8 jr fixup',
+    });
   });
 
   it('diagnoses rel8 out-of-range fixups', async () => {
@@ -34,6 +43,8 @@ describe('PR37 fixup negatives', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
       messageIncludes: 'jr target out of range for rel8 branch',
     });
   });
@@ -43,6 +54,8 @@ describe('PR37 fixup negatives', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
       messageIncludes: 'jr nz target out of range for rel8 branch',
     });
   });
@@ -52,6 +65,8 @@ describe('PR37 fixup negatives', () => {
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.artifacts).toEqual([]);
     expectDiagnostic(res.diagnostics, {
+      id: DiagnosticIds.EmitError,
+      severity: 'error',
       messageIncludes: 'djnz target out of range for rel8 branch',
     });
   });


### PR DESCRIPTION
## Summary

- Extend `toHaveDiagnostic` matcher: object form gains `column`; shorthand `(id)` / `(id, severity)`.
- `DiagnosticExpectation` + `makeDiagnosticMatcher` support `column`.
- Tighten selected suites (boundary conditions, fixup, lowering, parser recovery, op matrix, etc.) to pin `file`/`line`/`column` where relevant; `expectDiagnostic` rows include `severity` where appropriate.

Fixes #1137

Made with [Cursor](https://cursor.com)