### PR TITLE
[codex] document ASM80 baseline matrix

### DIFF
--- a/docs/design/asm80-compatibility-baseline.md
+++ b/docs/design/asm80-compatibility-baseline.md
@@ -55,6 +55,18 @@ The primary corpus is large enough to define the first practical subset:
 10,865 lines on the recursive build path, with normal labels, equates, raw
 data, includes, expressions, placement, and a broad set of Z80 opcodes.
 
+## Compatibility matrix
+
+| Area                     | Covered                                                                                                                                                    | Source of coverage                                 | Explicitly excluded or deferred                                      |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------------------- |
+| Source mode              | `.z80` and `.asm` classic ASM80 mode; `.zax` unchanged                                                                                                     | MON3, TEC-1G, `test/asm80/mon3_acceptance.test.ts` | Full ASM80 clone mode                                                |
+| Labels and equates       | Colon labels, label plus statement, `NAME: .equ`, `NAME .equ`, undotted `EQU`                                                                              | MON3, TEC-1G                                       | Macro-local and text-substitution label semantics                    |
+| Literals and expressions | Trailing `H`/`B`, `0xNN`, `$`, `+ - * /`, parentheses, one-character strings                                                                               | MON3, TEC-1G, directive tests                      | Broad ASM80 expression extensions unless corpus-driven               |
+| Data and directives      | `.org`, `.include`, `.db`, `.dw`, `.ds`, `.align`, `.cstr`, `.pstr`, `.istr`, `.binfrom`, `.binto`, `.end`; dotted, undotted, and mixed case where covered | MON3, TEC-1G, ASM80 directive/string/align tests   | `DUP`, `.incbin`, `.set`, segments, `.pragma`, `.ent`                |
+| Z80 syntax               | Ordinary MON3 instruction heads and operand/addressing forms; TEC-1G additions such as `SRA A` and `LD (addr),HL`                                          | MON3 audit, TEC-1G audit, opcode gap tests         | Instruction forms absent from real corpora do not block the baseline |
+| Includes and output      | Relative quoted includes, included-file diagnostics, post-`.end` `.binfrom`/`.binto`, no-`.org` sources starting at zero                                   | MON3, TEC-1G, directive and CLI diagnostics tests  | `.include file:block`                                                |
+| Baseline corpora         | MON3 recursive tree as the primary corpus; TEC-1G non-macro corpus as the secondary corpus                                                                 | `npm run test:asm80:baseline`                      | Macro-bearing TEC-1G `Education/tbasic.z80`                          |
+
 ## Required syntax
 
 The first compatibility level requires:
@@ -117,19 +129,19 @@ them and they do not undermine the assembler-first ZAX direction.
 Where ZAX and ASM80 already cover the same raw assembler concept, prefer the
 ASM80 spelling for the assembler-facing surface:
 
-| Concept | Preferred assembler spelling |
-|---|---|
-| source inclusion | `.include "file"` |
-| raw equate | `NAME: .equ expr` or `NAME .equ expr` |
-| placement | `.org expr` |
-| raw bytes | `.db expr, ...` |
-| raw words | `.dw expr, ...` |
-| reserve bytes | `.ds size` |
-| alignment | `.align expr` |
-| C string | `.cstr "text"` |
-| Pascal string | `.pstr "text"` |
-| high-bit terminated string | `.istr "text"` |
-| binary start | `.binfrom expr` |
+| Concept                    | Preferred assembler spelling          |
+| -------------------------- | ------------------------------------- |
+| source inclusion           | `.include "file"`                     |
+| raw equate                 | `NAME: .equ expr` or `NAME .equ expr` |
+| placement                  | `.org expr`                           |
+| raw bytes                  | `.db expr, ...`                       |
+| raw words                  | `.dw expr, ...`                       |
+| reserve bytes              | `.ds size`                            |
+| alignment                  | `.align expr`                         |
+| C string                   | `.cstr "text"`                        |
+| Pascal string              | `.pstr "text"`                        |
+| high-bit terminated string | `.istr "text"`                        |
+| binary start               | `.binfrom expr`                       |
 
 This does not make every ZAX construct obsolete. `const` remains a clean
 ZAX-level declaration, and typed storage, structured control, records, unions,
@@ -172,6 +184,49 @@ The secondary TEC-1G software corpus is tracked in
 `docs/design/asm80-tec1g-compatibility-audit.md`. It deliberately excludes
 sources containing `.macro`/`.endm`, and currently verifies 12 non-macro TEC-1G
 programs byte-for-byte against ASM80.
+
+## Baseline corpora and gates
+
+The standing local compatibility gate is:
+
+```sh
+npm run test:asm80:baseline
+```
+
+That command builds ZAX, runs the MON3 acceptance test, and compares the TEC-1G
+non-macro corpus against ASM80:
+
+- `scripts/dev/run-asm80-baseline.mjs`
+- `test/asm80/mon3_acceptance.test.ts`
+- `scripts/dev/compare-tec1g-corpus.mjs`
+
+The command defaults to the maintainer workspace layout. Override paths with
+`MON3_SOURCE`, `TEC1G_SOFTWARE_ROOT`, and `ASM80` or `ASM80_PATH` when running
+the gate from another checkout layout.
+
+## Candidate follow-up corpora
+
+Additional corpora should be added deliberately, one set at a time, and only
+after excluding Tiny Basic and files containing `.macro` or `.endm`.
+
+Recommended next candidates:
+
+- `/Users/johnhardy/Documents/projects/Software/monitors`
+- `/Users/johnhardy/Documents/projects/Software/games`
+- `/Users/johnhardy/Documents/projects/Software/magazine_code`
+- `/Users/johnhardy/Documents/projects/2024/TEC-1_Dev`
+- `/Users/johnhardy/Documents/projects/2024/asm80-node/test`
+
+The `Software` tree is the best next real-world expansion point, especially
+the monitor, game, and magazine-code directories. The `asm80-node/test` tree is
+better treated as targeted ASM80 compatibility pressure rather than as a
+handwritten application corpus, because it intentionally exercises features
+such as `.incbin`, `.ent`, segment pragmas, and `DEFB`/`DEFW`.
+
+Defer preprocessor-heavy corpora such as
+`/Users/johnhardy/Documents/projects/2024/z80float` until there is an explicit
+decision to support `#include`/`#define`-style source preprocessing and
+multi-statement line continuations.
 
 ## Acceptance threshold
 

--- a/docs/design/asm80-tec1g-compatibility-audit.md
+++ b/docs/design/asm80-tec1g-compatibility-audit.md
@@ -49,6 +49,13 @@ revisited, the preferred direction is to translate the specific behavior into a
 ZAX `ops`-style facility or a narrow assembler directive, not to implement the
 ASM80 text macro system.
 
+## Matrix Delta
+
+TEC-1G extends the central compatibility matrix with undotted directives,
+`.binto`, `DS count,fill`, `0xNN` literals, no-`.end` sources, no-`.org`
+sources that start at zero, `SRA A`, and absolute register stores such as
+`LD (addr),HL`.
+
 ## Added Coverage
 
 Compared with the MON3 baseline, the TEC-1G non-macro corpus adds useful

--- a/test/cli/cli_failure_contract_matrix.test.ts
+++ b/test/cli/cli_failure_contract_matrix.test.ts
@@ -137,6 +137,58 @@ describe('cli failure contract matrix', () => {
     await rm(work, { recursive: true, force: true });
   });
 
+  it('returns code 1 for ASM80 include parser diagnostics at the included file', async () => {
+    const work = await mkdtemp(join(tmpdir(), 'zax-cli-asm80-include-error-'));
+    const entry = join(work, 'entry.z80');
+    const child = join(work, 'child.z80');
+    const outBin = join(work, 'out.bin');
+    const base = join(work, 'out');
+    await writeFile(
+      entry,
+      ['.org 0100H', '.include "child.z80"', '.binfrom 0100H'].join('\n'),
+      'utf8',
+    );
+    await writeFile(child, ['.db 1', '.db BAD+'].join('\n'), 'utf8');
+
+    const res = await runCli(['--nolist', '--nohex', '--nod8m', '-t', 'bin', '-o', outBin, entry]);
+
+    expect(res.code).toBe(1);
+    expect(res.stdout).toBe('');
+    expect(res.stderr).toContain(`${child}:2:1`);
+    expect(res.stderr).toContain('[ZAX100]');
+    expect(res.stderr).toContain('Invalid imm expression: BAD+');
+    expect(res.stderr).not.toContain(`${entry}:3:1`);
+    await expectNoArtifacts(base);
+
+    await rm(work, { recursive: true, force: true });
+  });
+
+  it('returns code 1 for ASM80 include encoder diagnostics at the included file', async () => {
+    const work = await mkdtemp(join(tmpdir(), 'zax-cli-asm80-include-encode-error-'));
+    const entry = join(work, 'entry.z80');
+    const child = join(work, 'child.z80');
+    const outBin = join(work, 'out.bin');
+    const base = join(work, 'out');
+    await writeFile(
+      entry,
+      ['.org 0100H', '.include "child.z80"', '.binfrom 0100H'].join('\n'),
+      'utf8',
+    );
+    await writeFile(child, 'ld a,300\n', 'utf8');
+
+    const res = await runCli(['--nolist', '--nohex', '--nod8m', '-t', 'bin', '-o', outBin, entry]);
+
+    expect(res.code).toBe(1);
+    expect(res.stdout).toBe('');
+    expect(res.stderr).toContain(`${child}:1:1`);
+    expect(res.stderr).toContain('[ZAX200]');
+    expect(res.stderr).toContain('ld A, n expects imm8');
+    expect(res.stderr).not.toContain(`${entry}:2:1`);
+    await expectNoArtifacts(base);
+
+    await rm(work, { recursive: true, force: true });
+  });
+
   it('returns code 1 for encoder diagnostics and writes no artifacts', async () => {
     const work = await mkdtemp(join(tmpdir(), 'zax-cli-encode-error-'));
     const entry = join(work, 'encode-error.zax');


### PR DESCRIPTION
## Summary

Documents the current ASM80 baseline more explicitly and adds CLI regression coverage for include provenance.

Changes:

- adds a scan-friendly compatibility matrix to `docs/design/asm80-compatibility-baseline.md`
- documents the standing baseline gate and local override variables in the baseline doc
- records ranked follow-up corpus candidates discovered by the parallel corpus scan
- adds a TEC-1G matrix delta note
- adds CLI tests proving ASM80 include parser and encoder diagnostics report the included file, not the entry include site

## Parallel streams used

- Corpus discovery stream scanned sibling project corpora and recommended the next candidates without adding them prematurely.
- CLI diagnostics stream confirmed the formatter already prints `file:line:column` and recommended encoder-level include coverage.
- Docs stream proposed the compatibility matrix and insertion points.

## Verification

- `npx vitest run test/cli/cli_failure_contract_matrix.test.ts --testNamePattern "ASM80 include .* diagnostics"`
- `npm run typecheck -- --pretty false`
- `npm run lint`
- `npm run test:asm80:baseline`
- `npm run check:source-file-sizes:enforce`
- targeted Prettier check on changed docs/test files
- `git diff --check`
