### PR TITLE
[codex] add Software ASM80 corpus audit

### DIFF
--- a/docs/design/asm80-compatibility-baseline.md
+++ b/docs/design/asm80-compatibility-baseline.md
@@ -223,6 +223,10 @@ better treated as targeted ASM80 compatibility pressure rather than as a
 handwritten application corpus, because it intentionally exercises features
 such as `.incbin`, `.ent`, segment pragmas, and `DEFB`/`DEFW`.
 
+The Software-tree audit is tracked separately in
+`docs/design/asm80-software-compatibility-audit.md`. It is not part of the
+standing baseline gate.
+
 Defer preprocessor-heavy corpora such as
 `/Users/johnhardy/Documents/projects/2024/z80float` until there is an explicit
 decision to support `#include`/`#define`-style source preprocessing and

--- a/docs/design/asm80-software-compatibility-audit.md
+++ b/docs/design/asm80-software-compatibility-audit.md
@@ -1,0 +1,144 @@
+# ASM80 Software compatibility audit
+
+Status: exploratory compatibility audit for the ASM80-first language track
+Date: 2026-05-11
+
+## Purpose
+
+This audit expands beyond MON3 and TEC-1G into the sibling `Software` source
+tree. It is deliberately exploratory: it identifies useful next compatibility
+gaps and corpus candidates, but it does not change the standing ASM80 baseline
+gate.
+
+The goal is still the same narrow one: support ordinary macro-free Z80
+assembler source. This is not a decision to implement the full ASM80 language.
+
+## Relationship to the Standing Baseline
+
+The standing gate remains:
+
+```sh
+npm run test:asm80:baseline
+```
+
+That gate covers the recursive MON3 source tree and the TEC-1G non-macro
+corpus. The Software corpus is not part of that command yet.
+
+Promotion requires a later deliberate change to the baseline docs, comparison
+scripts, and `run-asm80-baseline.mjs`.
+
+## Corpus
+
+Root:
+
+- `/Users/johnhardy/Documents/projects/Software`
+
+Initial audit partitions:
+
+- `monitors`: 30 `.asm`/`.z80` files
+- `games`: 12 `.asm`/`.z80` files
+- `magazine_code`: 41 `.asm`/`.z80` files
+
+The broader tree contains additional candidate areas such as `music/sn76489`,
+`misc`, and `TEC-1G_software/source`, but those are outside the first Software
+audit slice.
+
+## Exclusion Policy
+
+The Software audit follows the same exclusion policy as the TEC-1G audit:
+
+- exclude files containing `.macro` or `.endm`
+- exclude Tiny Basic-style macro/preprocessor sources from the first slice
+- do not implement ASM80 text macros just to admit excluded files
+- record exclusions by relative path and reason when they become part of a
+  promoted corpus
+
+## Audit Method
+
+The exploratory command shape is:
+
+```sh
+npm run build
+node scripts/dev/compare-software-corpus.mjs /Users/johnhardy/Documents/projects/Software/<slice>
+```
+
+The Software wrapper delegates to the shared ASM80 corpus comparator. It is
+intentionally still a development script. The comparator walks both `.z80` and
+`.asm` files, copies sibling `.z80`/`.asm` files into the ASM80 temp directory
+so relative includes can resolve, and compares ZAX output against the ASM80
+reference bytes.
+
+## Current Result
+
+Initial exploratory results:
+
+```text
+Software/monitors:      30 included, 5 matched, 25 not yet compatible or not standalone
+Software/games:         12 included, 11 matched, 1 not yet compatible
+Software/magazine_code: 41 included, 41 matched
+```
+
+The strongest first promotion candidate is `Software/magazine_code`, because
+all 41 files currently match ASM80:
+
+```sh
+node scripts/dev/compare-software-corpus.mjs /Users/johnhardy/Documents/projects/Software/magazine_code
+```
+
+The next best candidate is `Software/games` after adding support for the `DEFB`
+byte-data alias used by `games/Tape/Invaders.z80`. In the current pass, 11 of
+12 game sources match ASM80.
+
+The `monitors` slice is valuable as a compatibility backlog, but it should not
+be promoted yet. It exposes broader gaps and non-standalone source files.
+
+## Compatibility Matrix Delta
+
+The Software audit adds pressure in these areas beyond MON3 and TEC-1G:
+
+- `.asm` files as classic source inputs, not only `.z80`
+- sibling relative includes during ASM80 reference comparison
+- `DEFB` byte-data alias
+- `RMB` reserve-byte alias
+- `RST 20H` immediate syntax
+- `$FE` hexadecimal literal syntax
+- relative branch fixup behavior for `JR` and `DJNZ`
+- non-standalone module files that depend on symbols from a larger build
+
+## Observed Blockers
+
+Examples from the first monitor/game pass:
+
+- `Software/games/Tape/Invaders.z80`: uses `DEFB`
+- `Software/monitors/JMon/JmonSource/JMON_SRC_01.asm`: uses `RST 20H`
+- `Software/monitors/JMon/JMON_SouthernCrossVersion/JMON_SCV01.asm`: uses `RMB`
+- `Software/monitors/Mon-2/Mon2a_JH/MON2A_JH.asm`: uses `$FE`
+- `Software/monitors/Mon-1/Mon-1A/mon1A.asm`: exposes `JR`/`DJNZ` branch
+  range/fixup gaps
+
+Some monitor files fail under ASM80 when compiled as standalone files because
+they depend on sibling modules or larger build context. Those should be handled
+as build roots, not as isolated source files.
+
+## Promotion Criteria
+
+Promote a Software slice into the standing baseline only after:
+
+1. The included file list is explicit.
+2. The excluded file list and reasons are explicit.
+3. All included files compare byte-for-byte against ASM80, or each intentional
+   difference is documented.
+4. `.org`, `.binfrom`, `.binto`, and full-64K ASM80 outputs have stable
+   normalization rules.
+5. Macro/text-substitution support remains out of scope.
+6. `run-asm80-baseline.mjs`, `package.json`, and the baseline docs are updated
+   in a separate promotion PR.
+
+## Baseline Decision
+
+The Software corpus is not part of `npm run test:asm80:baseline`.
+
+It is an exploratory audit corpus. It should drive focused compatibility tests
+and implementation slices, beginning with `DEFB` if the `games` slice is chosen
+next, or with direct promotion of `magazine_code` if the goal is to add a green
+third corpus quickly.

--- a/scripts/dev/compare-software-corpus.mjs
+++ b/scripts/dev/compare-software-corpus.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const defaultRoot = '/Users/johnhardy/Documents/projects/Software/magazine_code';
+const root = process.argv[2] ?? defaultRoot;
+
+if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  console.log(
+    [
+      'Usage: node scripts/dev/compare-software-corpus.mjs [software-slice-root]',
+      '',
+      `Default software slice root: ${defaultRoot}`,
+      'This is an exploratory audit helper. It is not part of npm run test:asm80:baseline.',
+    ].join('\n'),
+  );
+  process.exit(0);
+}
+
+if (process.argv.length > 3) {
+  console.error('Usage: node scripts/dev/compare-software-corpus.mjs [software-slice-root]');
+  process.exit(2);
+}
+
+if (!existsSync(root)) {
+  console.error(`Software corpus root not found: ${root}`);
+  process.exit(1);
+}
+
+const script = resolve('scripts/dev/compare-tec1g-corpus.mjs');
+const result = spawnSync(process.execPath, [script, root], {
+  cwd: process.cwd(),
+  stdio: 'inherit',
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/scripts/dev/compare-tec1g-corpus.mjs
+++ b/scripts/dev/compare-tec1g-corpus.mjs
@@ -39,13 +39,13 @@ function findAsm80() {
   return undefined;
 }
 
-function walkZ80Files(root) {
+function walkAsm80Files(root) {
   const out = [];
   for (const entry of readdirSync(root, { withFileTypes: true })) {
     const path = join(root, entry.name);
     if (entry.isDirectory()) {
-      out.push(...walkZ80Files(path));
-    } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.z80')) {
+      out.push(...walkAsm80Files(path));
+    } else if (entry.isFile() && /\.(z80|asm)$/i.test(entry.name)) {
       out.push(path);
     }
   }
@@ -93,13 +93,25 @@ function binaryFromListingRange(bytes, range) {
   return bytes.subarray(range.start, end);
 }
 
+function sourceStem(source) {
+  return basename(source).replace(/\.(z80|asm)$/i, '');
+}
+
+function copySiblingAsm80Sources(source, workDir) {
+  for (const entry of readdirSync(dirname(source), { withFileTypes: true })) {
+    if (entry.isFile() && /\.(z80|asm)$/i.test(entry.name)) {
+      copyFileSync(join(dirname(source), entry.name), join(workDir, entry.name));
+    }
+  }
+}
+
 function runAsm80(source, asm80) {
-  const workDir = mkdtempSync(join(tmpdir(), 'zax-tec1g-asm80-one-'));
-  const outName = `${basename(source, '.z80')}.bin`;
+  const workDir = mkdtempSync(join(tmpdir(), 'zax-asm80-reference-one-'));
+  const outName = `${sourceStem(source)}.bin`;
   const sourceName = basename(source);
-  const listingPath = join(workDir, `${basename(source, '.z80')}.lst`);
+  const listingPath = join(workDir, `${sourceStem(source)}.lst`);
   try {
-    copyFileSync(source, join(workDir, sourceName));
+    copySiblingAsm80Sources(source, workDir);
     const result = run(asm80, ['-m', 'Z80', '-t', 'bin', '-o', outName, sourceName], {
       cwd: workDir,
     });
@@ -114,7 +126,7 @@ function runAsm80(source, asm80) {
 }
 
 function runZax(source, outDir) {
-  const outPath = join(outDir, `${basename(source, '.z80')}.bin`);
+  const outPath = join(outDir, `${sourceStem(source)}.bin`);
   const result = run(
     process.execPath,
     [
@@ -209,11 +221,11 @@ function main(argv) {
 
   const zaxOut = mkdtempSync(join(tmpdir(), 'zax-tec1g-zax-'));
   try {
-    const sources = walkZ80Files(root);
+    const sources = walkAsm80Files(root);
     const included = sources.filter((source) => !isMacroSource(source));
     const excluded = sources.filter(isMacroSource);
-    console.log(`TEC-1G root: ${root}`);
-    console.log(`Included .z80 files: ${included.length}`);
+    console.log(`ASM80 corpus root: ${root}`);
+    console.log(`Included .asm/.z80 files: ${included.length}`);
     console.log(`Excluded macro files: ${excluded.length}`);
     for (const source of excluded) console.log(`EXCLUDED macro ${relative(root, source)}`);
 


### PR DESCRIPTION
## Summary

Adds an exploratory ASM80 audit for the sibling `Software` corpus without promoting it into the standing baseline gate.

Changes:

- generalizes the dev comparator to walk both `.z80` and `.asm` files
- copies sibling `.z80`/`.asm` files into ASM80 temp dirs so relative includes can resolve
- fixes comparator output/listing naming through an explicit source-stem helper
- adds `scripts/dev/compare-software-corpus.mjs` as a Software-specific wrapper, defaulting to the green `magazine_code` slice
- adds `docs/design/asm80-software-compatibility-audit.md`
- links the Software audit from the central ASM80 baseline doc

## Current audit result

Measured locally:

- `Software/magazine_code`: 41/41 matched ASM80
- `Software/games`: 11/12 matched; remaining visible blocker is `DEFB` in `Tape/Invaders.z80`
- `Software/monitors`: useful backlog, but not ready for promotion; gaps include `RMB`, `RST 20H`, `$FE`, `DEFB`, `JR`/`DJNZ` branch target behavior, and non-standalone monitor modules

This PR does not change `npm run test:asm80:baseline`.

## Verification

- `node scripts/dev/compare-software-corpus.mjs /Users/johnhardy/Documents/projects/Software/magazine_code`
- `node scripts/dev/compare-software-corpus.mjs --help`
- `node scripts/dev/compare-tec1g-corpus.mjs /Users/johnhardy/Documents/projects/TEC-1G/Software`
- `npm run test:asm80:baseline`
- `npm run typecheck -- --pretty false`
- `npm run lint`
- `npm run check:source-file-sizes:enforce`
- targeted Prettier check on changed docs/scripts
- `git diff --check`
