### PR TITLE
Remove ptr scalar keyword (Fixes #1321)

### DIFF
--- a/docs/codebase-tour.md
+++ b/docs/codebase-tour.md
@@ -408,7 +408,7 @@ This file is a single flat module of exported constants — think of it as the g
 - `IMM_OPERATOR_PRECEDENCE` — an array of `{ level, ops }` objects that defines the full operator precedence table for immediate expressions, from multiply/divide (level 7) down to bitwise OR (level 2). This drives the Pratt parser in `parseImm.ts`.
 - `MATCHER_TYPES` — the types that can appear in `op` parameter declarations: `reg8`, `reg16`, `idx16`, `cc`, `imm8`, `imm16`, `ea`, `mem8`, `mem16`.
 - `CHAR_ESCAPE_VALUES` — the escape sequences recognised in character and string literals.
-- `SCALAR_TYPES` — `byte`, `word`, `addr`, `ptr`.
+- `SCALAR_TYPES` — `byte`, `word`, `addr`.
 
 Nothing in `grammarData.ts` has any side effects; it is pure data.
 
@@ -599,7 +599,7 @@ Division by zero is caught and reported as a diagnostic.
 
 `sizeOfTypeExpr(typeExpr, env)` computes the byte size of a type expression:
 - `byte` → 1
-- `word`, `addr`, `ptr` → 2
+- `word`, `addr` → 2
 - `TypeName` → looks up the named type in `env.types` and recurses.
 - `ArrayType` → `element_size * length`.
 - `RecordType` → sum of all field sizes.

--- a/docs/design/grammar-parser-convergence-plan.md
+++ b/docs/design/grammar-parser-convergence-plan.md
@@ -68,7 +68,7 @@ Both contain the identical 15 keywords. Changes to one must be manually mirrored
 #### 4. Scalar Types — NOT validated at parse time
 
 - `parseImm.ts` `parseTypeExprFromText`: accepts any identifier as a type name
-- The valid scalar set `byte | word | addr | ptr` is in the grammar doc but the parser does not distinguish them from user-defined type names
+- The valid scalar set `byte | word | addr` is in the grammar doc but the parser does not distinguish them from user-defined type names
 
 #### 5. Operator Precedence — hardcoded switch statement
 
@@ -126,7 +126,7 @@ export const RETURN_REGISTERS = ['HL', 'DE', 'BC', 'AF'] as const;
 export const CONDITION_CODES = ['z', 'nz', 'c', 'nc', 'pe', 'po', 'm', 'p'] as const;
 
 // --- Scalar Types ---
-export const SCALAR_TYPES = ['byte', 'word', 'addr', 'ptr'] as const;
+export const SCALAR_TYPES = ['byte', 'word', 'addr'] as const;
 
 // --- Top-level Keywords ---
 export const TOP_LEVEL_KEYWORDS = [

--- a/docs/design/zax-algorithms-course.md
+++ b/docs/design/zax-algorithms-course.md
@@ -526,13 +526,13 @@ clarity.
 
 #### 2D: Linked List (K&R §6.5)
 
-A linked list node can be written today with a `ptr` field in an ordinary
+A linked list node can be written today with an `addr` field in an ordinary
 record, and traversed with `<Node>base.tail`:
 
 ```zax
 type Node
   value: word
-  next:  ptr       ; holds address of the next Node (or 0 for end-of-list)
+  next:  addr      ; holds address of the next Node (or 0 for end-of-list)
 end
 
 section data heap at $8400
@@ -566,7 +566,7 @@ The algorithm is fully expressible. The ergonomic gaps to note and document:
 
 - **No null literal** — `0` serves as null but there is no named sentinel.
   Using `addr` zero is a convention, not a language guarantee.
-- **`ptr` is untyped** — the `next` field is `ptr`, not `ptr<Node>`. The cast
+- **`addr` is untyped** — the `next` field is `addr`, not `ptr<Node>`. The cast
   `<Node>hl.next` must be written explicitly at every dereference site.
   Self-referential record declarations would allow the type to carry that
   intent, eliminating the cast at each traversal step.
@@ -579,9 +579,9 @@ and surfaces real friction.
 
 #### 2E: Binary Search Tree
 
-Same analysis as the linked list. A BST node has two `ptr` children (`left`,
+Same analysis as the linked list. A BST node has two `addr` children (`left`,
 `right`). Insert and search are fully expressible using `<Node>hl.left` and
-`<Node>hl.right`. The same ergonomic gaps apply: untyped `ptr` fields,
+`<Node>hl.right`. The same ergonomic gaps apply: untyped `addr` fields,
 explicit casts at each traversal, null-as-zero convention, fixed pool
 allocation.
 
@@ -655,7 +655,7 @@ than speculation.
 | Example Gap                                                                      | Status                                                                                                                        |
 | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | RPN calculator / quicksort software stack                                        | Stack-typed local or push/pop op idiom — not yet on roadmap                                                                   |
-| Linked list, BST — untyped `ptr` fields, explicit casts, null-as-zero convention | Pointer-typing ergonomics — Tier 2 friction; self-referential record declarations would improve precision, not yet on roadmap |
+| Linked list, BST — untyped `addr` fields, explicit casts, null-as-zero convention | Pointer-typing ergonomics — Tier 2 friction; self-referential record declarations would improve precision, not yet on roadmap |
 | Eight queens labeled exit                                                        | `break` / named exit — not yet on roadmap; course surfaces this                                                               |
 | Word frequency string ops                                                        | Standard `op` library — library workstream, separate from language/compiler roadmap                                           |
 | Ring buffer with exact-size sizeof                                               | Exact-size layout stream (#817–820) — complete                                                                                |
@@ -779,7 +779,7 @@ expresses them awkwardly, the gap is precisely located.
 | 5    | Records            | Ring buffer                                                        | `type`, `record`, `section data`, `sizeof`/`offsetof`, exact-size awareness                    |
 | 6    | Recursion          | Towers of Hanoi, recursive sum, recursive reverse                  | Recursive `func`, IX frame discipline, `<Type>base.tail`                                       |
 | 7    | Composition        | RPN calculator                                                     | All of the above: `op`, `record`, `select` ranges, `func`, software stack                      |
-| 8    | Pointer Structures | Linked list, BST                                                   | `ptr` fields, `<Type>base.tail` traversal, null-sentinel convention, fixed-pool allocation     |
+| 8    | Pointer Structures | Linked list, BST                                                   | `addr` fields, `<Type>base.tail` traversal, null-sentinel convention, fixed-pool allocation     |
 | 9    | Gaps and Futures   | Eight queens                                                       | Control-flow pressure case; `break` / `continue` now available, future design pressure remains |
 
 Unit 9 is intentionally incomplete. It is a design dialogue between the course

--- a/docs/reference/ZAX-quick-guide.md
+++ b/docs/reference/ZAX-quick-guide.md
@@ -16,7 +16,7 @@ ZAX combines:
 
 - raw Z80 instruction authoring (mnemonics, registers, and flags written directly)
 - structured control flow (`if`, `while`, `repeat`, `select`)
-- typed storage (`byte`, `word`, `addr`, `ptr`, arrays, records, unions)
+- typed storage (`byte`, `word`, `addr`, arrays, records, unions)
 - compile-time expressions (`const`, `sizeof`, `offsetof`, `enum`)
 - inline macro-instructions (`op`) with AST-level operand matching and overload resolution
 
@@ -136,13 +136,10 @@ The full CLI contract is in `docs/spec/zax-spec.md` Appendix D.
 | ------ | ------------ | -------------------------------------------------------------- |
 | `byte` | 1            | 8-bit unsigned                                                 |
 | `word` | 2            | 16-bit unsigned                                                |
-| `addr` | 2            | 16-bit address; semantic signal for "holds a memory address"   |
-| `ptr`  | 2            | 16-bit pointer; untyped in the current language (no `ptr<T>`)  |
+| `addr` | 2            | 16-bit address; used for raw addresses, pointers, and other address-sized scalars (no `ptr<T>` in the current language) |
 | `void` | —            | Return type only; not valid as a storage, field, or param type |
 
 There are no signed storage types in the current language.
-
-`ptr` and `addr` are identical in size and code generation. The distinction is semantic intent: `addr` signals "this holds a data address," `ptr` signals "this holds a pointer to something." Use whichever communicates your intent more clearly; the compiler treats them identically.
 
 `void` may only appear as a function return type. Using `void` as a variable type, parameter type, record field type, or array element type is a compile error.
 
@@ -886,7 +883,7 @@ Three declaration forms are valid inside a `var` block:
 
 The **typed alias form** `name: Type = rhs` is always a compile error.
 
-Only scalar types (`byte`, `word`, `addr`, `ptr`, or aliases resolving to those) may have frame slots. Non-scalar locals (arrays, records) are allowed only as alias declarations to direct module-scope storage — they name an existing address but allocate no storage:
+Only scalar types (`byte`, `word`, `addr`, or aliases resolving to those) may have frame slots. Non-scalar locals (arrays, records) are allowed only as alias declarations to direct module-scope storage — they name an existing address but allocate no storage:
 
 ```zax
 section data vars at $8000
@@ -931,7 +928,7 @@ When the compiler generates a call to a typed internal `func`, it enforces a pre
 | ----------------------------- | -------------------------------------------------------------- |
 | `HL`                          | **boundary-volatile** for all typed calls including `void`     |
 | `L`                           | carries 8-bit return value for `byte`-returning calls          |
-| `HL`                          | carries 16-bit return value for `word`/`addr`/`ptr` returns    |
+| `HL`                          | carries 16-bit return value for `word`/`addr` returns          |
 | all other registers and flags | **callee-preserved** — restored by compiler-generated epilogue |
 
 This guarantee applies **only** to typed internal `func` calls. It does not apply to:

--- a/docs/spec/zax-grammar.ebnf.md
+++ b/docs/spec/zax-grammar.ebnf.md
@@ -51,7 +51,7 @@ condition_code          = "z" | "nz" | "c" | "nc" | "pe" | "po" | "m" | "p" ;
 named_section_kind      = "code" | "data" ;
 legacy_section_kind     = named_section_kind | "var" ;
 
-scalar_type             = "byte" | "word" | "addr" | "ptr" ;
+scalar_type             = "byte" | "word" | "addr" ;
 return_reg              = "HL" | "DE" | "BC" | "AF" ;
 
 reg8                    = "A" | "B" | "C" | "D" | "E" | "H" | "L" ;

--- a/docs/spec/zax-spec.md
+++ b/docs/spec/zax-spec.md
@@ -300,13 +300,12 @@ Types exist for layout/width/intent only. No runtime type checks are emitted.
 
 - `byte` (8-bit unsigned)
 - `word` (16-bit unsigned)
-- `addr` (16-bit address)
-- `ptr` (16-bit pointer; treated as `addr` for codegen)
+- `addr` (16-bit address; used for raw addresses, pointers, and any 16-bit address-sized scalar storage)
 - `void` (function return type only)
 
 Notes (v0.1):
 
-- `ptr` is untyped in v0.1 (there is no `ptr<T>`). This is intentional; future versions may add optional pointer parameterization.
+- `addr` is untyped in v0.1 (there is no `ptr<T>` or typed pointers). This is intentional; future versions may add optional pointer parameterization.
 - `void` may only appear as a function return type. Using `void` as a variable type, parameter type, record field type, or array element type is a compile error.
 
 Type sizes (v0.1):
@@ -314,7 +313,6 @@ Type sizes (v0.1):
 - `sizeof(byte)` = 1
 - `sizeof(word)` = 2
 - `sizeof(addr)` = 2
-- `sizeof(ptr)` = 2
 - Composite types use exact semantic sizes.
 - `sizeof(T[n])` = `n * sizeof(T)`
 - `sizeof(record)` = `sum of field sizes`
@@ -327,13 +325,13 @@ Syntax:
 ````
 
 type Name byte
-type Ptr16 ptr
+type Ptr16 addr
 
 ```
 
 Type expressions (v0.2):
 
-- Scalar types: `byte`, `word`, `addr`, `ptr`
+- Scalar types: `byte`, `word`, `addr`
 - Arrays: `T[n]` (fixed length) or `T[]` (inferred length; see below). Nested arrays allowed.
 - Records: a record body starting on the next line and terminated by `end`
 
@@ -495,7 +493,7 @@ Layout rules:
 - Each field occupies its exact semantic size (`sizeof(fieldType)`).
 - The record's total size is `sum of field sizes`.
 - `byte` fields are 1 byte; `word` fields are 2 bytes.
-- `addr` and `ptr` fields are 2 bytes (same as `word`).
+- `addr` fields are 2 bytes (same as `word`).
 
 Field access:
 
@@ -530,7 +528,7 @@ Syntax:
 union Value
 b: byte
 w: word
-p: ptr
+p: addr
 end
 
 ```
@@ -1105,7 +1103,7 @@ Operand identifier resolution (v0.1):
 - Slot model in current ABI:
   - each argument is one 16-bit slot
   - local scalar storage declarations allocate one 16-bit slot each
-- Local storage allocation in this scope remains scalar-slot based (`byte`, `word`, `addr`, `ptr`, or aliases resolving to those scalar types).
+- Local storage allocation in this scope remains scalar-slot based (`byte`, `word`, `addr`, or aliases resolving to those scalar types).
 - Non-scalar locals are permitted only as alias declarations to direct module-scope storage (`name = GlobalStorageName`) and do not allocate frame slots.
 
 Frame shape:

--- a/learning/BOOK.md
+++ b/learning/BOOK.md
@@ -3842,11 +3842,10 @@ out of registers you spill to memory yourself. ZAX typed variables replace that
 manual tracking: you give a value a name and a type, and the compiler handles
 where it lives.
 
-ZAX has four scalar storage types: `byte` (8-bit unsigned), `word` (16-bit
-unsigned), `addr` (16-bit, signals a memory address), and `ptr` (16-bit,
-signals a pointer to something). In these examples only `byte` and `word`
-appear — the others become relevant when you start working with arrays and
-records.
+ZAX has three scalar storage types: `byte` (8-bit unsigned), `word` (16-bit
+unsigned), and `addr` (16-bit, for memory addresses and other address-sized
+values). In these examples only `byte` and `word` appear — `addr` becomes
+relevant when you start working with arrays and records.
 
 You can declare storage in two places: named `data` sections at module scope,
 and `var` blocks inside function bodies.
@@ -6392,7 +6391,7 @@ Each step is one line. But if a data structure required following a chain of
 fields — loading a node, reading one of its pointer fields, treating that as a
 node, reading another field — each hop would need its own address-load and cast.
 The current language has no way to express a pointer dereference path in a single
-step. `ptr` fields carry no type information: `next: addr` says that `next`
+step. `addr` fields carry no type information: `next: addr` says that `next`
 holds an address, but not that it is the address of another `ListNode`. That
 annotation must be written at the use site, every time, as `<ListNode>`.
 

--- a/learning/part2/01-foundations.md
+++ b/learning/part2/01-foundations.md
@@ -17,11 +17,10 @@ out of registers you spill to memory yourself. ZAX typed variables replace that
 manual tracking: you give a value a name and a type, and the compiler handles
 where it lives.
 
-ZAX has four scalar storage types: `byte` (8-bit unsigned), `word` (16-bit
-unsigned), `addr` (16-bit, signals a memory address), and `ptr` (16-bit,
-signals a pointer to something). In these examples only `byte` and `word`
-appear — the others become relevant when you start working with arrays and
-records.
+ZAX has three scalar storage types: `byte` (8-bit unsigned), `word` (16-bit
+unsigned), and `addr` (16-bit, for memory addresses and other address-sized
+values). In these examples only `byte` and `word` appear — `addr` becomes
+relevant when you start working with arrays and records.
 
 You can declare storage in two places: named `data` sections at module scope,
 and `var` blocks inside function bodies.

--- a/learning/part2/08-pointer-structures.md
+++ b/learning/part2/08-pointer-structures.md
@@ -280,7 +280,7 @@ Each step is one line. But if a data structure required following a chain of
 fields — loading a node, reading one of its pointer fields, treating that as a
 node, reading another field — each hop would need its own address-load and cast.
 The current language has no way to express a pointer dereference path in a single
-step. `ptr` fields carry no type information: `next: addr` says that `next`
+step. `addr` fields carry no type information: `next: addr` says that `next`
 holds an address, but not that it is the address of another `ListNode`. That
 annotation must be written at the use site, every time, as `<ListNode>`.
 

--- a/src/frontend/grammarData.ts
+++ b/src/frontend/grammarData.ts
@@ -122,7 +122,7 @@ export const ASM_CONTROL_KEYWORD_LIST = [
 ] as const;
 export const ASM_CONTROL_KEYWORDS = new Set<string>(ASM_CONTROL_KEYWORD_LIST);
 
-export const SCALAR_TYPE_LIST = ['byte', 'word', 'addr', 'ptr'] as const;
+export const SCALAR_TYPE_LIST = ['byte', 'word', 'addr'] as const;
 export const SCALAR_TYPES = new Set<string>(SCALAR_TYPE_LIST);
 
 export const IMM_OPERATOR_PRECEDENCE = [

--- a/src/lowering/programLoweringData.ts
+++ b/src/lowering/programLoweringData.ts
@@ -129,7 +129,7 @@ export function lowerDataBlock(
         if (!fieldValueExpr) continue;
         const scalar = ctx.resolveScalarKind(field.typeExpr);
         if (!scalar) {
-          ctx.diag(ctx.diagnostics, decl.span.file, `Unsupported record field type "${field.name}" in initializer for "${decl.name}" (expected byte/word/addr/ptr).`);
+          ctx.diag(ctx.diagnostics, decl.span.file, `Unsupported record field type "${field.name}" in initializer for "${decl.name}" (expected byte/word/addr).`);
           recordInitFailed = true;
           continue;
         }
@@ -180,7 +180,7 @@ export function lowerDataBlock(
     const elementScalar = type.kind === 'ArrayType' ? ctx.resolveScalarKind(type.element) : ctx.resolveScalarKind(type);
     const elementSize = elementScalar === 'word' || elementScalar === 'addr' ? 2 : elementScalar === 'byte' ? 1 : undefined;
     if (!elementSize) {
-      ctx.diag(ctx.diagnostics, decl.span.file, `Unsupported data type for "${decl.name}" (expected byte/word/addr/ptr or fixed-length arrays of those).`);
+      ctx.diag(ctx.diagnostics, decl.span.file, `Unsupported data type for "${decl.name}" (expected byte/word/addr or fixed-length arrays of those).`);
       continue;
     }
 

--- a/src/semantics/layout.ts
+++ b/src/semantics/layout.ts
@@ -21,7 +21,6 @@ function scalarSize(name: string): number | undefined {
       return 1;
     case 'word':
     case 'addr':
-    case 'ptr':
       return 2;
     default:
       return undefined;

--- a/src/semantics/storageView.ts
+++ b/src/semantics/storageView.ts
@@ -40,7 +40,6 @@ export function resolveScalarKindInEnv(
   if (typeExpr.kind !== 'TypeName') return undefined;
   const lower = typeExpr.name.toLowerCase();
   if (lower === 'byte' || lower === 'word' || lower === 'addr') return lower;
-  if (lower === 'ptr') return 'addr';
   if (seen.has(lower)) return undefined;
   seen.add(lower);
   const decl = resolveVisibleType(typeExpr.name, typeExpr.span.file, env);

--- a/src/semantics/typeQueries.ts
+++ b/src/semantics/typeQueries.ts
@@ -38,8 +38,6 @@ export function createTypeResolutionHelpers(ctx: TypeResolutionContext) {
     if (typeExpr.kind !== 'TypeName') return undefined;
     const lower = typeExpr.name.toLowerCase();
     if (lower === 'byte' || lower === 'word' || lower === 'addr') return lower;
-    // `ptr` is a source-language alias for address-sized scalar storage.
-    if (lower === 'ptr') return 'addr';
     if (seen.has(lower)) return undefined;
     seen.add(lower);
     const decl = resolveVisibleType(typeExpr.name, typeExpr.span.file, ctx.env);

--- a/test/fixtures/pr52_ptr_scalar_slots.zax
+++ b/test/fixtures/pr52_ptr_scalar_slots.zax
@@ -1,8 +1,8 @@
 export func main()
   var
-    p: ptr
+    p: addr
   end
-    ; Store an imm16 into a ptr-typed slot (treated as addr/word for codegen).
+    ; Store an imm16 into an addr-typed slot (16-bit scalar slot for codegen).
     ld (p), $1234
 end
 

--- a/test/fixtures/pr896_assignment_ea_ea.zax
+++ b/test/fixtures/pr896_assignment_ea_ea.zax
@@ -4,7 +4,7 @@ section data vars at $1000
   idx: byte = 1
   src_word: word = $1234
   dst_word: word = 0
-  ptr_slot: ptr = 0
+  ptr_slot: addr = 0
 end
 
 export func main()

--- a/test/pr1049_record_named_init_data_lowering.test.ts
+++ b/test/pr1049_record_named_init_data_lowering.test.ts
@@ -85,7 +85,7 @@ describe('PR1049 record data lowering', () => {
     });
     expectDiagnostic(result.diagnostics, {
       message:
-        'Unsupported record field type "pair" in initializer for "bad_nested" (expected byte/word/addr/ptr).',
+        'Unsupported record field type "pair" in initializer for "bad_nested" (expected byte/word/addr).',
     });
     expectDiagnostic(result.diagnostics, { message: 'Duplicate symbol name "dup".' });
   });

--- a/test/pr4_negative.test.ts
+++ b/test/pr4_negative.test.ts
@@ -52,7 +52,7 @@ describe('PR4 negative cases', () => {
       id: DiagnosticIds.EmitError,
       severity: 'error',
       message:
-        'Unsupported data type for "p" (expected byte/word/addr/ptr or fixed-length arrays of those).',
+        'Unsupported data type for "p" (expected byte/word/addr or fixed-length arrays of those).',
     });
   });
 });

--- a/test/pr50_union_field_access.test.ts
+++ b/test/pr50_union_field_access.test.ts
@@ -20,7 +20,7 @@ describe('PR50: union declarations + union field EA access', () => {
       id: DiagnosticIds.EmitError,
       severity: 'error',
       message:
-        'Unsupported data type for "v" (expected byte/word/addr/ptr or fixed-length arrays of those).',
+        'Unsupported data type for "v" (expected byte/word/addr or fixed-length arrays of those).',
     });
   });
 });

--- a/test/pr52_ptr_scalar_slots.test.ts
+++ b/test/pr52_ptr_scalar_slots.test.ts
@@ -9,8 +9,8 @@ import type { BinArtifact } from '../src/formats/types.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-describe('PR52: treat ptr as 16-bit scalar in codegen', () => {
-  it('allows ptr locals/args as 16-bit slots', async () => {
+describe('PR52: addr as 16-bit scalar in codegen', () => {
+  it('allows addr locals/args as 16-bit slots', async () => {
     const entry = join(__dirname, 'fixtures', 'pr52_ptr_scalar_slots.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
     expect(res.diagnostics).toEqual([]);

--- a/test/semantics/pr895_assignment_acceptance.test.ts
+++ b/test/semantics/pr895_assignment_acceptance.test.ts
@@ -34,7 +34,7 @@ section data globals at $8000
   arr2: byte[4]
   src_word: word
   dst: word
-  ptr: ptr
+  ptr: addr
 end
 
 section code text at $0000
@@ -66,7 +66,7 @@ end
 section data globals at $8000
   arr1: byte[4]
   arr2: byte[4]
-  ptr: ptr
+  ptr: addr
   dst_rec: Rec
   src_rec: Rec
 end

--- a/test/semantics/pr899_step_acceptance.test.ts
+++ b/test/semantics/pr899_step_acceptance.test.ts
@@ -65,7 +65,7 @@ end
 
 section data globals at $8000
   rec: Rec
-  ptr: ptr
+  addr_slot: addr
   raw_buf:
     db 1, 2, 3
 end
@@ -73,7 +73,7 @@ end
 section code text at $0000
 func main()
   step rec
-  step ptr
+  step addr_slot
   step raw_buf
   ret
 end

--- a/test/semantics/semantics_layout.test.ts
+++ b/test/semantics/semantics_layout.test.ts
@@ -127,10 +127,10 @@ describe('sizeOfTypeExpr', () => {
     expectNoDiagnostics(diagnostics);
   });
 
-  it('treats ptr as 16-bit scalar', () => {
+  it('treats addr as 16-bit scalar', () => {
     const diagnostics: Diagnostic[] = [];
     const env = emptyEnv();
-    const res = sizeOfTypeExpr({ kind: 'TypeName', span: s(), name: 'ptr' }, env, diagnostics);
+    const res = sizeOfTypeExpr({ kind: 'TypeName', span: s(), name: 'addr' }, env, diagnostics);
     expect(res).toBe(2);
     expectNoDiagnostics(diagnostics);
   });


### PR DESCRIPTION
Removes the `ptr` built-in scalar type (synonym for `addr`). Updates compiler grammar data, semantics, diagnostics, spec, learning, and tests. Regenerates grammar-atoms in `zax-grammar.ebnf.md`.

Made with [Cursor](https://cursor.com)