### PR TITLE
test: diag matrix tests use it.each + DiagnosticIds (#1133)

### DIFF
--- a/test/backend/pr144_isa_ed_cb_diag_matrix.test.ts
+++ b/test/backend/pr144_isa_ed_cb_diag_matrix.test.ts
@@ -3,44 +3,115 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../../src/compile.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-describe('PR144: ED/CB diagnostics parity matrix', () => {
-  it('reports explicit diagnostics for malformed ED/CB forms', async () => {
-    const entry = join(__dirname, '..', 'fixtures', 'pr144_isa_ed_cb_diag_matrix_invalid.zax');
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+const PR144_FIXTURE = join(__dirname, '..', 'fixtures', 'pr144_isa_ed_cb_diag_matrix_invalid.zax');
 
-    expectDiagnostic(res.diagnostics, { message: 'im expects 0, 1, or 2' });
-    expectDiagnostic(res.diagnostics, {
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  message: string;
+};
+
+describe('PR144: ED/CB diagnostics parity matrix', () => {
+  it.each([
+    { label: 'im', id: DiagnosticIds.EncodeError, message: 'im expects 0, 1, or 2' },
+    {
+      label: 'in a,(n) dest',
+      id: DiagnosticIds.EncodeError,
       message: 'in a,(n) immediate port form requires destination A',
-    });
-    expectDiagnostic(res.diagnostics, { message: 'in a,(n) expects an imm8 port number' });
-    expectDiagnostic(res.diagnostics, { message: 'in expects a reg8 destination' });
-    expectDiagnostic(res.diagnostics, { message: 'out (c), n immediate form supports n=0 only' });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'in a,(n) imm',
+      id: DiagnosticIds.EncodeError,
+      message: 'in a,(n) expects an imm8 port number',
+    },
+    {
+      label: 'in reg8',
+      id: DiagnosticIds.EncodeError,
+      message: 'in expects a reg8 destination',
+    },
+    {
+      label: 'out (c), n',
+      id: DiagnosticIds.EncodeError,
+      message: 'out (c), n immediate form supports n=0 only',
+    },
+    {
+      label: 'out (n),a src',
+      id: DiagnosticIds.EncodeError,
       message: 'out (n),a immediate port form requires source A',
-    });
-    expectDiagnostic(res.diagnostics, { message: 'out (n),a expects an imm8 port number' });
-    expectDiagnostic(res.diagnostics, { message: 'adc HL, rr expects BC/DE/HL/SP' });
-    expectDiagnostic(res.diagnostics, { message: 'sbc HL, rr expects BC/DE/HL/SP' });
-    expectDiagnostic(res.diagnostics, { message: 'bit expects bit index 0..7' });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'out (n),a imm',
+      id: DiagnosticIds.EncodeError,
+      message: 'out (n),a expects an imm8 port number',
+    },
+    {
+      label: 'adc HL',
+      id: DiagnosticIds.EncodeError,
+      message: 'adc HL, rr expects BC/DE/HL/SP',
+    },
+    {
+      label: 'sbc HL',
+      id: DiagnosticIds.EncodeError,
+      message: 'sbc HL, rr expects BC/DE/HL/SP',
+    },
+    {
+      label: 'bit index',
+      id: DiagnosticIds.EncodeError,
+      message: 'bit expects bit index 0..7',
+    },
+    {
+      label: 'res indexed src',
+      id: DiagnosticIds.EncodeError,
       message: 'res b,(ix/iy+disp),r requires an indexed memory source',
-    });
-    expectDiagnostic(res.diagnostics, { message: 'set (ix/iy+disp) expects disp8' });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'set disp',
+      id: DiagnosticIds.EncodeError,
+      message: 'set (ix/iy+disp) expects disp8',
+    },
+    {
+      label: 'rl two-op',
+      id: DiagnosticIds.EncodeError,
       message: 'rl two-operand form requires (ix/iy+disp) source',
-    });
-    expectDiagnostic(res.diagnostics, { message: 'rr (ix/iy+disp) expects disp8' });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'rr disp',
+      id: DiagnosticIds.EncodeError,
+      message: 'rr (ix/iy+disp) expects disp8',
+    },
+    {
+      label: 'sla indexed dest',
+      id: DiagnosticIds.EncodeError,
       message: 'sla indexed destination must use legacy reg8 B/C/D/E/H/L/A',
+    },
+    {
+      label: 'sra reg8 dest',
+      id: DiagnosticIds.EncodeError,
+      message: 'sra (ix/iy+disp),r expects reg8 destination',
+    },
+    {
+      label: 'rrc disp',
+      id: DiagnosticIds.EncodeError,
+      message: 'rrc (ix/iy+disp) expects disp8',
+    },
+  ] satisfies Row[])('$label — explicit diagnostics for malformed ED/CB forms', async (row) => {
+    const res = await compile(PR144_FIXTURE, {}, { formats: defaultFormatWriters });
+    expectDiagnostic(res.diagnostics, {
+      id: row.id,
+      severity: 'error',
+      message: row.message,
     });
-    expectDiagnostic(res.diagnostics, { message: 'sra (ix/iy+disp),r expects reg8 destination' });
-    expectDiagnostic(res.diagnostics, { message: 'rrc (ix/iy+disp) expects disp8' });
+  });
+
+  it('does not fall back to generic unsupported-instruction for the ED/CB matrix fixture', async () => {
+    const res = await compile(PR144_FIXTURE, {}, { formats: defaultFormatWriters });
     expectNoDiagnostic(res.diagnostics, { messageIncludes: 'Unsupported instruction:' });
   });
 });

--- a/test/backend/pr240_isa_register_target_diag_matrix.test.ts
+++ b/test/backend/pr240_isa_register_target_diag_matrix.test.ts
@@ -3,40 +3,64 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../../src/compile.js';
+import { DiagnosticIds } from '../../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from '../helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const PR240_FIXTURE = join(__dirname, '..', 'fixtures', 'pr240_isa_register_target_diag_matrix_invalid.zax');
+
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  message: string;
+};
+
 describe('PR240: ISA register-target diagnostics parity', () => {
-  it('emits explicit diagnostics for register-target misuse in call/jp/jr/djnz', async () => {
-    const entry = join(__dirname, '..', 'fixtures', 'pr240_isa_register_target_diag_matrix_invalid.zax');
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+  it.each([
+    {
+      label: 'call imm16',
+      id: DiagnosticIds.EncodeError,
       message: 'call does not support register targets; use imm16',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'jp parens',
+      id: DiagnosticIds.EncodeError,
       message: 'jp indirect form requires parentheses; use (hl), (ix), or (iy)',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'jp imm16',
+      id: DiagnosticIds.EncodeError,
       message: 'jp does not support register targets; use imm16',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'jr disp8',
+      id: DiagnosticIds.EmitError,
       message: 'jr does not support register targets; expects disp8',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'jr cc disp reg',
+      id: DiagnosticIds.EmitError,
       message: 'jr cc, disp does not support register targets; expects disp8',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'djnz disp8',
+      id: DiagnosticIds.EmitError,
       message: 'djnz does not support register targets; expects disp8',
+    },
+  ] satisfies Row[])('$label — explicit diagnostics for register-target misuse in call/jp/jr/djnz', async (row) => {
+    const res = await compile(PR240_FIXTURE, {}, { formats: defaultFormatWriters });
+    expectDiagnostic(res.diagnostics, {
+      id: row.id,
+      severity: 'error',
+      message: row.message,
     });
+  });
+
+  it('does not emit looser imm/disp placeholder diagnostics for the register-target matrix fixture', async () => {
+    const res = await compile(PR240_FIXTURE, {}, { formats: defaultFormatWriters });
     expectNoDiagnostic(res.diagnostics, {
       message: 'call expects imm16',
     });

--- a/test/frontend/pr184_func_extern_param_return_diag_matrix.test.ts
+++ b/test/frontend/pr184_func_extern_param_return_diag_matrix.test.ts
@@ -10,42 +10,59 @@ import { expectDiagnostic, expectNoDiagnostic } from '../helpers/diagnostics.js'
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-describe('PR184 parser: func/extern parameter and return diagnostics matrix', () => {
-  it('emits explicit expected-shape diagnostics for malformed parameter/return forms', async () => {
-    const entry = join(__dirname, '..', 'fixtures', 'pr184_func_extern_param_return_diag_matrix.zax');
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+const PR184_FIXTURE = join(__dirname, '..', 'fixtures', 'pr184_func_extern_param_return_diag_matrix.zax');
 
-    expectDiagnostic(res.diagnostics, {
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  line: number;
+  message: string;
+};
+
+describe('PR184 parser: func/extern parameter and return diagnostics matrix', () => {
+  it.each([
+    {
+      label: 'param decl',
       id: DiagnosticIds.ParseError,
-      severity: 'error',
       line: 1,
       message: 'Invalid parameter declaration: expected <name>: <type>',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'param type',
       id: DiagnosticIds.ParseError,
-      severity: 'error',
       line: 5,
       message: 'Invalid parameter type "[byte]": expected <type>',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'return reg (func)',
       id: DiagnosticIds.ParseError,
-      severity: 'error',
       line: 9,
       message: 'Invalid return register "[word]": expected HL, DE, BC, or AF.',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'op param decl',
       id: DiagnosticIds.ParseError,
-      severity: 'error',
       line: 13,
       message: 'Invalid op parameter declaration: expected <name>: <matcher>',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'return reg (extern block)',
       id: DiagnosticIds.ParseError,
-      severity: 'error',
       line: 19,
       message: 'Invalid return register "[word]": expected HL, DE, BC, or AF.',
+    },
+  ] satisfies Row[])('$label — explicit expected-shape diagnostics for malformed parameter/return forms', async (row) => {
+    const res = await compile(PR184_FIXTURE, {}, { formats: defaultFormatWriters });
+    expectDiagnostic(res.diagnostics, {
+      id: row.id,
+      severity: 'error',
+      line: row.line,
+      message: row.message,
     });
+  });
 
+  it('does not fall back to generic unsupported-type diagnostics for the parser matrix fixture', async () => {
+    const res = await compile(PR184_FIXTURE, {}, { formats: defaultFormatWriters });
     expectNoDiagnostic(res.diagnostics, {
       messageIncludes: 'Unsupported type in parameter declaration',
     });

--- a/test/pr133_arity_diag_matrix.test.ts
+++ b/test/pr133_arity_diag_matrix.test.ts
@@ -3,54 +3,87 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { expectDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-describe('PR133: broad arity diagnostics matrix', () => {
-  it('reports explicit arity diagnostics for unsupported instruction counts', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr133_arity_diag_matrix_invalid.zax');
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+const PR133_FIXTURE = join(__dirname, 'fixtures', 'pr133_arity_diag_matrix_invalid.zax');
 
-    expectDiagnostic(res.diagnostics, { message: 'add expects two operands' });
-    expectDiagnostic(res.diagnostics, { message: 'ld expects two operands' });
-    expectDiagnostic(res.diagnostics, { message: 'inc expects one operand' });
-    expectDiagnostic(res.diagnostics, { message: 'dec expects one operand' });
-    expectDiagnostic(res.diagnostics, { message: 'push expects one operand' });
-    expectDiagnostic(res.diagnostics, { message: 'pop expects one operand' });
-    expectDiagnostic(res.diagnostics, { message: 'ex expects two operands' });
-    expectDiagnostic(res.diagnostics, { message: 'bit expects two operands' });
-    expectDiagnostic(res.diagnostics, {
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  message: string;
+};
+
+describe('PR133: broad arity diagnostics matrix', () => {
+  it.each([
+    { label: 'add', id: DiagnosticIds.EncodeError, message: 'add expects two operands' },
+    { label: 'ld', id: DiagnosticIds.EncodeError, message: 'ld expects two operands' },
+    { label: 'inc', id: DiagnosticIds.EncodeError, message: 'inc expects one operand' },
+    { label: 'dec', id: DiagnosticIds.EncodeError, message: 'dec expects one operand' },
+    { label: 'push', id: DiagnosticIds.EncodeError, message: 'push expects one operand' },
+    { label: 'pop', id: DiagnosticIds.EncodeError, message: 'pop expects one operand' },
+    { label: 'ex', id: DiagnosticIds.EncodeError, message: 'ex expects two operands' },
+    { label: 'bit', id: DiagnosticIds.EncodeError, message: 'bit expects two operands' },
+    {
+      label: 'res',
+      id: DiagnosticIds.EncodeError,
       message: 'res expects two operands, or three with indexed source + reg8 destination',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'set',
+      id: DiagnosticIds.EncodeError,
       message: 'set expects two operands, or three with indexed source + reg8 destination',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'rl',
+      id: DiagnosticIds.EncodeError,
       message: 'rl expects one operand, or two with indexed source + reg8 destination',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'rr',
+      id: DiagnosticIds.EncodeError,
       message: 'rr expects one operand, or two with indexed source + reg8 destination',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'sla',
+      id: DiagnosticIds.EncodeError,
       message: 'sla expects one operand, or two with indexed source + reg8 destination',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'sra',
+      id: DiagnosticIds.EncodeError,
       message: 'sra expects one operand, or two with indexed source + reg8 destination',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'srl',
+      id: DiagnosticIds.EncodeError,
       message: 'srl expects one operand, or two with indexed source + reg8 destination',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'sll',
+      id: DiagnosticIds.EncodeError,
       message: 'sll expects one operand, or two with indexed source + reg8 destination',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'rlc',
+      id: DiagnosticIds.EncodeError,
       message: 'rlc expects one operand, or two with indexed source + reg8 destination',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'rrc',
+      id: DiagnosticIds.EncodeError,
       message: 'rrc expects one operand, or two with indexed source + reg8 destination',
+    },
+  ] satisfies Row[])('$label — explicit arity diagnostics for unsupported instruction counts', async (row) => {
+    const res = await compile(PR133_FIXTURE, {}, { formats: defaultFormatWriters });
+    expectDiagnostic(res.diagnostics, {
+      id: row.id,
+      severity: 'error',
+      message: row.message,
     });
   });
 });

--- a/test/pr147_known_head_diag_matrix.test.ts
+++ b/test/pr147_known_head_diag_matrix.test.ts
@@ -3,44 +3,97 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-describe('PR147: broad known-head diagnostic matrix', () => {
-  it('reports specific diagnostics for malformed known instruction heads', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr147_known_head_diag_matrix_invalid.zax');
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+const PR147_FIXTURE = join(__dirname, 'fixtures', 'pr147_known_head_diag_matrix_invalid.zax');
 
-    expectDiagnostic(res.diagnostics, { message: 'add expects two operands' });
-    expectDiagnostic(res.diagnostics, { message: 'ld expects two operands' });
-    expectDiagnostic(res.diagnostics, { message: 'inc expects one operand' });
-    expectDiagnostic(res.diagnostics, { message: 'dec expects one operand' });
-    expectDiagnostic(res.diagnostics, { message: 'push supports BC/DE/HL/AF/IX/IY only' });
-    expectDiagnostic(res.diagnostics, { message: 'pop supports BC/DE/HL/AF/IX/IY only' });
-    expectDiagnostic(res.diagnostics, { message: 'ex expects two operands' });
-    expectDiagnostic(res.diagnostics, {
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  message: string;
+};
+
+describe('PR147: broad known-head diagnostic matrix', () => {
+  it.each([
+    { label: 'add', id: DiagnosticIds.EncodeError, message: 'add expects two operands' },
+    { label: 'ld', id: DiagnosticIds.EncodeError, message: 'ld expects two operands' },
+    { label: 'inc', id: DiagnosticIds.EncodeError, message: 'inc expects one operand' },
+    { label: 'dec', id: DiagnosticIds.EncodeError, message: 'dec expects one operand' },
+    { label: 'push', id: DiagnosticIds.EncodeError, message: 'push supports BC/DE/HL/AF/IX/IY only' },
+    { label: 'pop', id: DiagnosticIds.EncodeError, message: 'pop supports BC/DE/HL/AF/IX/IY only' },
+    { label: 'ex', id: DiagnosticIds.EncodeError, message: 'ex expects two operands' },
+    {
+      label: 'call reg',
+      id: DiagnosticIds.EncodeError,
       message: 'call does not support register targets; use imm16',
-    });
-    expectDiagnostic(res.diagnostics, { message: 'call cc, nn expects two operands (cc, nn)' });
-    expectDiagnostic(res.diagnostics, { message: 'call cc, nn expects imm16' });
-    expectDiagnostic(res.diagnostics, { message: 'jp cc, nn expects two operands (cc, nn)' });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'call cc nn',
+      id: DiagnosticIds.EmitError,
+      message: 'call cc, nn expects two operands (cc, nn)',
+    },
+    {
+      label: 'call cc imm',
+      id: DiagnosticIds.EncodeError,
+      message: 'call cc, nn expects imm16',
+    },
+    {
+      label: 'jp cc nn',
+      id: DiagnosticIds.EmitError,
+      message: 'jp cc, nn expects two operands (cc, nn)',
+    },
+    {
+      label: 'jp indirect',
+      id: DiagnosticIds.EncodeError,
       message: 'jp indirect form supports (hl), (ix), or (iy) only',
-    });
-    expectDiagnostic(res.diagnostics, { message: 'jr cc, disp expects two operands (cc, disp8)' });
-    expectDiagnostic(res.diagnostics, { message: 'jr cc expects valid condition code NZ/Z/NC/C' });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'jr cc disp',
+      id: DiagnosticIds.EmitError,
+      message: 'jr cc, disp expects two operands (cc, disp8)',
+    },
+    {
+      label: 'jr cc',
+      id: DiagnosticIds.EmitError,
+      message: 'jr cc expects valid condition code NZ/Z/NC/C',
+    },
+    {
+      label: 'djnz',
+      id: DiagnosticIds.EmitError,
       message: 'djnz does not support register targets; expects disp8',
-    });
-    expectDiagnostic(res.diagnostics, { message: 'rst expects an imm8 multiple of 8 (0..56)' });
-    expectDiagnostic(res.diagnostics, { message: 'im expects 0, 1, or 2' });
-    expectDiagnostic(res.diagnostics, { message: 'in a,(n) expects an imm8 port number' });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'rst',
+      id: DiagnosticIds.EncodeError,
+      message: 'rst expects an imm8 multiple of 8 (0..56)',
+    },
+    { label: 'im', id: DiagnosticIds.EncodeError, message: 'im expects 0, 1, or 2' },
+    {
+      label: 'in',
+      id: DiagnosticIds.EncodeError,
+      message: 'in a,(n) expects an imm8 port number',
+    },
+    {
+      label: 'out',
+      id: DiagnosticIds.EncodeError,
       message: 'out (n),a immediate port form requires source A',
+    },
+  ] satisfies Row[])('$label — specific diagnostics for malformed known instruction heads', async (row) => {
+    const res = await compile(PR147_FIXTURE, {}, { formats: defaultFormatWriters });
+    expectDiagnostic(res.diagnostics, {
+      id: row.id,
+      severity: 'error',
+      message: row.message,
     });
+  });
+
+  it('does not fall back to generic unsupported-instruction for the known-head matrix fixture', async () => {
+    const res = await compile(PR147_FIXTURE, {}, { formats: defaultFormatWriters });
     expectNoDiagnostic(res.diagnostics, { messageIncludes: 'Unsupported instruction:' });
   });
 });

--- a/test/pr149_condition_diag_matrix.test.ts
+++ b/test/pr149_condition_diag_matrix.test.ts
@@ -3,35 +3,85 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-describe('PR149: condition diagnostics parity matrix', () => {
-  it('reports explicit diagnostics for malformed condition operands/forms', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr149_condition_diag_matrix_invalid.zax');
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+const PR149_FIXTURE = join(__dirname, 'fixtures', 'pr149_condition_diag_matrix_invalid.zax');
 
-    expectDiagnostic(res.diagnostics, { message: 'ret cc expects a valid condition code' });
-    expectDiagnostic(res.diagnostics, { message: 'ret expects no operands or one condition code' });
-    expectDiagnostic(res.diagnostics, { message: 'jp cc, nn expects two operands (cc, nn)' });
-    expectDiagnostic(res.diagnostics, {
+/** IDs from a real compile of the fixture (lowering uses EmitError ZAX300; encoder uses EncodeError ZAX200). */
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  message: string;
+};
+
+describe('PR149: condition diagnostics parity matrix', () => {
+  it.each([
+    {
+      label: 'ret condition',
+      id: DiagnosticIds.EmitError,
+      message: 'ret cc expects a valid condition code',
+    },
+    {
+      label: 'ret arity',
+      id: DiagnosticIds.EncodeError,
+      message: 'ret expects no operands or one condition code',
+    },
+    {
+      label: 'jp cc nn arity',
+      id: DiagnosticIds.EmitError,
+      message: 'jp cc, nn expects two operands (cc, nn)',
+    },
+    {
+      label: 'jp cc',
+      id: DiagnosticIds.EncodeError,
       message: 'jp cc expects valid condition code NZ/Z/NC/C/PO/PE/P/M',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'jp form',
+      id: DiagnosticIds.EncodeError,
       message: 'jp expects one operand (nn/(hl)/(ix)/(iy)) or two operands (cc, nn)',
-    });
-    expectDiagnostic(res.diagnostics, { message: 'call cc, nn expects two operands (cc, nn)' });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'call cc nn arity',
+      id: DiagnosticIds.EmitError,
+      message: 'call cc, nn expects two operands (cc, nn)',
+    },
+    {
+      label: 'call cc',
+      id: DiagnosticIds.EncodeError,
       message: 'call cc expects valid condition code NZ/Z/NC/C/PO/PE/P/M',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'call form',
+      id: DiagnosticIds.EncodeError,
       message: 'call expects one operand (nn) or two operands (cc, nn)',
+    },
+    {
+      label: 'jr cc disp',
+      id: DiagnosticIds.EmitError,
+      message: 'jr cc, disp expects two operands (cc, disp8)',
+    },
+    {
+      label: 'jr cc',
+      id: DiagnosticIds.EmitError,
+      message: 'jr cc expects valid condition code NZ/Z/NC/C',
+    },
+  ] satisfies Row[])('$label — explicit diagnostics for malformed condition operands/forms', async (row) => {
+    const res = await compile(PR149_FIXTURE, {}, { formats: defaultFormatWriters });
+    expectDiagnostic(res.diagnostics, {
+      id: row.id,
+      severity: 'error',
+      message: row.message,
     });
-    expectDiagnostic(res.diagnostics, { message: 'jr cc, disp expects two operands (cc, disp8)' });
-    expectDiagnostic(res.diagnostics, { message: 'jr cc expects valid condition code NZ/Z/NC/C' });
+  });
+
+  it('does not report generic unresolved/unsupported fallbacks for the condition matrix fixture', async () => {
+    const res = await compile(PR149_FIXTURE, {}, { formats: defaultFormatWriters });
     expectNoDiagnostic(res.diagnostics, { messageIncludes: 'Unresolved symbol' });
     expectNoDiagnostic(res.diagnostics, { messageIncludes: 'Unsupported instruction:' });
   });

--- a/test/pr151_zero_operand_head_diag_matrix.test.ts
+++ b/test/pr151_zero_operand_head_diag_matrix.test.ts
@@ -3,51 +3,68 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-describe('PR151: zero-operand known-head diagnostics matrix', () => {
-  it('rejects extra operands on zero-operand known heads without generic fallback', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr151_zero_operand_head_diag_matrix.zax');
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+const PR151_FIXTURE = join(__dirname, 'fixtures', 'pr151_zero_operand_head_diag_matrix.zax');
 
-    expectDiagnostic(res.diagnostics, { message: 'nop expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'halt expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'di expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'ei expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'scf expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'ccf expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'cpl expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'daa expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'rlca expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'rrca expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'rla expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'rra expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'exx expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'neg expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'reti expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'retn expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'rrd expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'rld expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'ldi expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'ldir expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'ldd expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'lddr expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'cpi expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'cpir expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'cpd expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'cpdr expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'ini expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'inir expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'ind expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'indr expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'outi expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'otir expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'outd expects no operands' });
-    expectDiagnostic(res.diagnostics, { message: 'otdr expects no operands' });
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  message: string;
+};
+
+describe('PR151: zero-operand known-head diagnostics matrix', () => {
+  it.each([
+    { label: 'nop', id: DiagnosticIds.EncodeError, message: 'nop expects no operands' },
+    { label: 'halt', id: DiagnosticIds.EncodeError, message: 'halt expects no operands' },
+    { label: 'di', id: DiagnosticIds.EncodeError, message: 'di expects no operands' },
+    { label: 'ei', id: DiagnosticIds.EncodeError, message: 'ei expects no operands' },
+    { label: 'scf', id: DiagnosticIds.EncodeError, message: 'scf expects no operands' },
+    { label: 'ccf', id: DiagnosticIds.EncodeError, message: 'ccf expects no operands' },
+    { label: 'cpl', id: DiagnosticIds.EncodeError, message: 'cpl expects no operands' },
+    { label: 'daa', id: DiagnosticIds.EncodeError, message: 'daa expects no operands' },
+    { label: 'rlca', id: DiagnosticIds.EncodeError, message: 'rlca expects no operands' },
+    { label: 'rrca', id: DiagnosticIds.EncodeError, message: 'rrca expects no operands' },
+    { label: 'rla', id: DiagnosticIds.EncodeError, message: 'rla expects no operands' },
+    { label: 'rra', id: DiagnosticIds.EncodeError, message: 'rra expects no operands' },
+    { label: 'exx', id: DiagnosticIds.EncodeError, message: 'exx expects no operands' },
+    { label: 'neg', id: DiagnosticIds.EncodeError, message: 'neg expects no operands' },
+    { label: 'reti', id: DiagnosticIds.EncodeError, message: 'reti expects no operands' },
+    { label: 'retn', id: DiagnosticIds.EncodeError, message: 'retn expects no operands' },
+    { label: 'rrd', id: DiagnosticIds.EncodeError, message: 'rrd expects no operands' },
+    { label: 'rld', id: DiagnosticIds.EncodeError, message: 'rld expects no operands' },
+    { label: 'ldi', id: DiagnosticIds.EncodeError, message: 'ldi expects no operands' },
+    { label: 'ldir', id: DiagnosticIds.EncodeError, message: 'ldir expects no operands' },
+    { label: 'ldd', id: DiagnosticIds.EncodeError, message: 'ldd expects no operands' },
+    { label: 'lddr', id: DiagnosticIds.EncodeError, message: 'lddr expects no operands' },
+    { label: 'cpi', id: DiagnosticIds.EncodeError, message: 'cpi expects no operands' },
+    { label: 'cpir', id: DiagnosticIds.EncodeError, message: 'cpir expects no operands' },
+    { label: 'cpd', id: DiagnosticIds.EncodeError, message: 'cpd expects no operands' },
+    { label: 'cpdr', id: DiagnosticIds.EncodeError, message: 'cpdr expects no operands' },
+    { label: 'ini', id: DiagnosticIds.EncodeError, message: 'ini expects no operands' },
+    { label: 'inir', id: DiagnosticIds.EncodeError, message: 'inir expects no operands' },
+    { label: 'ind', id: DiagnosticIds.EncodeError, message: 'ind expects no operands' },
+    { label: 'indr', id: DiagnosticIds.EncodeError, message: 'indr expects no operands' },
+    { label: 'outi', id: DiagnosticIds.EncodeError, message: 'outi expects no operands' },
+    { label: 'otir', id: DiagnosticIds.EncodeError, message: 'otir expects no operands' },
+    { label: 'outd', id: DiagnosticIds.EncodeError, message: 'outd expects no operands' },
+    { label: 'otdr', id: DiagnosticIds.EncodeError, message: 'otdr expects no operands' },
+  ] satisfies Row[])('$label — rejects extra operands on zero-operand known heads', async (row) => {
+    const res = await compile(PR151_FIXTURE, {}, { formats: defaultFormatWriters });
+    expectDiagnostic(res.diagnostics, {
+      id: row.id,
+      severity: 'error',
+      message: row.message,
+    });
+  });
+
+  it('does not fall back to generic unsupported-instruction for the zero-operand matrix fixture', async () => {
+    const res = await compile(PR151_FIXTURE, {}, { formats: defaultFormatWriters });
     expectNoDiagnostic(res.diagnostics, { messageIncludes: 'Unsupported instruction:' });
   });
 });

--- a/test/pr203_ld_diag_matrix.test.ts
+++ b/test/pr203_ld_diag_matrix.test.ts
@@ -3,36 +3,59 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const PR203_FIXTURE = join(__dirname, 'fixtures', 'pr203_ld_diag_matrix_invalid.zax');
+
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  message: string;
+};
+
 describe('PR203: ld diagnostics parity matrix', () => {
-  it('emits explicit ld diagnostics and avoids fallback/unresolved-fixup noise', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr203_ld_diag_matrix_invalid.zax');
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+  it.each([
+    {
+      label: 'mem-mem',
+      id: DiagnosticIds.EncodeError,
       message: 'ld does not support memory-to-memory transfers',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'r8 bc/de load',
+      id: DiagnosticIds.EncodeError,
       message: 'ld r8, (bc/de) supports destination A only',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'bc/de r8 store',
+      id: DiagnosticIds.EncodeError,
       message: 'ld (bc/de), r8 supports source A only',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'AF',
+      id: DiagnosticIds.EncodeError,
       message: 'ld does not support AF in this form',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'rr rr',
+      id: DiagnosticIds.EncodeError,
       message: 'ld rr, rr supports SP <- HL/IX/IY only',
+    },
+  ] satisfies Row[])('$label — explicit ld diagnostics (no fallback/unresolved-fixup noise)', async (row) => {
+    const res = await compile(PR203_FIXTURE, {}, { formats: defaultFormatWriters });
+    expectDiagnostic(res.diagnostics, {
+      id: row.id,
+      severity: 'error',
+      message: row.message,
     });
+  });
+
+  it('does not emit generic ld fallback or spurious bc/de fixup diagnostics', async () => {
+    const res = await compile(PR203_FIXTURE, {}, { formats: defaultFormatWriters });
     expectNoDiagnostic(res.diagnostics, {
       message: 'ld has unsupported operand form',
     });

--- a/test/pr204_adc_sbc_diag_matrix.test.ts
+++ b/test/pr204_adc_sbc_diag_matrix.test.ts
@@ -3,32 +3,54 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const PR204_FIXTURE = join(__dirname, 'fixtures', 'pr204_adc_sbc_diag_matrix_invalid.zax');
+
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  message: string;
+};
+
 describe('PR204: adc/sbc malformed-form diagnostics parity', () => {
-  it('emits explicit destination diagnostics for malformed two-operand forms', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr204_adc_sbc_diag_matrix_invalid.zax');
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+  it.each([
+    {
+      label: 'adc destination',
+      id: DiagnosticIds.EncodeError,
       message: 'adc expects destination A or HL',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'adc HL pair',
+      id: DiagnosticIds.EncodeError,
       message: 'adc HL, rr expects BC/DE/HL/SP',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'sbc destination',
+      id: DiagnosticIds.EncodeError,
       message: 'sbc expects destination A or HL',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'sbc HL pair',
+      id: DiagnosticIds.EncodeError,
       message: 'sbc HL, rr expects BC/DE/HL/SP',
+    },
+  ] satisfies Row[])('$label — explicit destination diagnostics for malformed two-operand forms', async (row) => {
+    const res = await compile(PR204_FIXTURE, {}, { formats: defaultFormatWriters });
+    expectDiagnostic(res.diagnostics, {
+      id: row.id,
+      severity: 'error',
+      message: row.message,
     });
+  });
+
+  it('does not report generic unsupported-operand fallbacks for the adc/sbc matrix fixture', async () => {
+    const res = await compile(PR204_FIXTURE, {}, { formats: defaultFormatWriters });
     expectNoDiagnostic(res.diagnostics, {
       message: 'adc has unsupported operand form',
     });

--- a/test/pr205_indexed_cb_destination_diag_matrix.test.ts
+++ b/test/pr205_indexed_cb_destination_diag_matrix.test.ts
@@ -3,52 +3,78 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const PR205_FIXTURE = join(
+  __dirname,
+  'fixtures',
+  'pr205_indexed_cb_destination_diag_matrix_invalid.zax',
+);
+
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  message: string;
+};
+
 describe('PR205: indexed CB destination diagnostics parity', () => {
-  it('reports explicit indexed destination legality diagnostics for CB/DD/FD forms', async () => {
-    const entry = join(
-      __dirname,
-      'fixtures',
-      'pr205_indexed_cb_destination_diag_matrix_invalid.zax',
-    );
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+  it.each([
+    {
+      label: 'res legacy reg',
+      id: DiagnosticIds.EncodeError,
       message: 'res indexed destination must use legacy reg8 B/C/D/E/H/L/A',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'res index family',
+      id: DiagnosticIds.EncodeError,
       message: 'res indexed destination family must match source index base',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'set legacy reg',
+      id: DiagnosticIds.EncodeError,
       message: 'set indexed destination must use legacy reg8 B/C/D/E/H/L/A',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'set index family',
+      id: DiagnosticIds.EncodeError,
       message: 'set indexed destination family must match source index base',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'rl legacy reg',
+      id: DiagnosticIds.EncodeError,
       message: 'rl indexed destination must use legacy reg8 B/C/D/E/H/L/A',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'rl index family',
+      id: DiagnosticIds.EncodeError,
       message: 'rl indexed destination family must match source index base',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'rrc legacy reg',
+      id: DiagnosticIds.EncodeError,
       message: 'rrc indexed destination must use legacy reg8 B/C/D/E/H/L/A',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'rrc index family',
+      id: DiagnosticIds.EncodeError,
       message: 'rrc indexed destination family must match source index base',
+    },
+  ] satisfies Row[])('$label — explicit indexed destination legality for CB/DD/FD forms', async (row) => {
+    const res = await compile(PR205_FIXTURE, {}, { formats: defaultFormatWriters });
+    expectDiagnostic(res.diagnostics, {
+      id: row.id,
+      severity: 'error',
+      message: row.message,
     });
+  });
+
+  it('does not emit looser placeholder reg8-destination diagnostics for the indexed CB matrix fixture', async () => {
+    const res = await compile(PR205_FIXTURE, {}, { formats: defaultFormatWriters });
     expectNoDiagnostic(res.diagnostics, {
       message: 'res b,(ix/iy+disp),r expects reg8 destination',
     });

--- a/test/pr206_in_out_indexed_reg_diag_matrix.test.ts
+++ b/test/pr206_in_out_indexed_reg_diag_matrix.test.ts
@@ -3,24 +3,44 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const PR206_FIXTURE = join(__dirname, 'fixtures', 'pr206_in_out_indexed_reg_diag_matrix_invalid.zax');
+
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  message: string;
+};
+
 describe('PR206: in/out indexed-byte-register diagnostics parity', () => {
-  it('emits explicit diagnostics for ED in/out forms using IX*/IY* byte registers', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr206_in_out_indexed_reg_diag_matrix_invalid.zax');
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+  it.each([
+    {
+      label: 'in destination',
+      id: DiagnosticIds.EncodeError,
       message: 'in destination must use legacy reg8 B/C/D/E/H/L/A',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'out source',
+      id: DiagnosticIds.EncodeError,
       message: 'out source must use legacy reg8 B/C/D/E/H/L/A',
+    },
+  ] satisfies Row[])('$label — explicit diagnostics for ED in/out forms using IX*/IY* byte registers', async (row) => {
+    const res = await compile(PR206_FIXTURE, {}, { formats: defaultFormatWriters });
+    expectDiagnostic(res.diagnostics, {
+      id: row.id,
+      severity: 'error',
+      message: row.message,
     });
+  });
+
+  it('does not fall back to generic reg8 in/out diagnostics for the indexed-reg matrix fixture', async () => {
+    const res = await compile(PR206_FIXTURE, {}, { formats: defaultFormatWriters });
     expectNoDiagnostic(res.diagnostics, {
       message: 'in expects a reg8 destination',
     });

--- a/test/pr207_jp_indirect_legality_diag_matrix.test.ts
+++ b/test/pr207_jp_indirect_legality_diag_matrix.test.ts
@@ -3,20 +3,39 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const PR207_FIXTURE = join(__dirname, 'fixtures', 'pr207_jp_indirect_legality_diag_matrix_invalid.zax');
+
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  message: string;
+};
+
 describe('PR207: jp indirect-form legality diagnostics parity', () => {
-  it('emits explicit diagnostics for unsupported indirect jp addressing forms', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr207_jp_indirect_legality_diag_matrix_invalid.zax');
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+  it.each([
+    {
+      label: 'jp indirect',
+      id: DiagnosticIds.EncodeError,
       message: 'jp indirect form supports (hl), (ix), or (iy) only',
+    },
+  ] satisfies Row[])('$label — explicit diagnostics for unsupported indirect jp addressing forms', async (row) => {
+    const res = await compile(PR207_FIXTURE, {}, { formats: defaultFormatWriters });
+    expectDiagnostic(res.diagnostics, {
+      id: row.id,
+      severity: 'error',
+      message: row.message,
     });
+  });
+
+  it('does not emit looser imm16 placeholder diagnostics for the jp indirect matrix fixture', async () => {
+    const res = await compile(PR207_FIXTURE, {}, { formats: defaultFormatWriters });
     expectNoDiagnostic(res.diagnostics, {
       message: 'jp expects imm16',
     });

--- a/test/pr208_call_indirect_legality_diag_matrix.test.ts
+++ b/test/pr208_call_indirect_legality_diag_matrix.test.ts
@@ -3,28 +3,48 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const PR208_FIXTURE = join(
+  __dirname,
+  'fixtures',
+  'pr208_call_indirect_legality_diag_matrix_invalid.zax',
+);
+
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  message: string;
+};
+
 describe('PR208: call indirect-form legality diagnostics parity', () => {
-  it('emits explicit diagnostics for unsupported indirect call targets', async () => {
-    const entry = join(
-      __dirname,
-      'fixtures',
-      'pr208_call_indirect_legality_diag_matrix_invalid.zax',
-    );
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+  it.each([
+    {
+      label: 'call indirect',
+      id: DiagnosticIds.EncodeError,
       message: 'call does not support indirect targets; use imm16',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'call cc indirect',
+      id: DiagnosticIds.EncodeError,
       message: 'call cc, nn does not support indirect targets',
+    },
+  ] satisfies Row[])('$label — explicit diagnostics for unsupported indirect call targets', async (row) => {
+    const res = await compile(PR208_FIXTURE, {}, { formats: defaultFormatWriters });
+    expectDiagnostic(res.diagnostics, {
+      id: row.id,
+      severity: 'error',
+      message: row.message,
     });
+  });
+
+  it('does not emit looser imm16 placeholder diagnostics for the call indirect matrix fixture', async () => {
+    const res = await compile(PR208_FIXTURE, {}, { formats: defaultFormatWriters });
     expectNoDiagnostic(res.diagnostics, {
       message: 'call expects imm16',
     });

--- a/test/pr209_jp_cc_indirect_legality_diag_matrix.test.ts
+++ b/test/pr209_jp_cc_indirect_legality_diag_matrix.test.ts
@@ -3,24 +3,43 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const PR209_FIXTURE = join(
+  __dirname,
+  'fixtures',
+  'pr209_jp_cc_indirect_legality_diag_matrix_invalid.zax',
+);
+
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  message: string;
+};
+
 describe('PR209: jp cc indirect-form legality diagnostics parity', () => {
-  it('emits explicit diagnostics for unsupported conditional indirect jp targets', async () => {
-    const entry = join(
-      __dirname,
-      'fixtures',
-      'pr209_jp_cc_indirect_legality_diag_matrix_invalid.zax',
-    );
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+  it.each([
+    {
+      label: 'jp cc indirect',
+      id: DiagnosticIds.EncodeError,
       message: 'jp cc, nn does not support indirect targets',
+    },
+  ] satisfies Row[])('$label — explicit diagnostics for unsupported conditional indirect jp targets', async (row) => {
+    const res = await compile(PR209_FIXTURE, {}, { formats: defaultFormatWriters });
+    expectDiagnostic(res.diagnostics, {
+      id: row.id,
+      severity: 'error',
+      message: row.message,
     });
+  });
+
+  it('does not emit looser condition+imm16 placeholder diagnostics for the jp cc indirect matrix fixture', async () => {
+    const res = await compile(PR209_FIXTURE, {}, { formats: defaultFormatWriters });
     expectNoDiagnostic(res.diagnostics, {
       message: 'jp cc, nn expects condition + imm16',
     });

--- a/test/pr210_jp_call_condition_vs_imm_diag_matrix.test.ts
+++ b/test/pr210_jp_call_condition_vs_imm_diag_matrix.test.ts
@@ -3,36 +3,58 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const PR210_FIXTURE = join(
+  __dirname,
+  'fixtures',
+  'pr210_jp_call_condition_vs_imm_diag_matrix_invalid.zax',
+);
+
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  message: string;
+};
+
 describe('PR210: conditional jp/call condition-vs-imm diagnostics parity', () => {
-  it('emits distinct diagnostics for invalid condition code vs invalid imm16', async () => {
-    const entry = join(
-      __dirname,
-      'fixtures',
-      'pr210_jp_call_condition_vs_imm_diag_matrix_invalid.zax',
-    );
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+  it.each([
+    {
+      label: 'jp cc',
+      id: DiagnosticIds.EncodeError,
       message: 'jp cc expects valid condition code NZ/Z/NC/C/PO/PE/P/M',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'jp cc imm',
+      id: DiagnosticIds.EncodeError,
       message: 'jp cc, nn expects imm16',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'call cc',
+      id: DiagnosticIds.EncodeError,
       message: 'call cc expects valid condition code NZ/Z/NC/C/PO/PE/P/M',
-    });
-    expectDiagnostic(res.diagnostics, {
-      severity: 'error',
+    },
+    {
+      label: 'call cc imm',
+      id: DiagnosticIds.EncodeError,
       message: 'call cc, nn expects imm16',
+    },
+  ] satisfies Row[])('$label — distinct diagnostics for invalid condition code vs invalid imm16', async (row) => {
+    const res = await compile(PR210_FIXTURE, {}, { formats: defaultFormatWriters });
+    expectDiagnostic(res.diagnostics, {
+      id: row.id,
+      severity: 'error',
+      message: row.message,
     });
+  });
+
+  it('does not collapse condition vs imm failures into a single placeholder diagnostic', async () => {
+    const res = await compile(PR210_FIXTURE, {}, { formats: defaultFormatWriters });
     expectNoDiagnostic(res.diagnostics, {
       message: 'jp cc, nn expects condition + imm16',
     });

--- a/test/pr211_jr_djnz_diag_matrix.test.ts
+++ b/test/pr211_jr_djnz_diag_matrix.test.ts
@@ -10,35 +10,52 @@ import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const PR211_FIXTURE = join(__dirname, 'fixtures', 'pr211_jr_djnz_diag_matrix_invalid.zax');
+
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  message: string;
+};
+
 describe('PR211: jr/djnz malformed-form diagnostics parity', () => {
-  it('emits explicit diagnostics for invalid condition, disp, and indirect forms', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr211_jr_djnz_diag_matrix_invalid.zax');
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    expectDiagnostic(res.diagnostics, {
+  it.each([
+    {
+      label: 'jr cc',
       id: DiagnosticIds.EmitError,
-      severity: 'error',
       message: 'jr cc expects valid condition code NZ/Z/NC/C',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'jr cc disp reg',
       id: DiagnosticIds.EmitError,
-      severity: 'error',
       message: 'jr cc, disp does not support register targets; expects disp8',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'jr cc disp indirect',
       id: DiagnosticIds.EmitError,
-      severity: 'error',
       message: 'jr cc, disp does not support indirect targets',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'jr indirect',
       id: DiagnosticIds.EmitError,
-      severity: 'error',
       message: 'jr does not support indirect targets; expects disp8',
-    });
-    expectDiagnostic(res.diagnostics, {
+    },
+    {
+      label: 'djnz indirect',
       id: DiagnosticIds.EmitError,
-      severity: 'error',
       message: 'djnz does not support indirect targets; expects disp8',
+    },
+  ] satisfies Row[])('$label — explicit diagnostics for invalid condition, disp, and indirect forms', async (row) => {
+    const res = await compile(PR211_FIXTURE, {}, { formats: defaultFormatWriters });
+    expectDiagnostic(res.diagnostics, {
+      id: row.id,
+      severity: 'error',
+      message: row.message,
     });
+  });
+
+  it('does not emit looser jr placeholder diagnostics for the jr/djnz matrix fixture', async () => {
+    const res = await compile(PR211_FIXTURE, {}, { formats: defaultFormatWriters });
     expectNoDiagnostic(res.diagnostics, {
       message: 'jr cc, disp expects NZ/Z/NC/C + disp8',
     });

--- a/test/pr212_condition_missing_operand_diag_matrix.test.ts
+++ b/test/pr212_condition_missing_operand_diag_matrix.test.ts
@@ -3,25 +3,53 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const PR212_FIXTURE = join(
+  __dirname,
+  'fixtures',
+  'pr212_condition_missing_operand_diag_matrix_invalid.zax',
+);
+
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  message: string;
+};
+
 describe('PR212: condition missing-operand diagnostics parity', () => {
-  it('emits explicit diagnostics when conditional jp/call/jr omit displacement/target', async () => {
-    const entry = join(
-      __dirname,
-      'fixtures',
-      'pr212_condition_missing_operand_diag_matrix_invalid.zax',
-    );
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+  it.each([
+    {
+      label: 'jp cc nn',
+      id: DiagnosticIds.EmitError,
+      message: 'jp cc, nn expects two operands (cc, nn)',
+    },
+    {
+      label: 'call cc nn',
+      id: DiagnosticIds.EmitError,
+      message: 'call cc, nn expects two operands (cc, nn)',
+    },
+    {
+      label: 'jr cc disp',
+      id: DiagnosticIds.EmitError,
+      message: 'jr cc, disp expects two operands (cc, disp8)',
+    },
+  ] satisfies Row[])('$label — explicit diagnostics when conditional jp/call/jr omit displacement/target', async (row) => {
+    const res = await compile(PR212_FIXTURE, {}, { formats: defaultFormatWriters });
+    expectDiagnostic(res.diagnostics, {
+      id: row.id,
+      severity: 'error',
+      message: row.message,
+    });
+  });
 
-    expectDiagnostic(res.diagnostics, { message: 'jp cc, nn expects two operands (cc, nn)' });
-    expectDiagnostic(res.diagnostics, { message: 'call cc, nn expects two operands (cc, nn)' });
-    expectDiagnostic(res.diagnostics, { message: 'jr cc, disp expects two operands (cc, disp8)' });
-
+  it('does not substitute bare imm/disp placeholder diagnostics for the missing-operand matrix fixture', async () => {
+    const res = await compile(PR212_FIXTURE, {}, { formats: defaultFormatWriters });
     expectNoDiagnostic(res.diagnostics, { message: 'jp expects imm16' });
     expectNoDiagnostic(res.diagnostics, { message: 'call expects imm16' });
     expectNoDiagnostic(res.diagnostics, { message: 'jr expects disp8' });

--- a/test/pr213_condition_symbolic_base_collision_diag_matrix.test.ts
+++ b/test/pr213_condition_symbolic_base_collision_diag_matrix.test.ts
@@ -3,24 +3,53 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-describe('PR213: condition-symbol base collision diagnostics parity', () => {
-  it('treats condition-code symbolic bases as malformed conditional arity, not label fixups', async () => {
-    const entry = join(
-      __dirname,
-      'fixtures',
-      'pr213_condition_symbolic_base_collision_invalid.zax',
-    );
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+const PR213_FIXTURE = join(
+  __dirname,
+  'fixtures',
+  'pr213_condition_symbolic_base_collision_invalid.zax',
+);
 
-    expectDiagnostic(res.diagnostics, { message: 'jp cc, nn expects two operands (cc, nn)' });
-    expectDiagnostic(res.diagnostics, { message: 'call cc, nn expects two operands (cc, nn)' });
-    expectDiagnostic(res.diagnostics, { message: 'jr cc, disp expects two operands (cc, disp8)' });
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  message: string;
+};
+
+describe('PR213: condition-symbol base collision diagnostics parity', () => {
+  it.each([
+    {
+      label: 'jp cc nn arity',
+      id: DiagnosticIds.EmitError,
+      message: 'jp cc, nn expects two operands (cc, nn)',
+    },
+    {
+      label: 'call cc nn arity',
+      id: DiagnosticIds.EmitError,
+      message: 'call cc, nn expects two operands (cc, nn)',
+    },
+    {
+      label: 'jr cc disp arity',
+      id: DiagnosticIds.EmitError,
+      message: 'jr cc, disp expects two operands (cc, disp8)',
+    },
+  ] satisfies Row[])('$label — treats condition-code symbolic bases as malformed conditional arity', async (row) => {
+    const res = await compile(PR213_FIXTURE, {}, { formats: defaultFormatWriters });
+    expectDiagnostic(res.diagnostics, {
+      id: row.id,
+      severity: 'error',
+      message: row.message,
+    });
+  });
+
+  it('emits duplicate arity diagnostics once per colliding site (NZ/NC/Z/C)', async () => {
+    const res = await compile(PR213_FIXTURE, {}, { formats: defaultFormatWriters });
     expect(
       res.diagnostics.filter((d) => d.message === 'jp cc, nn expects two operands (cc, nn)'),
     ).toHaveLength(2);
@@ -30,7 +59,10 @@ describe('PR213: condition-symbol base collision diagnostics parity', () => {
     expect(
       res.diagnostics.filter((d) => d.message === 'jr cc, disp expects two operands (cc, disp8)'),
     ).toHaveLength(2);
+  });
 
+  it('does not treat symbolic bases as label fixups or generic unsupported instructions', async () => {
+    const res = await compile(PR213_FIXTURE, {}, { formats: defaultFormatWriters });
     expectNoDiagnostic(res.diagnostics, { messageIncludes: 'Unresolved symbol' });
     expectNoDiagnostic(res.diagnostics, { messageIncludes: 'Unsupported instruction:' });
   });

--- a/test/pr225_indexed_rotate_destination_diag_matrix.test.ts
+++ b/test/pr225_indexed_rotate_destination_diag_matrix.test.ts
@@ -3,30 +3,60 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { compile } from '../src/compile.js';
+import { DiagnosticIds } from '../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../src/formats/index.js';
 import { expectDiagnostic, expectNoDiagnostic } from './helpers/diagnostics.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const PR225_FIXTURE = join(
+  __dirname,
+  'fixtures',
+  'pr225_indexed_rotate_destination_diag_matrix_invalid.zax',
+);
+
+const HEADS = ['rlc', 'rrc', 'rl', 'rr', 'sla', 'sra', 'sll', 'srl'] as const;
+
+type Row = {
+  label: string;
+  id: (typeof DiagnosticIds)[keyof typeof DiagnosticIds];
+  message: string;
+};
+
+function rowsForHead(head: (typeof HEADS)[number]): Row[] {
+  return [
+    {
+      label: `${head} legacy reg`,
+      id: DiagnosticIds.EncodeError,
+      message: `${head} indexed destination must use legacy reg8 B/C/D/E/H/L/A`,
+    },
+    {
+      label: `${head} index family`,
+      id: DiagnosticIds.EncodeError,
+      message: `${head} indexed destination family must match source index base`,
+    },
+  ];
+}
+
+const PR225_ROWS = HEADS.flatMap(rowsForHead);
+
 describe('PR225: indexed rotate/shift destination diagnostics parity matrix', () => {
-  it('emits explicit legacy-reg and index-family diagnostics across all indexed rotate/shift heads', async () => {
-    const entry = join(
-      __dirname,
-      'fixtures',
-      'pr225_indexed_rotate_destination_diag_matrix_invalid.zax',
-    );
-    const res = await compile(entry, {}, { formats: defaultFormatWriters });
-    const heads = ['rlc', 'rrc', 'rl', 'rr', 'sla', 'sra', 'sll', 'srl'];
-    for (const head of heads) {
+  it.each(PR225_ROWS)(
+    '$label — explicit legacy-reg and index-family diagnostics for indexed rotate/shift heads',
+    async (row) => {
+      const res = await compile(PR225_FIXTURE, {}, { formats: defaultFormatWriters });
       expectDiagnostic(res.diagnostics, {
+        id: row.id,
         severity: 'error',
-        message: `${head} indexed destination must use legacy reg8 B/C/D/E/H/L/A`,
+        message: row.message,
       });
-      expectDiagnostic(res.diagnostics, {
-        severity: 'error',
-        message: `${head} indexed destination family must match source index base`,
-      });
+    },
+  );
+
+  it('does not emit looser reg8-destination placeholder diagnostics for indexed rotate/shift heads', async () => {
+    const res = await compile(PR225_FIXTURE, {}, { formats: defaultFormatWriters });
+    for (const head of HEADS) {
       expectNoDiagnostic(res.diagnostics, {
         message: `${head} (ix/iy+disp),r expects reg8 destination`,
       });


### PR DESCRIPTION
## Summary
- Converts all `*diag_matrix*.test.ts` files under `test/`, `test/backend/`, and `test/frontend/` to `it.each` tables with explicit `DiagnosticIds` and full messages (or `line` for PR184 parse errors).
- Splits `expectNoDiagnostic` / duplicate-count checks into focused follow-up `it` blocks where the old tests had them (e.g. PR213 arity duplication, PR205 placeholder messages).

## Testing
- `npx vitest run` (1045 tests)

Fixes #1133

Made with [Cursor](https://cursor.com)