### PR TITLE
docs: format learning chapter prose

### DIFF
--- a/learning/part1/02-machine-code.md
+++ b/learning/part1/02-machine-code.md
@@ -14,15 +14,15 @@ The byte (or bytes) that represent an instruction are called its **opcode**. Eac
 
 A few examples from the Z80 instruction set:
 
-| Byte sequence | Instruction | What it does |
-|---------------|-------------|--------------|
-| `$3E n` | `ld a, n` | Load the constant value `n` into A |
-| `$06 n` | `ld b, n` | Load the constant value `n` into B |
-| `$47` | `ld b, a` | Copy A into B |
-| `$80` | `add a, b` | Add B to A; result goes into A |
-| `$32 lo hi` | `ld (nn), a` | Store A at the 16-bit address `nn` |
-| `$3A lo hi` | `ld a, (nn)` | Load A from the 16-bit address `nn` |
-| `$76` | `halt` | Stop the CPU |
+| Byte sequence | Instruction  | What it does                        |
+| ------------- | ------------ | ----------------------------------- |
+| `$3E n`       | `ld a, n`    | Load the constant value `n` into A  |
+| `$06 n`       | `ld b, n`    | Load the constant value `n` into B  |
+| `$47`         | `ld b, a`    | Copy A into B                       |
+| `$80`         | `add a, b`   | Add B to A; result goes into A      |
+| `$32 lo hi`   | `ld (nn), a` | Store A at the 16-bit address `nn`  |
+| `$3A lo hi`   | `ld a, (nn)` | Load A from the 16-bit address `nn` |
+| `$76`         | `halt`       | Stop the CPU                        |
 
 Address operands always follow the Z80's little-endian convention: low byte first, high byte second. The address `$8000` appears in the instruction stream as `$00 $80`. For a searchable reference of the full Z80 instruction set, see [Appendix 4](../appendices/04-classic-z80-instruction-support.md).
 

--- a/learning/part1/04-memory-access-and-data.md
+++ b/learning/part1/04-memory-access-and-data.md
@@ -28,7 +28,7 @@ IX and IY support displaced addressing — `(ix+d)` reads the byte at address IX
 > Parentheses always mean "go to this address in memory."
 >
 > `ld a, b` copies register B into A — no memory involved.
-> `ld a, (hl)` reads the *byte at the address held in HL* from memory.
+> `ld a, (hl)` reads the _byte at the address held in HL_ from memory.
 >
 > Missing or adding parentheses writes a completely different instruction —
 > one the assembler will happily accept, silently doing the wrong thing.
@@ -86,21 +86,21 @@ Both this and the `(BC)`/`(DE)` restriction above are examples of the same reali
 
 The table below is a reference — not something to memorise before you continue. Scan it once to see what shapes exist, then return to it when a specific form comes up in code.
 
-| Form | Example | Notes |
-|------|---------|-------|
-| reg8 ← reg8 | `ld a, b` | Any 8-bit register to any other |
-| reg8 ← n | `ld b, $FF` | Immediate 8-bit constant |
-| reg16 ← nn | `ld hl, $8000` | Immediate 16-bit constant |
-| reg8 ← (HL) | `ld c, (hl)` | Read byte at address HL |
-| (HL) ← reg8 | `ld (hl), d` | Write byte to address HL |
-| (HL) ← n | `ld (hl), 0` | Write immediate to address HL |
-| A ← (BC) | `ld a, (bc)` | Read byte at address BC; A only |
-| (DE) ← A | `ld (de), a` | Write A to address DE; A only |
-| A ← (nn) | `ld a, ($8000)` | Read byte from fixed address |
-| (nn) ← A | `ld ($8001), a` | Write A to fixed address |
-| reg16 ← (nn) | `ld hl, ($8002)` | Read 16-bit word from memory |
-| (nn) ← reg16 | `ld ($8004), hl` | Write 16-bit word to memory |
-| SP ← reg16 | `ld sp, hl` | SP = HL (or IX or IY) |
+| Form         | Example          | Notes                           |
+| ------------ | ---------------- | ------------------------------- |
+| reg8 ← reg8  | `ld a, b`        | Any 8-bit register to any other |
+| reg8 ← n     | `ld b, $FF`      | Immediate 8-bit constant        |
+| reg16 ← nn   | `ld hl, $8000`   | Immediate 16-bit constant       |
+| reg8 ← (HL)  | `ld c, (hl)`     | Read byte at address HL         |
+| (HL) ← reg8  | `ld (hl), d`     | Write byte to address HL        |
+| (HL) ← n     | `ld (hl), 0`     | Write immediate to address HL   |
+| A ← (BC)     | `ld a, (bc)`     | Read byte at address BC; A only |
+| (DE) ← A     | `ld (de), a`     | Write A to address DE; A only   |
+| A ← (nn)     | `ld a, ($8000)`  | Read byte from fixed address    |
+| (nn) ← A     | `ld ($8001), a`  | Write A to fixed address        |
+| reg16 ← (nn) | `ld hl, ($8002)` | Read 16-bit word from memory    |
+| (nn) ← reg16 | `ld ($8004), hl` | Write 16-bit word to memory     |
+| SP ← reg16   | `ld sp, hl`      | SP = HL (or IX or IY)           |
 
 For a compact LD quick table and the full addressing-shape reference, see [Appendix 3](../appendices/03-addressing-prefixes-and-instruction-forms.md).
 
@@ -196,7 +196,7 @@ ld hl, (scratch)
 ld b, $FF
 ```
 
-*(Hint: re-read the two-memory-locations section and the note about what `ld` cannot do.)*
+_(Hint: re-read the two-memory-locations section and the note about what `ld` cannot do.)_
 
 **3. Signed or unsigned?** For each byte value below, give both the unsigned interpretation (0–255) and the signed two's complement interpretation (−128 to +127):
 

--- a/learning/part1/05-flags-comparisons-jumps.md
+++ b/learning/part1/05-flags-comparisons-jumps.md
@@ -30,12 +30,12 @@ of the things that takes time to do automatically when reading Z80 code.
 
 The four flags you will use most:
 
-| Flag | Name | Set when |
-|------|------|----------|
-| Z | Zero | Result is zero |
-| C | Carry | Arithmetic produced a carry out of bit 7, or a borrow in subtraction |
-| S | Sign | Bit 7 of the result is 1 |
-| P/V | Parity/Overflow | Result parity is even; or signed overflow occurred |
+| Flag | Name            | Set when                                                             |
+| ---- | --------------- | -------------------------------------------------------------------- |
+| Z    | Zero            | Result is zero                                                       |
+| C    | Carry           | Arithmetic produced a carry out of bit 7, or a borrow in subtraction |
+| S    | Sign            | Bit 7 of the result is 1                                             |
+| P/V  | Parity/Overflow | Result parity is even; or signed overflow occurred                   |
 
 **Z** is the one you will reach for constantly. After `sub` or `cp`, Z is set
 when the two values were equal. After `dec`, Z is set when a register reaches
@@ -205,11 +205,11 @@ Z is set. The `n` prefix means "not": `nz` is "not zero", `nc` is "not carry".
 
 The condition codes you will use most:
 
-| Code | Meaning |
-|------|---------|
-| `z` | Jump if Z is set |
+| Code | Meaning            |
+| ---- | ------------------ |
+| `z`  | Jump if Z is set   |
 | `nz` | Jump if Z is clear |
-| `c` | Jump if C is set |
+| `c`  | Jump if C is set   |
 | `nc` | Jump if C is clear |
 
 `jp` also supports `m` (S set), `p` (S clear), `pe` (P/V set), and `po` (P/V
@@ -294,12 +294,12 @@ instruction itself, but the instruction is one byte shorter.
 `jr nz, label` jumps to `label` if Z is clear. The conditional forms support
 `z`, `nz`, `c`, and `nc` only — fewer conditions than `jp`.
 
-| | `jp` | `jr` |
-|---|---|---|
-| Address encoding | Full 16-bit address | Signed 8-bit displacement |
-| Instruction size | 3 bytes | 2 bytes |
-| Reach | Anywhere in 64K | ≈ 128 bytes backward / 127 forward |
-| Conditions available | z, nz, c, nc, m, p, pe, po | z, nz, c, nc only |
+|                      | `jp`                       | `jr`                               |
+| -------------------- | -------------------------- | ---------------------------------- |
+| Address encoding     | Full 16-bit address        | Signed 8-bit displacement          |
+| Instruction size     | 3 bytes                    | 2 bytes                            |
+| Reach                | Anywhere in 64K            | ≈ 128 bytes backward / 127 forward |
+| Conditions available | z, nz, c, nc, m, p, pe, po | z, nz, c, nc only                  |
 
 For short loops and nearby tests, `jr` saves a byte per jump and the range is
 rarely a problem. For anything that might be far away, or when you need a
@@ -313,8 +313,7 @@ the related `djnz` instruction (Chapter 6) are in
 ## Detecting a negative number: the `cp $80` technique
 
 Suppose A holds a signed value and you need its absolute value. The first step
-is finding out whether it is negative. A signed byte stores values from −128 to
-127. Negative values have bit 7 set, which means their unsigned interpretation
+is finding out whether it is negative. A signed byte stores values from −128 to 127. Negative values have bit 7 set, which means their unsigned interpretation
 is 128 or greater. You can test which half A falls in by comparing it against
 128 as an unsigned value:
 
@@ -514,7 +513,7 @@ Apply the three-question flag-before-branch check: (1) which instruction last se
 
 **3. Count down with flags.** Write a loop that starts with A = 10 and decrements A until A reaches zero. The loop body should store A to a named variable `last_a` on every iteration. Use `dec a` and a conditional jump — no DJNZ (that comes in Chapter 6). After the loop exits, what value is in A? What value is in `last_a`?
 
-**4. Bit test.** A status byte is stored at address `$8000`. Bit 2 is a "ready" flag. Write the two instructions needed to test bit 2 and jump to a label `not_ready` if the flag is clear, without disturbing any other bits in A. *(Hint: `and $04` isolates bit 2.)*
+**4. Bit test.** A status byte is stored at address `$8000`. Bit 2 is a "ready" flag. Write the two instructions needed to test bit 2 and jump to a label `not_ready` if the flag is clear, without disturbing any other bits in A. _(Hint: `and $04` isolates bit 2.)_
 
 ---
 

--- a/learning/part1/06-counting-loops-and-djnz.md
+++ b/learning/part1/06-counting-loops-and-djnz.md
@@ -344,7 +344,7 @@ loop_top:
 
 Write the corrected version that skips the loop entirely when `count_value` is zero.
 
-**2. Modify the sum loop.** The DJNZ sum loop from the chapter accumulates all five entries in `addends = { 3, 7, 2, 8, 5 }`. Change the loop so that it finds the **minimum** value instead of the sum. The result should be stored in a variable named `minimum`. *(Hint: start `minimum` at 255 and update it whenever the current byte is smaller. Chapter 5's `cp` and `jr nc` are the tools.)*
+**2. Modify the sum loop.** The DJNZ sum loop from the chapter accumulates all five entries in `addends = { 3, 7, 2, 8, 5 }`. Change the loop so that it finds the **minimum** value instead of the sum. The result should be stored in a variable named `minimum`. _(Hint: start `minimum` at 255 and update it whenever the current byte is smaller. Chapter 5's `cp` and `jr nc` are the tools.)_
 
 **3. Sentinel loop — find the zero.** A table of bytes ends with a zero sentinel:
 
@@ -359,11 +359,11 @@ Write a sentinel loop that scans `message` and stores the **index** (0-based pos
 **4. Loop analysis.** The flag-exit loop in the chapter example exits when the accumulated sum reaches or exceeds `$10` (16). The data is `{ 3, 7, 2, 8, 5 }`. Trace through the loop iteration by iteration:
 
 | Iteration | Byte added | A after add | `cp $10` → C set? | Exit? |
-|-----------|-----------|-------------|-------------------|-------|
-| 1 | 3 | ? | ? | ? |
-| 2 | 7 | ? | ? | ? |
-| 3 | 2 | ? | ? | ? |
-| 4 | 8 | ? | ? | ? |
+| --------- | ---------- | ----------- | ----------------- | ----- |
+| 1         | 3          | ?           | ?                 | ?     |
+| 2         | 7          | ?           | ?                 | ?     |
+| 3         | 2          | ?           | ?                 | ?     |
+| 4         | 8          | ?           | ?                 | ?     |
 
 Fill in the table. After the loop exits, what value is stored in `flagval`? Now change the threshold from `$10` to `$0C` (12) and redo the trace — does the loop exit one iteration earlier?
 

--- a/learning/part1/07-data-tables-and-indexed-access.md
+++ b/learning/part1/07-data-tables-and-indexed-access.md
@@ -371,7 +371,7 @@ no_new_max:
 ld (max_score), a
 ```
 
-*(Hint: `inc hl` is missing somewhere. Where? And what does HL read on every iteration as a result?)*
+_(Hint: `inc hl` is missing somewhere. Where? And what does HL read on every iteration as a result?)_
 
 ---
 

--- a/learning/part1/08-stack-and-subroutines.md
+++ b/learning/part1/08-stack-and-subroutines.md
@@ -439,7 +439,7 @@ pop de
 pop hl
 ```
 
-After all four instructions: what is in DE? What is in HL? What is SP? *(Remember: the stack is last-in-first-out — the pair pushed last is the first to be popped.)*
+After all four instructions: what is in DE? What is in HL? What is SP? _(Remember: the stack is last-in-first-out — the pair pushed last is the first to be popped.)_
 
 **2. Spot the push/pop mismatch.** This subroutine has a stack-balance bug. Identify it and explain precisely what will happen when `ret` executes:
 

--- a/learning/part1/09-io-and-ports.md
+++ b/learning/part1/09-io-and-ports.md
@@ -283,7 +283,7 @@ in a, (C)         ; form B
 
 After which form can you safely write `jr z, handle_zero` without any additional instruction? After which form must you add `or a` first? Write the minimum correct version for each case that branches to a label `is_zero` if the byte read was zero.
 
-**2. Modify the ready-check loop.** The `poll_and_recv` function in the chapter waits for bit 0 of the status port. Change it to wait for bit 3 instead. Write the modified function. *(Hint: you need to change exactly one value — the mask in the `and` instruction. What is the bit-3 mask in hex?)*
+**2. Modify the ready-check loop.** The `poll_and_recv` function in the chapter waits for bit 0 of the status port. Change it to wait for bit 3 instead. Write the modified function. _(Hint: you need to change exactly one value — the mask in the `and` instruction. What is the bit-3 mask in hex?)_
 
 **3. Write a receive loop.** The chapter shows `send_block` but not its counterpart. Write a ZAX `func` called `recv_block` that reads B bytes from the port in C into memory starting at the address in HL. The function should use the same structure as `send_block` — a DJNZ loop with `in` instead of `out`.
 

--- a/learning/part1/10-a-phase-a-program.md
+++ b/learning/part1/10-a-phase-a-program.md
@@ -158,7 +158,7 @@ hedge is often correct. Here it happens to be unnecessary.
 
 The double `cp c` in the loop body is a separate cost of a different kind.
 `cp c` sets carry when A < C, and sets Z when A == C. To test "strictly greater
-than" you need both: carry clear *and* Z clear. The raw code tests them with two
+than" you need both: carry clear _and_ Z clear. The raw code tests them with two
 separate `cp c` / `jr` pairs — the comparison runs twice per element. This is
 not a mistake; it is what the instruction set requires when you have no
 structured greater-than operator. The code is correct and the cost is small. But
@@ -259,17 +259,17 @@ None of this hides the machine. Everything translates to the same Z80 instructio
 **1. Trace `find_max` by hand.** The table is `{ 23, 47, 91, 5, 67, 12, 88, 34 }`. Step through `find_max` iteration by iteration, recording the value of A (the running maximum) and C (the current element) after each `ld c, (hl)`. Fill in the table:
 
 | Iteration | C (current) | A before cp | Update A? | A after |
-|-----------|-------------|-------------|-----------|---------|
-| 1 | 23 | 0 | yes | 23 |
-| 2 | 47 | 23 | ? | ? |
-| 3 | 91 | ? | ? | ? |
-| … | … | … | … | … |
+| --------- | ----------- | ----------- | --------- | ------- |
+| 1         | 23          | 0           | yes       | 23      |
+| 2         | 47          | 23          | ?         | ?       |
+| 3         | 91          | ?           | ?         | ?       |
+| …         | …           | …           | …         | …       |
 
 What is A when the loop exits? Does it match the expected result (91)?
 
 **2. The invisible side effect.** `main` reloads `ld hl, values` before calling `count_above`. Why? What value would HL hold after `find_max` returns if you did not reload it? What would `count_above` scan if HL were not reloaded, and what result would `above_64` receive?
 
-**3. Find the redundancy.** The `count_above` function runs `cp c` twice in the loop body. Explain in one sentence why each `cp c` is there and what flag it is testing. Could you combine them into a single test using a different jump? *(Hint: after the first `jr c, skip`, you know A is ≥ C. What additional condition do you need to check?)*
+**3. Find the redundancy.** The `count_above` function runs `cp c` twice in the loop body. Explain in one sentence why each `cp c` is there and what flag it is testing. Could you combine them into a single test using a different jump? _(Hint: after the first `jr c, skip`, you know A is ≥ C. What additional condition do you need to check?)_
 
 **4. Add a third task.** Extend the program to also count entries that are strictly less than 32, storing the count in a new variable named `below_32`. Write just the additional subroutine and the three lines in `main` that call it. Identify which registers carry each argument and what you must reload before the call.
 

--- a/learning/part1/11-functions-and-the-ix-frame.md
+++ b/learning/part1/11-functions-and-the-ix-frame.md
@@ -272,7 +272,7 @@ func process(src: addr, count: byte, limit: byte): AF
 end
 ```
 
-Draw the stack layout diagram at the start of the function body (after the prologue). For each parameter and local, state its IX offset and whether you would access it with `+0` only or `+0`/`+1`. *(Hint: parameters are pushed right-to-left in call order, so the first argument ends up at the highest positive offset.)*
+Draw the stack layout diagram at the start of the function body (after the prologue). For each parameter and local, state its IX offset and whether you would access it with `+0` only or `+0`/`+1`. _(Hint: parameters are pushed right-to-left in call order, so the first argument ends up at the highest positive offset.)_
 
 **2. The IXH/IXL trap.** A framed function contains this sequence:
 

--- a/learning/part1/12-structured-control-flow.md
+++ b/learning/part1/12-structured-control-flow.md
@@ -353,7 +353,6 @@ dispatch sequence may modify A and flags, so do not rely on A still holding
 the selector value inside a case body. When the selector is any other register,
 that register is preserved across dispatch.
 
-
 ---
 
 ## Before and after: the same two loops
@@ -598,7 +597,7 @@ found_zero:
 scan_done:
 ```
 
-*(Hint: you will need `or a` before `while` to establish flags from B. Inside the loop, `inc hl` should come before the `dec b` / flag re-establishment for this to be cleanest. Preserve the "store HL when zero is found" behaviour in the `if Z` branch.)*
+_(Hint: you will need `or a` before `while` to establish flags from B. Inside the loop, `inc hl` should come before the `dec b` / flag re-establishment for this to be cleanest. Preserve the "store HL when zero is found" behaviour in the `if Z` branch.)_
 
 **3. `break` vs `continue` in nested loops.** In the nested loop below, identify which loop each `break` and `continue` exits or restarts:
 
@@ -631,7 +630,7 @@ end
 
 For `continue` (2): what instruction must execute immediately before `continue` to ensure the `while NZ` test fires correctly on the next iteration?
 
-**4. `while` vs `repeat...until`.** Rewrite the following `while` loop as a `repeat...until` loop that produces exactly the same result. Then explain one situation where `repeat...until` would be the *wrong* choice — i.e. a case where the loop body must not execute if the initial count is zero.
+**4. `while` vs `repeat...until`.** Rewrite the following `while` loop as a `repeat...until` loop that produces exactly the same result. Then explain one situation where `repeat...until` would be the _wrong_ choice — i.e. a case where the loop body must not execute if the initial count is zero.
 
 ```zax
 ld a, b

--- a/learning/part1/14-op-macros-and-pseudo-opcodes.md
+++ b/learning/part1/14-op-macros-and-pseudo-opcodes.md
@@ -174,6 +174,7 @@ fails. If two overloads match equally — neither is more specific than the othe
 has a unique best match for every call pattern you intend to use.
 
 **Specificity ranking (from most to least specific):**
+
 1. Fixed-register match (e.g., `A`, `HL`)
 2. Class match (`reg8`, `reg16`, `imm8`, `mem8`, `mem16`)
 3. Wider class match (`imm16`, `ea`)
@@ -228,14 +229,14 @@ The assembler emits the two-instruction sequence automatically. No new opcode is
 
 The full set of synthetic 16-bit register transfers:
 
-| Pseudo-opcode | Expands to |
-|---------------|------------|
-| `ld hl, de` | `ld h, d` / `ld l, e` |
-| `ld hl, bc` | `ld h, b` / `ld l, c` |
-| `ld de, hl` | `ld d, h` / `ld e, l` |
-| `ld de, bc` | `ld d, b` / `ld e, c` |
-| `ld bc, hl` | `ld b, h` / `ld c, l` |
-| `ld bc, de` | `ld b, d` / `ld c, e` |
+| Pseudo-opcode | Expands to            |
+| ------------- | --------------------- |
+| `ld hl, de`   | `ld h, d` / `ld l, e` |
+| `ld hl, bc`   | `ld h, b` / `ld l, c` |
+| `ld de, hl`   | `ld d, h` / `ld e, l` |
+| `ld de, bc`   | `ld d, b` / `ld e, c` |
+| `ld bc, hl`   | `ld b, h` / `ld c, l` |
+| `ld bc, de`   | `ld b, d` / `ld c, e` |
 
 Each expands to two one-byte instructions — the same two `ld` moves you would write by hand. ZAX adds nothing at run time.
 
@@ -276,7 +277,7 @@ while NZ
 end
 ```
 
-**2. `op` vs `func` cost comparison.** You have a six-instruction sequence you need to use in five places in your program. Compare the total instruction count in the binary for each approach: (a) a `func` call — include the six instructions plus the `call`, `ret`, and frame overhead; (b) an `op` — include the six instructions repeated at all five call sites. Which produces fewer total instructions? At what body length would the two approaches produce the same total instruction count? *(Assume frameless function: 2 overhead instructions — `call` and `ret`.)*
+**2. `op` vs `func` cost comparison.** You have a six-instruction sequence you need to use in five places in your program. Compare the total instruction count in the binary for each approach: (a) a `func` call — include the six instructions plus the `call`, `ret`, and frame overhead; (b) an `op` — include the six instructions repeated at all five call sites. Which produces fewer total instructions? At what body length would the two approaches produce the same total instruction count? _(Assume frameless function: 2 overhead instructions — `call` and `ret`.)_
 
 **3. Overload resolution.** Given these two `op` declarations:
 

--- a/learning/part2/01-foundations.md
+++ b/learning/part2/01-foundations.md
@@ -22,13 +22,13 @@ func power(base: word, exponent: word): HL
 end
 ```
 
-Each local occupies a 16-bit slot in the IX stack frame. The `var` block is closed by its own `end`; a second `end` closes the function. *(Part 1 Chapter 11 covers the full frame layout.)*
+Each local occupies a 16-bit slot in the IX stack frame. The `var` block is closed by its own `end`; a second `end` closes the function. _(Part 1 Chapter 11 covers the full frame layout.)_
 
 ---
 
 ## The `:=` Assignment Operator
 
-`:=` assigns from right to left between typed storage and a register. The compiler resolves names to frame offsets and emits the right instruction sequence — including multi-instruction sequences for word-sized locals. *(Part 1 Chapter 13 covers the full detail.)*
+`:=` assigns from right to left between typed storage and a register. The compiler resolves names to frame offsets and emits the right instruction sequence — including multi-instruction sequences for word-sized locals. _(Part 1 Chapter 13 covers the full detail.)_
 
 In practice, `:=` and raw Z80 instructions appear together in the same function body:
 
@@ -69,7 +69,7 @@ func gcd_iterative(left_input: word, right_input: word): HL
 
 ## Basic Control Flow: `if` and `while`
 
-Any Z80 condition code is valid: `if NZ`, `if Z`, `if C`, `if NC`, `if M`, `if P`, `if PE`, `if PO`. The compiler generates the hidden labels and jumps; you write the condition and the body. Flags must be established by a Z80 instruction immediately before the `if` or `while`. *(Part 1 Chapters 5 and 12 cover the full rules.)*
+Any Z80 condition code is valid: `if NZ`, `if Z`, `if C`, `if NC`, `if M`, `if P`, `if PE`, `if PO`. The compiler generates the hidden labels and jumps; you write the condition and the body. Flags must be established by a Z80 instruction immediately before the `if` or `while`. _(Part 1 Chapters 5 and 12 cover the full rules.)_
 
 A concrete pattern from these examples: testing whether a 16-bit value is zero:
 
@@ -99,7 +99,7 @@ A concrete pattern from these examples: testing whether a 16-bit value is zero:
     step offset, 4           ; +4
 ```
 
-`step` is the standard way to advance or retreat a counter local throughout these loops. *(Part 1 Chapter 13 covers `step` in full.)*
+`step` is the standard way to advance or retreat a counter local throughout these loops. _(Part 1 Chapter 13 covers `step` in full.)_
 
 ---
 


### PR DESCRIPTION
## Summary
- format the 12 learning chapter files that failed the previous docs-fast check
- keep the follow-up limited to the markdown files flagged by PR #1354 CI

## Review
- Findings: the prior learning PR had one actionable issue: `docs (fast)` failed because these files were not Prettier-formatted
- No prose-accuracy or structural blockers found in the sampled chapter changes

## Testing
- npx prettier -c learning/part1/02-machine-code.md learning/part1/04-memory-access-and-data.md learning/part1/05-flags-comparisons-jumps.md learning/part1/06-counting-loops-and-djnz.md learning/part1/07-data-tables-and-indexed-access.md learning/part1/08-stack-and-subroutines.md learning/part1/09-io-and-ports.md learning/part1/10-a-phase-a-program.md learning/part1/11-functions-and-the-ix-frame.md learning/part1/12-structured-control-flow.md learning/part1/14-op-macros-and-pseudo-opcodes.md learning/part2/01-foundations.md
