### PR TITLE
[codex] add ASM80 baseline acceptance gate

### DIFF
--- a/docs/reference/testing-verification-guide.md
+++ b/docs/reference/testing-verification-guide.md
@@ -37,6 +37,18 @@ Run full suite when your slice touches broad behavior:
 npm test
 ```
 
+Run the opt-in external ASM80 replacement baseline when touching classic ASM80
+parsing, lowering, CLI binary output, or ASM80 compatibility docs:
+
+```sh
+npm run test:asm80:baseline
+```
+
+This builds the local ZAX CLI, runs the MON3 byte-for-byte acceptance test
+against a fresh ASM80-built reference, and runs the TEC-1G non-macro corpus
+comparison. It depends on sibling local projects/tools, so normal CI does not
+run it by default.
+
 For docs-only changes, check changed docs paths with Prettier:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "test:coverage": "vitest run --coverage",
     "test:ci:coverage-core": "vitest run --coverage --exclude 'test/cli_*.test.ts' --exclude 'test/cli/**/*.test.ts'",
     "test:ci:slow-reliability": "vitest run --no-file-parallelism --maxWorkers=1 --minWorkers=1 --testTimeout=20000 --hookTimeout=300000 --passWithNoTests 'test/cli_*.test.ts' 'test/cli/**/*.test.ts'",
+    "test:asm80:baseline": "node scripts/dev/run-asm80-baseline.mjs",
     "test:watch": "vitest",
     "format": "prettier -w .",
     "format:check": "prettier -c .",

--- a/scripts/dev/run-asm80-baseline.mjs
+++ b/scripts/dev/run-asm80-baseline.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const mon3Source = '/Users/johnhardy/Documents/projects/MON3/src/mon3.z80';
+
+function normalizeExecutableCandidate(candidate) {
+  return candidate.includes('/') || candidate.includes('\\') ? resolve(candidate) : candidate;
+}
+
+function findAsm80() {
+  const candidates = [
+    process.env.ASM80,
+    process.env.ASM80_PATH,
+    '/Users/johnhardy/Documents/projects/debug80/node_modules/.bin/asm80',
+    'asm80',
+  ]
+    .filter((candidate) => candidate && candidate.trim().length > 0)
+    .map(normalizeExecutableCandidate);
+  for (const candidate of candidates) {
+    const probe = spawnSync(candidate, ['-h'], {
+      encoding: 'utf8',
+      shell: process.platform === 'win32',
+    });
+    if (!probe.error) return candidate;
+  }
+  return undefined;
+}
+
+const commands = [
+  {
+    label: 'build ZAX CLI',
+    command: 'npm',
+    args: ['run', 'build'],
+    env: {},
+  },
+  {
+    label: 'MON3 ASM80 acceptance',
+    command: 'npx',
+    args: ['vitest', 'run', 'test/asm80/mon3_acceptance.test.ts'],
+    env: { ZAX_RUN_MON3_ACCEPTANCE: '1' },
+  },
+  {
+    label: 'TEC-1G ASM80 corpus comparison',
+    command: 'node',
+    args: ['scripts/dev/compare-tec1g-corpus.mjs'],
+    env: {},
+  },
+];
+
+function runStep(step) {
+  console.log(`\n==> ${step.label}`);
+  const result = spawnSync(step.command, step.args, {
+    cwd: process.cwd(),
+    env: { ...process.env, ...step.env },
+    shell: process.platform === 'win32',
+    stdio: 'inherit',
+  });
+  if (result.error) {
+    console.error(result.error.message);
+    return 1;
+  }
+  return result.status ?? 1;
+}
+
+if (!existsSync(mon3Source)) {
+  console.error(`MON3 source not found: ${mon3Source}`);
+  process.exit(1);
+}
+
+if (!findAsm80()) {
+  console.error('asm80 executable not found. Set ASM80 or ASM80_PATH.');
+  process.exit(1);
+}
+
+for (const step of commands) {
+  const status = runStep(step);
+  if (status !== 0) {
+    console.error(`\nASM80 baseline failed at: ${step.label}`);
+    process.exit(status);
+  }
+}
+
+console.log('\nASM80 baseline passed.');

--- a/test/asm80/asm80_baseline_workflow.test.ts
+++ b/test/asm80/asm80_baseline_workflow.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = join(__dirname, '..', '..');
+
+describe('ASM80 baseline acceptance workflow', () => {
+  it('exposes a single npm script for the external MON3 and TEC-1G gates', () => {
+    const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(pkg.scripts?.['test:asm80:baseline']).toBe('node scripts/dev/run-asm80-baseline.mjs');
+  });
+
+  it('documents the opt-in baseline command with both external corpora', () => {
+    const doc = readFileSync(
+      join(repoRoot, 'docs', 'reference', 'testing-verification-guide.md'),
+      'utf8',
+    );
+
+    expect(doc).toContain('npm run test:asm80:baseline');
+    expect(doc).toContain('MON3');
+    expect(doc).toContain('TEC-1G');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a single opt-in acceptance command for the external ASM80 replacement baseline:

```bash
npm run test:asm80:baseline
```

The wrapper builds the local ZAX CLI, runs the MON3 byte-for-byte acceptance test with `ZAX_RUN_MON3_ACCEPTANCE=1`, then runs the TEC-1G non-macro corpus comparator.

## Why

MON3 and the TEC-1G non-macro corpus are now the concrete ASM80 compatibility baseline. This PR makes that baseline discoverable and repeatable without relying on contributors to remember several separate commands.

The gate remains opt-in because it depends on local sibling projects/tools:

- `/Users/johnhardy/Documents/projects/MON3`
- `/Users/johnhardy/Documents/projects/TEC-1G/Software`
- an available `asm80` executable, usually from Debug80 or `ASM80` / `ASM80_PATH`

## Notes

The wrapper is Node-based rather than shell-based so the npm script can work consistently across platforms. Normal CI still does not run this by default.

## Verification

- `npx vitest run test/asm80/asm80_baseline_workflow.test.ts`
- `npm run test:asm80:baseline`
- `npm run typecheck -- --pretty false`
- `npm run lint`
- `npm run check:source-file-sizes:enforce`
