### PR TITLE
ci(publish): restore npm token publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,18 +1,14 @@
 # Publish @jhlagado/zax to npm when a GitHub Release is published.
 #
-# Uses npm Trusted Publishing (OIDC) — no long-lived NPM_TOKEN for publish.
-# https://docs.npmjs.com/trusted-publishers/
+# Repository secret (Settings → Secrets and variables → Actions):
+#   NPM_TOKEN — npm granular access token with publish for @jhlagado/zax
+#   (use "bypass 2FA" if your package requires 2FA for publish)
 #
-# Prerequisite on npmjs.com → package → Settings → Trusted publishing:
-#   Provider: GitHub Actions
-#   Repository: jhlagado/ZAX (must match package.json "repository.url")
-#   Workflow filename: publish-npm.yml  (filename only, under .github/workflows/)
-#
-# After trusted publishing works, set Publishing access to
-# "Require two-factor authentication and disallow tokens" (recommended).
+# Package → Publishing access: must allow token-based publish (e.g. option that
+# permits a granular token with bypass 2FA), not "disallow tokens only".
 #
 # Prerequisite: bump `version` in package.json on main, merge, then create a
-# Release whose tag matches the version (e.g. v0.2.2 for 0.2.2).
+# Release whose tag matches the version (e.g. v0.2.3 for 0.2.3).
 
 name: Publish npm
 
@@ -22,7 +18,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write # OIDC for npm trusted publishing
 
 jobs:
   publish:
@@ -37,13 +32,9 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          # Trusted publishing requires Node >= 22.14 and npm >= 11.5.1
-          node-version: "22"
+          node-version: "20"
           cache: npm
           registry-url: "https://registry.npmjs.org"
-
-      - name: npm CLI for trusted publishing
-        run: npm install -g npm@^11.5.1
 
       - name: Verify release tag matches package.json version
         shell: bash
@@ -67,5 +58,7 @@ jobs:
       - name: Test
         run: npm test
 
-      - name: Publish to npm (OIDC)
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public


### PR DESCRIPTION
Revert the release workflow to **token-based** `npm publish` via `NODE_AUTH_TOKEN` / `NPM_TOKEN` secret.

Removes OIDC-only requirements (`id-token: write`, npm 11.5+, Node 22). Matches local `engines` (Node 20).

**On npm:** set Publishing access to allow a **granular token with bypass 2FA** (not *disallow tokens only*). Ensure **NPM_TOKEN** is set in repo Actions secrets.

Made with [Cursor](https://cursor.com)