### PR TITLE
fix(ops): PortImm8 op parameter substitution (v0.2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.4
+
+- Op expansion: `imm8` / `imm16` parameters now substitute into immediate port operands (`in a,(n)` / `out (n), r` — `PortImm8`).
+
 ## Unreleased
 
 - Added stable `exports` entry points for `@jhlagado/zax`, `@jhlagado/zax/tooling`, and `@jhlagado/zax/compile`.

--- a/docs/spec/zax-spec.md
+++ b/docs/spec/zax-spec.md
@@ -1405,6 +1405,7 @@ Operand substitution (v0.1):
 - `op` parameters bind to parsed operands (AST operands), not text.
   - `reg8`/`reg16` parameters substitute the matched register token(s).
   - `imm8`/`imm16` parameters substitute the immediate expression value.
+  - Immediate port operands in `in a,(n)` / `out (n), r` use the same immediate expression substitution: the `n` position binds like other `imm8`/`imm16` parameters.
   - `ea` parameters substitute the storage-location expression (without implicit parentheses).
   - `mem8`/`mem16` parameters substitute the full dereference operand including parentheses.
     - Example: if `src: mem8` matches `(hero.flags)`, then `ld a, src` emits `ld a, (hero.flags)`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jhlagado/zax",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "ZAX assembler for the Z80 family (Node.js CLI)",
   "license": "GPL-3.0-only",
   "engines": {

--- a/src/lowering/opSubstitution.ts
+++ b/src/lowering/opSubstitution.ts
@@ -79,6 +79,9 @@ export function createOpSubstitutionHelpers(ctx: OpSubstitutionContext) {
       return { ...operand, expr: substituteImm(operand.expr) };
     }
     if (operand.kind === 'Imm') return { ...operand, expr: substituteImm(operand.expr) };
+    if (operand.kind === 'PortImm8') {
+      return { ...operand, expr: substituteImm(operand.expr) };
+    }
     if ((operand.kind === 'Ea' || operand.kind === 'Mem') && operand.expr.kind === 'EaName') {
       const bound = ctx.bindings.get(operand.expr.name.toLowerCase());
       if (bound?.kind === 'Ea') return ctx.cloneOperand(bound);
@@ -191,6 +194,9 @@ export function createOpSubstitutionHelpers(ctx: OpSubstitutionContext) {
         ...operand,
         expr: substituteEaWithOpLabels(operand.expr),
       };
+    }
+    if (operand.kind === 'PortImm8') {
+      return { ...operand, expr: substituteImmWithOpLabels(operand.expr, localLabelMap) };
     }
     return substituteOperand(operand);
   };

--- a/test/fixtures/coverage-map.md
+++ b/test/fixtures/coverage-map.md
@@ -11,9 +11,9 @@
 
 **Include/import graph cycles detected** (see section below).
 
-Total fixture files (excludes sentinels): 529
+Total fixture files (excludes sentinels): 530
 Sentinel files: 1
-Reachable from tests (direct refs ∪ fixture closure): 316
+Reachable from tests (direct refs ∪ fixture closure): 317
 Potentially unreferenced fixtures: 213
 
 ## Direct test reference counts
@@ -133,6 +133,7 @@ Potentially unreferenced fixtures: 213
 | pr135_isa_jr_djnz_invalid.zax | 0 |
 | pr135_isa_jr_djnz.zax | 0 |
 | pr136_bit_indexed_dest_invalid.zax | 1 |
+| pr1367_op_port_imm_substitution.zax | 1 |
 | pr137_cb_rotate_two_operand_invalid.zax | 1 |
 | pr138_rel8_out_of_range_matrix.zax | 0 |
 | pr138_rel8_valid_matrix.zax | 0 |
@@ -897,6 +898,7 @@ Excluded from the main fixture inventory (`.keep`, `.gitkeep`).
 | pr135_isa_jr_djnz_invalid.zax |  |
 | pr135_isa_jr_djnz.zax |  |
 | pr136_bit_indexed_dest_invalid.zax | test/pr136_bit_indexed_dest_invalid.test.ts |
+| pr1367_op_port_imm_substitution.zax | test/lowering/pr1367_op_port_imm_substitution.test.ts |
 | pr137_cb_rotate_two_operand_invalid.zax | test/pr137_cb_rotate_two_operand_invalid.test.ts |
 | pr138_rel8_out_of_range_matrix.zax |  |
 | pr138_rel8_valid_matrix.zax |  |

--- a/test/fixtures/pr1367_op_port_imm_substitution.zax
+++ b/test/fixtures/pr1367_op_port_imm_substitution.zax
@@ -1,0 +1,24 @@
+; PR1367: imm8 op parameters substitute into in/out immediate port operands (PortImm8).
+
+const PORT_RED = $06
+const PORT_GREEN = $F8
+
+op out_from_hl(p: imm8)
+  ld a, (hl)
+  out (p), a
+  inc hl
+end
+
+op in_to_a(p: imm8)
+  in a, (p)
+end
+
+section code main at $8000
+export func main(): AF, BC, DE, HL
+  ld hl, $9000
+  out_from_hl PORT_RED
+  out_from_hl PORT_GREEN
+  in_to_a PORT_RED
+  ret
+end
+end

--- a/test/lowering/pr1367_op_port_imm_substitution.test.ts
+++ b/test/lowering/pr1367_op_port_imm_substitution.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR1367: op imm8 substitution into PortImm8 (in/out immediate port)', () => {
+  it('compiles ops that use out (p), a and in a, (p) with imm8 parameters', async () => {
+    const entry = join(__dirname, '..', 'fixtures', 'pr1367_op_port_imm_substitution.zax');
+    const res = await compile(entry, { emitListing: false, emitAsm80: false }, { formats: defaultFormatWriters });
+    expect(res.diagnostics).toEqual([]);
+    const bin = res.artifacts.find((a) => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin || bin.kind !== 'bin') return;
+    const bytes = bin.bytes;
+    expect(bytes.includes(0xd3)).toBe(true);
+    expect(bytes.includes(0x06)).toBe(true);
+    expect(bytes.includes(0xf8)).toBe(true);
+    expect(bytes.includes(0xdb)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Substitute `imm8`/`imm16` op parameters into `in a,(n)` / `out (n), r` (`PortImm8` operands).
- Spec note + PR1367 fixture and lowering test.

## Version
- **0.2.4** (patch)

## Verification
- `npm run build && npm test -- test/lowering/pr1367_op_port_imm_substitution.test.ts`

Made with [Cursor](https://cursor.com)