### PR TITLE
feat(lowering): aggregate record/union params as addr at typed calls (#1340)

### DIFF
--- a/src/lowering/functionCallLowering.ts
+++ b/src/lowering/functionCallLowering.ts
@@ -17,7 +17,7 @@ import type { OpStackPolicyMode } from '../pipeline.js';
 import type { Callable, ResolvedArrayType, SourceSegmentTag } from './loweringTypes.js';
 import type { OpOverloadSelection } from './opMatching.js';
 import type { OpStackSummary } from './opStackAnalysis.js';
-import type { ScalarKind } from './typeResolution.js';
+import type { AggregateType, ScalarKind } from './typeResolution.js';
 import type { FlowState, OpExpansionFrame } from './functionBodySetup.js';
 import { createAsmRangeLoweringHelpers } from './asmRangeLowering.js';
 import { createOpExpansionOrchestrationHelpers } from './opExpansionOrchestration.js';
@@ -75,6 +75,7 @@ type FunctionCallLoweringHelpersContext = {
   env: CompileEnv;
   evalImmExpr: (expr: ImmExprNode, env: CompileEnv, diagnostics: Diagnostic[]) => number | undefined;
   resolveScalarKind: (typeExpr: TypeExprNode) => ScalarKind | undefined;
+  resolveAggregateType: (typeExpr: TypeExprNode) => AggregateType | undefined;
   reg8: Set<string>;
   reg16: Set<string>;
   emitInstr: (head: string, operands: AsmOperandNode[], span: SourceSpan) => boolean;
@@ -275,7 +276,9 @@ export function createFunctionCallLoweringHelpers(ctx: FunctionCallLoweringHelpe
         for (let ai = args.length - 1; ai >= 0; ai--) {
           const arg = args[ai]!;
           const param = params[ai]!;
-          const scalarKind = ctx.resolveScalarKind(param.typeExpr);
+          const scalarKind =
+            ctx.resolveScalarKind(param.typeExpr) ??
+            (ctx.resolveAggregateType(param.typeExpr) ? 'addr' : undefined);
           if (!scalarKind) {
             const argType = typeForArg(arg);
             if (!argType) {

--- a/src/lowering/functionLoweringPhases.ts
+++ b/src/lowering/functionLoweringPhases.ts
@@ -566,6 +566,7 @@ export function prepareFunctionBodyLoweringPhase(ctx: BodyContext): FunctionBody
     env: fp.types.env,
     evalImmExpr: fp.types.evalImmExpr,
     resolveScalarKind: fp.types.resolveScalarKind,
+    resolveAggregateType: fp.types.resolveAggregateType,
     reg8: fp.registers.reg8,
     reg16: fp.registers.reg16,
     emitInstr,

--- a/test/fixtures/coverage-map.md
+++ b/test/fixtures/coverage-map.md
@@ -120,6 +120,7 @@ Potentially unreferenced fixtures: 209
 | pr1334_record_local_init_negative.zax | 1 |
 | pr1338_typed_local_addr_arg.zax | 1 |
 | pr134_alu_arity_diag_invalid.zax | 1 |
+| pr1340_aggregate_param.zax | 1 |
 | pr135_isa_jr_djnz_invalid.zax | 0 |
 | pr135_isa_jr_djnz.zax | 0 |
 | pr136_bit_indexed_dest_invalid.zax | 1 |
@@ -870,6 +871,7 @@ Excluded from the main fixture inventory (`.keep`, `.gitkeep`).
 | pr1334_record_local_init_negative.zax | test/lowering/pr1334_typed_aggregate_local.test.ts |
 | pr1338_typed_local_addr_arg.zax | test/lowering/pr1338_typed_local_addr_arg_call.test.ts |
 | pr134_alu_arity_diag_invalid.zax | test/pr134_alu_arity_diag.test.ts |
+| pr1340_aggregate_param.zax | test/lowering/pr1340_aggregate_param.test.ts |
 | pr135_isa_jr_djnz_invalid.zax |  |
 | pr135_isa_jr_djnz.zax |  |
 | pr136_bit_indexed_dest_invalid.zax | test/pr136_bit_indexed_dest_invalid.test.ts |

--- a/test/fixtures/pr1340_aggregate_param.zax
+++ b/test/fixtures/pr1340_aggregate_param.zax
@@ -1,0 +1,26 @@
+type TreeNode
+  value: byte
+  left: addr
+  right: addr
+end
+
+section data vars at $8000
+  root: TreeNode
+end
+
+func search(node: TreeNode, target: byte): HL
+  a := node.value
+  b := target
+  cp b
+  if Z
+    ld hl, 1
+    ret
+  end
+  hl := node.left
+  search hl, target
+end
+
+export func main()
+  hl := @root
+  search hl, 5
+end

--- a/test/lowering/pr1340_aggregate_param.test.ts
+++ b/test/lowering/pr1340_aggregate_param.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import { expectNoErrors } from '../helpers/diagnostics.js';
+
+describe('PR1340 aggregate record parameters as addr-width at call sites', () => {
+  it('compiles recursive search with TreeNode parameter and typed calls', async () => {
+    const entry = join(__dirname, '..', 'fixtures', 'pr1340_aggregate_param.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expectNoErrors(res.diagnostics);
+  });
+});


### PR DESCRIPTION
Treats `resolveScalarKind`-unknown parameter types that are record/union aggregates as `addr`-width for typed call lowering so callees receive a pointer-sized argument.

Includes `pr1340_aggregate_param.zax` + compile test and fixture coverage map refresh.

Made with [Cursor](https://cursor.com)