### PR TITLE
[codex] compare MON3 against fresh ASM80 reference

### DIFF
--- a/docs/design/asm80-compatibility-baseline.md
+++ b/docs/design/asm80-compatibility-baseline.md
@@ -161,11 +161,9 @@ slice of this baseline:
 
 The remaining baseline work is to harden acceptance around the full MON3 build:
 
-- resolve the current MON3 source/reference metadata mismatch: ZAX now compiles
-  the recursive source tree without diagnostics and emits 16 KiB, but the
-  opt-in byte comparison first differs at output offset `0x3ff8` because the
-  source defines `REL_TXT: .equ "2025.16"` while the checked-in reference binary
-  contains `BC25.16`
+- keep the opt-in MON3 byte comparison tied to a fresh ASM80 build from the
+  same source tree, not to the checked-in release binary; the release binary can
+  carry patched metadata that differs from the published source
 - make source-location diagnostics good enough for real MON3 failures
 - keep expanding tests from real MON3 slices rather than synthetic syntax only
 - decide how `.asm` and `.z80` are introduced into the wider Debug80 toolchain

--- a/scripts/dev/compare-mon3-binary.mjs
+++ b/scripts/dev/compare-mon3-binary.mjs
@@ -1,19 +1,21 @@
 #!/usr/bin/env node
-import { existsSync, readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { copyFileSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(__filename), '..', '..');
 const defaultSource = '/Users/johnhardy/Documents/projects/MON3/src/mon3.z80';
-const defaultReference = '/Users/johnhardy/Documents/projects/MON3/MON3-1G_BC25-16.bin';
 
 function usage() {
   return [
     'Usage: node scripts/dev/compare-mon3-binary.mjs [source.z80] [reference.bin]',
     '',
     `Default source: ${defaultSource}`,
-    `Default reference: ${defaultReference}`,
+    'Default reference: fresh asm80 build from the same source tree',
+    'Set ASM80 or ASM80_PATH to choose the asm80 executable.',
   ].join('\n');
 }
 
@@ -63,6 +65,10 @@ function summarizeBinaryMismatch(actual, reference) {
   return lines.join('\n');
 }
 
+function normalizeExecutableCandidate(candidate) {
+  return candidate.includes('/') || candidate.includes('\\') ? resolve(candidate) : candidate;
+}
+
 async function loadCompiler() {
   const compilePath = resolve(repoRoot, 'dist', 'src', 'compile.js');
   const formatsPath = resolve(repoRoot, 'dist', 'src', 'formats', 'index.js');
@@ -77,6 +83,60 @@ async function loadCompiler() {
   return { compile, defaultFormatWriters };
 }
 
+function findAsm80() {
+  const candidates = [
+    process.env.ASM80,
+    process.env.ASM80_PATH,
+    '/Users/johnhardy/Documents/projects/debug80/node_modules/.bin/asm80',
+    'asm80',
+  ]
+    .filter((candidate) => candidate && candidate.trim().length > 0)
+    .map(normalizeExecutableCandidate);
+  for (const candidate of candidates) {
+    const probe = spawnSync(candidate, ['-h'], { encoding: 'utf8' });
+    if (!probe.error) return candidate;
+  }
+  return undefined;
+}
+
+function copyAsm80SourceTree(source, outDir) {
+  for (const entry of readdirSync(dirname(source))) {
+    if (entry.toLowerCase().endsWith('.z80')) {
+      copyFileSync(join(dirname(source), entry), join(outDir, entry));
+    }
+  }
+}
+
+function buildAsm80Reference(source, asm80) {
+  const outDir = mkdtempSync(join(tmpdir(), 'zax-mon3-asm80-reference-'));
+  const outName = 'mon3-reference.bin';
+  const outBin = join(outDir, outName);
+  try {
+    copyAsm80SourceTree(source, outDir);
+    const result = spawnSync(
+      asm80,
+      ['-m', 'Z80', '-t', 'bin', '-o', outName, basename(source)],
+      {
+        cwd: outDir,
+        encoding: 'utf8',
+      },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(
+        [
+          `asm80 failed with status ${result.status}`,
+          result.stdout.trim(),
+          result.stderr.trim(),
+        ].filter((part) => part.length > 0).join('\n'),
+      );
+    }
+    return readFileSync(outBin);
+  } finally {
+    rmSync(outDir, { recursive: true, force: true });
+  }
+}
+
 async function main(argv) {
   if (argv.includes('--help') || argv.includes('-h')) {
     console.log(usage());
@@ -88,9 +148,11 @@ async function main(argv) {
   }
 
   const source = argv[0] ?? defaultSource;
-  const referencePath = argv[1] ?? defaultReference;
+  const referencePath = argv[1];
   if (!existsSync(source)) throw new Error(`MON3 source not found: ${source}`);
-  if (!existsSync(referencePath)) throw new Error(`Reference binary not found: ${referencePath}`);
+  if (referencePath !== undefined && !existsSync(referencePath)) {
+    throw new Error(`Reference binary not found: ${referencePath}`);
+  }
 
   const { compile, defaultFormatWriters } = await loadCompiler();
   const res = await compile(
@@ -110,7 +172,14 @@ async function main(argv) {
   if (!bin) throw new Error('Compiler did not emit a bin artifact.');
 
   const actual = Buffer.from(bin.bytes);
-  const reference = readFileSync(referencePath);
+  let reference;
+  if (referencePath !== undefined) {
+    reference = readFileSync(referencePath);
+  } else {
+    const asm80 = findAsm80();
+    if (!asm80) throw new Error('asm80 executable not found. Set ASM80 or ASM80_PATH.');
+    reference = buildAsm80Reference(source, asm80);
+  }
   console.log(summarizeBinaryMismatch(actual, reference));
   return actual.length === reference.length && findFirstMismatch(actual, reference) === -1 ? 0 : 1;
 }

--- a/test/asm80/mon3_acceptance.test.ts
+++ b/test/asm80/mon3_acceptance.test.ts
@@ -1,5 +1,7 @@
-import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { copyFileSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
@@ -17,12 +19,28 @@ const classicAsm80Available = existsSync(classicParserPath);
 const classicModuleLoweringAvailable = true;
 const manifest = {
   source: '/Users/johnhardy/Documents/projects/MON3/src/mon3.z80',
-  referenceBin: '/Users/johnhardy/Documents/projects/MON3/MON3-1G_BC25-16.bin',
 };
-const mon3FilesAvailable = existsSync(manifest.source) && existsSync(manifest.referenceBin);
+
+function normalizeExecutableCandidate(candidate: string): string {
+  return candidate.includes('/') || candidate.includes('\\') ? resolve(candidate) : candidate;
+}
+
+const asm80Candidates = [
+  process.env.ASM80,
+  process.env.ASM80_PATH,
+  '/Users/johnhardy/Documents/projects/debug80/node_modules/.bin/asm80',
+  'asm80',
+]
+  .filter((candidate): candidate is string => candidate !== undefined && candidate.trim().length > 0)
+  .map(normalizeExecutableCandidate);
+const asm80 = asm80Candidates.find((candidate) => {
+  const probe = spawnSync(candidate, ['-h'], { encoding: 'utf8' });
+  return !probe.error;
+});
+const mon3FilesAvailable = existsSync(manifest.source);
 const runMon3Acceptance = process.env.ZAX_RUN_MON3_ACCEPTANCE === '1';
 const describeMon3 =
-  classicAsm80Available && classicModuleLoweringAvailable && mon3FilesAvailable && runMon3Acceptance
+  classicAsm80Available && classicModuleLoweringAvailable && mon3FilesAvailable && asm80 && runMon3Acceptance
     ? describe
     : describe.skip;
 
@@ -71,6 +89,45 @@ function summarizeBinaryMismatch(actual: Buffer, reference: Buffer): string {
     lines.push('First mismatch: none');
   }
   return lines.join('\n');
+}
+
+function copyAsm80SourceTree(source: string, outDir: string): void {
+  for (const entry of readdirSync(dirname(source))) {
+    if (entry.toLowerCase().endsWith('.z80')) {
+      copyFileSync(join(dirname(source), entry), join(outDir, entry));
+    }
+  }
+}
+
+function buildAsm80Reference(source: string): Buffer {
+  if (!asm80) throw new Error('asm80 executable not found');
+  const outDir = mkdtempSync(join(tmpdir(), 'zax-mon3-asm80-reference-'));
+  const outName = 'mon3-reference.bin';
+  const outBin = join(outDir, outName);
+  try {
+    copyAsm80SourceTree(source, outDir);
+    const result = spawnSync(
+      asm80,
+      ['-m', 'Z80', '-t', 'bin', '-o', outName, basename(source)],
+      {
+        cwd: outDir,
+        encoding: 'utf8',
+      },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(
+        [
+          `asm80 failed with status ${result.status}`,
+          result.stdout.trim(),
+          result.stderr.trim(),
+        ].filter((part) => part.length > 0).join('\n'),
+      );
+    }
+    return readFileSync(outBin);
+  } finally {
+    rmSync(outDir, { recursive: true, force: true });
+  }
 }
 
 describe('MON3 acceptance failure summaries', () => {
@@ -124,7 +181,7 @@ describe('MON3 acceptance failure summaries', () => {
 });
 
 describeMon3('ASM80 MON3 acceptance', () => {
-  it('compiles MON3 and matches the reference binary bytes', async () => {
+  it('compiles MON3 and matches a fresh ASM80-built reference binary', async () => {
     const res = await compile(
       manifest.source,
       { emitBin: true, emitHex: false, emitD8m: false, emitListing: false },
@@ -138,7 +195,7 @@ describeMon3('ASM80 MON3 acceptance', () => {
     if (!bin) throw new Error('missing bin artifact');
 
     const actual = Buffer.from(bin.bytes);
-    const expected = readFileSync(manifest.referenceBin);
+    const expected = buildAsm80Reference(manifest.source);
     const binarySummary = summarizeBinaryMismatch(actual, expected);
 
     if (actual.length !== expected.length || findFirstMismatch(actual, expected) !== -1) {
@@ -153,7 +210,11 @@ if (!classicAsm80Available || !classicModuleLoweringAvailable) {
   });
 } else if (!mon3FilesAvailable) {
   describe('ASM80 MON3 acceptance', () => {
-    it.todo('skipped: local MON3 source/reference binary is unavailable');
+    it.todo('skipped: local MON3 source is unavailable');
+  });
+} else if (!asm80) {
+  describe('ASM80 MON3 acceptance', () => {
+    it.todo('skipped: asm80 executable is unavailable');
   });
 } else if (!runMon3Acceptance) {
   describe('ASM80 MON3 acceptance', () => {

--- a/test/fixtures/asm80/mon3-manifest.json
+++ b/test/fixtures/asm80/mon3-manifest.json
@@ -1,4 +1,4 @@
 {
   "source": "/Users/johnhardy/Documents/projects/MON3/src/mon3.z80",
-  "referenceBin": "/Users/johnhardy/Documents/projects/MON3/MON3-1G_BC25-16.bin"
+  "reference": "fresh asm80 build from source"
 }


### PR DESCRIPTION
## Summary
- build the MON3 acceptance reference by running ASM80 against a temp copy of the same source tree
- stop using the checked-in MON3 release binary as the default comparison target, because it can contain patched metadata that differs from source
- keep explicit reference-binary comparison available in the dev script for manual investigations
- update the ASM80 baseline notes and MON3 fixture manifest to describe the fresh-reference policy

## Reviewer Notes
The immediate issue was `REL_TXT: .equ "2025.16"`: both ZAX and a fresh ASM80 build from source emit `2025.16`, while the checked-in `MON3-1G_BC25-16.bin` contains `BC25.16`. That makes the release binary a poor default oracle for source compatibility.

The opt-in acceptance test now copies the MON3 `.z80` source siblings into a temporary directory, runs ASM80 there, and compares ZAX output against that generated binary. This avoids writing artifacts into `/Users/johnhardy/Documents/projects/MON3` and avoids relying on stale or patched release metadata.

`node scripts/dev/compare-mon3-binary.mjs` follows the same default behavior. Passing an explicit `[reference.bin]` still works for checking release binaries or investigating patched images.

## Verification
- `ZAX_RUN_MON3_ACCEPTANCE=1 npx vitest run test/asm80/mon3_acceptance.test.ts`
- `npm run build`
- `npx vitest run test/asm80/mon3_opcode_gap.test.ts test/asm80/mon3_acceptance.test.ts`
- `node scripts/dev/compare-mon3-binary.mjs`
- `npm run typecheck -- --pretty false`
- `npm run check:source-file-sizes:enforce`
- `git diff --check`
- `npm run lint`
- `npm run check:fixture-coverage`
