### PR TITLE
test/docs: PR1350 review follow-ups (ld a,(hl), D8M line)

### DIFF
--- a/docs/reference/ZAX-quick-guide.md
+++ b/docs/reference/ZAX-quick-guide.md
@@ -113,6 +113,8 @@ Common outputs:
 | `.d8.json` | D8 Debug Map for Debug80 and compatible tools     |
 | `.z80`        | ASM80-compatible lowered source (assembler-valid) |
 
+In `.d8.json` (D8M v1), source-attributed per-file `segments` include **`line`**: the canonical **1-based line number in the `.zax` source** for debuggers (e.g. Debug80); **`lstLine`** remains listing-oriented correlation on the same segment.
+
 By default, ZAX derives all artifact paths from the primary output path. Use `-o <file>` to set the primary output; `-t hex` or `-t bin` to choose the primary type (default: `hex`). Suppress individual outputs with `--nolist`, `--nobin`, `--nohex`, `--nod8m`. Emit ASM80 output explicitly with `--asm80`.
 
 Useful diagnostic options:

--- a/src/lowering/asmInstructionLdHelpers.ts
+++ b/src/lowering/asmInstructionLdHelpers.ts
@@ -160,6 +160,7 @@ export function createAsmInstructionLdHelpers(ctx: LdHelperContext) {
     if (!memExpr || memExpr.kind !== 'EaName') return false;
     // Register-indirect `(hl)`, `(bc)`, `(de)`, `(ix)`, `(iy)` use `EaName`; these are not
     // the absolute-address `ld r/(nn)` forms handled below (see `isRegisterLikeMemEa`).
+    // Storage labels that spell HL/BC/DE/IX/IY cannot use `(name)` for absolute mem here—`(hl)` is always HL indirect.
     if (ctx.reg16.has(memExpr.name.toUpperCase())) return false;
     const baseLower = resolveRawLabelName(memExpr.name).toLowerCase();
     if (ctx.isFrameSlotName(baseLower)) return false;

--- a/test/backend/pr1349_ld_a_indirect_hl_regression.test.ts
+++ b/test/backend/pr1349_ld_a_indirect_hl_regression.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR1349 / PR1350: ld a, (hl) vs absolute-address LD fixup', () => {
+  it('compiles cleanly (no ZAX300 "Unresolved symbol hl" from emitAbs16LdFixup)', async () => {
+    const entry = join(__dirname, '..', 'fixtures', 'pr1349_ld_a_indirect_hl.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+  });
+
+  it('emits opcode 0x7e (ld a,(hl)) in the binary image', async () => {
+    const entry = join(__dirname, '..', 'fixtures', 'pr1349_ld_a_indirect_hl.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+    const bin = res.artifacts.find((a) => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin || bin.kind !== 'bin') return;
+    expect(bin.bytes.includes(0x7e)).toBe(true);
+  });
+});

--- a/test/fixtures/coverage-map.md
+++ b/test/fixtures/coverage-map.md
@@ -11,9 +11,9 @@
 
 **Include/import graph cycles detected** (see section below).
 
-Total fixture files (excludes sentinels): 522
+Total fixture files (excludes sentinels): 523
 Sentinel files: 1
-Reachable from tests (direct refs ∪ fixture closure): 313
+Reachable from tests (direct refs ∪ fixture closure): 314
 Potentially unreferenced fixtures: 209
 
 ## Direct test reference counts
@@ -123,6 +123,7 @@ Potentially unreferenced fixtures: 209
 | pr1340_aggregate_param.zax | 1 |
 | pr1344_addr_of_type_positive.zax | 1 |
 | pr1344_self_ref_requires_addr.zax | 1 |
+| pr1349_ld_a_indirect_hl.zax | 1 |
 | pr135_isa_jr_djnz_invalid.zax | 0 |
 | pr135_isa_jr_djnz.zax | 0 |
 | pr136_bit_indexed_dest_invalid.zax | 1 |
@@ -876,6 +877,7 @@ Excluded from the main fixture inventory (`.keep`, `.gitkeep`).
 | pr1340_aggregate_param.zax | test/lowering/pr1340_aggregate_param.test.ts |
 | pr1344_addr_of_type_positive.zax | test/lowering/pr1344_addr_of_type.test.ts |
 | pr1344_self_ref_requires_addr.zax | test/lowering/pr1344_addr_of_type.test.ts |
+| pr1349_ld_a_indirect_hl.zax | test/backend/pr1349_ld_a_indirect_hl_regression.test.ts |
 | pr135_isa_jr_djnz_invalid.zax |  |
 | pr135_isa_jr_djnz.zax |  |
 | pr136_bit_indexed_dest_invalid.zax | test/pr136_bit_indexed_dest_invalid.test.ts |

--- a/test/fixtures/pr1349_ld_a_indirect_hl.zax
+++ b/test/fixtures/pr1349_ld_a_indirect_hl.zax
@@ -1,0 +1,12 @@
+; Minimal regression for #1349 / PR1350: ld a, (hl) must not use emitAbs16LdFixup
+; absolute-address path (would mis-resolve symbol "hl").
+
+section data d at $1000
+  buf: byte = 1
+end
+
+export func main()
+  ld hl, buf
+  ld a, (hl)
+  ret
+end


### PR DESCRIPTION
Addresses post-merge review of #1350.

- **Regression:** `test/fixtures/pr1349_ld_a_indirect_hl.zax` + `pr1349_ld_a_indirect_hl_regression.test.ts` — clean compile and `0x7E` in bin (pins `ld a,(hl)` vs absolute fixup path).
- **Docs:** Quick guide sentence on D8M `line` (canonical 1-based source) vs `lstLine`.
- **Comment:** Assembler note on `(hl)` vs storage label names spelling HL/BC/…
- **coverage-map:** regenerated (includes new fixture).

Made with [Cursor](https://cursor.com)