### PR TITLE
refactor(lowering): descriptive Context type names (#1313)

### DIFF
--- a/src/lowering/asmBodyOrchestration.ts
+++ b/src/lowering/asmBodyOrchestration.ts
@@ -1,7 +1,7 @@
 import type { AsmItemNode, SourceSpan } from '../frontend/ast.js';
 import type { FlowState } from './functionBodySetup.js';
 
-type Context = {
+type AsmBodyOrchestrationContext = {
   asmItems: readonly AsmItemNode[];
   itemName: string;
   itemSpan: SourceSpan;
@@ -17,7 +17,7 @@ type Context = {
   traceFunctionEnd: () => void;
 };
 
-export function createAsmBodyOrchestrationHelpers(ctx: Context) {
+export function createAsmBodyOrchestrationHelpers(ctx: AsmBodyOrchestrationContext) {
   const lowerAndFinalizeFunctionBody = (): void => {
     const consumed = ctx.lowerAsmRange(ctx.asmItems, 0, new Set());
     if (consumed < ctx.asmItems.length) {

--- a/src/lowering/asmUtils.ts
+++ b/src/lowering/asmUtils.ts
@@ -1,6 +1,6 @@
 import type { AsmOperandNode, EaExprNode, ImmExprNode, OffsetofPathNode } from '../frontend/ast.js';
 
-type Context = {
+type AsmUtilsContext = {
   /** Returns true when `name` matches a declared enum (used to normalize asm tokens); callback must stay pure. */
   isEnumName: (name: string) => boolean;
 };
@@ -77,7 +77,7 @@ export function flattenEaDottedName(ea: EaExprNode): string | undefined {
   return undefined;
 }
 
-export function createAsmUtilityHelpers(ctx: Context) {
+export function createAsmUtilityHelpers(ctx: AsmUtilsContext) {
   const enumImmExprFromOperand = (op: AsmOperandNode): ImmExprNode | undefined => {
     if (op.kind === 'Imm') return op.expr;
     if (op.kind !== 'Ea') return undefined;

--- a/src/lowering/emissionCore.ts
+++ b/src/lowering/emissionCore.ts
@@ -1,7 +1,7 @@
 import type { AsmOperandNode, ImmExprNode, SourceSpan } from '../frontend/ast.js';
 import { renderStepInstr, type StepInstr, type StepPipeline } from './steps.js';
 
-type Context = {
+type EmissionCoreContext = {
   /** Current code emission offset. */
   getCodeOffset: () => number;
   /** Sets absolute code offset cursor. */
@@ -36,7 +36,7 @@ type Context = {
   ) => void;
 };
 
-export function createEmissionCoreHelpers(ctx: Context) {
+export function createEmissionCoreHelpers(ctx: EmissionCoreContext) {
   const emitCodeBytes = (bs: Uint8Array, _file: string): number => {
     const start = ctx.getCodeOffset();
     let codeOffset = start;

--- a/src/lowering/emitFinalizationSetup.ts
+++ b/src/lowering/emitFinalizationSetup.ts
@@ -8,7 +8,7 @@ import { diag, diagAt } from './loweringDiagnostics.js';
 import type { EmitPhase1Workspace } from './emitPhase1Workspace.js';
 import type { EmitPhase1Helpers } from './emitPhase1Helpers.js';
 
-type Context = {
+type EmitFinalizationSetupContext = {
   /** Semantic environment for imm evaluation during finalization. */
   env: CompileEnv;
   /** Mutable diagnostic sink for placement and fixup phases. */
@@ -21,7 +21,7 @@ type Context = {
   helpers: EmitPhase1Helpers;
 };
 
-export function buildEmitFinalizationPhaseEnv(ctx: Context): EmitFinalizationPhaseEnv {
+export function buildEmitFinalizationPhaseEnv(ctx: EmitFinalizationSetupContext): EmitFinalizationPhaseEnv {
   return {
     namedSectionSinks: ctx.helpers.namedSectionSinks,
     diagnostics: ctx.diagnostics,

--- a/src/lowering/emitPhase1Helpers.ts
+++ b/src/lowering/emitPhase1Helpers.ts
@@ -86,7 +86,7 @@ export type EmitPhase1Helpers = {
   namedSectionSinks: ReturnType<typeof createEmitStateHelpers>['namedSectionSinks'];
 };
 
-type Context = {
+type EmitPhase1HelpersContext = {
   /** Whole program AST. */
   program: ProgramNode;
   /** Compile environment (consts, types, modules). */
@@ -99,7 +99,7 @@ type Context = {
   workspace: EmitPhase1Workspace;
 };
 
-export function createEmitPhase1Helpers(ctx: Context): EmitPhase1Helpers {
+export function createEmitPhase1Helpers(ctx: EmitPhase1HelpersContext): EmitPhase1Helpers {
   let applySpTracking: ((headRaw: string, operands: AsmOperandNode[]) => void) | undefined;
   let invalidateSpTracking: (() => void) | undefined;
   let emitCodeBytes: (bs: Uint8Array, file: string) => void;

--- a/src/lowering/emitState.ts
+++ b/src/lowering/emitState.ts
@@ -9,7 +9,7 @@ import type {
   LoweredAsmStreamBlock,
 } from './loweredAsmTypes.js';
 
-type Context = {
+type EmitStateContext = {
   /** Optional named section metadata for contribution sinks. */
   namedSectionKeys?: NonBankedSectionKeyCollection;
   /** Full source text per file for listings. */
@@ -49,7 +49,7 @@ type Context = {
   typeDisplay: (typeExpr: import('../frontend/ast.js').TypeExprNode) => string;
 };
 
-export function createEmitStateHelpers(ctx: Context) {
+export function createEmitStateHelpers(ctx: EmitStateContext) {
   let activeSection: SectionKind = 'code';
   let codeOffset = 0;
   let dataOffset = 0;

--- a/src/lowering/emitVisibility.ts
+++ b/src/lowering/emitVisibility.ts
@@ -3,7 +3,7 @@ import { moduleQualifierOf } from '../moduleVisibility.js';
 import type { Callable } from './loweringTypes.js';
 import type { OpDeclNode } from '../frontend/ast.js';
 
-type Context = {
+type EmitVisibilityContext = {
   /** Compile environment (module ids, imports) used with visibility maps. */
   env: CompileEnv;
   /** Per-file map of lowered callables keyed by lowercased name. */
@@ -16,7 +16,7 @@ type Context = {
   visibleOpsByName: Map<string, OpDeclNode[]>;
 };
 
-export function createEmitVisibilityHelpers(ctx: Context) {
+export function createEmitVisibilityHelpers(ctx: EmitVisibilityContext) {
   const canAccessLoweredQualifiedName = (name: string, file: string): boolean => {
     const qualifier = moduleQualifierOf(name);
     if (!qualifier) return true;

--- a/src/lowering/fixupEmission.ts
+++ b/src/lowering/fixupEmission.ts
@@ -35,7 +35,7 @@ type EvalImmExpr = (expr: ImmExprNode) => number | undefined;
 
 type TraceInstruction = (start: number, bytes: Uint8Array, asmText: string) => void;
 
-type Context = {
+type FixupEmissionContext = {
   /** Current code offset. */
   getCodeOffset: () => number;
   /** Sets code offset. */
@@ -56,7 +56,7 @@ type Context = {
   evalImmExpr: EvalImmExpr;
 };
 
-export function createFixupEmissionHelpers(ctx: Context) {
+export function createFixupEmissionHelpers(ctx: FixupEmissionContext) {
   const recordLoweredInstr = (bytes: Uint8Array, asmText: string, span: SourceSpan): void => {
     ctx.recordLoweredInstr?.(bytes, asmText, span);
   };

--- a/src/lowering/functionBodySetup.ts
+++ b/src/lowering/functionBodySetup.ts
@@ -23,7 +23,7 @@ export type OpExpansionFrame = {
   callSiteSpan: SourceSpan;
 };
 
-type Context = {
+type FunctionBodySetupContext = {
   diagnostics: Diagnostic[];
   diagAt: (diagnostics: Diagnostic[], span: SourceSpan, message: string) => void;
   diagAtWithId: (
@@ -95,7 +95,7 @@ export function createFunctionBodySetupHelpers({
   reg8,
   generatedLabelCounterRef,
   formatAsmOperandForOpDiag,
-}: Context) {
+}: FunctionBodySetupContext) {
   const currentOpExpansionFrame = (
     opExpansionStack: OpExpansionFrame[],
   ): OpExpansionFrame | undefined =>

--- a/src/lowering/functionCallLowering.ts
+++ b/src/lowering/functionCallLowering.ts
@@ -37,7 +37,7 @@ type FunctionCallMaterializationContext = {
   pushImm16: (value: number, span: SourceSpan) => boolean;
 };
 
-type Context = {
+type FunctionCallLoweringHelpersContext = {
   diagnostics: Diagnostic[];
   asmItemSpanSourceTag: (span: SourceSpan) => SourceSegmentTag;
   getCurrentCodeSegmentTag: () => SourceSegmentTag | undefined;
@@ -132,7 +132,7 @@ type Context = {
   ) => void;
 };
 
-export function createFunctionCallLoweringHelpers(ctx: Context) {
+export function createFunctionCallLoweringHelpers(ctx: FunctionCallLoweringHelpersContext) {
   const emitAsmInstruction = (asmItem: AsmInstructionNode): void => {
     const prevTag = ctx.getCurrentCodeSegmentTag();
     const diagnosticsStart = ctx.diagnostics.length;

--- a/src/lowering/opExpansionOrchestration.ts
+++ b/src/lowering/opExpansionOrchestration.ts
@@ -29,7 +29,7 @@ type OpExpansionStackEntry = {
   callSiteSpan: SourceSpan;
 };
 
-type Context = LoweringDiagnosticsWithSeverityCapability &
+type OpExpansionOrchestrationContext = LoweringDiagnosticsWithSeverityCapability &
   CompileEnvCapability &
   OpCandidateResolverCapability &
   OpOperandFormattingCapability &
@@ -47,7 +47,7 @@ type Context = LoweringDiagnosticsWithSeverityCapability &
   opExpansionStack: OpExpansionStackEntry[];
 };
 
-export function createOpExpansionOrchestrationHelpers(ctx: Context) {
+export function createOpExpansionOrchestrationHelpers(ctx: OpExpansionOrchestrationContext) {
   const tryHandleOpExpansion = (asmItem: AsmInstructionNode): boolean => {
     const opCandidates = ctx.resolveOpCandidates(asmItem.head, asmItem.span.file);
     if (!opCandidates || opCandidates.length === 0) return false;

--- a/src/lowering/opMatching.ts
+++ b/src/lowering/opMatching.ts
@@ -1,6 +1,6 @@
 import type { AsmOperandNode, EaExprNode, ImmExprNode, OpDeclNode, OpMatcherNode } from '../frontend/ast.js';
 
-type Context = {
+type OpMatchingContext = {
   /** 8-bit register names for matching. */
   reg8: Set<string>;
   /** True when operand uses IX/IY indexed memory form. */
@@ -53,7 +53,7 @@ export type OpOverloadSelection =
 const fitsImm8 = (value: number): boolean => value >= -0x80 && value <= 0xff;
 const fitsImm16 = (value: number): boolean => value >= -0x8000 && value <= 0xffff;
 
-export function createOpMatchingHelpers(ctx: Context) {
+export function createOpMatchingHelpers(ctx: OpMatchingContext) {
   const enumImmExprFromOperand = (op: AsmOperandNode): ImmExprNode | undefined => {
     switch (op.kind) {
       case 'Imm':

--- a/src/lowering/opStackAnalysis.ts
+++ b/src/lowering/opStackAnalysis.ts
@@ -4,12 +4,12 @@ export type OpStackSummary =
   | { kind: 'known'; delta: number; hasUntrackedSpMutation: boolean }
   | { kind: 'complex' };
 
-type Context = {
+type OpStackAnalysisContext = {
   /** Resolves op declarations by name in `file`; `undefined` means no candidates (not an error by itself). */
   resolveOpCandidates: (name: string, file: string) => OpDeclNode[] | undefined;
 };
 
-export function createOpStackAnalysisHelpers({ resolveOpCandidates }: Context) {
+export function createOpStackAnalysisHelpers({ resolveOpCandidates }: OpStackAnalysisContext) {
   const opStackSummaryCache = new Map<OpDeclNode, OpStackSummary>();
 
   const opStackSummaryKey = (decl: OpDeclNode): string =>

--- a/src/lowering/sectionPlacement.ts
+++ b/src/lowering/sectionPlacement.ts
@@ -31,7 +31,7 @@ export type PlacedNamedSectionRegion = {
   contributions: PlacedNamedSectionContribution[];
 };
 
-type Context = {
+type SectionPlacementContext = {
   /** Diagnostic sink. */
   diagnostics: Diagnostic[];
   /** Compile environment for imm eval. */
@@ -66,7 +66,7 @@ function startOf(sink: NamedSectionContributionSink): {
   };
 }
 
-function evaluateAnchorBase(ctx: Context, sink: NamedSectionContributionSink): number | undefined {
+function evaluateAnchorBase(ctx: SectionPlacementContext, sink: NamedSectionContributionSink): number | undefined {
   const anchor = sink.anchor.node.anchor;
   if (!anchor) return undefined;
   const at = ctx.evalImmExpr(anchor.at, ctx.env, ctx.diagnostics);
@@ -92,7 +92,7 @@ function evaluateAnchorBase(ctx: Context, sink: NamedSectionContributionSink): n
 }
 
 function evaluateCapacity(
-  ctx: Context,
+  ctx: SectionPlacementContext,
   sink: NamedSectionContributionSink,
   baseAddress: number,
 ): number | undefined {
@@ -161,7 +161,7 @@ function evaluateCapacity(
 
 export function placeNonBankedSectionContributions(
   sinks: NamedSectionContributionSink[],
-  ctx: Context,
+  ctx: SectionPlacementContext,
 ): { placedRegions: PlacedNamedSectionRegion[]; placedContributions: PlacedNamedSectionContribution[] } {
   const placedRegions: PlacedNamedSectionRegion[] = [];
   const placedContributions: PlacedNamedSectionContribution[] = [];


### PR DESCRIPTION
Renames 14 internal `type Context` aliases to scoped names (no behavior change). Lint + build verified; lowering test folder passed.

Fixes #1313

Made with [Cursor](https://cursor.com)