### PR TITLE
test: expectDiagnostic for PR572/576/611/573/689 (#1132)

### DIFF
--- a/test/frontend/pr572_named_sections_parser.test.ts
+++ b/test/frontend/pr572_named_sections_parser.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import { parseProgram } from '../../src/frontend/parser.js';
+import { expectDiagnostic } from '../helpers/diagnostics/index.js';
 
 describe('PR572 named section parser scaffolding', () => {
   it('parses named sections with anchors and section-contained declarations', () => {
@@ -85,12 +87,16 @@ describe('PR572 named section parser scaffolding', () => {
     });
     expect(program.files[0]?.items).toHaveLength(1);
     expect(diagnostics).toHaveLength(2);
-    expect(diagnostics[0]).toMatchObject({
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
       message: 'import is only permitted at module scope',
       line: 2,
       column: 1,
     });
-    expect(diagnostics[1]).toMatchObject({
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
       message:
         'Legacy active-counter section directive "section data at ..." is removed; use a named section like "section data <name> at ..." instead.',
       line: 5,
@@ -111,7 +117,9 @@ describe('PR572 named section parser scaffolding', () => {
     );
 
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]).toMatchObject({
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
       message: 'export not supported on bin declarations',
       line: 2,
       column: 1,

--- a/test/frontend/pr576_unified_data_sections.test.ts
+++ b/test/frontend/pr576_unified_data_sections.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from 'vitest';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import { parseProgram } from '../../src/frontend/parser.js';
 import { compile } from '../../src/compile.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
 import type { D8mArtifact } from '../../src/formats/types.js';
+import { expectDiagnostic } from '../helpers/diagnostics/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -42,7 +44,9 @@ describe('PR576 unified data declarations inside data sections', () => {
     });
 
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]).toMatchObject({
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
       message: 'Data declarations are only permitted inside data sections.',
       line: 5,
       column: 1,

--- a/test/frontend/pr611_parser_data_marker_enforcement.test.ts
+++ b/test/frontend/pr611_parser_data_marker_enforcement.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import { parseProgram } from '../../src/frontend/parser.js';
+import { expectDiagnostic } from '../helpers/diagnostics/index.js';
 
 describe('PR611 parser data marker enforcement', () => {
   it('rejects bare data marker lines inside named sections', () => {
@@ -26,7 +28,9 @@ describe('PR611 parser data marker enforcement', () => {
     expect(section.items[0]).toMatchObject({ kind: 'DataDecl', name: 'counter' });
 
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]).toMatchObject({
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
       line: 2,
       column: 1,
       message:
@@ -42,15 +46,13 @@ describe('PR611 parser data marker enforcement', () => {
       diagnostics,
     );
 
-    expect(diagnostics).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          line: 1,
-          column: 1,
-          message:
-            'Legacy top-level "data ... end" blocks are removed; use direct declarations inside named data sections.',
-        }),
-      ]),
-    );
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
+      line: 1,
+      column: 1,
+      message:
+        'Legacy top-level "data ... end" blocks are removed; use direct declarations inside named data sections.',
+    });
   });
 });

--- a/test/frontend/pr689_callable_header_parser.test.ts
+++ b/test/frontend/pr689_callable_header_parser.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import { parseCallableHeader } from '../../src/frontend/parseCallableHeader.js';
 import { makeSourceFile, span } from '../../src/frontend/source.js';
+import { expectDiagnostic } from '../helpers/diagnostics/index.js';
 
 describe('PR689 callable header parser primitive', () => {
   it('parses shared callable header shape and params', () => {
@@ -49,7 +51,9 @@ describe('PR689 callable header parser primitive', () => {
 
     expect(parsed).toBeUndefined();
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]).toMatchObject({
+    expectDiagnostic(diagnostics, {
+      id: DiagnosticIds.ParseError,
+      severity: 'error',
       message: 'Invalid op name "1bad": expected <identifier>.',
       line: 1,
       column: 1,

--- a/test/pr573_section_key_collection.test.ts
+++ b/test/pr573_section_key_collection.test.ts
@@ -4,6 +4,7 @@ import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import type { Diagnostic } from '../src/diagnosticTypes.js';
 import { parseProgram } from '../src/frontend/parser.js';
 import { collectNonBankedSectionKeys, createNonBankedSectionKey } from '../src/sectionKeys.js';
+import { expectDiagnostic } from './helpers/diagnostics/index.js';
 
 describe('PR573 non-banked section key collection', () => {
   it('validates the section key constructor boundary', () => {
@@ -66,7 +67,7 @@ describe('PR573 non-banked section key collection', () => {
       ['code', 'shared', 'dep.zax', 1],
     ]);
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]).toMatchObject({
+    expectDiagnostic(diagnostics, {
       id: DiagnosticIds.EmitError,
       severity: 'error',
       file: 'dep.zax',
@@ -88,7 +89,7 @@ describe('PR573 non-banked section key collection', () => {
     collectNonBankedSectionKeys(program, diagnostics);
 
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]).toMatchObject({
+    expectDiagnostic(diagnostics, {
       id: DiagnosticIds.EmitError,
       severity: 'error',
       file: 'missing-anchor.zax',
@@ -112,7 +113,7 @@ describe('PR573 non-banked section key collection', () => {
     expect(collected.orderedAnchors).toHaveLength(1);
     expect(collected.orderedContributions).toHaveLength(0);
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]).toMatchObject({
+    expectDiagnostic(diagnostics, {
       id: DiagnosticIds.EmitWarning,
       severity: 'warning',
       file: 'empty-anchor.zax',


### PR DESCRIPTION
Part of #1132

Switches parser and section-key tests from diagnostics index / toMatchObject to expectDiagnostic with DiagnosticIds, severity, and pinned line/column/file where applicable.

Files: pr572_named_sections_parser, pr576_unified_data_sections, pr611_parser_data_marker_enforcement, pr573_section_key_collection, pr689_callable_header_parser.

Made with [Cursor](https://cursor.com)