### PR TITLE
ci(publish): npm Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,11 +1,18 @@
 # Publish @jhlagado/zax to npm when a GitHub Release is published.
 #
-# Prerequisite: bump `version` in package.json on main (or the release target branch),
-# merge, then create a Release whose tag matches the version (recommended: `v0.2.0` for 0.2.0).
+# Uses npm Trusted Publishing (OIDC) — no long-lived NPM_TOKEN for publish.
+# https://docs.npmjs.com/trusted-publishers/
 #
-# Repository secret (Settings → Secrets and variables → Actions):
-#   NPM_TOKEN — npm automation token with publish permission for @jhlagado scope
-#   (npm profile → Access Tokens → Granular or Classic with publish).
+# Prerequisite on npmjs.com → package → Settings → Trusted publishing:
+#   Provider: GitHub Actions
+#   Repository: jhlagado/ZAX (must match package.json "repository.url")
+#   Workflow filename: publish-npm.yml  (filename only, under .github/workflows/)
+#
+# After trusted publishing works, set Publishing access to
+# "Require two-factor authentication and disallow tokens" (recommended).
+#
+# Prerequisite: bump `version` in package.json on main, merge, then create a
+# Release whose tag matches the version (e.g. v0.2.2 for 0.2.2).
 
 name: Publish npm
 
@@ -15,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write # OIDC for npm trusted publishing
 
 jobs:
   publish:
@@ -29,9 +37,13 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          # Trusted publishing requires Node >= 22.14 and npm >= 11.5.1
+          node-version: "22"
           cache: npm
           registry-url: "https://registry.npmjs.org"
+
+      - name: npm CLI for trusted publishing
+        run: npm install -g npm@^11.5.1
 
       - name: Verify release tag matches package.json version
         shell: bash
@@ -55,7 +67,5 @@ jobs:
       - name: Test
         run: npm test
 
-      - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm (OIDC)
         run: npm publish --access public


### PR DESCRIPTION
Switch the release publish workflow to [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers/): `id-token: write`, Node 22+, npm ^11.5.1, and no `NPM_TOKEN` on `npm publish`.

**On npmjs.com** (before the next release publish): add Trusted publisher → GitHub Actions → repo `jhlagado/ZAX`, workflow filename `publish-npm.yml` (exact match). `package.json` `repository.url` already points at `https://github.com/jhlagado/ZAX.git`.

**Publishing access:** Option 2 (disallow tokens) is compatible with OIDC per npm docs; configure trusted publishing first, then save Option 2.

Removes reliance on a bypass-2FA automation token for publish.

Made with [Cursor](https://cursor.com)