### PR TITLE
[codex] add TEC-1G ASM80 compatibility baseline

### DIFF
--- a/docs/design/asm80-compatibility-baseline.md
+++ b/docs/design/asm80-compatibility-baseline.md
@@ -168,6 +168,11 @@ The remaining baseline work is to harden acceptance around the full MON3 build:
 - keep expanding tests from real MON3 slices rather than synthetic syntax only
 - decide how `.asm` and `.z80` are introduced into the wider Debug80 toolchain
 
+The secondary TEC-1G software corpus is tracked in
+`docs/design/asm80-tec1g-compatibility-audit.md`. It deliberately excludes
+sources containing `.macro`/`.endm`, and currently verifies 12 non-macro TEC-1G
+programs byte-for-byte against ASM80.
+
 ## Acceptance threshold
 
 The compatibility baseline is reached when:

--- a/docs/design/asm80-tec1g-compatibility-audit.md
+++ b/docs/design/asm80-tec1g-compatibility-audit.md
@@ -1,0 +1,117 @@
+# ASM80 TEC-1G compatibility audit
+
+Status: compatibility baseline input for the ASM80-first language track
+Date: 2026-05-11
+
+## Purpose
+
+This audit extends the MON3 compatibility baseline with standalone TEC-1G
+software examples. The goal is still not full ASM80 compatibility. The goal is
+to support ordinary Z80 assembler source that matches the macro-free style used
+by MON3 and common TEC-1G examples.
+
+## Corpus
+
+Root:
+
+- `/Users/johnhardy/Documents/projects/TEC-1G/Software`
+
+Included files:
+
+- `Education/FastForw.z80`
+- `Education/TECMag.z80`
+- `Games/GOL.z80`
+- `Games/Games.z80`
+- `Games/Invader.z80`
+- `Games/Invaders.z80`
+- `Games/LCDRun.z80`
+- `Games/MagicSq.z80`
+- `Games/Maze.z80`
+- `Games/MazeMan.z80`
+- `Games/Snake.z80`
+- `Music/Banger.z80`
+
+Excluded files:
+
+- `Education/tbasic.z80`
+
+`tbasic.z80` is excluded because it contains ASM80 text macros:
+
+```asm
+.macro DWA
+        .db msb(%%1) + 128
+        .db lsb(%%1)
+.endm
+```
+
+Macro-bearing files are deliberately outside the baseline. If this source is
+revisited, the preferred direction is to translate the specific behavior into a
+ZAX `ops`-style facility or a narrow assembler directive, not to implement the
+ASM80 text macro system.
+
+## Added Coverage
+
+Compared with the MON3 baseline, the TEC-1G non-macro corpus adds useful
+coverage for these forms:
+
+- undotted directives: `ORG`, `EQU`, `DB`, `DW`, `DS`
+- mixed-case and dotted variants such as `.ORG` and `.END`
+- `DS count` and `DS count,fill`
+- `.binto` as an inclusive binary upper-bound directive
+- `0xNN` hexadecimal literals in equates
+- classic files without `.end`
+- classic files without `.org`, which start at address zero under ASM80
+- `SRA A`
+- absolute 16-bit register stores such as `LD (ASCII_STR),HL`
+
+The corpus also reinforces existing MON3 requirements:
+
+- trailing-`H` hex and trailing-`B` binary literals
+- current-location `$` expressions
+- symbol arithmetic in operands and equates
+- single- and double-quoted string data in `DB`
+- IX/IY displacement operands
+
+## Current Result
+
+The repeatable audit command is:
+
+```bash
+npm run build
+node scripts/dev/compare-tec1g-corpus.mjs
+```
+
+Current result:
+
+```text
+Included .z80 files: 12
+Excluded macro files: 1
+EXCLUDED macro Education/tbasic.z80
+Education/FastForw.z80: match bytes=175
+Education/TECMag.z80: match bytes=2399
+Games/Games.z80: match bytes=1869
+Games/GOL.z80: match bytes=425
+Games/Invader.z80: match bytes=1441
+Games/Invaders.z80: match bytes=1021
+Games/LCDRun.z80: match bytes=666
+Games/MagicSq.z80: match bytes=322
+Games/Maze.z80: match bytes=1791
+Games/MazeMan.z80: match bytes=995
+Games/Snake.z80: match bytes=724
+Music/Banger.z80: match bytes=38
+```
+
+ASM80 emits full 64 KiB binaries for several origin-based sources that do not
+use `.binfrom`. The comparison script normalizes those by comparing ZAX output
+against the ASM80 byte range beginning at the first `ORG` address. Files that
+use `.binfrom`/`.binto` compare directly against ASM80's cropped output.
+
+## Baseline Decision
+
+The TEC-1G non-macro corpus is now acceptable as a secondary ASM80 baseline:
+
+- MON3 remains the primary replacement target.
+- TEC-1G non-macro files are a broader regression corpus for common assembler
+  style.
+- Macro-bearing sources are excluded until ZAX has a deliberate higher-level
+  answer for that use case.

--- a/scripts/dev/compare-tec1g-corpus.mjs
+++ b/scripts/dev/compare-tec1g-corpus.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+import { copyFileSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { basename, dirname, join, relative, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(__filename), '..', '..');
+const defaultRoot = '/Users/johnhardy/Documents/projects/TEC-1G/Software';
+
+function usage() {
+  return [
+    'Usage: node scripts/dev/compare-tec1g-corpus.mjs [software-root]',
+    '',
+    `Default software root: ${defaultRoot}`,
+    'Files containing .macro or .endm are excluded from the baseline corpus.',
+    'Set ASM80 or ASM80_PATH to choose the asm80 executable.',
+  ].join('\n');
+}
+
+function normalizeExecutableCandidate(candidate) {
+  return candidate.includes('/') || candidate.includes('\\') ? resolve(candidate) : candidate;
+}
+
+function findAsm80() {
+  const candidates = [
+    process.env.ASM80,
+    process.env.ASM80_PATH,
+    '/Users/johnhardy/Documents/projects/debug80/node_modules/.bin/asm80',
+    'asm80',
+  ]
+    .filter((candidate) => candidate && candidate.trim().length > 0)
+    .map(normalizeExecutableCandidate);
+  for (const candidate of candidates) {
+    const probe = spawnSync(candidate, ['-h'], { encoding: 'utf8' });
+    if (!probe.error) return candidate;
+  }
+  return undefined;
+}
+
+function walkZ80Files(root) {
+  const out = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkZ80Files(path));
+    } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.z80')) {
+      out.push(path);
+    }
+  }
+  return out.sort((a, b) => a.localeCompare(b));
+}
+
+function isMacroSource(source) {
+  const text = readFileSync(source, 'utf8');
+  return /^\s*\.?(macro|endm)\b/im.test(text);
+}
+
+function run(command, args, options) {
+  return spawnSync(command, args, { encoding: 'utf8', ...options });
+}
+
+function parseListingWrittenRange(listingPath) {
+  const text = readFileSync(listingPath, 'utf8');
+  let start;
+  let end = 0;
+  for (const line of text.split(/\r?\n/)) {
+    const match = /^([0-9A-Fa-f]{4})\s+/.exec(line);
+    if (!match) continue;
+    const address = Number.parseInt(match[1], 16);
+    const bytes = line
+      .slice(7, 31)
+      .trim()
+      .split(/\s+/)
+      .filter((token) => /^[0-9A-Fa-f]{2}$/.test(token)).length;
+    if (bytes === 0) continue;
+    start = start === undefined ? address : Math.min(start, address);
+    end = Math.max(end, address + bytes);
+  }
+  return { start: start ?? 0, end };
+}
+
+function binaryFromListingRange(bytes, range) {
+  if (bytes.length !== 0x10000) return bytes;
+  let end = range.end;
+  for (let index = bytes.length - 1; index >= range.start; index--) {
+    if (bytes[index] !== 0) {
+      end = Math.max(end, index + 1);
+      break;
+    }
+  }
+  return bytes.subarray(range.start, end);
+}
+
+function runAsm80(source, asm80) {
+  const workDir = mkdtempSync(join(tmpdir(), 'zax-tec1g-asm80-one-'));
+  const outName = `${basename(source, '.z80')}.bin`;
+  const sourceName = basename(source);
+  const listingPath = join(workDir, `${basename(source, '.z80')}.lst`);
+  try {
+    copyFileSync(source, join(workDir, sourceName));
+    const result = run(
+      asm80,
+      ['-m', 'Z80', '-t', 'bin', '-o', outName, sourceName],
+      { cwd: workDir },
+    );
+    if (result.error) return { ok: false, message: result.error.message };
+    if (result.status !== 0) return { ok: false, message: compactError(result) };
+    const bytes = readFileSync(join(workDir, outName));
+    const range = existsSync(listingPath) ? parseListingWrittenRange(listingPath) : undefined;
+    return { ok: true, bytes: range ? binaryFromListingRange(bytes, range) : bytes, range };
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+function runZax(source, outDir) {
+  const outPath = join(outDir, `${basename(source, '.z80')}.bin`);
+  const result = run(
+    process.execPath,
+    [join(repoRoot, 'dist', 'src', 'cli.js'), '--nolist', '--nohex', '--nod8m', '-t', 'bin', '-o', outPath, source],
+    { cwd: repoRoot },
+  );
+  if (result.error) return { ok: false, message: result.error.message };
+  if (result.status !== 0) return { ok: false, message: compactError(result) };
+  return { ok: true, bytes: readFileSync(outPath), outPath };
+}
+
+function compactError(result) {
+  return [result.stdout, result.stderr]
+    .join('\n')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 4)
+    .join(' | ');
+}
+
+function findFirstMismatch(actual, reference) {
+  const maxLength = Math.max(actual.length, reference.length);
+  for (let i = 0; i < maxLength; i++) {
+    if (actual[i] !== reference[i]) return i;
+  }
+  return -1;
+}
+
+function hex(value, width = 4) {
+  return `0x${value.toString(16).padStart(width, '0')}`;
+}
+
+function comparableAsm80Bytes(asm) {
+  return asm.bytes;
+}
+
+function compareBytes(actual, asm) {
+  const comparableReference = comparableAsm80Bytes(asm);
+  const mismatch = findFirstMismatch(actual, comparableReference);
+  if (mismatch < 0) return `match bytes=${actual.length}`;
+  const actualByte = actual[mismatch];
+  const referenceByte = comparableReference[mismatch];
+  const range = asm.range ? ` range=${hex(asm.range.start)}..${hex(Math.max(asm.range.start, asm.range.end) - 1)}` : '';
+  return `mismatch actual=${actual.length} reference=${comparableReference.length}${range} first=${hex(mismatch)} zax=${actualByte === undefined ? 'EOF' : hex(actualByte, 2)} asm80=${referenceByte === undefined ? 'EOF' : hex(referenceByte, 2)}`;
+}
+
+function main(argv) {
+  if (argv.includes('--help') || argv.includes('-h')) {
+    console.log(usage());
+    return 0;
+  }
+  if (argv.length > 1) {
+    console.error(usage());
+    return 2;
+  }
+  const root = argv[0] ?? defaultRoot;
+  if (!existsSync(root)) throw new Error(`TEC-1G software root not found: ${root}`);
+  const asm80 = findAsm80();
+  if (!asm80) throw new Error('asm80 executable not found. Set ASM80 or ASM80_PATH.');
+  const zaxCli = join(repoRoot, 'dist', 'src', 'cli.js');
+  if (!existsSync(zaxCli)) throw new Error('Built ZAX CLI not found. Run `npm run build` first.');
+
+  const zaxOut = mkdtempSync(join(tmpdir(), 'zax-tec1g-zax-'));
+  try {
+    const sources = walkZ80Files(root);
+    const included = sources.filter((source) => !isMacroSource(source));
+    const excluded = sources.filter(isMacroSource);
+    console.log(`TEC-1G root: ${root}`);
+    console.log(`Included .z80 files: ${included.length}`);
+    console.log(`Excluded macro files: ${excluded.length}`);
+    for (const source of excluded) console.log(`EXCLUDED macro ${relative(root, source)}`);
+
+    let failures = 0;
+    for (const source of included) {
+      const rel = relative(root, source);
+      const asm = runAsm80(source, asm80);
+      const zax = runZax(source, zaxOut);
+      const matched = asm.ok && zax.ok && findFirstMismatch(zax.bytes, comparableAsm80Bytes(asm)) < 0;
+      if (!matched) failures++;
+      const status =
+        asm.ok && zax.ok
+          ? compareBytes(zax.bytes, asm)
+          : `asm80=${asm.ok ? 'ok' : `fail ${asm.message}`} zax=${zax.ok ? 'ok' : `fail ${zax.message}`}`;
+      console.log(`${rel}: ${status}`);
+    }
+    return failures === 0 ? 0 : 1;
+  } finally {
+    rmSync(zaxOut, { recursive: true, force: true });
+  }
+}
+
+try {
+  process.exitCode = main(process.argv.slice(2));
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exitCode = 1;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -392,8 +392,8 @@ export async function runCli(argv: string[]): Promise<number> {
         rawTypedCallWarnings: parsed.rawTypedCallWarnings,
         includeDirs: parsed.includeDirs,
         sourceMode: parsed.sourceMode,
-        requireMain: true,
-        defaultCodeBase: 0x0100,
+        requireMain: parsed.sourceMode === 'zax',
+        defaultCodeBase: parsed.sourceMode === 'zax' ? 0x0100 : 0,
       },
       { formats: defaultFormatWriters },
     );

--- a/src/formats/writeBin.ts
+++ b/src/formats/writeBin.ts
@@ -2,6 +2,7 @@ import type { BinArtifact, EmittedByteMap, SymbolEntry, WriteBinOptions } from '
 import { getWrittenRange } from './range.js';
 
 const BINFROM_SYMBOL_NAME = '__zax_binfrom';
+const BINTO_SYMBOL_NAME = '__zax_binto';
 
 /**
  * Create a flat binary artifact from an emitted address->byte map.
@@ -20,9 +21,13 @@ export function writeBin(
   const symbolStart = symbols.find(
     (symbol) => symbol.kind === 'constant' && symbol.name === BINFROM_SYMBOL_NAME,
   );
+  const symbolEnd = symbols.find(
+    (symbol) => symbol.kind === 'constant' && symbol.name === BINTO_SYMBOL_NAME,
+  );
   const start =
     optionStart ?? (symbolStart?.kind === 'constant' ? symbolStart.value : writtenStart);
-  const out = new Uint8Array(Math.max(0, end - start));
+  const exclusiveEnd = symbolEnd?.kind === 'constant' ? symbolEnd.value + 1 : end;
+  const out = new Uint8Array(Math.max(0, exclusiveEnd - start));
   for (let i = 0; i < out.length; i++) {
     const addr = start + i;
     out[i] = map.bytes.get(addr) ?? 0;

--- a/src/frontend/asm80/classicLine.ts
+++ b/src/frontend/asm80/classicLine.ts
@@ -4,11 +4,12 @@ export type ClassicLine =
   | { kind: 'org'; exprText: string }
   | { kind: 'align'; exprText: string }
   | { kind: 'binfrom'; exprText: string }
+  | { kind: 'binto'; exprText: string }
   | { kind: 'end' }
   | {
       kind: 'rawData';
       label?: string;
-      directive: 'db' | 'dw' | 'cstr' | 'pstr' | 'istr';
+      directive: 'db' | 'dw' | 'ds' | 'cstr' | 'pstr' | 'istr';
       valuesText: string;
     }
   | { kind: 'instruction'; label?: string; head: string; operandText: string };
@@ -67,15 +68,23 @@ function parseStatement(text: string, label?: string): ClassicLine | undefined {
   const equ = /^\.?equ\b\s*(.+)$/i.exec(text);
   if (equ && label) return { kind: 'equ', name: label, exprText: equ[1]!.trim() };
 
-  const directive = /^\.([A-Za-z][A-Za-z0-9_]*)\b\s*(.*)$/.exec(text);
+  const directive = /^\.?([A-Za-z][A-Za-z0-9_]*)\b\s*(.*)$/.exec(text);
   if (directive) {
     const name = directive[1]!.toLowerCase();
     const payload = directive[2]!.trim();
     if (name === 'org') return { kind: 'org', exprText: payload };
     if (name === 'align') return { kind: 'align', exprText: payload };
     if (name === 'binfrom') return { kind: 'binfrom', exprText: payload };
+    if (name === 'binto') return { kind: 'binto', exprText: payload };
     if (name === 'end') return { kind: 'end' };
-    if (name === 'db' || name === 'dw' || name === 'cstr' || name === 'pstr' || name === 'istr') {
+    if (
+      name === 'db' ||
+      name === 'dw' ||
+      name === 'ds' ||
+      name === 'cstr' ||
+      name === 'pstr' ||
+      name === 'istr'
+    ) {
       return { kind: 'rawData', ...(label ? { label } : {}), directive: name, valuesText: payload };
     }
   }

--- a/src/frontend/asm80/parseClassicModule.ts
+++ b/src/frontend/asm80/parseClassicModule.ts
@@ -152,7 +152,7 @@ export function parseClassicModule(
     const lineSpan = span(file, lineStart, rawLineEndOffset(sourceText, lineStart));
     const parsed = parseClassicLine(path, raw, index + 1, lineStart);
     if (!parsed) continue;
-    if (ended && parsed.kind !== 'binfrom') continue;
+    if (ended && parsed.kind !== 'binfrom' && parsed.kind !== 'binto') continue;
 
     switch (parsed.kind) {
       case 'label': {
@@ -209,6 +209,15 @@ export function parseClassicModule(
         } as ClassicItemNode);
         pendingRawLabel = undefined;
         break;
+      case 'binto':
+        items.push({
+          kind: 'ClassicBinTo',
+          span: lineSpan,
+          exprText: parsed.exprText,
+          value: parseImmExprFromText(path, parsed.exprText, lineSpan, _diagnostics),
+        } as ClassicItemNode);
+        pendingRawLabel = undefined;
+        break;
       case 'align': {
         const value = parseImmExprFromText(path, parsed.exprText, lineSpan, _diagnostics);
         if (value) {
@@ -233,6 +242,12 @@ export function parseClassicModule(
           ),
           valuesText: parsed.valuesText,
         } as unknown as ClassicItemNode;
+        if (parsed.directive === 'ds') {
+          const values = (rawData as unknown as { values?: unknown[] }).values;
+          const rawDataWithSize = rawData as unknown as { size?: unknown; fill?: unknown };
+          rawDataWithSize.size = values?.[0];
+          if (values?.[1]) rawDataWithSize.fill = values[1];
+        }
         if (parsed.label) {
           items.push({ kind: 'AsmLabel', span: lineSpan, name: parsed.label });
         } else if (pendingRawLabel) {

--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -63,6 +63,7 @@ export type ClassicItemNode =
   | ClassicEquNode
   | ClassicOrgNode
   | ClassicBinFromNode
+  | ClassicBinToNode
   | ClassicEndNode
   | AsmLabelNode
   | (AsmInstructionNode & { operandText?: string })
@@ -81,6 +82,11 @@ export interface ClassicOrgNode extends BaseNode {
 
 export interface ClassicBinFromNode extends BaseNode {
   kind: 'ClassicBinFrom';
+  exprText: string;
+}
+
+export interface ClassicBinToNode extends BaseNode {
+  kind: 'ClassicBinTo';
   exprText: string;
 }
 
@@ -310,6 +316,7 @@ export type RawDataDeclNode =
       name: string;
       directive: 'ds';
       size: ImmExprNode;
+      fill?: ImmExprNode;
     };
 
 /**

--- a/src/frontend/parseImm.ts
+++ b/src/frontend/parseImm.ts
@@ -93,6 +93,9 @@ export function parseNumberLiteral(text: string): number | undefined {
   if (/^0b[01]+$/.test(t)) {
     return Number.parseInt(t.slice(2), 2);
   }
+  if (/^0x[0-9A-Fa-f]+$/i.test(t)) {
+    return Number.parseInt(t.slice(2), 16);
+  }
   if (/^[0-9]+$/.test(t)) {
     return Number.parseInt(t, 10);
   }
@@ -249,7 +252,7 @@ function tokenizeImm(text: string): ImmToken[] | undefined {
       continue;
     }
     const num =
-      /^(%[01]+|0b[01]+|[0-9][0-9A-Fa-f]*[Hh]|[01]+[Bb]|[0-9]+)/.exec(
+      /^([0-9][0-9A-Fa-f]*[Hh]|%[01]+|0b[01]+|0x[0-9A-Fa-f]+|[01]+[Bb]|[0-9]+)/i.exec(
         s.slice(i),
       );
     if (num) {

--- a/src/lowering/classicInstructionLowering.ts
+++ b/src/lowering/classicInstructionLowering.ts
@@ -97,6 +97,25 @@ function ldReg16MemOpcode(nameRaw: string): { prefix?: number; opcode: number } 
   }
 }
 
+function ldMemReg16Opcode(nameRaw: string): { prefix?: number; opcode: number } | undefined {
+  switch (nameRaw.toUpperCase()) {
+    case 'BC':
+      return { prefix: 0xed, opcode: 0x43 };
+    case 'DE':
+      return { prefix: 0xed, opcode: 0x53 };
+    case 'HL':
+      return { opcode: 0x22 };
+    case 'SP':
+      return { prefix: 0xed, opcode: 0x73 };
+    case 'IX':
+      return { prefix: 0xdd, opcode: 0x22 };
+    case 'IY':
+      return { prefix: 0xfd, opcode: 0x22 };
+    default:
+      return undefined;
+  }
+}
+
 function memSymbolicTarget(
   ctx: LoweringContext,
   op: AsmOperandNode | undefined,
@@ -447,6 +466,33 @@ export function lowerClassicInstruction(ctx: LoweringContext, item: ClassicInstr
       const symbolic = memSymbolicTarget(ctx, first);
       if (symbolic) {
         ctx.emitAbs16Fixup(0x32, symbolic.baseLower, symbolic.addend, item.span);
+        return;
+      }
+    }
+    if (first?.kind === 'Mem' && second?.kind === 'Reg') {
+      const memOpcode = ldMemReg16Opcode(second.name);
+      const value = evalMemAddress(ctx, first);
+      if (memOpcode && value !== undefined) {
+        const bytes =
+          memOpcode.prefix !== undefined
+            ? Uint8Array.of(memOpcode.prefix, memOpcode.opcode, value & 0xff, (value >> 8) & 0xff)
+            : Uint8Array.of(memOpcode.opcode, value & 0xff, (value >> 8) & 0xff);
+        ctx.emitRawCodeBytes(bytes, item.span.file, `ld (nn),${second.name}`);
+        return;
+      }
+      const symbolic = memSymbolicTarget(ctx, first);
+      if (memOpcode && symbolic) {
+        if (memOpcode.prefix !== undefined) {
+          ctx.emitAbs16FixupPrefixed(
+            memOpcode.prefix,
+            memOpcode.opcode,
+            symbolic.baseLower,
+            symbolic.addend,
+            item.span,
+          );
+        } else {
+          ctx.emitAbs16Fixup(memOpcode.opcode, symbolic.baseLower, symbolic.addend, item.span);
+        }
         return;
       }
     }

--- a/src/lowering/programLoweringDeclarations.ts
+++ b/src/lowering/programLoweringDeclarations.ts
@@ -27,6 +27,7 @@ type RawDataLike = {
   directive: 'db' | 'dw' | 'ds' | 'cstr' | 'pstr' | 'istr';
   values?: RawValueLike[];
   size?: ImmExprNode;
+  fill?: ImmExprNode;
 };
 
 function rawStringValue(value: RawValueLike): string | undefined {
@@ -398,11 +399,16 @@ export function createProgramLoweringDeclarationHelpers(ctx: Context): {
         {
           kind: 'ds',
           size: ctx.lowerImmExprForLoweredAsm(decl.size),
-          fill: { kind: 'literal', value: 0 },
+          fill: decl.fill ? ctx.lowerImmExprForLoweredAsm(decl.fill) : { kind: 'literal', value: 0 },
         },
         decl.span,
       );
-      for (let i = 0; i < size; i++) writeByte(0);
+      const fill = decl.fill ? ctx.evalImmExpr(decl.fill, ctx.env, ctx.diagnostics) : 0;
+      if (fill === undefined) {
+        ctx.diag(ctx.diagnostics, decl.span.file, `Failed to evaluate raw data fill for "${name}".`);
+        return;
+      }
+      for (let i = 0; i < size; i++) writeByte(fill);
       return;
     }
 

--- a/src/lowering/programLoweringTraversal.ts
+++ b/src/lowering/programLoweringTraversal.ts
@@ -20,6 +20,7 @@ import { createProgramLoweringDeclarationHelpers } from './programLoweringDeclar
 import { lowerClassicInstruction } from './classicInstructionLowering.js';
 
 const BINFROM_SYMBOL_NAME = '__zax_binfrom';
+const BINTO_SYMBOL_NAME = '__zax_binto';
 
 type ClassicNode = {
   kind: string;
@@ -30,6 +31,7 @@ type ClassicNode = {
   directive?: 'db' | 'dw' | 'ds' | 'cstr' | 'pstr' | 'istr';
   values?: unknown[];
   size?: import('../frontend/ast.js').ImmExprNode;
+  fill?: import('../frontend/ast.js').ImmExprNode;
   head?: string;
   operands?: import('../frontend/ast.js').AsmOperandNode[];
 };
@@ -56,6 +58,10 @@ function isClassicRawData(item: { kind: string }): boolean {
 
 function isClassicBinFrom(item: { kind: string }): boolean {
   return isKind(item, 'ClassicBinFrom', 'ClassicBinFromDirective', 'BinFromDirective');
+}
+
+function isClassicBinTo(item: { kind: string }): boolean {
+  return isKind(item, 'ClassicBinTo', 'ClassicBinToDirective', 'BinToDirective');
 }
 
 function isClassicEnd(item: { kind: string }): boolean {
@@ -384,6 +390,40 @@ function lowerClassicBinFrom(ctx: LoweringContext, item: ClassicNode): void {
   });
 }
 
+function lowerClassicBinTo(ctx: LoweringContext, item: ClassicNode): void {
+  const expr = classicExpr(item);
+  if (!expr) {
+    ctx.diag(ctx.diagnostics, item.span.file, `Missing binto address.`);
+    return;
+  }
+  const value = ctx.evalImmExpr(expr, ctx.env, ctx.diagnostics);
+  if (value === undefined) {
+    ctx.diag(ctx.diagnostics, item.span.file, `Failed to evaluate binto address.`);
+    return;
+  }
+  if (value < 0 || value > 0xffff) {
+    ctx.diag(ctx.diagnostics, item.span.file, `binto address out of range (0..65535).`);
+    return;
+  }
+  const existing = ctx.symbols.find(
+    (symbol) => symbol.kind === 'constant' && symbol.name === BINTO_SYMBOL_NAME,
+  );
+  if (existing?.kind === 'constant') {
+    existing.value = value;
+    existing.address = value;
+    return;
+  }
+  ctx.symbols.push({
+    kind: 'constant',
+    name: BINTO_SYMBOL_NAME,
+    value,
+    address: value,
+    file: item.span.file,
+    line: item.span.start.line,
+    scope: 'global',
+  });
+}
+
 function lowerItem(
   ctx: LoweringContext,
   lowerBinDecl: ReturnType<typeof createProgramLoweringDeclarationHelpers>['lowerBinDecl'],
@@ -408,6 +448,10 @@ function lowerItem(
   }
   if (isClassicBinFrom(item)) {
     lowerClassicBinFrom(ctx, item as ClassicNode);
+    return;
+  }
+  if (isClassicBinTo(item)) {
+    lowerClassicBinTo(ctx, item as ClassicNode);
     return;
   }
   if (item.kind === 'AsmLabel') {
@@ -679,7 +723,7 @@ export function lowerProgramDeclarations(ctx: LoweringContext): LoweringResult {
         classicEnded = true;
         continue;
       }
-      if (classicEnded && !isClassicBinFrom(item)) continue;
+      if (classicEnded && !isClassicBinFrom(item) && !isClassicBinTo(item)) continue;
       lowerItem(ctx, lowerBinDecl, lowerRawDataDecl, lowerClassicRawDataDecl, item);
     }
   }

--- a/test/asm80/asm80_directives_integration.test.ts
+++ b/test/asm80/asm80_directives_integration.test.ts
@@ -137,6 +137,73 @@ describe('asm80 directive lowering integration', () => {
     expect(bytes).toEqual([0x00, 0x00, 0x7e]);
   });
 
+  it('honors post-end binto as an inclusive binary upper bound', () => {
+    const { bytes, diagnostics } = emitBytes([
+      { kind: 'ClassicOrg', span: span(1), value: lit(0x4000, 1) },
+      {
+        kind: 'ClassicRawData',
+        span: span(2),
+        directive: 'db',
+        values: [lit(1, 2), lit(2, 2), lit(3, 2), lit(4, 2)],
+      },
+      { kind: 'ClassicEnd', span: span(3) },
+      { kind: 'ClassicBinFrom', span: span(4), value: lit(0x4001, 4) },
+      { kind: 'ClassicBinTo', span: span(5), value: lit(0x4002, 5) },
+    ]);
+
+    expect(diagnostics).toEqual([]);
+    expect(bytes).toEqual([2, 3]);
+  });
+
+  it('pads through binto when the upper bound extends past written bytes', () => {
+    const { bytes, diagnostics } = emitBytes([
+      { kind: 'ClassicOrg', span: span(1), value: lit(0x4000, 1) },
+      {
+        kind: 'ClassicRawData',
+        span: span(2),
+        directive: 'db',
+        values: [lit(1, 2)],
+      },
+      { kind: 'ClassicBinFrom', span: span(3), value: lit(0x4000, 3) },
+      { kind: 'ClassicBinTo', span: span(4), value: lit(0x4003, 4) },
+    ]);
+
+    expect(diagnostics).toEqual([]);
+    expect(bytes).toEqual([1, 0, 0, 0]);
+  });
+
+  it('compiles undotted directives, ds fill, 0x literals, and binto from classic source', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-tec1g-directives-'));
+    const entry = join(dir, 'tec1g-directives.z80');
+    writeFileSync(
+      entry,
+      ['ORG 4000H', 'API: EQU 0x10', 'DB API', 'DS 2,0FFH', 'DB 4', 'END', '.binfrom 4000H', '.binto 4002H'].join('\n'),
+      'utf8',
+    );
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin) throw new Error('missing bin artifact');
+    expect([...bin.bytes]).toEqual([0x10, 0xff, 0xff]);
+  });
+
+  it('compiles classic source without org from address zero', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-no-org-'));
+    const entry = join(dir, 'no-org.z80');
+    writeFileSync(entry, ['xor a', 'jr $', '.binto 0003H'].join('\n'), 'utf8');
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin) throw new Error('missing bin artifact');
+    expect([...bin.bytes]).toEqual([0xaf, 0x18, 0xfe, 0x00]);
+  });
+
   it('resolves ASM80 current-location expressions in relative branches and raw words', () => {
     const { bytes, diagnostics } = emitBytes([
       { kind: 'ClassicOrg', span: span(1), value: lit(0x0100, 1) },
@@ -234,6 +301,56 @@ describe('asm80 directive lowering integration', () => {
     expect(bin).toBeDefined();
     if (!bin) throw new Error('missing bin artifact');
     expect([...bin.bytes]).toEqual([0xdd, 0x7e, 0x00, 0xfd, 0x7e, 0x0c]);
+  });
+
+  it('compiles classic absolute 16-bit register stores', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-ld-mem-reg16-'));
+    const entry = join(dir, 'ld-mem-reg16.z80');
+    writeFileSync(
+      entry,
+      [
+        'org 0100H',
+        'PTR: equ 0900H',
+        'ld (PTR),hl',
+        'ld (PTR),bc',
+        'ld (PTR),de',
+        'ld (PTR),sp',
+        'ld (PTR),ix',
+        'ld (PTR),iy',
+        'binfrom 0100H',
+        'end',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin) throw new Error('missing bin artifact');
+    expect([...bin.bytes]).toEqual([
+      0x22, 0x00, 0x09,
+      0xed, 0x43, 0x00, 0x09,
+      0xed, 0x53, 0x00, 0x09,
+      0xed, 0x73, 0x00, 0x09,
+      0xdd, 0x22, 0x00, 0x09,
+      0xfd, 0x22, 0x00, 0x09,
+    ]);
+  });
+
+  it('compiles classic SRA A', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-sra-a-'));
+    const entry = join(dir, 'sra-a.z80');
+    writeFileSync(entry, ['org 0100H', 'SRA A', 'binfrom 0100H', 'end'].join('\n'), 'utf8');
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin) throw new Error('missing bin artifact');
+    expect([...bin.bytes]).toEqual([0xcb, 0x2f]);
   });
 
   it('emits parsed db string fragments and string-character expressions', () => {

--- a/test/frontend/asm80_classic_line.test.ts
+++ b/test/frontend/asm80_classic_line.test.ts
@@ -12,8 +12,10 @@ describe('classic ASM80 logical line parser', () => {
       '        .org BASE_ADDR+08H',
       '        .db "Enter ",0',
       '        .dw DATA_FROM',
+      '        ds 2,0',
       '        .binfrom 0C000H',
-      '        .end',
+      '        .binto 0C010H',
+      '        END',
     ].map((text, index) => parseClassicLine('/classic.z80', text, index + 1, 0));
 
     expect(lines).toEqual([
@@ -24,8 +26,25 @@ describe('classic ASM80 logical line parser', () => {
       { kind: 'org', exprText: 'BASE_ADDR+08H' },
       { kind: 'rawData', directive: 'db', valuesText: '"Enter ",0' },
       { kind: 'rawData', directive: 'dw', valuesText: 'DATA_FROM' },
+      { kind: 'rawData', directive: 'ds', valuesText: '2,0' },
       { kind: 'binfrom', exprText: '0C000H' },
+      { kind: 'binto', exprText: '0C010H' },
       { kind: 'end' },
+    ]);
+  });
+
+  it('parses undotted ASM80 data and placement directives', () => {
+    const lines = ['ORG 4000H', 'DB "OK"', 'DW START', 'DS 3', 'BINFROM 4000H', 'BINTO 4004H'].map(
+      (text, index) => parseClassicLine('/classic.z80', text, index + 1, 0),
+    );
+
+    expect(lines).toEqual([
+      { kind: 'org', exprText: '4000H' },
+      { kind: 'rawData', directive: 'db', valuesText: '"OK"' },
+      { kind: 'rawData', directive: 'dw', valuesText: 'START' },
+      { kind: 'rawData', directive: 'ds', valuesText: '3' },
+      { kind: 'binfrom', exprText: '4000H' },
+      { kind: 'binto', exprText: '4004H' },
     ]);
   });
 

--- a/test/frontend/asm80_classic_module.test.ts
+++ b/test/frontend/asm80_classic_module.test.ts
@@ -85,11 +85,11 @@ describe('classic ASM80 module parser', () => {
     });
   });
 
-  it('keeps post-end binfrom while ignoring ordinary post-end source', () => {
+  it('keeps post-end binary range directives while ignoring ordinary post-end source', () => {
     const diagnostics: unknown[] = [];
     const module = parseClassicModule(
       '/classic.z80',
-      ['.org 0100H', '.db 1', '.end', 'after: nop', '.binfrom 0100H'].join('\n'),
+      ['.org 0100H', '.db 1', '.end', 'after: nop', '.binfrom 0100H', '.binto 0101H'].join('\n'),
       diagnostics as never[],
     );
 
@@ -99,6 +99,29 @@ describe('classic ASM80 module parser', () => {
       'ClassicRawData',
       'ClassicEnd',
       'ClassicBinFrom',
+      'ClassicBinTo',
+    ]);
+  });
+
+  it('parses classic ds size and optional fill values', () => {
+    const diagnostics: unknown[] = [];
+    const module = parseClassicModule('/classic.z80', ['buf: ds 2,0FFH', 'tail: .ds 1'].join('\n'), diagnostics as never[]);
+
+    expect(diagnostics).toEqual([]);
+    expect(module.items.filter((item) => (item as { kind: string }).kind === 'ClassicRawData')).toMatchObject([
+      {
+        kind: 'ClassicRawData',
+        name: 'buf',
+        directive: 'ds',
+        size: { kind: 'ImmLiteral', value: 2 },
+        fill: { kind: 'ImmLiteral', value: 0xff },
+      },
+      {
+        kind: 'ClassicRawData',
+        name: 'tail',
+        directive: 'ds',
+        size: { kind: 'ImmLiteral', value: 1 },
+      },
     ]);
   });
 


### PR DESCRIPTION
## Summary

Adds the TEC-1G non-macro ASM80 corpus as a second compatibility baseline for ZAX classic ASM80 mode.

This expands the assembler subset beyond MON3 with the minimum features needed to assemble the TEC-1G sources that do not use ASM80 macros:

- optional-dot classic directives such as `ORG`, `DB`, `DW`, `DS`, `EQU`, `END`, `BINFROM`, and `BINTO`
- `.binto` / `BINTO` support with ASM80-style inclusive upper bound and zero padding
- `DS size, fill` support
- `0x` hexadecimal literal support
- classic CLI compilation without requiring a ZAX `main`
- zero-origin default for classic ASM80 input without `.org`
- `SRA A`
- `LD (nn),BC/DE/HL/SP/IX/IY`

## Corpus Decision

The TEC-1G scan includes 12 `.z80` files under `/Users/johnhardy/Documents/projects/TEC-1G/Software` and excludes `Education/tbasic.z80` because it uses `.macro` / `.endm`. That matches the current compatibility policy: macros are explicitly out of scope for the ASM80 baseline and can be revisited later through ZAX OPS-style macro support.

## Reviewer Notes

The new comparator script is:

```bash
node scripts/dev/compare-tec1g-corpus.mjs
```

It runs ASM80 in a temporary directory so the external TEC-1G tree is not modified by generated `.bin` or `.lst` files. It then compares ZAX output against the ASM80 reference for all included non-macro files.

## Validation

Already run locally/subagent-reviewed:

- `npm run build`
- `npm run typecheck -- --pretty false`
- `npm run lint`
- `npx vitest run test/asm80 test/frontend/asm80_classic_line.test.ts test/frontend/asm80_classic_module.test.ts`
- `ZAX_RUN_MON3_ACCEPTANCE=1 npx vitest run test/asm80/mon3_acceptance.test.ts`
- `npm run check:fixture-coverage`
- `npm run check:source-file-sizes:enforce`
- `node scripts/dev/compare-tec1g-corpus.mjs`
- independent subagent review found no remaining blockers before PR creation
