### PR TITLE
fix(semantics): ImmName typed-call args load aggregate pointer slots

### DIFF
--- a/learning/part2/08-pointer-structures.md
+++ b/learning/part2/08-pointer-structures.md
@@ -300,6 +300,10 @@ questions.
 
 - `type RecordName` / `field: type` / `end` defines a record. Fields have
   explicit types; the compiler tracks offsets.
+- A local declared with a record or union type (`local: RecordName`) holds an
+  addr-sized slot (one pointer word). You can use `.field` without a cast, and
+  you can pass the local name as an `addr` or `word` argument like any other
+  pointer value.
 - `<Type>local.field` applies a type cast at the access site to read or write
   a field through a stored `addr` (or register-sized base). A local declared with
   a record or union type (`local: RecordName`) uses the same slot width and can

--- a/src/semantics/typeQueries.ts
+++ b/src/semantics/typeQueries.ts
@@ -203,6 +203,12 @@ export function createTypeResolutionHelpers(ctx: TypeResolutionContext) {
   const resolveEaTypeExpr = (ea: EaExprNode): TypeExprNode | undefined =>
     resolveEaTypeExprInternal(ea, new Set<string>());
 
+  const stackSlotAggregateIsAddrWidth = (
+    nameLower: string,
+    typeExpr: TypeExprNode,
+  ): boolean =>
+    ctx.stackSlotTypes.has(nameLower) && resolveAggregateType(typeExpr) !== undefined;
+
   const resolveScalarBinding = (name: string): ScalarKind | undefined => {
     const lower = name.toLowerCase();
     if (ctx.rawAddressSymbols.has(lower)) return undefined;
@@ -215,7 +221,28 @@ export function createTypeResolutionHelpers(ctx: TypeResolutionContext) {
         return resolveEaTypeExpr(aliasTarget);
       })();
     if (!typeExpr) return undefined;
-    return resolveScalarKind(typeExpr);
+    const sk = resolveScalarKind(typeExpr);
+    if (sk) return sk;
+    if (stackSlotAggregateIsAddrWidth(lower, typeExpr)) return 'addr';
+    return undefined;
+  };
+
+  /**
+   * Record/union-typed locals occupy one addr-sized frame slot that stores a
+   * pointer; value loads (ld, calls, mem push) must use the word at that slot,
+   * not the slot address. When `resolveScalarKind(typeExpr)` is undefined but
+   * the name is a stack slot with an aggregate type, treat as `addr` width.
+   */
+  const scalarKindForEaValueSemantics = (
+    ea: EaExprNode,
+    typeExpr: TypeExprNode,
+  ): ScalarKind | undefined => {
+    const sk = resolveScalarKind(typeExpr);
+    if (sk) return sk;
+    if (ea.kind === 'EaName' && stackSlotAggregateIsAddrWidth(ea.name.toLowerCase(), typeExpr)) {
+      return 'addr';
+    }
+    return undefined;
   };
 
   /**
@@ -228,7 +255,7 @@ export function createTypeResolutionHelpers(ctx: TypeResolutionContext) {
     if (base && ctx.rawAddressSymbols.has(base.toLowerCase())) return undefined;
     const typeExpr = resolveEaTypeExpr(ea);
     if (!typeExpr) return undefined;
-    return resolveScalarKind(typeExpr);
+    return scalarKindForEaValueSemantics(ea, typeExpr);
   };
 
   /**
@@ -240,16 +267,7 @@ export function createTypeResolutionHelpers(ctx: TypeResolutionContext) {
     if (ea.kind === 'EaName' && ctx.rawAddressSymbols.has(ea.name.toLowerCase())) return undefined;
     const typeExpr = resolveEaTypeExpr(ea);
     if (!typeExpr) return undefined;
-    const sk = resolveScalarKind(typeExpr);
-    if (sk) return sk;
-    if (
-      ea.kind === 'EaName' &&
-      ctx.stackSlotTypes.has(ea.name.toLowerCase()) &&
-      resolveAggregateType(typeExpr)
-    ) {
-      return 'addr';
-    }
-    return undefined;
+    return scalarKindForEaValueSemantics(ea, typeExpr);
   };
 
   return {

--- a/test/fixtures/coverage-map.md
+++ b/test/fixtures/coverage-map.md
@@ -11,9 +11,9 @@
 
 **Include/import graph cycles detected** (see section below).
 
-Total fixture files (excludes sentinels): 518
+Total fixture files (excludes sentinels): 519
 Sentinel files: 1
-Reachable from tests (direct refs ∪ fixture closure): 309
+Reachable from tests (direct refs ∪ fixture closure): 310
 Potentially unreferenced fixtures: 209
 
 ## Direct test reference counts
@@ -118,6 +118,7 @@ Potentially unreferenced fixtures: 209
 | pr132_control_flow_arity_invalid.zax | 1 |
 | pr133_arity_diag_matrix_invalid.zax | 1 |
 | pr1334_record_local_init_negative.zax | 1 |
+| pr1338_typed_local_addr_arg.zax | 1 |
 | pr134_alu_arity_diag_invalid.zax | 1 |
 | pr135_isa_jr_djnz_invalid.zax | 0 |
 | pr135_isa_jr_djnz.zax | 0 |
@@ -867,6 +868,7 @@ Excluded from the main fixture inventory (`.keep`, `.gitkeep`).
 | pr132_control_flow_arity_invalid.zax | test/pr132_control_flow_arity_diag.test.ts |
 | pr133_arity_diag_matrix_invalid.zax | test/pr133_arity_diag_matrix.test.ts |
 | pr1334_record_local_init_negative.zax | test/lowering/pr1334_typed_aggregate_local.test.ts |
+| pr1338_typed_local_addr_arg.zax | test/lowering/pr1338_typed_local_addr_arg_call.test.ts |
 | pr134_alu_arity_diag_invalid.zax | test/pr134_alu_arity_diag.test.ts |
 | pr135_isa_jr_djnz_invalid.zax |  |
 | pr135_isa_jr_djnz.zax |  |

--- a/test/fixtures/pr1338_typed_local_addr_arg.zax
+++ b/test/fixtures/pr1338_typed_local_addr_arg.zax
@@ -1,0 +1,19 @@
+type Node
+  x: byte
+end
+
+section data vars at $8000
+  n: Node
+end
+
+func consume(p: addr)
+  ret
+end
+
+export func main()
+  var
+    cur: Node
+  end
+  cur := @n
+  consume cur
+end

--- a/test/lowering/pr1338_typed_local_addr_arg_call.test.ts
+++ b/test/lowering/pr1338_typed_local_addr_arg_call.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+
+import { compilePlacedProgram, formatLoweredInstructions } from '../helpers/lowered_program.js';
+
+describe('PR1338 follow-up: typed aggregate local as addr call argument', () => {
+  it('loads the pointer word from the slot (not the slot address) when passing a bare name', async () => {
+    const { program, diagnostics } = await compilePlacedProgram(
+      join(__dirname, '..', 'fixtures', 'pr1338_typed_local_addr_arg.zax'),
+    );
+    expect(diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const lines = formatLoweredInstructions(program).map((line) => line.toUpperCase());
+    expect(lines.some((line) => line.includes('LD E, (IX-$02)') || line.includes('LD E,(IX-$02)'))).toBe(
+      true,
+    );
+    expect(lines.some((line) => line.includes('LD D, (IX-$01)') || line.includes('LD D,(IX-$01)'))).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
Follow-up to #1338: `resolveScalarBinding` must treat record/union stack locals as `addr` width so `consume cur` (ImmName) uses `pushMemValue`, not the slot address. Unifies `resolveScalarTypeForLd` with `scalarKindForEaValueSemantics`.

Adds `pr1338_typed_local_addr_arg` fixture + lowering test, chapter 8 summary bullet, and fixture coverage map refresh.

Made with [Cursor](https://cursor.com)