### PR TITLE
[codex] improve ASM80 baseline diagnostics

### DIFF
--- a/docs/reference/testing-verification-guide.md
+++ b/docs/reference/testing-verification-guide.md
@@ -49,6 +49,16 @@ against a fresh ASM80-built reference, and runs the TEC-1G non-macro corpus
 comparison. It depends on sibling local projects/tools, so normal CI does not
 run it by default.
 
+The default local paths match the maintainer workspace. Override them when your
+checkout layout differs:
+
+```sh
+MON3_SOURCE=/path/to/MON3/src/mon3.z80 \
+TEC1G_SOFTWARE_ROOT=/path/to/TEC-1G/Software \
+ASM80=/path/to/asm80 \
+npm run test:asm80:baseline
+```
+
 For docs-only changes, check changed docs paths with Prettier:
 
 ```sh

--- a/scripts/dev/compare-tec1g-corpus.mjs
+++ b/scripts/dev/compare-tec1g-corpus.mjs
@@ -100,11 +100,9 @@ function runAsm80(source, asm80) {
   const listingPath = join(workDir, `${basename(source, '.z80')}.lst`);
   try {
     copyFileSync(source, join(workDir, sourceName));
-    const result = run(
-      asm80,
-      ['-m', 'Z80', '-t', 'bin', '-o', outName, sourceName],
-      { cwd: workDir },
-    );
+    const result = run(asm80, ['-m', 'Z80', '-t', 'bin', '-o', outName, sourceName], {
+      cwd: workDir,
+    });
     if (result.error) return { ok: false, message: result.error.message };
     if (result.status !== 0) return { ok: false, message: compactError(result) };
     const bytes = readFileSync(join(workDir, outName));
@@ -119,7 +117,17 @@ function runZax(source, outDir) {
   const outPath = join(outDir, `${basename(source, '.z80')}.bin`);
   const result = run(
     process.execPath,
-    [join(repoRoot, 'dist', 'src', 'cli.js'), '--nolist', '--nohex', '--nod8m', '-t', 'bin', '-o', outPath, source],
+    [
+      join(repoRoot, 'dist', 'src', 'cli.js'),
+      '--nolist',
+      '--nohex',
+      '--nod8m',
+      '-t',
+      'bin',
+      '-o',
+      outPath,
+      source,
+    ],
     { cwd: repoRoot },
   );
   if (result.error) return { ok: false, message: result.error.message };
@@ -149,6 +157,13 @@ function hex(value, width = 4) {
   return `0x${value.toString(16).padStart(width, '0')}`;
 }
 
+function byteWindow(bytes, center, radius = 4) {
+  if (center === undefined || center < 0) return '[]';
+  const start = Math.max(0, center - radius);
+  const end = Math.min(bytes.length, center + radius + 1);
+  return `[${Array.from(bytes.subarray(start, end), (byte) => hex(byte, 2)).join(' ')}]`;
+}
+
 function comparableAsm80Bytes(asm) {
   return asm.bytes;
 }
@@ -159,8 +174,21 @@ function compareBytes(actual, asm) {
   if (mismatch < 0) return `match bytes=${actual.length}`;
   const actualByte = actual[mismatch];
   const referenceByte = comparableReference[mismatch];
-  const range = asm.range ? ` range=${hex(asm.range.start)}..${hex(Math.max(asm.range.start, asm.range.end) - 1)}` : '';
-  return `mismatch actual=${actual.length} reference=${comparableReference.length}${range} first=${hex(mismatch)} zax=${actualByte === undefined ? 'EOF' : hex(actualByte, 2)} asm80=${referenceByte === undefined ? 'EOF' : hex(referenceByte, 2)}`;
+  const range = asm.range
+    ? ` range=${hex(asm.range.start)}..${hex(Math.max(asm.range.start, asm.range.end) - 1)}`
+    : '';
+  return [
+    `mismatch actual=${actual.length} reference=${comparableReference.length}`,
+    `lengthDelta=${actual.length - comparableReference.length}`,
+    range.trim(),
+    `first=${hex(mismatch)}`,
+    `zax=${actualByte === undefined ? 'EOF' : hex(actualByte, 2)}`,
+    `asm80=${referenceByte === undefined ? 'EOF' : hex(referenceByte, 2)}`,
+    `zaxWindow=${byteWindow(actual, mismatch)}`,
+    `asm80Window=${byteWindow(comparableReference, mismatch)}`,
+  ]
+    .filter(Boolean)
+    .join(' ');
 }
 
 function main(argv) {
@@ -194,7 +222,8 @@ function main(argv) {
       const rel = relative(root, source);
       const asm = runAsm80(source, asm80);
       const zax = runZax(source, zaxOut);
-      const matched = asm.ok && zax.ok && findFirstMismatch(zax.bytes, comparableAsm80Bytes(asm)) < 0;
+      const matched =
+        asm.ok && zax.ok && findFirstMismatch(zax.bytes, comparableAsm80Bytes(asm)) < 0;
       if (!matched) failures++;
       const status =
         asm.ok && zax.ok

--- a/scripts/dev/run-asm80-baseline.mjs
+++ b/scripts/dev/run-asm80-baseline.mjs
@@ -3,7 +3,10 @@ import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-const mon3Source = '/Users/johnhardy/Documents/projects/MON3/src/mon3.z80';
+const mon3Source =
+  process.env.MON3_SOURCE ?? '/Users/johnhardy/Documents/projects/MON3/src/mon3.z80';
+const tec1gSoftwareRoot =
+  process.env.TEC1G_SOFTWARE_ROOT ?? '/Users/johnhardy/Documents/projects/TEC-1G/Software';
 
 function normalizeExecutableCandidate(candidate) {
   return candidate.includes('/') || candidate.includes('\\') ? resolve(candidate) : candidate;
@@ -44,7 +47,7 @@ const commands = [
   {
     label: 'TEC-1G ASM80 corpus comparison',
     command: 'node',
-    args: ['scripts/dev/compare-tec1g-corpus.mjs'],
+    args: ['scripts/dev/compare-tec1g-corpus.mjs', tec1gSoftwareRoot],
     env: {},
   },
 ];
@@ -66,6 +69,13 @@ function runStep(step) {
 
 if (!existsSync(mon3Source)) {
   console.error(`MON3 source not found: ${mon3Source}`);
+  console.error('Set MON3_SOURCE to override the local MON3 entry path.');
+  process.exit(1);
+}
+
+if (!existsSync(tec1gSoftwareRoot)) {
+  console.error(`TEC-1G software root not found: ${tec1gSoftwareRoot}`);
+  console.error('Set TEC1G_SOFTWARE_ROOT to override the local TEC-1G software path.');
   process.exit(1);
 }
 

--- a/test/asm80/asm80_baseline_workflow.test.ts
+++ b/test/asm80/asm80_baseline_workflow.test.ts
@@ -24,4 +24,43 @@ describe('ASM80 baseline acceptance workflow', () => {
     expect(doc).toContain('MON3');
     expect(doc).toContain('TEC-1G');
   });
+
+  it('documents local path overrides for the external baseline', () => {
+    const doc = readFileSync(
+      join(repoRoot, 'docs', 'reference', 'testing-verification-guide.md'),
+      'utf8',
+    );
+
+    expect(doc).toContain('MON3_SOURCE');
+    expect(doc).toContain('TEC1G_SOFTWARE_ROOT');
+    expect(doc).toContain('ASM80');
+  });
+
+  it('wires the baseline wrapper to the documented override variables', () => {
+    const script = readFileSync(join(repoRoot, 'scripts', 'dev', 'run-asm80-baseline.mjs'), 'utf8');
+
+    expect(script).toContain('process.env.MON3_SOURCE');
+    expect(script).toContain('process.env.TEC1G_SOFTWARE_ROOT');
+    expect(script).toContain('process.env.ASM80');
+  });
+
+  it('wires the MON3 acceptance test to the documented source override', () => {
+    const testSource = readFileSync(
+      join(repoRoot, 'test', 'asm80', 'mon3_acceptance.test.ts'),
+      'utf8',
+    );
+
+    expect(testSource).toContain('process.env.MON3_SOURCE');
+  });
+
+  it('keeps TEC-1G mismatch diagnostics source and byte focused', () => {
+    const script = readFileSync(
+      join(repoRoot, 'scripts', 'dev', 'compare-tec1g-corpus.mjs'),
+      'utf8',
+    );
+
+    expect(script).toContain('lengthDelta=');
+    expect(script).toContain('zaxWindow=');
+    expect(script).toContain('asm80Window=');
+  });
 });

--- a/test/asm80/mon3_acceptance.test.ts
+++ b/test/asm80/mon3_acceptance.test.ts
@@ -18,7 +18,7 @@ const classicParserPath = join(repoRoot, 'src', 'frontend', 'asm80', 'parseClass
 const classicAsm80Available = existsSync(classicParserPath);
 const classicModuleLoweringAvailable = true;
 const manifest = {
-  source: '/Users/johnhardy/Documents/projects/MON3/src/mon3.z80',
+  source: process.env.MON3_SOURCE ?? '/Users/johnhardy/Documents/projects/MON3/src/mon3.z80',
 };
 
 function normalizeExecutableCandidate(candidate: string): string {
@@ -31,7 +31,9 @@ const asm80Candidates = [
   '/Users/johnhardy/Documents/projects/debug80/node_modules/.bin/asm80',
   'asm80',
 ]
-  .filter((candidate): candidate is string => candidate !== undefined && candidate.trim().length > 0)
+  .filter(
+    (candidate): candidate is string => candidate !== undefined && candidate.trim().length > 0,
+  )
   .map(normalizeExecutableCandidate);
 const asm80 = asm80Candidates.find((candidate) => {
   const probe = spawnSync(candidate, ['-h'], { encoding: 'utf8' });
@@ -40,7 +42,11 @@ const asm80 = asm80Candidates.find((candidate) => {
 const mon3FilesAvailable = existsSync(manifest.source);
 const runMon3Acceptance = process.env.ZAX_RUN_MON3_ACCEPTANCE === '1';
 const describeMon3 =
-  classicAsm80Available && classicModuleLoweringAvailable && mon3FilesAvailable && asm80 && runMon3Acceptance
+  classicAsm80Available &&
+  classicModuleLoweringAvailable &&
+  mon3FilesAvailable &&
+  asm80 &&
+  runMon3Acceptance
     ? describe
     : describe.skip;
 
@@ -58,14 +64,18 @@ function diagnosticLocation(diagnostic: Diagnostic): string {
 }
 
 function summarizeDiagnostics(diagnostics: Diagnostic[], limit = 3): string {
-  const preview = diagnostics.slice(0, limit).map((diagnostic) =>
-    `${diagnosticLocation(diagnostic)}: ${diagnostic.severity} [${diagnostic.id}] ${
-      diagnostic.message
-    }`,
-  );
-  return [`Diagnostics preview (showing ${preview.length} of ${diagnostics.length}):`, ...preview].join(
-    '\n',
-  );
+  const preview = diagnostics
+    .slice(0, limit)
+    .map(
+      (diagnostic) =>
+        `${diagnosticLocation(diagnostic)}: ${diagnostic.severity} [${diagnostic.id}] ${
+          diagnostic.message
+        }`,
+    );
+  return [
+    `Diagnostics preview (showing ${preview.length} of ${diagnostics.length}):`,
+    ...preview,
+  ].join('\n');
 }
 
 function findFirstMismatch(actual: Buffer, reference: Buffer): number {
@@ -106,22 +116,16 @@ function buildAsm80Reference(source: string): Buffer {
   const outBin = join(outDir, outName);
   try {
     copyAsm80SourceTree(source, outDir);
-    const result = spawnSync(
-      asm80,
-      ['-m', 'Z80', '-t', 'bin', '-o', outName, basename(source)],
-      {
-        cwd: outDir,
-        encoding: 'utf8',
-      },
-    );
+    const result = spawnSync(asm80, ['-m', 'Z80', '-t', 'bin', '-o', outName, basename(source)], {
+      cwd: outDir,
+      encoding: 'utf8',
+    });
     if (result.error) throw result.error;
     if (result.status !== 0) {
       throw new Error(
-        [
-          `asm80 failed with status ${result.status}`,
-          result.stdout.trim(),
-          result.stderr.trim(),
-        ].filter((part) => part.length > 0).join('\n'),
+        [`asm80 failed with status ${result.status}`, result.stdout.trim(), result.stderr.trim()]
+          .filter((part) => part.length > 0)
+          .join('\n'),
       );
     }
     return readFileSync(outBin);
@@ -174,7 +178,9 @@ describe('MON3 acceptance failure summaries', () => {
       ].join('\n'),
     );
 
-    expect(summarizeBinaryMismatch(Buffer.from([0x00, 0x02]), Buffer.from([0x00, 0x01, 0x03]))).toBe(
+    expect(
+      summarizeBinaryMismatch(Buffer.from([0x00, 0x02]), Buffer.from([0x00, 0x01, 0x03])),
+    ).toBe(
       'Binary length: actual=2 reference=3\nFirst mismatch @0x0001: actual=0x02 reference=0x01',
     );
   });
@@ -204,7 +210,19 @@ describeMon3('ASM80 MON3 acceptance', () => {
   });
 });
 
-if (!classicAsm80Available || !classicModuleLoweringAvailable) {
+if (runMon3Acceptance && !mon3FilesAvailable) {
+  describe('ASM80 MON3 acceptance', () => {
+    it('requires the local MON3 source when opt-in acceptance is enabled', () => {
+      throw new Error(`MON3 source is unavailable: ${manifest.source}`);
+    });
+  });
+} else if (runMon3Acceptance && !asm80) {
+  describe('ASM80 MON3 acceptance', () => {
+    it('requires asm80 when opt-in acceptance is enabled', () => {
+      throw new Error('asm80 executable is unavailable. Set ASM80 or ASM80_PATH.');
+    });
+  });
+} else if (!classicAsm80Available || !classicModuleLoweringAvailable) {
   describe('ASM80 MON3 acceptance', () => {
     it.todo('BLOCKED: enable when classic ASM80 module parsing/lowering is wired into compile()');
   });


### PR DESCRIPTION
## Summary

Improves the opt-in ASM80 baseline workflow introduced in #1376.

Changes:

- `npm run test:asm80:baseline` now supports path overrides:
  - `MON3_SOURCE`
  - `TEC1G_SOFTWARE_ROOT`
  - existing `ASM80` / `ASM80_PATH`
- the wrapper preflights both the MON3 source and TEC-1G software root with explicit override guidance
- TEC-1G mismatch output now includes length delta and byte windows around the first mismatch
- the testing guide documents the override variables
- workflow coverage checks the npm script, docs, override wiring, and diagnostic markers

## Why

The ASM80 baseline gate now has the right shape for ongoing use outside one local checkout layout, and failures should be easier to diagnose when the TEC-1G corpus drifts.

## Verification

- `npx vitest run test/asm80/asm80_baseline_workflow.test.ts`
- `npm run test:asm80:baseline`
- `npm run typecheck -- --pretty false`
- `npm run lint`
- `npm run check:source-file-sizes:enforce`
- `npx prettier -c docs/reference/testing-verification-guide.md scripts/dev/run-asm80-baseline.mjs scripts/dev/compare-tec1g-corpus.mjs test/asm80/asm80_baseline_workflow.test.ts`
- `git diff --check`
