### PR TITLE
[codex] advance MON3 ASM80 acceptance

### DIFF
--- a/docs/design/asm80-compatibility-baseline.md
+++ b/docs/design/asm80-compatibility-baseline.md
@@ -161,7 +161,11 @@ slice of this baseline:
 
 The remaining baseline work is to harden acceptance around the full MON3 build:
 
-- compare ZAX output against the current ASM80/MON3 reference artifact
+- resolve the current MON3 source/reference metadata mismatch: ZAX now compiles
+  the recursive source tree without diagnostics and emits 16 KiB, but the
+  opt-in byte comparison first differs at output offset `0x3ff8` because the
+  source defines `REL_TXT: .equ "2025.16"` while the checked-in reference binary
+  contains `BC25.16`
 - make source-location diagnostics good enough for real MON3 failures
 - keep expanding tests from real MON3 slices rather than synthetic syntax only
 - decide how `.asm` and `.z80` are introduced into the wider Debug80 toolchain

--- a/src/frontend/asm80/parseClassicModule.ts
+++ b/src/frontend/asm80/parseClassicModule.ts
@@ -132,11 +132,13 @@ export function parseClassicModule(
   const file = makeSourceFile(path, sourceText);
   const items: ClassicItemNode[] = [];
   let pendingRawLabel: AsmLabelNode | undefined;
+  let ended = false;
 
   const lines = sourceText.split(/\r?\n/);
   const stringEquates = new Map<string, string>();
   for (let index = 0; index < lines.length; index++) {
     const parsed = parseClassicLine(path, lines[index]!, index + 1, file.lineStarts[index] ?? 0);
+    if (parsed?.kind === 'end') break;
     if (parsed?.kind !== 'equ') continue;
     const rawString = parseWholeQuotedString(parsed.exprText);
     if (rawString !== undefined && rawString.length > 1) {
@@ -150,6 +152,7 @@ export function parseClassicModule(
     const lineSpan = span(file, lineStart, rawLineEndOffset(sourceText, lineStart));
     const parsed = parseClassicLine(path, raw, index + 1, lineStart);
     if (!parsed) continue;
+    if (ended && parsed.kind !== 'binfrom') continue;
 
     switch (parsed.kind) {
       case 'label': {
@@ -241,7 +244,9 @@ export function parseClassicModule(
       }
       case 'end':
         items.push({ kind: 'ClassicEnd', span: lineSpan });
-        return { kind: 'ClassicModuleFile', span: span(file, 0, sourceText.length), path, items };
+        ended = true;
+        pendingRawLabel = undefined;
+        break;
     }
   }
 

--- a/src/lowering/classicInstructionLowering.ts
+++ b/src/lowering/classicInstructionLowering.ts
@@ -113,6 +113,9 @@ function memSymbolicTarget(
     (op.expr.kind === 'EaAdd' || op.expr.kind === 'EaSub') &&
     op.expr.base.kind === 'EaName'
   ) {
+    if (op.expr.base.name.toUpperCase() === 'IX' || op.expr.base.name.toUpperCase() === 'IY') {
+      return undefined;
+    }
     return ctx.symbolicTargetFromExpr({
       kind: 'ImmBinary',
       span: op.span,

--- a/src/lowering/programLoweringFinalize.ts
+++ b/src/lowering/programLoweringFinalize.ts
@@ -88,6 +88,9 @@ export function finalizeProgramEmission(ctx: ProgramEmissionFinalizeContext): {
     if (!ok) continue;
     addrByNameLower.set(ps.name.toLowerCase(), base + ps.offset);
   }
+  for (const [name, value] of ctx.env.consts) {
+    addrByNameLower.set(name.toLowerCase(), value);
+  }
   for (const sym of ctx.symbols) {
     if (sym.kind === 'constant') continue;
     addrByNameLower.set(sym.name.toLowerCase(), sym.address);

--- a/test/asm80/asm80_directives_integration.test.ts
+++ b/test/asm80/asm80_directives_integration.test.ts
@@ -200,6 +200,42 @@ describe('asm80 directive lowering integration', () => {
     expect([...bin.bytes]).toEqual([0x41, 0x00]);
   });
 
+  it('resolves classic equates used as absolute memory operands', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-equ-abs-mem-'));
+    const entry = join(dir, 'equ-abs-mem.z80');
+    writeFileSync(
+      entry,
+      ['.org 0100H', 'BUF: .equ 0900H', 'ld hl,(BUF)', '.binfrom 0100H', '.end'].join('\n'),
+      'utf8',
+    );
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin) throw new Error('missing bin artifact');
+    expect([...bin.bytes]).toEqual([0x2a, 0x00, 0x09]);
+  });
+
+  it('compiles classic IX/IY indexed memory operands', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-ixiy-indexed-'));
+    const entry = join(dir, 'ixiy-indexed.z80');
+    writeFileSync(
+      entry,
+      ['.org 0100H', 'ld a,(ix+0)', 'ld a,(iy+12)', '.binfrom 0100H', '.end'].join('\n'),
+      'utf8',
+    );
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin) throw new Error('missing bin artifact');
+    expect([...bin.bytes]).toEqual([0xdd, 0x7e, 0x00, 0xfd, 0x7e, 0x0c]);
+  });
+
   it('emits parsed db string fragments and string-character expressions', () => {
     const diagnostics: Diagnostic[] = [];
     const module = parseClassicModuleFile(

--- a/test/frontend/asm80_classic_module.test.ts
+++ b/test/frontend/asm80_classic_module.test.ts
@@ -85,6 +85,39 @@ describe('classic ASM80 module parser', () => {
     });
   });
 
+  it('keeps post-end binfrom while ignoring ordinary post-end source', () => {
+    const diagnostics: unknown[] = [];
+    const module = parseClassicModule(
+      '/classic.z80',
+      ['.org 0100H', '.db 1', '.end', 'after: nop', '.binfrom 0100H'].join('\n'),
+      diagnostics as never[],
+    );
+
+    expect(diagnostics).toEqual([]);
+    expect(module.items.map((item: ClassicItemNode) => item.kind)).toEqual([
+      'ClassicOrg',
+      'ClassicRawData',
+      'ClassicEnd',
+      'ClassicBinFrom',
+    ]);
+  });
+
+  it('does not let post-end string equates affect pre-end raw data', () => {
+    const diagnostics: unknown[] = [];
+    const module = parseClassicModule(
+      '/classic.z80',
+      ['.db MSG', '.end', 'MSG: .equ "XY"'].join('\n'),
+      diagnostics as never[],
+    );
+
+    expect(diagnostics).toEqual([]);
+    expect(module.items[0]).toMatchObject({
+      kind: 'ClassicRawData',
+      directive: 'db',
+      values: [{ kind: 'ImmName', name: 'MSG' }],
+    });
+  });
+
   it('parses MON3 db string fragments without splitting quoted contents', () => {
     const diagnostics: unknown[] = [];
     const module = parseClassicModule(

--- a/test/frontend/issue1356_parse_classic_mem_indirect.test.ts
+++ b/test/frontend/issue1356_parse_classic_mem_indirect.test.ts
@@ -18,4 +18,5 @@ describe('Issue #1356: (hl)/(bc)/(de) asm mem operands are register-indirect', (
     expect(op.expr.name).toMatch(/^(HL|BC|DE)$/);
     expect(op.expr.name).toBe(text.replace(/[()]/g, '').toUpperCase());
   });
+
 });


### PR DESCRIPTION
## Summary\n- resolve classic .equ constants during final 16-bit fixup resolution so MON3 equated memory operands assemble\n- parse classic (ix+d)/(iy+d) operands as indexed memory and teach the Z80 encoder to consume that form\n- preserve post-.end .binfrom from real classic source while still ignoring ordinary post-end code\n- document the current MON3 source/reference metadata mismatch now that ZAX reaches same-length output\n\n## Verification\n- npm run typecheck -- --pretty false\n- npm run lint\n- npm run check:source-file-sizes:enforce\n- npx vitest run test/frontend/asm80_classic_module.test.ts test/frontend/issue1356_parse_classic_mem_indirect.test.ts test/asm80/asm80_directives_integration.test.ts test/asm80/mon3_acceptance.test.ts test/asm80/mon3_opcode_gap.test.ts\n- git diff --check\n\n## MON3 opt-in status\n- ZAX now compiles /Users/johnhardy/Documents/projects/MON3/src/mon3.z80 without diagnostics and emits a 16384-byte binary.\n- The opt-in byte-for-byte check still fails at output offset 0x3ff8: actual 0x32 (source string "2025.16") vs reference 0x42 (reference string "BC25.16"). The MON3 source and MON3 source zip both currently define REL_TXT as "2025.16", while the checked-in reference binary contains "BC25.16".