### PR TITLE
docs: CONTRIBUTING.md minimal workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing to ZAX
+
+Short workflow. Prefer this over ad-hoc branch names and long cherry-pick recipes.
+
+## Before you start
+
+```sh
+git fetch origin && git checkout main && git pull --ff-only
+```
+
+## Branch and PR
+
+- **One topic → one branch from `main`.** Name it clearly (`fix/diagnostic-assertions`, `test/layout-edge-cases`). No required `deva/` / `devb/` prefixes.
+- **One PR per topic** (or one clearly scoped series). Avoid landing commits on the wrong branch; if you did: `git stash -u`, recreate the branch from `main`, then `cherry-pick` the good commit or re-apply the stash once.
+
+## Issues
+
+- **`Fixes #NNNN`** in the PR body when that PR **fully** closes the issue.
+- **`Part of #NNNN`** for incremental work; close the issue when the **last** PR merges.
+
+## Checks before push
+
+```sh
+npm run typecheck
+npm run lint
+npx vitest run
+```
+
+If **`npm run check:fixture-coverage`** fails, regenerate the map in the **same** PR:
+
+```sh
+node scripts/dev/fixture-coverage.js > test/fixtures/coverage-map.md
+```
+
+## Reviews
+
+- Focus on **code and tests** in the diff. CI is the merge gate; don’t block on duplicate CI narration in chat unless something is red.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ ZAX constructs and raw Z80 instructions mix freely. The machine model does not c
 [ZAX Language Spec](docs/spec/zax-spec.md) — normative specification.
 
 **Contributing?**
-[Dev Playbook](docs/reference/zax-dev-playbook.md) — workflow, review, and testing.
+[CONTRIBUTING.md](CONTRIBUTING.md) — branches, PRs, issues, and pre-push checks.
+[Dev Playbook](docs/reference/zax-dev-playbook.md) — deeper workflow and testing detail.
 
 ---
 

--- a/docs/reference/zax-dev-playbook.md
+++ b/docs/reference/zax-dev-playbook.md
@@ -1,5 +1,7 @@
 # ZAX Developer Playbook (Non-normative)
 
+For a short branch → PR → checks checklist, see [`CONTRIBUTING.md`](../../CONTRIBUTING.md) at the repo root. This playbook goes deeper (authority, refactors, review norms).
+
 This document is the contributor workflow guide.
 
 It is intentionally narrow. It does not own roadmap history, version closeout status,


### PR DESCRIPTION
Adds a short `CONTRIBUTING.md` (branch from `main`, one PR per topic, Fixes/Part of, pre-push checks, fixture map regen). Links from README and a one-line pointer at the top of the dev playbook so the long doc stays optional.

Made with [Cursor](https://cursor.com)