### PR TITLE
Fix invalid D8M synthetic segment lines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jhlagado/zax",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jhlagado/zax",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "GPL-3.0-only",
       "bin": {
         "zax": "dist/src/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jhlagado/zax",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "ZAX assembler for the Z80 family (Node.js CLI)",
   "license": "GPL-3.0-only",
   "engines": {

--- a/src/formats/writeD8m.ts
+++ b/src/formats/writeD8m.ts
@@ -152,6 +152,16 @@ function rangesOverlap(a: SymbolAddressRange, b: SymbolAddressRange): boolean {
   return a.start < b.end && b.start < a.end;
 }
 
+function hasOverlappingSourceSegment(
+  sourceSegmentsByFile: ReadonlyMap<string, EmittedSourceSegment[]>,
+  file: string,
+  range: SymbolAddressRange,
+): boolean {
+  return (sourceSegmentsByFile.get(file) ?? []).some((segment) =>
+    rangesOverlap({ start: segment.start, end: segment.end }, range),
+  );
+}
+
 /**
  * Create a minimal D8 Debug Map (D8M) v1 JSON artifact.
  *
@@ -229,6 +239,15 @@ export function writeD8m(
       confidence: segment.confidence,
     });
   }
+  const sourceSegmentsByFile = new Map<string, EmittedSourceSegment[]>();
+  for (const segment of normalizedSourceSegments) {
+    const entries = sourceSegmentsByFile.get(segment.file);
+    if (entries) {
+      entries.push(segment);
+    } else {
+      sourceSegmentsByFile.set(segment.file, [segment]);
+    }
+  }
 
   const symbolRangesByFile = new Map<string, SymbolAddressRange[]>();
   for (const symbol of serializedSymbols) {
@@ -258,10 +277,12 @@ export function writeD8m(
       .sort((a, b) => a.localeCompare(b));
     const targets = fileKeys.length > 0 ? fileKeys : [fileList[0] ?? ''];
     for (const target of targets) {
+      if (hasOverlappingSourceSegment(sourceSegmentsByFile, target, segmentRange)) continue;
       ensureFileEntry(target).segments.push({
         start: segment.start,
         end: segment.end,
-        lstLine: 0,
+        // Synthetic file-attribution segments have no exact source line; use a valid fallback.
+        lstLine: 1,
         kind: 'unknown',
         confidence: 'low',
       });

--- a/test/backend/pr1349_d8m_segment_line.test.ts
+++ b/test/backend/pr1349_d8m_segment_line.test.ts
@@ -37,7 +37,7 @@ describe('PR1349 D8M segment line (canonical source line)', () => {
     expect(code?.confidence).toBe('high');
   });
 
-  it('omits line on synthetic low-confidence segments when the source line is unknown', () => {
+  it('omits line and keeps lstLine valid on synthetic low-confidence segments', () => {
     const map: EmittedByteMap = {
       bytes: new Map<number, number>([[0x0200, 0xc9]]),
     };
@@ -53,6 +53,36 @@ describe('PR1349 D8M segment line (canonical source line)', () => {
     const low = segs.find((s) => s.kind === 'unknown' && s.confidence === 'low');
     expect(low).toBeDefined();
     expect(low).not.toHaveProperty('line');
-    expect(low?.lstLine).toBe(0);
+    expect(low?.lstLine).toBe(1);
+  });
+
+  it('does not emit overlapping synthetic file segments when source-attributed segments already exist', () => {
+    const map: EmittedByteMap = {
+      bytes: new Map<number, number>([
+        [0x0100, 0x00],
+        [0x0101, 0x00],
+      ]),
+      sourceSegments: [
+        {
+          start: 0x0100,
+          end: 0x0102,
+          file: 'sample.zax',
+          line: 42,
+          column: 1,
+          kind: 'code',
+          confidence: 'high',
+        },
+      ],
+    };
+    const symbols: SymbolEntry[] = [
+      { kind: 'label', name: 'sample', address: 0x0100, file: 'sample.zax', scope: 'global' },
+    ];
+    const artifact = writeD8m(map, symbols);
+    const files = artifact.json.files as Record<
+      string,
+      { segments?: Array<Record<string, unknown>> }
+    >;
+    const segs = files['sample.zax']?.segments ?? [];
+    expect(segs.some((s) => s.kind === 'unknown' && s.confidence === 'low')).toBe(false);
   });
 });

--- a/test/language-tour/00_call_with_arg_and_local_baseline.d8.json
+++ b/test/language-tour/00_call_with_arg_and_local_baseline.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 346,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 264,
           "end": 268,
           "lstLine": 3,

--- a/test/language-tour/01_args_locals_basics.d8.json
+++ b/test/language-tour/01_args_locals_basics.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 395,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 275,
           "lstLine": 2,

--- a/test/language-tour/02_fibonacci_args_locals.d8.json
+++ b/test/language-tour/02_fibonacci_args_locals.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 442,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 264,
           "end": 268,
           "lstLine": 3,

--- a/test/language-tour/03_globals_and_aliases.d8.json
+++ b/test/language-tour/03_globals_and_aliases.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 344,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 270,
           "lstLine": 6,
@@ -97,7 +90,7 @@
         {
           "start": 4096,
           "end": 4182,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/10_arrays_and_indexing.d8.json
+++ b/test/language-tour/10_arrays_and_indexing.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 363,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 270,
           "lstLine": 7,
@@ -129,7 +122,7 @@
         {
           "start": 4096,
           "end": 4220,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/11_records_and_fields.d8.json
+++ b/test/language-tour/11_records_and_fields.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 366,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 268,
           "end": 276,
           "lstLine": 11,
@@ -121,7 +114,7 @@
         {
           "start": 4096,
           "end": 4182,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/12_args_with_arrays_records.d8.json
+++ b/test/language-tour/12_args_with_arrays_records.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 373,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 284,
           "lstLine": 7,
@@ -113,7 +106,7 @@
         {
           "start": 4096,
           "end": 4220,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/13_structured_control_flow.d8.json
+++ b/test/language-tour/13_structured_control_flow.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 379,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 268,
           "end": 271,
           "lstLine": 6,
@@ -225,7 +218,7 @@
         {
           "start": 4096,
           "end": 4180,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/14_ops_and_calls.d8.json
+++ b/test/language-tour/14_ops_and_calls.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 333,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 270,
           "lstLine": 20,
@@ -113,7 +106,7 @@
         {
           "start": 4096,
           "end": 4190,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/30_scalar_byte_glob.d8.json
+++ b/test/language-tour/30_scalar_byte_glob.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 308,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 270,
           "lstLine": 7,
@@ -89,7 +82,7 @@
         {
           "start": 8192,
           "end": 8276,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/31_scalar_byte_frame.d8.json
+++ b/test/language-tour/31_scalar_byte_frame.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 314,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 270,
           "lstLine": 7,
@@ -89,7 +82,7 @@
         {
           "start": 8192,
           "end": 8276,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/32_scalar_word_glob.d8.json
+++ b/test/language-tour/32_scalar_word_glob.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 305,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 270,
           "lstLine": 7,
@@ -73,7 +66,7 @@
         {
           "start": 8192,
           "end": 8278,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/33_scalar_word_frame.d8.json
+++ b/test/language-tour/33_scalar_word_frame.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 318,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 273,
           "lstLine": 7,
@@ -81,7 +74,7 @@
         {
           "start": 8192,
           "end": 8278,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/34_byte_glob_const.d8.json
+++ b/test/language-tour/34_byte_glob_const.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 313,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 275,
           "lstLine": 7,
@@ -89,7 +82,7 @@
         {
           "start": 8192,
           "end": 8290,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/35_byte_glob_reg8.d8.json
+++ b/test/language-tour/35_byte_glob_reg8.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 342,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 284,
           "lstLine": 7,
@@ -89,7 +82,7 @@
         {
           "start": 8192,
           "end": 8290,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/36_byte_glob_reg16.d8.json
+++ b/test/language-tour/36_byte_glob_reg16.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 334,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 275,
           "lstLine": 7,
@@ -97,7 +90,7 @@
         {
           "start": 8192,
           "end": 8290,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/37_byte_fvar_const.d8.json
+++ b/test/language-tour/37_byte_fvar_const.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 356,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 301,
           "lstLine": 7,
@@ -89,7 +82,7 @@
         {
           "start": 8192,
           "end": 8290,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/38_byte_fvar_reg8.d8.json
+++ b/test/language-tour/38_byte_fvar_reg8.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 360,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 290,
           "lstLine": 7,
@@ -89,7 +82,7 @@
         {
           "start": 8192,
           "end": 8290,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/39_byte_fvar_reg16.d8.json
+++ b/test/language-tour/39_byte_fvar_reg16.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 352,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 275,
           "lstLine": 7,
@@ -97,7 +90,7 @@
         {
           "start": 8192,
           "end": 8290,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/40_byte_glob_fvar.d8.json
+++ b/test/language-tour/40_byte_glob_fvar.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 342,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 284,
           "lstLine": 7,
@@ -89,7 +82,7 @@
         {
           "start": 8192,
           "end": 8290,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/41_byte_fvar_fvar.d8.json
+++ b/test/language-tour/41_byte_fvar_fvar.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 362,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 290,
           "lstLine": 7,
@@ -89,7 +82,7 @@
         {
           "start": 8192,
           "end": 8290,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/42_byte_fvar_glob.d8.json
+++ b/test/language-tour/42_byte_fvar_glob.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 346,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 285,
           "lstLine": 8,
@@ -89,7 +82,7 @@
         {
           "start": 8192,
           "end": 8300,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/43_byte_glob_glob.d8.json
+++ b/test/language-tour/43_byte_glob_glob.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 326,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 279,
           "lstLine": 8,
@@ -89,7 +82,7 @@
         {
           "start": 8192,
           "end": 8300,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/60_word_glob_const.d8.json
+++ b/test/language-tour/60_word_glob_const.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 323,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 288,
           "lstLine": 7,
@@ -73,7 +66,7 @@
         {
           "start": 8192,
           "end": 8306,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/61_word_glob_reg8.d8.json
+++ b/test/language-tour/61_word_glob_reg8.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 345,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 287,
           "lstLine": 7,
@@ -73,7 +66,7 @@
         {
           "start": 8192,
           "end": 8306,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/62_word_glob_reg16.d8.json
+++ b/test/language-tour/62_word_glob_reg16.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 339,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 275,
           "lstLine": 7,
@@ -89,7 +82,7 @@
         {
           "start": 8192,
           "end": 8306,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/63_word_fvar_const.d8.json
+++ b/test/language-tour/63_word_fvar_const.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 363,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 305,
           "lstLine": 7,
@@ -73,7 +66,7 @@
         {
           "start": 8192,
           "end": 8306,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/64_word_fvar_reg8.d8.json
+++ b/test/language-tour/64_word_fvar_reg8.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 366,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 295,
           "lstLine": 7,
@@ -81,7 +74,7 @@
         {
           "start": 8192,
           "end": 8306,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/65_word_fvar_reg16.d8.json
+++ b/test/language-tour/65_word_fvar_reg16.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 361,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 275,
           "lstLine": 7,
@@ -97,7 +90,7 @@
         {
           "start": 8192,
           "end": 8306,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/66_word_glob_fvar.d8.json
+++ b/test/language-tour/66_word_glob_fvar.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 345,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 287,
           "lstLine": 7,
@@ -73,7 +66,7 @@
         {
           "start": 8192,
           "end": 8306,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/67_word_fvar_fvar.d8.json
+++ b/test/language-tour/67_word_fvar_fvar.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 366,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 295,
           "lstLine": 7,
@@ -81,7 +74,7 @@
         {
           "start": 8192,
           "end": 8306,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/68_word_fvar_glob.d8.json
+++ b/test/language-tour/68_word_fvar_glob.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 355,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 292,
           "lstLine": 8,
@@ -73,7 +66,7 @@
         {
           "start": 8192,
           "end": 8316,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }

--- a/test/language-tour/69_word_glob_glob.d8.json
+++ b/test/language-tour/69_word_glob_glob.d8.json
@@ -16,13 +16,6 @@
           "confidence": "high"
         },
         {
-          "start": 256,
-          "end": 329,
-          "lstLine": 0,
-          "kind": "unknown",
-          "confidence": "low"
-        },
-        {
           "start": 267,
           "end": 282,
           "lstLine": 8,
@@ -73,7 +66,7 @@
         {
           "start": 8192,
           "end": 8316,
-          "lstLine": 0,
+          "lstLine": 1,
           "kind": "unknown",
           "confidence": "low"
         }


### PR DESCRIPTION
## Summary
- stop emitting overlapping low-confidence synthetic file segments when source-attributed segments already cover the same range
- give remaining synthetic file-attribution segments a valid fallback `lstLine` instead of `0`
- add regression coverage for both behaviors

## Verification
- npm test -- --run test/backend/pr1349_d8m_segment_line.test.ts test/backend/pr241_d8m_contract_hardening.test.ts test/backend/pr200_d8m_appendix_mapping.test.ts