### PR TITLE
[codex] clarify ASM80 baseline and branch target semantics

### DIFF
--- a/docs/design/asm80-compatibility-baseline.md
+++ b/docs/design/asm80-compatibility-baseline.md
@@ -62,7 +62,7 @@ data, includes, expressions, placement, and a broad set of Z80 opcodes.
 | Source mode              | `.z80` and `.asm` classic ASM80 mode; `.zax` unchanged                                                                                                     | MON3, TEC-1G, `test/asm80/mon3_acceptance.test.ts` | Full ASM80 clone mode                                                |
 | Labels and equates       | Colon labels, label plus statement, `NAME: .equ`, `NAME .equ`, undotted `EQU`                                                                              | MON3, TEC-1G                                       | Macro-local and text-substitution label semantics                    |
 | Literals and expressions | Trailing `H`/`B`, `0xNN`, `$`, `+ - * /`, parentheses, one-character strings                                                                               | MON3, TEC-1G, directive tests                      | Broad ASM80 expression extensions unless corpus-driven               |
-| Data and directives      | `.org`, `.include`, `.db`, `.dw`, `.ds`, `.align`, `.cstr`, `.pstr`, `.istr`, `.binfrom`, `.binto`, `.end`; dotted, undotted, and mixed case where covered | MON3, TEC-1G, ASM80 directive/string/align tests   | `DUP`, `.incbin`, `.set`, segments, `.pragma`, `.ent`                |
+| Data and directives      | `.org`, `.include`, `.db`, `.dw`, `.ds`, `.align`, `.cstr`, `.pstr`, `.istr`, `.binfrom`, `.binto`, `.end`; dotted, undotted, and mixed case where covered | MON3, TEC-1G, ASM80 directive/string/align tests   | dialect aliases such as `DEFB`/`DEFW`/`RMB`, `DUP`, `.incbin`, `.set`, segments, `.pragma`, `.ent` |
 | Z80 syntax               | Ordinary MON3 instruction heads and operand/addressing forms; TEC-1G additions such as `SRA A` and `LD (addr),HL`                                          | MON3 audit, TEC-1G audit, opcode gap tests         | Instruction forms absent from real corpora do not block the baseline |
 | Includes and output      | Relative quoted includes, included-file diagnostics, post-`.end` `.binfrom`/`.binto`, no-`.org` sources starting at zero                                   | MON3, TEC-1G, directive and CLI diagnostics tests  | `.include file:block`                                                |
 | Baseline corpora         | MON3 recursive tree as the primary corpus; TEC-1G non-macro corpus as the secondary corpus                                                                 | `npm run test:asm80:baseline`                      | Macro-bearing TEC-1G `Education/tbasic.z80`                          |
@@ -113,6 +113,8 @@ Do not implement these for the first compatibility level:
 - text-substitution macro semantics
 - non-Z80 processor compatibility
 - broad ASM80 directive coverage not used by MON3 or selected follow-up samples
+- dialect directive aliases such as `DEFB`, `DEFW`, and `RMB`; normalize
+  imported source to `DB`, `DW`, and `DS` before assembly instead
 - VS Code extension work or LSP/language-server integration
 - Debug80 workflow integration beyond compatibility reference checks
 
@@ -149,6 +151,9 @@ modules, OPS, and other higher-level features remain ZAX extensions.
 
 The rule is narrower: raw assembler concepts should not force users to learn a
 second ZAX spelling when the ASM80 spelling is already familiar and adequate.
+For byte, word, and reserve directives, the canonical assembler surface is
+`DB`/`.db`, `DW`/`.dw`, and `DS`/`.ds`. Dialect aliases should be source
+normalization inputs, not additional ZAX core directive names.
 
 ## Current implementation status
 
@@ -219,9 +224,10 @@ Recommended next candidates:
 
 The `Software` tree is the best next real-world expansion point, especially
 the monitor, game, and magazine-code directories. The `asm80-node/test` tree is
-better treated as targeted ASM80 compatibility pressure rather than as a
-handwritten application corpus, because it intentionally exercises features
-such as `.incbin`, `.ent`, segment pragmas, and `DEFB`/`DEFW`.
+better treated as targeted compatibility pressure rather than as a handwritten
+application corpus, because it intentionally exercises features such as
+`.incbin`, `.ent`, and segment pragmas. Dialect aliases such as `DEFB`/`DEFW`
+belong in a source-normalization layer if those files are used.
 
 The Software-tree audit is tracked separately in
 `docs/design/asm80-software-compatibility-audit.md`. It is not part of the

--- a/docs/design/asm80-mon3-compatibility-audit.md
+++ b/docs/design/asm80-mon3-compatibility-audit.md
@@ -70,9 +70,13 @@ Preferred ASM80 forms:
 | ASM80-style raw constants | `Name: .equ expr` or `Name .equ expr` |
 | ZAX-level constants | `const Name = expr` remains a clean ZAX spelling |
 | `align expr` | `.align expr` |
-| `db` / `dw` / `ds` raw data | `.db` / `.dw` / `.ds`, with undotted aliases tolerated |
+| `db` / `dw` / `ds` raw data | `.db` / `.dw` / `.ds`, with undotted ASM80 forms tolerated |
 | low-level string blobs | `.cstr`, `.pstr`, `.istr` where those encodings are intended |
 | binary output trim/start controls | `.binfrom` and later `.binto` |
+
+This tolerance is limited to the canonical ASM80 spellings already in the
+baseline. Dialect aliases such as `DEFB`, `DEFW`, and `RMB` should be
+normalized to `.db`, `.dw`, and `.ds` before ZAX sees the source.
 
 ZAX-only forms remain justified when they carry typed language semantics:
 

--- a/docs/design/asm80-software-compatibility-audit.md
+++ b/docs/design/asm80-software-compatibility-audit.md
@@ -85,9 +85,9 @@ all 41 files currently match ASM80:
 node scripts/dev/compare-software-corpus.mjs /Users/johnhardy/Documents/projects/Software/magazine_code
 ```
 
-The next best candidate is `Software/games` after adding support for the `DEFB`
-byte-data alias used by `games/Tape/Invaders.z80`. In the current pass, 11 of
-12 game sources match ASM80.
+The next best candidate is `Software/games` after normalizing the `DEFB`
+byte-data dialect alias used by `games/Tape/Invaders.z80` to the canonical
+`DB`/`.db` spelling. In the current pass, 11 of 12 game sources match ASM80.
 
 The `monitors` slice is valuable as a compatibility backlog, but it should not
 be promoted yet. It exposes broader gaps and non-standalone source files.
@@ -98,8 +98,8 @@ The Software audit adds pressure in these areas beyond MON3 and TEC-1G:
 
 - `.asm` files as classic source inputs, not only `.z80`
 - sibling relative includes during ASM80 reference comparison
-- `DEFB` byte-data alias
-- `RMB` reserve-byte alias
+- source-normalization pressure for byte/word/reserve dialect aliases such as
+  `DEFB -> DB`, `DEFW -> DW`, and `RMB -> DS`
 - `RST 20H` immediate syntax
 - `$FE` hexadecimal literal syntax
 - relative branch fixup behavior for `JR` and `DJNZ`
@@ -109,9 +109,11 @@ The Software audit adds pressure in these areas beyond MON3 and TEC-1G:
 
 Examples from the first monitor/game pass:
 
-- `Software/games/Tape/Invaders.z80`: uses `DEFB`
+- `Software/games/Tape/Invaders.z80`: uses `DEFB`, which is a normalization
+  blocker rather than a ZAX core directive
 - `Software/monitors/JMon/JmonSource/JMON_SRC_01.asm`: uses `RST 20H`
-- `Software/monitors/JMon/JMON_SouthernCrossVersion/JMON_SCV01.asm`: uses `RMB`
+- `Software/monitors/JMon/JMON_SouthernCrossVersion/JMON_SCV01.asm`: uses
+  `RMB`, which is a normalization blocker rather than a ZAX core directive
 - `Software/monitors/Mon-2/Mon2a_JH/MON2A_JH.asm`: uses `$FE`
 - `Software/monitors/Mon-1/Mon-1A/mon1A.asm`: exposes `JR`/`DJNZ` branch
   range/fixup gaps
@@ -138,7 +140,8 @@ Promote a Software slice into the standing baseline only after:
 
 The Software corpus is not part of `npm run test:asm80:baseline`.
 
-It is an exploratory audit corpus. It should drive focused compatibility tests
-and implementation slices, beginning with `DEFB` if the `games` slice is chosen
-next, or with direct promotion of `magazine_code` if the goal is to add a green
-third corpus quickly.
+It is an exploratory audit corpus. It should drive focused compatibility tests,
+normalization work for dialect aliases, and implementation slices for real ZAX
+gaps. If the `games` slice is chosen next, the first step is normalizing `DEFB`
+outside the core grammar. Direct promotion of `magazine_code` remains the
+quickest green third-corpus option.

--- a/src/frontend/asm80/parseClassicModule.ts
+++ b/src/frontend/asm80/parseClassicModule.ts
@@ -7,6 +7,7 @@ import type {
   ModuleFileNode,
 } from '../ast.js';
 import { parseAsmInstruction } from '../parseAsmInstruction.js';
+import { parseDiag } from '../parseDiagnostics.js';
 import { parseImmExprFromText } from '../parseImm.js';
 import { makeSourceFile, type SourceFile, span } from '../source.js';
 import { parseClassicLine } from './classicLine.js';
@@ -136,6 +137,19 @@ function splitTopLevelComma(text: string): string[] {
   return parts;
 }
 
+function canonicalDirectiveForRejectedAlias(head: string): string | undefined {
+  switch (head.toLowerCase()) {
+    case 'defb':
+      return 'DB';
+    case 'defw':
+      return 'DW';
+    case 'rmb':
+      return 'DS';
+    default:
+      return undefined;
+  }
+}
+
 export function parseClassicModule(
   path: string,
   sourceText: string,
@@ -178,6 +192,17 @@ export function parseClassicModule(
       case 'instruction': {
         if (parsed.label) {
           items.push({ kind: 'AsmLabel', span: lineSpan, name: parsed.label });
+        }
+        const canonicalDirective = canonicalDirectiveForRejectedAlias(parsed.head);
+        if (canonicalDirective) {
+          parseDiag(
+            _diagnostics,
+            linePath,
+            `${parsed.head.toUpperCase()} is not part of the supported ASM80 baseline; use ${canonicalDirective}.`,
+            { line: index + 1, column: raw.indexOf(parsed.head) + 1 },
+          );
+          pendingRawLabel = undefined;
+          break;
         }
         const instruction = parseAsmInstruction(
           linePath,

--- a/src/lowering/classicInstructionLowering.ts
+++ b/src/lowering/classicInstructionLowering.ts
@@ -217,6 +217,32 @@ export function lowerClassicInstruction(ctx: LoweringContext, item: ClassicInstr
     ctx.emitRawCodeBytes(Uint8Array.of(opcode, displacement & 0xff), item.span.file, `${head} ${displacement}`);
     return true;
   };
+  const emitRelativeAbsoluteTarget = (
+    opcode: number,
+    targetExpr: ImmExprNode,
+  ): boolean => {
+    const current = currentActiveAddress(ctx);
+    if (current === undefined) {
+      ctx.diag(ctx.diagnostics, item.span.file, `Failed to evaluate current location.`);
+      return true;
+    }
+    const target = evalClassicImmAtCurrent(ctx, targetExpr, current);
+    if (target === undefined) {
+      ctx.diag(ctx.diagnostics, item.span.file, `Failed to evaluate ${head} target.`);
+      return true;
+    }
+    const displacement = target - (current + 2);
+    if (displacement < -128 || displacement > 127) {
+      ctx.diag(
+        ctx.diagnostics,
+        item.span.file,
+        `${head} relative branch displacement out of range (-128..127): ${displacement}.`,
+      );
+      return true;
+    }
+    ctx.emitRawCodeBytes(Uint8Array.of(opcode, displacement & 0xff), item.span.file, `${head} ${displacement}`);
+    return true;
+  };
 
   if (head === 'djnz' && item.operands.length === 1 && first?.kind === 'Imm') {
     if (emitRelativeCurrentTarget(0x10, first.expr)) return;
@@ -225,6 +251,7 @@ export function lowerClassicInstruction(ctx: LoweringContext, item: ClassicInstr
       ctx.emitRel8Fixup(0x10, symbolic.baseLower, symbolic.addend, item.span, 'djnz');
       return;
     }
+    if (emitRelativeAbsoluteTarget(0x10, first.expr)) return;
   }
   if (head === 'jr' && item.operands.length === 1 && first?.kind === 'Imm') {
     if (emitRelativeCurrentTarget(0x18, first.expr)) return;
@@ -233,6 +260,7 @@ export function lowerClassicInstruction(ctx: LoweringContext, item: ClassicInstr
       ctx.emitRel8Fixup(0x18, symbolic.baseLower, symbolic.addend, item.span, 'jr');
       return;
     }
+    if (emitRelativeAbsoluteTarget(0x18, first.expr)) return;
   }
   if (head === 'jr' && item.operands.length === 2) {
     const cc =
@@ -250,6 +278,7 @@ export function lowerClassicInstruction(ctx: LoweringContext, item: ClassicInstr
         ctx.emitRel8Fixup(opcode, symbolic.baseLower, symbolic.addend, item.span, `jr ${cc}`);
         return;
       }
+      if (emitRelativeAbsoluteTarget(opcode, target.expr)) return;
     }
   }
   if (head === 'call') {

--- a/test/asm80/asm80_directives_integration.test.ts
+++ b/test/asm80/asm80_directives_integration.test.ts
@@ -271,6 +271,63 @@ describe('asm80 directive lowering integration', () => {
     expect([...bin.bytes]).toEqual([0x28, 0x03, 0x10, 0xfe, 0x04, 0x01]);
   });
 
+  it('treats classic JR and DJNZ numeric operands as absolute targets', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-absolute-branches-'));
+    const entry = join(dir, 'absolute-branches.z80');
+    writeFileSync(
+      entry,
+      ['.org 0100H', 'jr 0104H', 'djnz 0106H', 'jr z,0108H', '.binfrom 0100H', '.end'].join('\n'),
+      'utf8',
+    );
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin) throw new Error('missing bin artifact');
+    expect([...bin.bytes]).toEqual([0x18, 0x02, 0x10, 0x02, 0x28, 0x02]);
+  });
+
+  it('rejects out-of-range classic numeric relative branch targets', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-absolute-branch-oob-'));
+    const entry = join(dir, 'absolute-branch-oob.z80');
+    writeFileSync(entry, ['.org 0100H', 'jr 2', 'djnz 2', '.binfrom 0100H', '.end'].join('\n'), 'utf8');
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'error',
+          message: expect.stringContaining('jr relative branch displacement out of range'),
+        }),
+        expect.objectContaining({
+          severity: 'error',
+          message: expect.stringContaining('djnz relative branch displacement out of range'),
+        }),
+      ]),
+    );
+  });
+
+  it('compiles classic dollar-prefixed hex and RST trailing-H operands', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-hex-rst-'));
+    const entry = join(dir, 'hex-rst.z80');
+    writeFileSync(
+      entry,
+      ['.org 0100H', 'cp $FE', 'rst 20H', '.binfrom 0100H', '.end'].join('\n'),
+      'utf8',
+    );
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin) throw new Error('missing bin artifact');
+    expect([...bin.bytes]).toEqual([0xfe, 0xfe, 0xe7]);
+  });
+
   it('compiles single-quoted character literals in raw words', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-word-char-'));
     const entry = join(dir, 'word-char.z80');

--- a/test/backend/pr135_isa_jr_djnz.test.ts
+++ b/test/backend/pr135_isa_jr_djnz.test.ts
@@ -3,16 +3,16 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import { compile } from '../src/compile.js';
-import { defaultFormatWriters } from '../src/formats/index.js';
-import type { BinArtifact } from '../src/formats/types.js';
+import { compile } from '../../src/compile.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import type { BinArtifact } from '../../src/formats/types.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe('PR135 ZAX-mode JR/DJNZ displacement operands', () => {
   it('keeps numeric JR and DJNZ operands as rel8 displacements in ZAX mode', async () => {
-    const entry = join(__dirname, 'fixtures', 'pr135_isa_jr_djnz.zax');
+    const entry = join(__dirname, '..', 'fixtures', 'pr135_isa_jr_djnz.zax');
     const res = await compile(entry, {}, { formats: defaultFormatWriters });
 
     expect(res.diagnostics.filter((diagnostic) => diagnostic.severity === 'error')).toEqual([]);

--- a/test/fixtures/coverage-map.md
+++ b/test/fixtures/coverage-map.md
@@ -13,8 +13,8 @@
 
 Total fixture files (excludes sentinels): 532
 Sentinel files: 1
-Reachable from tests (direct refs ∪ fixture closure): 318
-Potentially unreferenced fixtures: 214
+Reachable from tests (direct refs ∪ fixture closure): 319
+Potentially unreferenced fixtures: 213
 
 ## Direct test reference counts
 
@@ -133,7 +133,7 @@ Potentially unreferenced fixtures: 214
 | pr1349_ld_indirect_bc_store.zax | 0 |
 | pr1349_ld_indirect_de_store.zax | 0 |
 | pr135_isa_jr_djnz_invalid.zax | 0 |
-| pr135_isa_jr_djnz.zax | 0 |
+| pr135_isa_jr_djnz.zax | 1 |
 | pr136_bit_indexed_dest_invalid.zax | 1 |
 | pr1367_op_port_imm_substitution.zax | 1 |
 | pr137_cb_rotate_two_operand_invalid.zax | 1 |
@@ -627,7 +627,6 @@ Not reachable from any test’s literal `fixtures/...` reference via the include
 - pr1349_ld_a_indirect_de.zax
 - pr1349_ld_indirect_bc_store.zax
 - pr1349_ld_indirect_de_store.zax
-- pr135_isa_jr_djnz.zax
 - pr135_isa_jr_djnz_invalid.zax
 - pr138_rel8_out_of_range_matrix.zax
 - pr138_rel8_valid_matrix.zax
@@ -901,7 +900,7 @@ Excluded from the main fixture inventory (`.keep`, `.gitkeep`).
 | pr1349_ld_indirect_bc_store.zax |  |
 | pr1349_ld_indirect_de_store.zax |  |
 | pr135_isa_jr_djnz_invalid.zax |  |
-| pr135_isa_jr_djnz.zax |  |
+| pr135_isa_jr_djnz.zax | test/pr135_isa_jr_djnz.test.ts |
 | pr136_bit_indexed_dest_invalid.zax | test/pr136_bit_indexed_dest_invalid.test.ts |
 | pr1367_op_port_imm_substitution.zax | test/lowering/pr1367_op_port_imm_substitution.test.ts |
 | pr137_cb_rotate_two_operand_invalid.zax | test/pr137_cb_rotate_two_operand_invalid.test.ts |

--- a/test/fixtures/coverage-map.md
+++ b/test/fixtures/coverage-map.md
@@ -900,7 +900,7 @@ Excluded from the main fixture inventory (`.keep`, `.gitkeep`).
 | pr1349_ld_indirect_bc_store.zax |  |
 | pr1349_ld_indirect_de_store.zax |  |
 | pr135_isa_jr_djnz_invalid.zax |  |
-| pr135_isa_jr_djnz.zax | test/pr135_isa_jr_djnz.test.ts |
+| pr135_isa_jr_djnz.zax | test/backend/pr135_isa_jr_djnz.test.ts |
 | pr136_bit_indexed_dest_invalid.zax | test/pr136_bit_indexed_dest_invalid.test.ts |
 | pr1367_op_port_imm_substitution.zax | test/lowering/pr1367_op_port_imm_substitution.test.ts |
 | pr137_cb_rotate_two_operand_invalid.zax | test/pr137_cb_rotate_two_operand_invalid.test.ts |

--- a/test/frontend/asm80_classic_module.test.ts
+++ b/test/frontend/asm80_classic_module.test.ts
@@ -125,6 +125,26 @@ describe('classic ASM80 module parser', () => {
     ]);
   });
 
+  it('rejects non-baseline dialect aliases with canonical directive guidance', () => {
+    const diagnostics: { message: string }[] = [];
+    const module = parseClassicModule(
+      '/classic.z80',
+      ['bytes: DEFB 1,2', 'words: defw 1234H', 'buf: RMB 8'].join('\n'),
+      diagnostics as never[],
+    );
+
+    expect(module.items).toMatchObject([
+      { kind: 'AsmLabel', name: 'bytes' },
+      { kind: 'AsmLabel', name: 'words' },
+      { kind: 'AsmLabel', name: 'buf' },
+    ]);
+    expect(diagnostics.map((diagnostic) => diagnostic.message)).toEqual([
+      'DEFB is not part of the supported ASM80 baseline; use DB.',
+      'DEFW is not part of the supported ASM80 baseline; use DW.',
+      'RMB is not part of the supported ASM80 baseline; use DS.',
+    ]);
+  });
+
   it('does not let post-end string equates affect pre-end raw data', () => {
     const diagnostics: unknown[] = [];
     const module = parseClassicModule(

--- a/test/pr135_isa_jr_djnz.test.ts
+++ b/test/pr135_isa_jr_djnz.test.ts
@@ -1,0 +1,41 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { compile } from '../src/compile.js';
+import { defaultFormatWriters } from '../src/formats/index.js';
+import type { BinArtifact } from '../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('PR135 ZAX-mode JR/DJNZ displacement operands', () => {
+  it('keeps numeric JR and DJNZ operands as rel8 displacements in ZAX mode', async () => {
+    const entry = join(__dirname, 'fixtures', 'pr135_isa_jr_djnz.zax');
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((diagnostic) => diagnostic.severity === 'error')).toEqual([]);
+    const bin = res.artifacts.find((artifact): artifact is BinArtifact => artifact.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin) throw new Error('missing bin artifact');
+    expect([...bin.bytes].slice(12, 28)).toEqual([
+      0x18,
+      0x00,
+      0x18,
+      0xfe,
+      0x20,
+      0x05,
+      0x28,
+      0xfb,
+      0x30,
+      0x7f,
+      0x38,
+      0x80,
+      0x10,
+      0x01,
+      0x10,
+      0xff,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

This PR tightens the ASM80 baseline boundary and fixes one real classic-mode branch semantic gap found during the Software corpus audit.

- Documents that dialect aliases such as `DEFB`, `DEFW`, and `RMB` are not ZAX core ASM80-baseline syntax.
- Treats those aliases as source-normalization inputs and adds clear parser diagnostics pointing to `DB`, `DW`, and `DS`.
- Fixes classic ASM80 `JR`/`DJNZ` numeric operands so they are interpreted as absolute target addresses, matching ASM80.
- Keeps ZAX-mode `JR`/`DJNZ` numeric operands as displacement values, with explicit regression coverage.
- Adds focused classic integration coverage for `$FE` and `RST 20H`, which were suspected gaps but already worked.

## Rationale

The ASM80 replacement direction should not become a multi-dialect alias sink. The baseline should stay small and teach one canonical assembler surface. Imported source can be normalized before assembly when it uses dialect spellings.

The actual compiler behavior gap was classic `JR`/`DJNZ`: symbolic targets already behaved like ASM80 absolute targets, but numeric operands fell through to the generic ZAX encoder and were treated as rel8 displacement literals. That meant classic `jr 0104H` failed where ASM80 emits `18 02`, while classic `jr 2` incorrectly assembled as a displacement. This PR fixes that only in the classic ASM80 lowering path.

## Reviewer Notes

The key files are:

- `docs/design/asm80-compatibility-baseline.md`
- `docs/design/asm80-mon3-compatibility-audit.md`
- `docs/design/asm80-software-compatibility-audit.md`
- `src/frontend/asm80/parseClassicModule.ts`
- `src/lowering/classicInstructionLowering.ts`
- `test/asm80/asm80_directives_integration.test.ts`
- `test/pr135_isa_jr_djnz.test.ts`

Things to check carefully:

- `DEFB`/`DEFW`/`RMB` are rejected, not accepted as aliases.
- Classic ASM80 numeric `JR`/`DJNZ` operands are absolute targets.
- ZAX-mode numeric `JR`/`DJNZ` operands remain displacement literals.
- `$FE` and `RST 20H` coverage is test-only, not a behavioral rewrite.

## Verification

- `npm test -- --run test/pr135_isa_jr_djnz.test.ts test/asm80/asm80_directives_integration.test.ts test/frontend/asm80_classic_module.test.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint`
- `npm run check:fixture-coverage`
- `npm run check:source-file-sizes:enforce`
- `npm run test:asm80:baseline`
