### PR TITLE
chore: npm package @jhlagado/zax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ coverage/
 .tmp/
 
 out/
+*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
-  "name": "zax",
-  "version": "0.0.0",
+  "name": "@jhlagado/zax",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "zax",
-      "version": "0.0.0",
+      "name": "@jhlagado/zax",
+      "version": "0.1.0",
       "license": "GPL-3.0-only",
+      "bin": {
+        "zax": "dist/src/cli.js"
+      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^22.13.1",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,36 @@
 {
-  "name": "zax",
-  "private": true,
-  "version": "0.0.0",
-  "description": "ZAX assembler (Node.js)",
+  "name": "@jhlagado/zax",
+  "version": "0.1.0",
+  "description": "ZAX assembler for the Z80 family (Node.js CLI)",
   "license": "GPL-3.0-only",
   "engines": {
     "node": ">=20"
   },
   "type": "module",
+  "bin": {
+    "zax": "dist/src/cli.js"
+  },
+  "files": [
+    "dist/src"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jhlagado/ZAX.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jhlagado/ZAX/issues"
+  },
+  "homepage": "https://github.com/jhlagado/ZAX#readme",
+  "keywords": [
+    "assembler",
+    "z80",
+    "zax",
+    "retro",
+    "8-bit"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
@@ -28,7 +51,8 @@
     "regen:language-tour": "bash scripts/regenerate-language-tour.sh",
     "regen:codegen-corpus": "node scripts/regenerate-codegen-corpus.mjs",
     "book": "bash scripts/build-book.sh",
-    "regen:grammar-atoms": "node scripts/generate-grammar-atoms.mjs"
+    "regen:grammar-atoms": "node scripts/generate-grammar-atoms.mjs",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
Prepares the repo for publishing the CLI as `@jhlagado/zax` on the public npm registry.

- Scoped package name, `bin` → `zax`, `files` limited to `dist/src`
- `publishConfig.access: public`, `prepublishOnly` runs build
- Repository, homepage, bugs, and keywords metadata
- Ignore `*.tgz` artifacts from `npm pack`

Made with [Cursor](https://cursor.com)