### PR TITLE
Add stable tooling API surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+- Added stable `exports` entry points for `@jhlagado/zax`, `@jhlagado/zax/tooling`, and `@jhlagado/zax/compile`.
+- Added a tooling API with `loadProgram()` for parse/load access, entry-buffer `preloadedText`, and `analyzeProgram()` for semantics-only validation.
+- Documented the public API, semver policy, syntax-highlighting example, and migration away from deep `dist/src/*` imports.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ ZAX constructs and raw Z80 instructions mix freely. The machine model does not c
 **Want the language reference?**
 [ZAX Quick Guide](docs/reference/ZAX-quick-guide.md) — full syntax in practical terms.
 [ZAX Language Spec](docs/spec/zax-spec.md) — normative specification.
+[Tooling API](docs/tooling-api.md) — stable Node imports for parse/load/analyze/compile.
 
 **Contributing?**
 [CONTRIBUTING.md](CONTRIBUTING.md) — branches, PRs, issues, and pre-push checks.
@@ -86,6 +87,16 @@ zax [options] <entry.zax>
   -V, --version
   -h, --help
 ```
+
+## Programmatic API
+
+`@jhlagado/zax` now exposes documented, semver-governed Node entry points:
+
+- `@jhlagado/zax` — root barrel for the stable public surface
+- `@jhlagado/zax/tooling` — Layer A/B APIs for parsing, loading, spans, diagnostics, and semantics-only analysis
+- `@jhlagado/zax/compile` — Layer C compile API plus default format writers
+
+Deep imports like `@jhlagado/zax/dist/src/moduleLoader.js` are not part of the supported contract. Use the public barrels above instead. See [docs/tooling-api.md](docs/tooling-api.md) for examples and compatibility policy.
 
 ---
 

--- a/docs/tooling-api.md
+++ b/docs/tooling-api.md
@@ -1,0 +1,126 @@
+# ZAX Tooling API
+
+`@jhlagado/zax` exposes a stable programmatic surface for Node tooling. Use these imports instead of deep paths under `dist/src`.
+
+## Stable entry points
+
+- `@jhlagado/zax`
+  Re-exports the stable public surface.
+- `@jhlagado/zax/tooling`
+  Layer A/B APIs for parsing, loading, diagnostics, spans, and semantics-only analysis.
+- `@jhlagado/zax/compile`
+  Layer C compile API and default format writers.
+
+## Layer A: Load and Parse
+
+Use `loadProgram()` when you need the same AST, spans, and diagnostics that the compiler uses, but without lowering or writing artifacts.
+
+```ts
+import { loadProgram } from '@jhlagado/zax/tooling';
+
+const result = await loadProgram({
+  entryFile: '/abs/path/to/main.zax',
+  includeDirs: ['/abs/path/to/includes'],
+  preloadedText: 'export func main()\\nend\\n',
+});
+
+if (result.loadedProgram) {
+  console.log(result.loadedProgram.program.kind); // "Program"
+}
+
+for (const diagnostic of result.diagnostics) {
+  console.log(diagnostic.id, diagnostic.message);
+}
+```
+
+Notes:
+
+- `preloadedText` applies to the entry file only. This is intended for unsaved editor buffers.
+- `signal?: AbortSignal` is accepted for best-effort cancellation of stale editor work.
+- `parseEntryOnly` is not part of v1. Use `loadProgram()` and debounce at the caller when needed.
+
+## Layer B: Analyze Without Emitting
+
+Use `analyzeProgram()` after `loadProgram()` to run the current non-codegen semantic checks:
+
+- entry contract validation such as `requireMain`
+- case-style linting
+- environment building
+- instruction acceptance checks that do not require lowering
+
+```ts
+import { analyzeProgram, loadProgram } from '@jhlagado/zax/tooling';
+
+const loaded = await loadProgram({ entryFile: '/abs/path/to/main.zax' });
+if (!loaded.loadedProgram) {
+  throw new Error('Parse/load failed');
+}
+
+const analysis = analyzeProgram(loaded.loadedProgram, {
+  caseStyle: 'consistent',
+  requireMain: true,
+});
+
+console.log(analysis.diagnostics);
+```
+
+`analysis.env` is returned only when semantic analysis completes without errors.
+
+## Layer C: Full Compile
+
+Use `compile()` when you want lowering plus output artifacts.
+
+```ts
+import { compile, defaultFormatWriters } from '@jhlagado/zax/compile';
+
+const result = await compile(
+  '/abs/path/to/main.zax',
+  { emitAsm80: true },
+  { formats: defaultFormatWriters },
+);
+```
+
+## Public Types
+
+The public tooling surface includes:
+
+- `Diagnostic`, `DiagnosticIds`, severity/id types
+- `SourcePosition`, `SourceSpan`
+- `ProgramNode`, `ModuleFileNode`, `ModuleItemNode`, `SectionItemNode`
+- `LoadedProgram`
+- `CompileEnv`
+
+In v1, the AST exported from `src/frontend/ast.ts` is part of the public contract. Additive fields are minor-version changes; breaking shape changes are major-version changes.
+
+## Syntax Highlighting Example
+
+Syntax colouring is an example consumer of the tooling API:
+
+1. Call `loadProgram()` with the file path and optional unsaved buffer text.
+2. Walk `ProgramNode` and inspect `node.kind` plus `node.span`.
+3. Map those spans to TextMate scopes or semantic token kinds in the editor.
+4. Fall back to regex/TextMate-only colouring if parsing fails or the editor needs a cheaper fast path.
+
+The same spans and node kinds also support outline views, hover preparation, diagnostics, and navigation features.
+
+## Migration From Deep Imports
+
+Replace unstable imports such as:
+
+```ts
+import { loadProgram } from '@jhlagado/zax/dist/src/moduleLoader.js';
+```
+
+with:
+
+```ts
+import { loadProgram } from '@jhlagado/zax/tooling';
+```
+
+Likewise, prefer `@jhlagado/zax/compile` over `@jhlagado/zax/dist/src/compile.js`.
+
+## Semver Policy
+
+- Patch: bug fixes that preserve the intent of exported APIs and types
+- Minor: additive exports, additive AST fields, new optional options
+- Major: breaking changes to exported types, AST node shapes, or public function behavior

--- a/package.json
+++ b/package.json
@@ -19,7 +19,14 @@
     "./tooling": {
       "types": "./dist/src/api-tooling.d.ts",
       "import": "./dist/src/api-tooling.js"
-    }
+    },
+    "./cli": {
+      "types": "./dist/src/cli.d.ts",
+      "import": "./dist/src/cli.js",
+      "require": "./dist/src/cli.js",
+      "default": "./dist/src/cli.js"
+    },
+    "./package.json": "./package.json"
   },
   "types": "dist/src/index.d.ts",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,21 @@
     "node": ">=20"
   },
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js"
+    },
+    "./compile": {
+      "types": "./dist/src/api-compile.d.ts",
+      "import": "./dist/src/api-compile.js"
+    },
+    "./tooling": {
+      "types": "./dist/src/api-tooling.d.ts",
+      "import": "./dist/src/api-tooling.js"
+    }
+  },
+  "types": "dist/src/index.d.ts",
   "bin": {
     "zax": "dist/src/cli.js"
   },

--- a/src/analysis.ts
+++ b/src/analysis.ts
@@ -1,0 +1,83 @@
+import { dirname } from 'node:path';
+
+import { hasErrors } from './compileShared.js';
+import type { Diagnostic } from './diagnosticTypes.js';
+import { DiagnosticIds } from './diagnosticTypes.js';
+import type { LoadedProgram } from './moduleLoader.js';
+import type { CompilerOptions } from './pipeline.js';
+import { lintCaseStyle } from './lintCaseStyle.js';
+import type { ModuleItemNode, ProgramNode, SectionItemNode } from './frontend/ast.js';
+import { validateAssignmentAcceptance } from './semantics/assignmentAcceptance.js';
+import { buildEnv, type CompileEnv } from './semantics/env.js';
+import { validateStepAcceptance } from './semantics/stepAcceptance.js';
+
+export interface AnalyzeProgramOptions
+  extends Pick<CompilerOptions, 'caseStyle' | 'requireMain'> {}
+
+export interface AnalyzeProgramResult {
+  diagnostics: Diagnostic[];
+  env?: CompileEnv;
+}
+
+function hasMainFunction(program: ProgramNode): boolean {
+  const hasMainInItems = (items: Array<ModuleItemNode | SectionItemNode>): boolean => {
+    for (const item of items) {
+      if (item.kind === 'FuncDecl' && item.name.toLowerCase() === 'main') return true;
+      if (item.kind === 'NamedSection' && item.section === 'code' && hasMainInItems(item.items)) return true;
+    }
+    return false;
+  };
+  return program.files.some((moduleFile) => hasMainInItems(moduleFile.items));
+}
+
+export function analyzeLoadedProgram(
+  loadedProgram: LoadedProgram,
+  options: AnalyzeProgramOptions = {},
+): AnalyzeProgramResult {
+  const diagnostics: Diagnostic[] = [];
+  const { program, sourceTexts, resolvedImportGraph } = loadedProgram;
+  const hasNonImportDeclaration = program.files.some((moduleFile) =>
+    moduleFile.items.some((item) => item.kind !== 'Import'),
+  );
+  if (!hasNonImportDeclaration) {
+    diagnostics.push({
+      id: DiagnosticIds.SemanticsError,
+      severity: 'error',
+      message: 'Program contains no declarations or instruction streams.',
+      file: program.entryFile,
+      ...(program.span?.start
+        ? { line: program.span.start.line, column: program.span.start.column }
+        : {}),
+    });
+    return { diagnostics };
+  }
+
+  if ((options.requireMain ?? false) && !hasMainFunction(program)) {
+    diagnostics.push({
+      id: DiagnosticIds.SemanticsError,
+      severity: 'error',
+      message: 'Program must define a callable "main" entry function.',
+      file: program.entryFile,
+      ...(program.span?.start
+        ? { line: program.span.start.line, column: program.span.start.column }
+        : {}),
+    });
+    return { diagnostics };
+  }
+
+  lintCaseStyle(program, sourceTexts, options.caseStyle ?? 'off', diagnostics);
+
+  const env = buildEnv(program, diagnostics, {
+    moduleIdRootDir: dirname(program.entryFile),
+    resolvedImportGraph,
+  });
+  if (hasErrors(diagnostics)) return { diagnostics };
+
+  validateAssignmentAcceptance(program, env, diagnostics);
+  if (hasErrors(diagnostics)) return { diagnostics };
+
+  validateStepAcceptance(program, env, diagnostics);
+  if (hasErrors(diagnostics)) return { diagnostics };
+
+  return { diagnostics, env };
+}

--- a/src/api-compile.ts
+++ b/src/api-compile.ts
@@ -1,0 +1,13 @@
+export { compile } from './compile.js';
+export type {
+  CaseStyleMode,
+  CompileFn,
+  CompileResult,
+  CompilerOptions,
+  OpStackPolicyMode,
+  PipelineDeps,
+} from './pipeline.js';
+export { defaultFormatWriters } from './formats/index.js';
+export type { Artifact, FormatWriters } from './formats/types.js';
+export type { Diagnostic, DiagnosticId, DiagnosticSeverity } from './diagnosticTypes.js';
+export { DiagnosticIds } from './diagnosticTypes.js';

--- a/src/api-tooling.ts
+++ b/src/api-tooling.ts
@@ -1,0 +1,44 @@
+import type { Diagnostic } from './diagnosticTypes.js';
+import { analyzeLoadedProgram, type AnalyzeProgramOptions, type AnalyzeProgramResult } from './analysis.js';
+import { loadProgram as loadProgramInternal, type LoadedProgram, type LoadProgramOptions } from './moduleLoader.js';
+
+export type { Diagnostic, DiagnosticId, DiagnosticSeverity } from './diagnosticTypes.js';
+export { DiagnosticIds } from './diagnosticTypes.js';
+export type {
+  BaseNode,
+  ModuleFileNode,
+  ModuleItemNode,
+  ProgramNode,
+  SectionItemNode,
+  SourcePosition,
+  SourceSpan,
+} from './frontend/ast.js';
+export type { CompileEnv } from './semantics/env.js';
+export type { LoadedProgram, LoadProgramOptions, AnalyzeProgramOptions, AnalyzeProgramResult };
+
+export interface ToolingLoadProgramResult {
+  diagnostics: Diagnostic[];
+  loadedProgram?: LoadedProgram;
+}
+
+/**
+ * Layer A: resolve imports/includes and parse the program tree without emitting artifacts.
+ */
+export async function loadProgram(options: LoadProgramOptions & { entryFile: string }): Promise<ToolingLoadProgramResult> {
+  const diagnostics: Diagnostic[] = [];
+  const loadedProgram = await loadProgramInternal(options.entryFile, diagnostics, options);
+  return {
+    diagnostics,
+    ...(loadedProgram ? { loadedProgram } : {}),
+  };
+}
+
+/**
+ * Layer B: run semantic checks without lowering or writing output artifacts.
+ */
+export function analyzeProgram(
+  loadedProgram: LoadedProgram,
+  options: AnalyzeProgramOptions = {},
+): AnalyzeProgramResult {
+  return analyzeLoadedProgram(loadedProgram, options);
+}

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1,20 +1,16 @@
 import { dirname } from 'node:path';
 
+import { analyzeLoadedProgram } from './analysis.js';
 import { hasErrors, normalizePath } from './compileShared.js';
 import type { Diagnostic } from './diagnosticTypes.js';
 import { DiagnosticIds } from './diagnosticTypes.js';
 import type { CompileFn, CompilerOptions, CompileResult, PipelineDeps } from './pipeline.js';
 
-import type { ModuleItemNode, ProgramNode, SectionItemNode } from './frontend/ast.js';
-import { lintCaseStyle } from './lintCaseStyle.js';
 import { emitProgram } from './lowering/emit.js';
 import { STARTUP_ENTRY_LABEL } from './lowering/startupInit.js';
 import type { Artifact } from './formats/types.js';
 import { collectNonBankedSectionKeys } from './sectionKeys.js';
 import { loadProgram } from './moduleLoader.js';
-import { validateAssignmentAcceptance } from './semantics/assignmentAcceptance.js';
-import { buildEnv } from './semantics/env.js';
-import { validateStepAcceptance } from './semantics/stepAcceptance.js';
 
 function withDefaults(
   options: CompilerOptions,
@@ -36,18 +32,6 @@ function withDefaults(
   return { emitBin, emitHex, emitD8m, emitListing, emitAsm80 };
 }
 
-
-function hasMainFunction(program: ProgramNode): boolean {
-  const hasMainInItems = (items: Array<ModuleItemNode | SectionItemNode>): boolean => {
-    for (const item of items) {
-      if (item.kind === 'FuncDecl' && item.name.toLowerCase() === 'main') return true;
-      if (item.kind === 'NamedSection' && item.section === 'code' && hasMainInItems(item.items)) return true;
-    }
-    return false;
-  };
-  return program.files.some((moduleFile) => hasMainInItems(moduleFile.items));
-}
-
 /**
  * Compile a ZAX program starting from an entry file.
  *
@@ -62,11 +46,10 @@ export const compile: CompileFn = async (
   deps: PipelineDeps,
 ): Promise<CompileResult> => {
   const entryPath = normalizePath(entryFile);
-  const moduleIdRootDir = dirname(entryPath);
   const diagnostics: Diagnostic[] = [];
   const loaded = await loadProgram(entryPath, diagnostics, options);
   if (!loaded) return { diagnostics, artifacts: [] };
-  const { program, sourceTexts, sourceLineComments, moduleTraversal, resolvedImportGraph } = loaded;
+  const { program, sourceTexts, sourceLineComments, moduleTraversal } = loaded;
 
   if (hasErrors(diagnostics)) {
     return { diagnostics, artifacts: [] };
@@ -77,53 +60,13 @@ export const compile: CompileFn = async (
     return { diagnostics, artifacts: [] };
   }
 
-  const hasNonImportDeclaration = program.files.some((moduleFile) =>
-    moduleFile.items.some((item) => item.kind !== 'Import'),
-  );
-  if (!hasNonImportDeclaration) {
-    diagnostics.push({
-      id: DiagnosticIds.SemanticsError,
-      severity: 'error',
-      message: 'Program contains no declarations or instruction streams.',
-      file: program.entryFile,
-      ...(program.span?.start
-        ? { line: program.span.start.line, column: program.span.start.column }
-        : {}),
-    });
-    return { diagnostics, artifacts: [] };
-  }
-
-  if ((options.requireMain ?? false) && !hasMainFunction(program)) {
-    diagnostics.push({
-      id: DiagnosticIds.SemanticsError,
-      severity: 'error',
-      message: 'Program must define a callable "main" entry function.',
-      file: program.entryFile,
-      ...(program.span?.start
-        ? { line: program.span.start.line, column: program.span.start.column }
-        : {}),
-    });
-    return { diagnostics, artifacts: [] };
-  }
-
-  lintCaseStyle(program, sourceTexts, options.caseStyle ?? 'off', diagnostics);
-
-  const env = buildEnv(program, diagnostics, {
-    moduleIdRootDir,
-    resolvedImportGraph,
+  const analysis = analyzeLoadedProgram(loaded, {
+    ...(options.caseStyle !== undefined ? { caseStyle: options.caseStyle } : {}),
+    ...(options.requireMain !== undefined ? { requireMain: options.requireMain } : {}),
   });
-  if (hasErrors(diagnostics)) {
-    return { diagnostics, artifacts: [] };
-  }
-
-  validateAssignmentAcceptance(program, env, diagnostics);
-  if (hasErrors(diagnostics)) {
-    return { diagnostics, artifacts: [] };
-  }
-  validateStepAcceptance(program, env, diagnostics);
-  if (hasErrors(diagnostics)) {
-    return { diagnostics, artifacts: [] };
-  }
+  diagnostics.push(...analysis.diagnostics);
+  if (hasErrors(diagnostics) || !analysis.env) return { diagnostics, artifacts: [] };
+  const env = analysis.env;
 
   const { map, symbols, placedLoweredAsmProgram } = emitProgram(program, env, diagnostics, {
     ...(options.includeDirs ? { includeDirs: options.includeDirs } : {}),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export * from './api-compile.js';
+export * from './api-tooling.js';

--- a/src/moduleLoader.ts
+++ b/src/moduleLoader.ts
@@ -30,16 +30,27 @@ export type LoadedProgram = {
   resolvedImportGraph: Map<string, string[]>;
 };
 
+export interface LoadProgramOptions extends Pick<CompilerOptions, 'includeDirs'> {
+  preloadedText?: string;
+  signal?: AbortSignal;
+}
+
 type ExpandedSource = { text: string; lineFiles: string[]; lineBaseLines: number[] };
 type ModuleEdges = Map<string, Map<string, { line: number; column: number }>>;
 type ImportTarget = ReturnType<typeof importTargets>[number];
+
+function throwIfAborted(signal?: AbortSignal): void {
+  signal?.throwIfAborted();
+}
 
 async function readModuleSource(
   modulePath: string,
   diagnostics: Diagnostic[],
   importer?: string,
   preloadedText?: string,
+  signal?: AbortSignal,
 ): Promise<string | undefined> {
+  throwIfAborted(signal);
   try {
     return preloadedText ?? (await readFile(modulePath, 'utf8'));
   } catch (err) {
@@ -87,10 +98,12 @@ async function resolveIncludeSource(
   includeDirs: string[],
   diagnostics: Diagnostic[],
   sourceTexts: Map<string, string>,
+  signal?: AbortSignal,
 ): Promise<{ resolved: string; resolvedText: string } | 'hard-failure' | undefined> {
   const candidates = resolveIncludeCandidates(modulePath, spec, includeDirs);
 
   for (const c of candidates) {
+    throwIfAborted(signal);
     try {
       const resolvedText = await readFile(c, 'utf8');
       const resolvedKey = normalizePath(c);
@@ -132,8 +145,9 @@ async function expandIncludesForFile(args: {
   diagnostics: Diagnostic[];
   sourceTexts: Map<string, string>;
   includeStack: string[];
+  signal?: AbortSignal;
 }): Promise<ExpandedSource | undefined> {
-  const { modulePath, sourceText, includeDirs, diagnostics, sourceTexts, includeStack } = args;
+  const { modulePath, sourceText, includeDirs, diagnostics, sourceTexts, includeStack, signal } = args;
   const moduleKey = normalizePath(modulePath);
   if (!sourceTexts.has(moduleKey)) sourceTexts.set(moduleKey, sourceText);
   const lines = sourceText.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
@@ -142,6 +156,7 @@ async function expandIncludesForFile(args: {
   const lineBaseLines: number[] = [];
 
   for (let i = 0; i < lines.length; i++) {
+    throwIfAborted(signal);
     const raw = lines[i] ?? '';
     const stripped = stripLineComment(raw).trim();
     const lineNo = i + 1;
@@ -162,6 +177,7 @@ async function expandIncludesForFile(args: {
       includeDirs,
       diagnostics,
       sourceTexts,
+      signal,
     );
     if (resolvedInclude === 'hard-failure') return undefined;
     if (!resolvedInclude) {
@@ -193,6 +209,7 @@ async function expandIncludesForFile(args: {
       diagnostics,
       sourceTexts,
       includeStack: [...includeStack, resolvedInclude.resolved],
+      ...(signal ? { signal } : {}),
     });
     if (expanded === undefined) return undefined;
 
@@ -233,10 +250,12 @@ async function resolveImportSource(
   imp: ImportTarget,
   includeDirs: string[],
   diagnostics: Diagnostic[],
+  signal?: AbortSignal,
 ): Promise<{ resolved: string; resolvedText: string } | 'hard-failure' | undefined> {
   const candidates = resolveImportCandidates(modulePath, imp, includeDirs);
 
   for (const c of candidates) {
+    throwIfAborted(signal);
     try {
       return { resolved: c, resolvedText: await readFile(c, 'utf8') };
     } catch (err) {
@@ -377,7 +396,7 @@ function collectModuleTraversal(entryPath: string, edges: ModuleEdges): string[]
 export async function loadProgram(
   entryFile: string,
   diagnostics: Diagnostic[],
-  options: Pick<CompilerOptions, 'includeDirs'>,
+  options: LoadProgramOptions,
 ): Promise<LoadedProgram | undefined> {
   const entryPath = normalizePath(entryFile);
   const modules = new Map<string, ModuleFileNode>();
@@ -386,16 +405,18 @@ export async function loadProgram(
   const edges = new Map<string, Map<string, { line: number; column: number }>>();
   const includeDirs = (options.includeDirs ?? []).map(normalizePath);
   const moduleIdRootDir = dirname(entryPath);
+  const signal = options.signal;
 
   const loadModule = async (
     modulePath: string,
     importer?: string,
     preloadedText?: string,
   ): Promise<void> => {
+    throwIfAborted(signal);
     const p = normalizePath(modulePath);
     if (modules.has(p)) return;
 
-    const sourceText = await readModuleSource(p, diagnostics, importer, preloadedText);
+    const sourceText = await readModuleSource(p, diagnostics, importer, preloadedText, signal);
     if (sourceText === undefined) return;
     if (!sourceTexts.has(p)) sourceTexts.set(p, sourceText);
     const expanded = await expandIncludesForFile({
@@ -405,6 +426,7 @@ export async function loadProgram(
       diagnostics,
       sourceTexts,
       includeStack: [p],
+      ...(signal ? { signal } : {}),
     });
     if (expanded === undefined) return;
 
@@ -415,7 +437,7 @@ export async function loadProgram(
     edges.set(p, new Map());
 
     for (const imp of importTargets(moduleFile)) {
-      const resolvedImport = await resolveImportSource(p, imp, includeDirs, diagnostics);
+      const resolvedImport = await resolveImportSource(p, imp, includeDirs, diagnostics, signal);
       if (resolvedImport === 'hard-failure') return;
       if (!resolvedImport) continue;
 
@@ -424,7 +446,7 @@ export async function loadProgram(
     }
   };
 
-  await loadModule(entryPath);
+  await loadModule(entryPath, undefined, options.preloadedText);
   if (hasErrors(diagnostics)) return undefined;
 
   if (!validateCanonicalModuleIds(modules, moduleIdRootDir, diagnostics)) return undefined;

--- a/test/fixtures/coverage-map.md
+++ b/test/fixtures/coverage-map.md
@@ -11,10 +11,10 @@
 
 **Include/import graph cycles detected** (see section below).
 
-Total fixture files (excludes sentinels): 524
+Total fixture files (excludes sentinels): 529
 Sentinel files: 1
-Reachable from tests (direct refs ∪ fixture closure): 315
-Potentially unreferenced fixtures: 209
+Reachable from tests (direct refs ∪ fixture closure): 316
+Potentially unreferenced fixtures: 213
 
 ## Direct test reference counts
 
@@ -40,6 +40,7 @@ Potentially unreferenced fixtures: 209
 | isa_indexed_incdec.zax | 0 |
 | isa_indexed_ld.zax | 0 |
 | isa_indexed_rotates.zax | 0 |
+| issue1356_named_section_ld_bc_de_indirect.zax | 1 |
 | issue1356_named_section_ld_hl_indirect.zax | 1 |
 | parser_case_invalid_value_comma.zax | 1 |
 | parser_case_invalid_value_list.zax | 1 |
@@ -124,7 +125,11 @@ Potentially unreferenced fixtures: 209
 | pr1340_aggregate_param.zax | 1 |
 | pr1344_addr_of_type_positive.zax | 1 |
 | pr1344_self_ref_requires_addr.zax | 1 |
+| pr1349_ld_a_indirect_bc.zax | 0 |
+| pr1349_ld_a_indirect_de.zax | 0 |
 | pr1349_ld_a_indirect_hl.zax | 1 |
+| pr1349_ld_indirect_bc_store.zax | 0 |
+| pr1349_ld_indirect_de_store.zax | 0 |
 | pr135_isa_jr_djnz_invalid.zax | 0 |
 | pr135_isa_jr_djnz.zax | 0 |
 | pr136_bit_indexed_dest_invalid.zax | 1 |
@@ -614,6 +619,10 @@ Not reachable from any test’s literal `fixtures/...` reference via the include
 - pr12_call_wrong_arity.zax
 - pr12_extern_call.zax
 - pr12_func_call_forward.zax
+- pr1349_ld_a_indirect_bc.zax
+- pr1349_ld_a_indirect_de.zax
+- pr1349_ld_indirect_bc_store.zax
+- pr1349_ld_indirect_de_store.zax
 - pr135_isa_jr_djnz.zax
 - pr135_isa_jr_djnz_invalid.zax
 - pr138_rel8_out_of_range_matrix.zax
@@ -795,6 +804,7 @@ Excluded from the main fixture inventory (`.keep`, `.gitkeep`).
 | isa_indexed_incdec.zax |  |
 | isa_indexed_ld.zax |  |
 | isa_indexed_rotates.zax |  |
+| issue1356_named_section_ld_bc_de_indirect.zax | test/backend/issue1356_named_section_ld_hl.test.ts |
 | issue1356_named_section_ld_hl_indirect.zax | test/backend/issue1356_named_section_ld_hl.test.ts |
 | parser_case_invalid_value_comma.zax | test/frontend/pr97_parser_span_structured_control.test.ts |
 | parser_case_invalid_value_list.zax | test/frontend/pr97_parser_span_structured_control.test.ts |
@@ -879,7 +889,11 @@ Excluded from the main fixture inventory (`.keep`, `.gitkeep`).
 | pr1340_aggregate_param.zax | test/lowering/pr1340_aggregate_param.test.ts |
 | pr1344_addr_of_type_positive.zax | test/lowering/pr1344_addr_of_type.test.ts |
 | pr1344_self_ref_requires_addr.zax | test/lowering/pr1344_addr_of_type.test.ts |
+| pr1349_ld_a_indirect_bc.zax |  |
+| pr1349_ld_a_indirect_de.zax |  |
 | pr1349_ld_a_indirect_hl.zax | test/backend/pr1349_ld_a_indirect_hl_regression.test.ts |
+| pr1349_ld_indirect_bc_store.zax |  |
+| pr1349_ld_indirect_de_store.zax |  |
 | pr135_isa_jr_djnz_invalid.zax |  |
 | pr135_isa_jr_djnz.zax |  |
 | pr136_bit_indexed_dest_invalid.zax | test/pr136_bit_indexed_dest_invalid.test.ts |

--- a/test/public_api_surface.test.ts
+++ b/test/public_api_surface.test.ts
@@ -1,0 +1,119 @@
+import { execFile } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { ensureCliBuilt } from './helpers/cliBuild.js';
+
+const execFileAsync = promisify(execFile);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, '..');
+
+async function runPackageScript(source: string, args: string[] = []): Promise<unknown> {
+  const { stdout } = await execFileAsync('node', ['--input-type=module', '--eval', source, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  return JSON.parse(stdout.trim()) as unknown;
+}
+
+describe('public package API surface', () => {
+  beforeAll(async () => {
+    await ensureCliBuilt();
+  }, 180_000);
+
+  it('exposes tooling load/analyze through the stable subpath with preloaded entry text', async () => {
+    const entryFile = resolve(repoRoot, 'test', 'fixtures', 'virtual_public_api_entry.zax');
+    const source = `
+      import { analyzeProgram, loadProgram } from '@jhlagado/zax/tooling';
+
+      const result = await loadProgram({
+        entryFile: process.argv[1],
+        preloadedText: 'export func main()\\n    helper\\nend\\n\\nfunc helper()\\nend\\n',
+      });
+      const analysis = result.loadedProgram
+        ? analyzeProgram(result.loadedProgram, { requireMain: true })
+        : { diagnostics: [] };
+
+      console.log(JSON.stringify({
+        loadDiagnostics: result.diagnostics,
+        analyzed: Boolean(result.loadedProgram && analysis.env),
+        analysisDiagnostics: analysis.diagnostics,
+        programKind: result.loadedProgram?.program.kind ?? null,
+        fileCount: result.loadedProgram?.program.files.length ?? 0,
+      }));
+    `;
+
+    const output = (await runPackageScript(source, [entryFile])) as {
+      loadDiagnostics: unknown[];
+      analyzed: boolean;
+      analysisDiagnostics: unknown[];
+      programKind: string | null;
+      fileCount: number;
+    };
+
+    expect(output.loadDiagnostics).toEqual([]);
+    expect(output.analysisDiagnostics).toEqual([]);
+    expect(output.analyzed).toBe(true);
+    expect(output.programKind).toBe('Program');
+    expect(output.fileCount).toBe(1);
+  });
+
+  it('exposes compile through the stable compile subpath', async () => {
+    const entryFile = resolve(repoRoot, 'examples', 'hello.zax');
+    const source = `
+      import { compile, defaultFormatWriters } from '@jhlagado/zax/compile';
+
+      const result = await compile(
+        process.argv[1],
+        { emitListing: false, emitAsm80: false },
+        { formats: defaultFormatWriters },
+      );
+
+      console.log(JSON.stringify({
+        diagnostics: result.diagnostics,
+        artifactKinds: result.artifacts.map((artifact) => artifact.kind),
+      }));
+    `;
+
+    const output = (await runPackageScript(source, [entryFile])) as {
+      diagnostics: unknown[];
+      artifactKinds: string[];
+    };
+
+    expect(output.diagnostics).toEqual([]);
+    expect(output.artifactKinds).toEqual(['bin', 'hex', 'd8m']);
+  });
+
+  it('re-exports the stable surface from the package root', async () => {
+    const entryFile = resolve(repoRoot, 'test', 'fixtures', 'virtual_public_api_root.zax');
+    const source = `
+      import { DiagnosticIds, analyzeProgram, loadProgram } from '@jhlagado/zax';
+
+      const result = await loadProgram({
+        entryFile: process.argv[1],
+        preloadedText: 'export func main()\\nend\\n',
+      });
+      const analysis = result.loadedProgram ? analyzeProgram(result.loadedProgram) : { diagnostics: [] };
+
+      console.log(JSON.stringify({
+        hasProgram: Boolean(result.loadedProgram),
+        diagnostics: [...result.diagnostics, ...analysis.diagnostics],
+        semanticErrorId: DiagnosticIds.SemanticsError,
+      }));
+    `;
+
+    const output = (await runPackageScript(source, [entryFile])) as {
+      hasProgram: boolean;
+      diagnostics: unknown[];
+      semanticErrorId: string;
+    };
+
+    expect(output.hasProgram).toBe(true);
+    expect(output.diagnostics).toEqual([]);
+    expect(output.semanticErrorId).toBe('ZAX400');
+  });
+});


### PR DESCRIPTION
## Summary
- add stable package exports for root, compile, and tooling entry points
- expose load/analyze APIs for non-emitting tooling workflows, including entry preloaded text support
- document the tooling API and add public-surface tests that import through the package name

## Verification
- npm run typecheck
- npm run build
- npm test -- --run test/public_api_surface.test.ts