### PR TITLE
[codex] preserve ASM80 include diagnostic provenance

### DIFF
--- a/src/frontend/asm80/parseClassicModule.ts
+++ b/src/frontend/asm80/parseClassicModule.ts
@@ -1,9 +1,14 @@
 import type { Diagnostic } from '../../diagnosticTypes.js';
 
-import type { AsmLabelNode, ClassicItemNode, ClassicModuleFileNode, ModuleFileNode } from '../ast.js';
+import type {
+  AsmLabelNode,
+  ClassicItemNode,
+  ClassicModuleFileNode,
+  ModuleFileNode,
+} from '../ast.js';
 import { parseAsmInstruction } from '../parseAsmInstruction.js';
 import { parseImmExprFromText } from '../parseImm.js';
-import { makeSourceFile, span } from '../source.js';
+import { makeSourceFile, type SourceFile, span } from '../source.js';
 import { parseClassicLine } from './classicLine.js';
 
 function rawLineEndOffset(sourceText: string, startOffset: number): number {
@@ -20,7 +25,9 @@ function parseClassicRawValues(
   stringEquates: Map<string, string>,
 ): unknown[] {
   const out: unknown[] = [];
-  const parts = splitTopLevelComma(valuesText).map((part) => part.trim()).filter((part) => part.length > 0);
+  const parts = splitTopLevelComma(valuesText)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
   for (const part of parts) {
     const rawString = parseWholeQuotedString(part);
     if (rawString !== undefined) {
@@ -41,7 +48,12 @@ function parseClassicRawValues(
       out.push({ kind: 'ClassicString', value: stringEquate });
       continue;
     }
-    const expr = parseImmExprFromText(path, normalizeDoubleQuotedCharExpr(part), lineSpan, diagnostics);
+    const expr = parseImmExprFromText(
+      path,
+      normalizeDoubleQuotedCharExpr(part),
+      lineSpan,
+      diagnostics,
+    );
     if (expr) out.push(expr);
   }
   return out;
@@ -128,8 +140,9 @@ export function parseClassicModule(
   path: string,
   sourceText: string,
   _diagnostics: Diagnostic[],
+  sourceFile?: SourceFile,
 ): ClassicModuleFileNode {
-  const file = makeSourceFile(path, sourceText);
+  const file = sourceFile ?? makeSourceFile(path, sourceText);
   const items: ClassicItemNode[] = [];
   let pendingRawLabel: AsmLabelNode | undefined;
   let ended = false;
@@ -150,6 +163,7 @@ export function parseClassicModule(
     const raw = lines[index]!;
     const lineStart = file.lineStarts[index] ?? sourceText.length;
     const lineSpan = span(file, lineStart, rawLineEndOffset(sourceText, lineStart));
+    const linePath = lineSpan.file;
     const parsed = parseClassicLine(path, raw, index + 1, lineStart);
     if (!parsed) continue;
     if (ended && parsed.kind !== 'binfrom' && parsed.kind !== 'binto') continue;
@@ -166,7 +180,7 @@ export function parseClassicModule(
           items.push({ kind: 'AsmLabel', span: lineSpan, name: parsed.label });
         }
         const instruction = parseAsmInstruction(
-          path,
+          linePath,
           parsed.operandText.length > 0 ? `${parsed.head} ${parsed.operandText}` : parsed.head,
           lineSpan,
           _diagnostics,
@@ -182,7 +196,7 @@ export function parseClassicModule(
           name: parsed.name,
           exprText: parsed.exprText,
           value: parseImmExprFromText(
-            path,
+            linePath,
             normalizeDoubleQuotedCharExpr(parsed.exprText),
             lineSpan,
             _diagnostics,
@@ -196,7 +210,7 @@ export function parseClassicModule(
           kind: 'ClassicOrg',
           span: lineSpan,
           exprText: parsed.exprText,
-          value: parseImmExprFromText(path, parsed.exprText, lineSpan, _diagnostics),
+          value: parseImmExprFromText(linePath, parsed.exprText, lineSpan, _diagnostics),
         } as ClassicItemNode);
         pendingRawLabel = undefined;
         break;
@@ -205,7 +219,7 @@ export function parseClassicModule(
           kind: 'ClassicBinFrom',
           span: lineSpan,
           exprText: parsed.exprText,
-          value: parseImmExprFromText(path, parsed.exprText, lineSpan, _diagnostics),
+          value: parseImmExprFromText(linePath, parsed.exprText, lineSpan, _diagnostics),
         } as ClassicItemNode);
         pendingRawLabel = undefined;
         break;
@@ -214,12 +228,12 @@ export function parseClassicModule(
           kind: 'ClassicBinTo',
           span: lineSpan,
           exprText: parsed.exprText,
-          value: parseImmExprFromText(path, parsed.exprText, lineSpan, _diagnostics),
+          value: parseImmExprFromText(linePath, parsed.exprText, lineSpan, _diagnostics),
         } as ClassicItemNode);
         pendingRawLabel = undefined;
         break;
       case 'align': {
-        const value = parseImmExprFromText(path, parsed.exprText, lineSpan, _diagnostics);
+        const value = parseImmExprFromText(linePath, parsed.exprText, lineSpan, _diagnostics);
         if (value) {
           items.push({ kind: 'ClassicAlign', span: lineSpan, value } as unknown as ClassicItemNode);
         }
@@ -234,7 +248,7 @@ export function parseClassicModule(
           name,
           directive: parsed.directive,
           values: parseClassicRawValues(
-            path,
+            linePath,
             parsed.valuesText,
             lineSpan,
             _diagnostics,
@@ -272,8 +286,9 @@ export function parseClassicModuleFile(
   path: string,
   sourceText: string,
   diagnostics: Diagnostic[],
+  sourceFile?: SourceFile,
 ): ModuleFileNode {
-  const parsed = parseClassicModule(path, sourceText, diagnostics);
+  const parsed = parseClassicModule(path, sourceText, diagnostics, sourceFile);
   return {
     kind: 'ModuleFile',
     span: parsed.span,

--- a/src/moduleLoader.ts
+++ b/src/moduleLoader.ts
@@ -250,7 +250,12 @@ function parseExpandedModuleFile(
   diagnostics: Diagnostic[],
   sourceMode: SourceMode,
 ): ModuleFileNode | undefined {
-  if (sourceMode === 'asm80') return parseClassicModuleFile(modulePath, expanded.text, diagnostics);
+  if (sourceMode === 'asm80') {
+    const sourceFile = makeSourceFile(modulePath, expanded.text);
+    sourceFile.lineFiles = expanded.lineFiles;
+    sourceFile.lineBaseLines = expanded.lineBaseLines;
+    return parseClassicModuleFile(modulePath, expanded.text, diagnostics, sourceFile);
+  }
 
   try {
     const sourceFile = makeSourceFile(modulePath, expanded.text);
@@ -490,7 +495,10 @@ export async function loadProgram(
     sourceLineComments,
     moduleTraversal: collectModuleTraversal(entryPath, edges),
     resolvedImportGraph: new Map(
-      Array.from(edges.entries(), ([modulePath, moduleEdges]) => [modulePath, Array.from(moduleEdges.keys())]),
+      Array.from(edges.entries(), ([modulePath, moduleEdges]) => [
+        modulePath,
+        Array.from(moduleEdges.keys()),
+      ]),
     ),
   };
 }

--- a/test/asm80/asm80_directives_integration.test.ts
+++ b/test/asm80/asm80_directives_integration.test.ts
@@ -36,7 +36,12 @@ function current(line = 1): ImmExprNode {
   return { kind: 'ImmCurrentLocation', span: span(line) };
 }
 
-function binary(op: Extract<ImmExprNode, { kind: 'ImmBinary' }>['op'], left: ImmExprNode, right: ImmExprNode, line = 1): ImmExprNode {
+function binary(
+  op: Extract<ImmExprNode, { kind: 'ImmBinary' }>['op'],
+  left: ImmExprNode,
+  right: ImmExprNode,
+  line = 1,
+): ImmExprNode {
   return { kind: 'ImmBinary', span: span(line), op, left, right };
 }
 
@@ -70,7 +75,11 @@ describe('asm80 directive lowering integration', () => {
   it('compiles EX AF,AF prime with a trailing comment', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-af-prime-'));
     const entry = join(dir, 'af-prime.z80');
-    writeFileSync(entry, [".org 0100H", "ex af,af'           ;start saving registers"].join('\n'), 'utf8');
+    writeFileSync(
+      entry,
+      ['.org 0100H', "ex af,af'           ;start saving registers"].join('\n'),
+      'utf8',
+    );
 
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
@@ -177,7 +186,16 @@ describe('asm80 directive lowering integration', () => {
     const entry = join(dir, 'tec1g-directives.z80');
     writeFileSync(
       entry,
-      ['ORG 4000H', 'API: EQU 0x10', 'DB API', 'DS 2,0FFH', 'DB 4', 'END', '.binfrom 4000H', '.binto 4002H'].join('\n'),
+      [
+        'ORG 4000H',
+        'API: EQU 0x10',
+        'DB API',
+        'DS 2,0FFH',
+        'DB 4',
+        'END',
+        '.binfrom 4000H',
+        '.binto 4002H',
+      ].join('\n'),
       'utf8',
     );
 
@@ -330,12 +348,8 @@ describe('asm80 directive lowering integration', () => {
     expect(bin).toBeDefined();
     if (!bin) throw new Error('missing bin artifact');
     expect([...bin.bytes]).toEqual([
-      0x22, 0x00, 0x09,
-      0xed, 0x43, 0x00, 0x09,
-      0xed, 0x53, 0x00, 0x09,
-      0xed, 0x73, 0x00, 0x09,
-      0xdd, 0x22, 0x00, 0x09,
-      0xfd, 0x22, 0x00, 0x09,
+      0x22, 0x00, 0x09, 0xed, 0x43, 0x00, 0x09, 0xed, 0x53, 0x00, 0x09, 0xed, 0x73, 0x00, 0x09,
+      0xdd, 0x22, 0x00, 0x09, 0xfd, 0x22, 0x00, 0x09,
     ]);
   });
 
@@ -351,6 +365,29 @@ describe('asm80 directive lowering integration', () => {
     expect(bin).toBeDefined();
     if (!bin) throw new Error('missing bin artifact');
     expect([...bin.bytes]).toEqual([0xcb, 0x2f]);
+  });
+
+  it('reports diagnostics from classic ASM80 includes at the included file', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-include-diag-'));
+    const entry = join(dir, 'entry.z80');
+    const child = join(dir, 'child.z80');
+    writeFileSync(
+      entry,
+      ['.org 0100H', '.include "child.z80"', '.binfrom 0100H'].join('\n'),
+      'utf8',
+    );
+    writeFileSync(child, ['.db 1', '.db BAD+'].join('\n'), 'utf8');
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          file: child,
+          line: 2,
+        }),
+      ]),
+    );
   });
 
   it('emits parsed db string fragments and string-character expressions', () => {


### PR DESCRIPTION
## Summary

Preserves include provenance for classic ASM80 diagnostics.

Previously the module loader expanded `.include` sources with per-line file/line metadata, but the classic ASM80 parser was called with only the expanded text. Diagnostics from included ASM80 files could therefore point at the entry file and expanded line number instead of the original included source.

Changes:

- pass the expanded `SourceFile` line map into `parseClassicModuleFile` for ASM80 mode
- allow `parseClassicModule` / `parseClassicModuleFile` to accept an existing include-aware source file
- use each line span's mapped file when parsing classic instructions and immediate expressions
- add regression coverage for a bad `.db BAD+` inside an included `.z80` file

## Verification

- `npx vitest run test/asm80/asm80_directives_integration.test.ts --testNamePattern "reports diagnostics from classic ASM80 includes"`
- `npx vitest run test/asm80/asm80_directives_integration.test.ts test/frontend/asm80_classic_module.test.ts test/frontend/asm80_classic_line.test.ts test/pr950_include_text_only.test.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint`
- `npm run test:asm80:baseline`
- `npm run check:source-file-sizes:enforce`
- targeted Prettier check on touched files
- `git diff --check`
