### PR TITLE
Fix ASM80 DS and forward EQU compatibility

### DIFF
--- a/src/frontend/asm80/parseClassicModule.ts
+++ b/src/frontend/asm80/parseClassicModule.ts
@@ -287,9 +287,7 @@ export function parseClassicModule(
           rawDataWithSize.size = values?.[0];
           if (values?.[1]) rawDataWithSize.fill = values[1];
         }
-        if (parsed.label) {
-          items.push({ kind: 'AsmLabel', span: lineSpan, name: parsed.label });
-        } else if (pendingRawLabel) {
+        if (!parsed.label && pendingRawLabel) {
           items.pop();
         }
         items.push(rawData);

--- a/src/lowering/classicInstructionLowering.ts
+++ b/src/lowering/classicInstructionLowering.ts
@@ -447,15 +447,6 @@ export function lowerClassicInstruction(ctx: LoweringContext, item: ClassicInstr
       }
     }
     const memOpcode = ldReg16MemOpcode(first.name);
-    const memValue = evalMemAddress(ctx, source);
-    if (memOpcode && memValue !== undefined) {
-      const bytes =
-        memOpcode.prefix !== undefined
-          ? Uint8Array.of(memOpcode.prefix, memOpcode.opcode, memValue & 0xff, (memValue >> 8) & 0xff)
-          : Uint8Array.of(memOpcode.opcode, memValue & 0xff, (memValue >> 8) & 0xff);
-      ctx.emitRawCodeBytes(bytes, item.span.file, `ld ${first.name},(${memValue})`);
-      return;
-    }
     const memSymbolic = memSymbolicTarget(ctx, source);
     if (memOpcode && memSymbolic) {
       if (memOpcode.prefix !== undefined) {
@@ -471,44 +462,44 @@ export function lowerClassicInstruction(ctx: LoweringContext, item: ClassicInstr
       }
       return;
     }
+    const memValue = evalMemAddress(ctx, source);
+    if (memOpcode && memValue !== undefined) {
+      const bytes =
+        memOpcode.prefix !== undefined
+          ? Uint8Array.of(memOpcode.prefix, memOpcode.opcode, memValue & 0xff, (memValue >> 8) & 0xff)
+          : Uint8Array.of(memOpcode.opcode, memValue & 0xff, (memValue >> 8) & 0xff);
+      ctx.emitRawCodeBytes(bytes, item.span.file, `ld ${first.name},(${memValue})`);
+      return;
+    }
   }
   if (head === 'ld' && item.operands.length === 2) {
     const second = item.operands[1];
     if (first?.kind === 'Reg' && first.name.toUpperCase() === 'A' && second?.kind === 'Mem') {
-      const value = evalMemAddress(ctx, second);
-      if (value !== undefined) {
-        ctx.emitRawCodeBytes(Uint8Array.of(0x3a, value & 0xff, (value >> 8) & 0xff), item.span.file, 'ld a,(nn)');
-        return;
-      }
       const symbolic = memSymbolicTarget(ctx, second);
       if (symbolic) {
         ctx.emitAbs16Fixup(0x3a, symbolic.baseLower, symbolic.addend, item.span);
         return;
       }
-    }
-    if (first?.kind === 'Mem' && second?.kind === 'Reg' && second.name.toUpperCase() === 'A') {
-      const value = evalMemAddress(ctx, first);
+      const value = evalMemAddress(ctx, second);
       if (value !== undefined) {
-        ctx.emitRawCodeBytes(Uint8Array.of(0x32, value & 0xff, (value >> 8) & 0xff), item.span.file, 'ld (nn),a');
+        ctx.emitRawCodeBytes(Uint8Array.of(0x3a, value & 0xff, (value >> 8) & 0xff), item.span.file, 'ld a,(nn)');
         return;
       }
+    }
+    if (first?.kind === 'Mem' && second?.kind === 'Reg' && second.name.toUpperCase() === 'A') {
       const symbolic = memSymbolicTarget(ctx, first);
       if (symbolic) {
         ctx.emitAbs16Fixup(0x32, symbolic.baseLower, symbolic.addend, item.span);
         return;
       }
+      const value = evalMemAddress(ctx, first);
+      if (value !== undefined) {
+        ctx.emitRawCodeBytes(Uint8Array.of(0x32, value & 0xff, (value >> 8) & 0xff), item.span.file, 'ld (nn),a');
+        return;
+      }
     }
     if (first?.kind === 'Mem' && second?.kind === 'Reg') {
       const memOpcode = ldMemReg16Opcode(second.name);
-      const value = evalMemAddress(ctx, first);
-      if (memOpcode && value !== undefined) {
-        const bytes =
-          memOpcode.prefix !== undefined
-            ? Uint8Array.of(memOpcode.prefix, memOpcode.opcode, value & 0xff, (value >> 8) & 0xff)
-            : Uint8Array.of(memOpcode.opcode, value & 0xff, (value >> 8) & 0xff);
-        ctx.emitRawCodeBytes(bytes, item.span.file, `ld (nn),${second.name}`);
-        return;
-      }
       const symbolic = memSymbolicTarget(ctx, first);
       if (memOpcode && symbolic) {
         if (memOpcode.prefix !== undefined) {
@@ -522,6 +513,15 @@ export function lowerClassicInstruction(ctx: LoweringContext, item: ClassicInstr
         } else {
           ctx.emitAbs16Fixup(memOpcode.opcode, symbolic.baseLower, symbolic.addend, item.span);
         }
+        return;
+      }
+      const value = evalMemAddress(ctx, first);
+      if (memOpcode && value !== undefined) {
+        const bytes =
+          memOpcode.prefix !== undefined
+            ? Uint8Array.of(memOpcode.prefix, memOpcode.opcode, value & 0xff, (value >> 8) & 0xff)
+            : Uint8Array.of(memOpcode.opcode, value & 0xff, (value >> 8) & 0xff);
+        ctx.emitRawCodeBytes(bytes, item.span.file, `ld (nn),${second.name}`);
         return;
       }
     }

--- a/src/lowering/classicTraversalHelpers.ts
+++ b/src/lowering/classicTraversalHelpers.ts
@@ -1,0 +1,70 @@
+import type { AsmOperandNode, ImmExprNode, SourceSpan } from '../frontend/ast.js';
+import type { LoweringContext } from './programLowering.js';
+
+export type ClassicNode = {
+  kind: string;
+  span: SourceSpan;
+  name?: string;
+  value?: ImmExprNode;
+  expr?: ImmExprNode;
+  directive?: 'db' | 'dw' | 'ds' | 'cstr' | 'pstr' | 'istr';
+  values?: unknown[];
+  size?: ImmExprNode;
+  fill?: ImmExprNode;
+  head?: string;
+  operands?: AsmOperandNode[];
+};
+
+function isKind(item: { kind: string }, ...kinds: string[]): boolean {
+  return kinds.includes(item.kind);
+}
+
+export function isClassicEqu(item: { kind: string }): boolean {
+  return isKind(item, 'ClassicEqu', 'ClassicEquDecl', 'EquDecl');
+}
+
+export function isClassicOrg(item: { kind: string }): boolean {
+  return isKind(item, 'ClassicOrg', 'ClassicOrgDirective', 'OrgDirective');
+}
+
+export function isClassicAlign(item: { kind: string }): boolean {
+  return isKind(item, 'ClassicAlign', 'ClassicAlignDirective');
+}
+
+export function isClassicRawData(item: { kind: string }): boolean {
+  return isKind(item, 'ClassicRawData', 'ClassicRawDataDecl') || 'valuesText' in item;
+}
+
+export function isClassicBinFrom(item: { kind: string }): boolean {
+  return isKind(item, 'ClassicBinFrom', 'ClassicBinFromDirective', 'BinFromDirective');
+}
+
+export function isClassicBinTo(item: { kind: string }): boolean {
+  return isKind(item, 'ClassicBinTo', 'ClassicBinToDirective', 'BinToDirective');
+}
+
+export function isClassicEnd(item: { kind: string }): boolean {
+  return isKind(item, 'ClassicEnd', 'ClassicEndDirective');
+}
+
+export function classicExpr(item: ClassicNode): ImmExprNode | undefined {
+  return item.value ?? item.expr;
+}
+
+export function activeSectionOffset(ctx: LoweringContext): number {
+  return ctx.activeSectionRef.current === 'data' ? ctx.dataOffsetRef.current : ctx.codeOffsetRef.current;
+}
+
+export function activeSectionAddress(ctx: LoweringContext): number | undefined {
+  const offset = activeSectionOffset(ctx);
+  const baseExpr =
+    ctx.activeSectionRef.current === 'data' ? ctx.baseExprs.data : ctx.baseExprs.code;
+  if (!baseExpr) return offset;
+  const base = ctx.evalImmExpr(baseExpr, ctx.env, ctx.diagnostics);
+  return base === undefined ? undefined : base + offset;
+}
+
+export function publishClassicAddressConst(ctx: LoweringContext, name: string, address: number): void {
+  ctx.env.consts.set(name, address);
+  ctx.env.consts.set(name.toLowerCase(), address);
+}

--- a/src/lowering/emitFinalization.ts
+++ b/src/lowering/emitFinalization.ts
@@ -216,6 +216,7 @@ export function finalizeEmitProgram(context: EmitFinalizationContext): {
     context.diagnostics,
     context.bytes,
     context.symbols,
+    context.env,
   );
 
   syncLoweredAsmInstructionBytesFromFinalBytes(placedProgram, context.bytes, context.env);

--- a/src/lowering/loweredAsmByteEmission.ts
+++ b/src/lowering/loweredAsmByteEmission.ts
@@ -1,5 +1,6 @@
 import type { Diagnostic } from '../diagnosticTypes.js';
-import type { CompileEnv } from '../semantics/env.js';
+import type { ImmExprNode } from '../frontend/ast.js';
+import { evalImmExpr as evalImmExprWithEnv, type CompileEnv } from '../semantics/env.js';
 import type { LoweredAsmBlock, LoweredAsmProgram, LoweredAsmItem, LoweredImmExpr } from './loweredAsmTypes.js';
 import type { SectionKind } from './loweringTypes.js';
 
@@ -22,6 +23,82 @@ const toByte = (value: number): number => value & 0xff;
 const toWord = (value: number): number => value & 0xffff;
 
 function evalLoweredImmExpr(expr: LoweredImmExpr, env: CompileEnv): number | undefined {
+  const evalClassicAliasExpr = (
+    classicExpr: ImmExprNode,
+    visiting: Set<string>,
+    currentLocation?: number,
+  ): number | undefined => {
+    const value =
+      currentLocation === undefined
+        ? evalImmExprWithEnv(classicExpr, env)
+        : evalImmExprWithEnv(classicExpr, env, undefined, { currentLocation });
+    if (value !== undefined) return value;
+
+    switch (classicExpr.kind) {
+      case 'ImmCurrentLocation':
+        return currentLocation;
+      case 'ImmName':
+        return evalClassicAliasSymbol(classicExpr.name, visiting);
+      case 'ImmUnary': {
+        const v = evalClassicAliasExpr(classicExpr.expr, visiting, currentLocation);
+        if (v === undefined) return undefined;
+        switch (classicExpr.op) {
+          case '+':
+            return +v;
+          case '-':
+            return -v;
+          case '~':
+            return ~v;
+        }
+        return undefined;
+      }
+      case 'ImmBinary': {
+        const left = evalClassicAliasExpr(classicExpr.left, visiting, currentLocation);
+        const right = evalClassicAliasExpr(classicExpr.right, visiting, currentLocation);
+        if (left === undefined || right === undefined) return undefined;
+        switch (classicExpr.op) {
+          case '*':
+            return left * right;
+          case '/':
+            return right === 0 ? undefined : Math.trunc(left / right);
+          case '%':
+            return right === 0 ? undefined : left % right;
+          case '+':
+            return left + right;
+          case '-':
+            return left - right;
+          case '&':
+            return left & right;
+          case '^':
+            return left ^ right;
+          case '|':
+            return left | right;
+          case '<<':
+            return left << right;
+          case '>>':
+            return left >> right;
+        }
+        return undefined;
+      }
+      default:
+        return undefined;
+    }
+  };
+
+  const evalClassicAliasSymbol = (name: string, visiting = new Set<string>()): number | undefined => {
+    const direct = env.consts.get(name) ?? env.enums.get(name);
+    if (direct !== undefined) return direct;
+    const lower = name.toLowerCase();
+    const alt = env.consts.get(lower) ?? env.enums.get(lower);
+    if (alt !== undefined) return alt;
+    const equ = env.classicEquExprs?.get(name) ?? env.classicEquExprs?.get(lower);
+    if (!equ || visiting.has(lower)) return undefined;
+    visiting.add(lower);
+    const value = evalClassicAliasExpr(equ.expr, visiting, equ.currentLocation);
+    if (value !== undefined) env.consts.set(lower, value);
+    return value;
+  };
+
   switch (expr.kind) {
     case 'literal':
       return expr.value;
@@ -31,6 +108,8 @@ function evalLoweredImmExpr(expr: LoweredImmExpr, env: CompileEnv): number | und
       const lower = expr.name.toLowerCase();
       const alt = env.consts.get(lower) ?? env.enums.get(lower);
       if (alt !== undefined) return alt + expr.addend;
+      const classicAlias = evalClassicAliasSymbol(expr.name);
+      if (classicAlias !== undefined) return classicAlias + expr.addend;
       return undefined;
     }
     case 'unary': {

--- a/src/lowering/programLoweringDeclarations.ts
+++ b/src/lowering/programLoweringDeclarations.ts
@@ -96,6 +96,19 @@ export function createProgramLoweringDeclarationHelpers(ctx: Context): {
     return undefined;
   };
 
+  const publishClassicAddressConst = (
+    name: string,
+    activeSection: SectionKind,
+    offset: number,
+  ): void => {
+    const baseExpr = activeSection === 'code' ? ctx.baseExprs.code : ctx.baseExprs.data;
+    const base = baseExpr ? ctx.evalImmExpr(baseExpr, ctx.env, ctx.diagnostics) : 0;
+    if (base === undefined) return;
+    const address = base + offset;
+    ctx.env.consts.set(name, address);
+    ctx.env.consts.set(name.toLowerCase(), address);
+  };
+
   const lowerBinDecl = (binDecl: BinDeclNode, namedSection?: NamedSectionTarget): void => {
     const withTempSection = (section: SectionKind, fn: () => void): void => {
       const prev = ctx.activeSectionRef.current;
@@ -334,6 +347,7 @@ export function createProgramLoweringDeclarationHelpers(ctx: Context): {
         const offset =
           namedSection?.sink.offset ??
           (activeSection === 'code' ? ctx.codeOffsetRef.current : ctx.dataOffsetRef.current);
+        publishClassicAddressConst(name, activeSection, offset);
         const pending = {
           kind: 'label' as const,
           name,
@@ -395,17 +409,27 @@ export function createProgramLoweringDeclarationHelpers(ctx: Context): {
         );
         return;
       }
+      const fill = decl.fill ? ctx.evalImmExpr(decl.fill, ctx.env, ctx.diagnostics) : undefined;
+      if (decl.fill && fill === undefined) {
+        ctx.diag(ctx.diagnostics, decl.span.file, `Failed to evaluate raw data fill for "${name}".`);
+        return;
+      }
       ctx.recordLoweredAsmItem(
         {
           kind: 'ds',
           size: ctx.lowerImmExprForLoweredAsm(decl.size),
-          fill: decl.fill ? ctx.lowerImmExprForLoweredAsm(decl.fill) : { kind: 'literal', value: 0 },
+          ...(decl.fill ? { fill: ctx.lowerImmExprForLoweredAsm(decl.fill) } : {}),
         },
         decl.span,
       );
-      const fill = decl.fill ? ctx.evalImmExpr(decl.fill, ctx.env, ctx.diagnostics) : 0;
       if (fill === undefined) {
-        ctx.diag(ctx.diagnostics, decl.span.file, `Failed to evaluate raw data fill for "${name}".`);
+        if (namedSection) {
+          namedSection.sink.offset += size;
+        } else if (activeSection === 'code') {
+          ctx.codeOffsetRef.current += size;
+        } else {
+          ctx.dataOffsetRef.current += size;
+        }
         return;
       }
       for (let i = 0; i < size; i++) writeByte(fill);

--- a/src/lowering/programLoweringFinalize.ts
+++ b/src/lowering/programLoweringFinalize.ts
@@ -5,6 +5,8 @@ import type {
 import type { SectionKind } from './loweringTypes.js';
 import type { ProgramEmissionFinalizeContext } from './programLowering.js';
 import { parseNumberLiteral } from '../frontend/parseImm.js';
+import type { ImmExprNode } from '../frontend/ast.js';
+import { evalImmExpr as evalImmExprWithEnv } from '../semantics/env.js';
 
 export function computeSectionBases(
   ctx: Pick<ProgramEmissionFinalizeContext, 'baseExprs' | 'evalImmExpr' | 'env' | 'diagnostics' | 'diag' | 'primaryFile' | 'alignTo' | 'codeOffset' | 'dataOffset'>,
@@ -129,12 +131,87 @@ export function finalizeProgramEmission(ctx: ProgramEmissionFinalizeContext): {
     });
   }
 
-  const resolveFixupBase = (nameLower: string): number | undefined => {
+  const evalClassicAliasExpr = (
+    expr: ImmExprNode,
+    visiting: Set<string>,
+    currentLocation?: number,
+  ): number | undefined => {
+    const aliasEnv = { ...ctx.env, consts: new Map(ctx.env.consts) };
+    for (const [name, value] of addrByNameLower) aliasEnv.consts.set(name, value);
+    const value =
+      currentLocation === undefined
+        ? ctx.evalImmExpr(expr, aliasEnv, [])
+        : evalImmExprWithEnv(expr, aliasEnv, [], { currentLocation });
+    if (value !== undefined) return value;
+
+    switch (expr.kind) {
+      case 'ImmCurrentLocation':
+        return currentLocation;
+      case 'ImmName':
+        return resolveFixupBase(expr.name.toLowerCase(), visiting);
+      case 'ImmUnary': {
+        const v = evalClassicAliasExpr(expr.expr, visiting, currentLocation);
+        if (v === undefined) return undefined;
+        switch (expr.op) {
+          case '+':
+            return +v;
+          case '-':
+            return -v;
+          case '~':
+            return ~v;
+        }
+        return undefined;
+      }
+      case 'ImmBinary': {
+        const l = evalClassicAliasExpr(expr.left, visiting, currentLocation);
+        const r = evalClassicAliasExpr(expr.right, visiting, currentLocation);
+        if (l === undefined || r === undefined) return undefined;
+        switch (expr.op) {
+          case '*':
+            return l * r;
+          case '/':
+            return r === 0 ? undefined : (l / r) | 0;
+          case '%':
+            return r === 0 ? undefined : l % r;
+          case '+':
+            return l + r;
+          case '-':
+            return l - r;
+          case '&':
+            return l & r;
+          case '^':
+            return l ^ r;
+          case '|':
+            return l | r;
+          case '<<':
+            return l << r;
+          case '>>':
+            return l >> r;
+        }
+        return undefined;
+      }
+      default:
+        return undefined;
+    }
+  };
+
+  const resolveFixupBase = (nameLower: string, visiting = new Set<string>()): number | undefined => {
     const sym = addrByNameLower.get(nameLower);
     if (sym !== undefined) return sym;
     const literal = parseNumberLiteral(nameLower);
     if (literal !== undefined) return literal;
     if (/^-?[0-9]+$/.test(nameLower)) return Number.parseInt(nameLower, 10);
+    const equ = ctx.env.classicEquExprs?.get(nameLower);
+    if (equ) {
+      if (visiting.has(nameLower)) return undefined;
+      visiting.add(nameLower);
+      const value = evalClassicAliasExpr(equ.expr, visiting, equ.currentLocation);
+      if (value !== undefined) {
+        addrByNameLower.set(nameLower, value);
+        ctx.env.consts.set(nameLower, value);
+        return value;
+      }
+    }
     return undefined;
   };
 

--- a/src/lowering/programLoweringTraversal.ts
+++ b/src/lowering/programLoweringTraversal.ts
@@ -9,68 +9,32 @@ import type {
   HexDeclNode,
   NamedSectionNode,
   RawDataDeclNode,
-  SourceSpan,
   VarBlockNode,
 } from '../frontend/ast.js';
 import type { NamedSectionContributionSink } from './sectionContributions.js';
 import type { LoweringContext, LoweringResult } from './programLowering.js';
+import { evalImmExpr as evalImmExprWithEnv } from '../semantics/env.js';
 import { sizeOfTypeExpr } from '../semantics/layout.js';
 import { lowerDataBlock } from './programLoweringData.js';
 import { createProgramLoweringDeclarationHelpers } from './programLoweringDeclarations.js';
 import { lowerClassicInstruction } from './classicInstructionLowering.js';
+import {
+  activeSectionAddress,
+  activeSectionOffset,
+  classicExpr,
+  type ClassicNode,
+  isClassicAlign,
+  isClassicBinFrom,
+  isClassicBinTo,
+  isClassicEnd,
+  isClassicEqu,
+  isClassicOrg,
+  isClassicRawData,
+  publishClassicAddressConst,
+} from './classicTraversalHelpers.js';
 
 const BINFROM_SYMBOL_NAME = '__zax_binfrom';
 const BINTO_SYMBOL_NAME = '__zax_binto';
-
-type ClassicNode = {
-  kind: string;
-  span: SourceSpan;
-  name?: string;
-  value?: import('../frontend/ast.js').ImmExprNode;
-  expr?: import('../frontend/ast.js').ImmExprNode;
-  directive?: 'db' | 'dw' | 'ds' | 'cstr' | 'pstr' | 'istr';
-  values?: unknown[];
-  size?: import('../frontend/ast.js').ImmExprNode;
-  fill?: import('../frontend/ast.js').ImmExprNode;
-  head?: string;
-  operands?: import('../frontend/ast.js').AsmOperandNode[];
-};
-
-function isKind(item: { kind: string }, ...kinds: string[]): boolean {
-  return kinds.includes(item.kind);
-}
-
-function isClassicEqu(item: { kind: string }): boolean {
-  return isKind(item, 'ClassicEqu', 'ClassicEquDecl', 'EquDecl');
-}
-
-function isClassicOrg(item: { kind: string }): boolean {
-  return isKind(item, 'ClassicOrg', 'ClassicOrgDirective', 'OrgDirective');
-}
-
-function isClassicAlign(item: { kind: string }): boolean {
-  return isKind(item, 'ClassicAlign', 'ClassicAlignDirective');
-}
-
-function isClassicRawData(item: { kind: string }): boolean {
-  return isKind(item, 'ClassicRawData', 'ClassicRawDataDecl') || 'valuesText' in item;
-}
-
-function isClassicBinFrom(item: { kind: string }): boolean {
-  return isKind(item, 'ClassicBinFrom', 'ClassicBinFromDirective', 'BinFromDirective');
-}
-
-function isClassicBinTo(item: { kind: string }): boolean {
-  return isKind(item, 'ClassicBinTo', 'ClassicBinToDirective', 'BinToDirective');
-}
-
-function isClassicEnd(item: { kind: string }): boolean {
-  return isKind(item, 'ClassicEnd', 'ClassicEndDirective');
-}
-
-function classicExpr(item: ClassicNode): import('../frontend/ast.js').ImmExprNode | undefined {
-  return item.value ?? item.expr;
-}
 
 function sinkOffsetRef(sink: NamedSectionContributionSink) {
   return {
@@ -216,14 +180,34 @@ function lowerExternDecl(ctx: LoweringContext, externDecl: ExternDeclNode): void
 
 function lowerClassicEqu(ctx: LoweringContext, item: ClassicNode): void {
   if (!item.name) return;
-  const value = ctx.env.consts.get(item.name) ?? ctx.env.consts.get(item.name.toLowerCase());
-  if (value === undefined) return;
   const lower = item.name.toLowerCase();
   if (ctx.taken.has(lower)) {
     ctx.diag(ctx.diagnostics, item.span.file, `Duplicate symbol name "${item.name}".`);
     return;
   }
   ctx.taken.add(lower);
+  const expr = classicExpr(item);
+  const currentLocation = activeSectionAddress(ctx);
+  if (expr) {
+    const record =
+      currentLocation === undefined ? { expr } : { expr, currentLocation };
+    ctx.env.classicEquExprs?.set(item.name, record);
+    ctx.env.classicEquExprs?.set(item.name.toLowerCase(), record);
+  }
+  const value =
+    expr && currentLocation !== undefined
+      ? evalImmExprWithEnv(expr, ctx.env, ctx.diagnostics, { currentLocation })
+      : ctx.env.consts.get(item.name) ?? ctx.env.consts.get(item.name.toLowerCase());
+  if (value === undefined) {
+    if (expr) {
+      ctx.recordLoweredAsmItem(
+        { kind: 'const', name: item.name, value: ctx.lowerImmExprForLoweredAsm(expr) },
+        item.span,
+      );
+    }
+    return;
+  }
+  publishClassicAddressConst(ctx, item.name, value);
   ctx.symbols.push({
     kind: 'constant',
     name: item.name,
@@ -335,20 +319,20 @@ function lowerClassicAlign(ctx: LoweringContext, item: ClassicNode): void {
 
 function lowerClassicLabel(ctx: LoweringContext, item: ClassicNode): void {
   if (!item.name) return;
+  const offset = activeSectionOffset(ctx);
+  const address = activeSectionAddress(ctx);
   const lower = item.name.toLowerCase();
   if (ctx.taken.has(lower)) {
     ctx.diag(ctx.diagnostics, item.span.file, `Duplicate symbol name "${item.name}".`);
     return;
   }
   ctx.taken.add(lower);
+  if (address !== undefined) publishClassicAddressConst(ctx, item.name, address);
   ctx.pending.push({
     kind: 'label',
     name: item.name,
     section: ctx.activeSectionRef.current,
-    offset:
-      ctx.activeSectionRef.current === 'data'
-        ? ctx.dataOffsetRef.current
-        : ctx.codeOffsetRef.current,
+    offset,
     file: item.span.file,
     line: item.span.start.line,
     scope: 'global',

--- a/src/lowering/sectionPlacement.ts
+++ b/src/lowering/sectionPlacement.ts
@@ -1,11 +1,12 @@
 import type { Diagnostic } from '../diagnosticTypes.js';
 import type { SymbolEntry } from '../formats/types.js';
-import type { CompileEnv } from '../semantics/env.js';
+import { evalImmExpr, type CompileEnv } from '../semantics/env.js';
 import type { ImmExprNode, SourceSpan } from '../frontend/ast.js';
 import { diagAt } from './loweringDiagnostics.js';
 import type { NamedSectionContributionSink } from './sectionContributions.js';
 import type { NonBankedSectionKeyId } from '../sectionKeys.js';
 import { formatNonBankedSectionKey } from '../sectionKeys.js';
+import { parseNumberLiteral } from '../frontend/parseImm.js';
 
 export type PlacedNamedSectionContribution = {
   /** Sink carrying bytes/fixups for one contribution. */
@@ -281,18 +282,105 @@ export function resolvePlacedNamedSectionFixups(
   diagnostics: Diagnostic[],
   bytes: Map<number, number>,
   symbols: SymbolEntry[],
+  env: CompileEnv,
 ): void {
   const addrByNameLower = new Map<string, number>();
+  for (const [name, value] of env.consts) {
+    addrByNameLower.set(name.toLowerCase(), value);
+  }
   for (const sym of symbols) {
     if (sym.kind === 'constant' || sym.address === undefined) continue;
     addrByNameLower.set(sym.name.toLowerCase(), sym.address);
   }
+  const evalClassicAliasExpr = (
+    expr: ImmExprNode,
+    visiting: Set<string>,
+    currentLocation?: number,
+  ): number | undefined => {
+    const aliasEnv = { ...env, consts: new Map(env.consts) };
+    for (const [name, value] of addrByNameLower) aliasEnv.consts.set(name, value);
+    const value =
+      currentLocation === undefined
+        ? evalImmExpr(expr, aliasEnv)
+        : evalImmExpr(expr, aliasEnv, undefined, { currentLocation });
+    if (value !== undefined) return value;
+
+    switch (expr.kind) {
+      case 'ImmCurrentLocation':
+        return currentLocation;
+      case 'ImmName':
+        return resolveFixupBase(expr.name.toLowerCase(), visiting);
+      case 'ImmUnary': {
+        const v = evalClassicAliasExpr(expr.expr, visiting, currentLocation);
+        if (v === undefined) return undefined;
+        switch (expr.op) {
+          case '+':
+            return +v;
+          case '-':
+            return -v;
+          case '~':
+            return ~v;
+        }
+        return undefined;
+      }
+      case 'ImmBinary': {
+        const l = evalClassicAliasExpr(expr.left, visiting, currentLocation);
+        const r = evalClassicAliasExpr(expr.right, visiting, currentLocation);
+        if (l === undefined || r === undefined) return undefined;
+        switch (expr.op) {
+          case '*':
+            return l * r;
+          case '/':
+            return r === 0 ? undefined : (l / r) | 0;
+          case '%':
+            return r === 0 ? undefined : l % r;
+          case '+':
+            return l + r;
+          case '-':
+            return l - r;
+          case '&':
+            return l & r;
+          case '^':
+            return l ^ r;
+          case '|':
+            return l | r;
+          case '<<':
+            return l << r;
+          case '>>':
+            return l >> r;
+        }
+        return undefined;
+      }
+      default:
+        return undefined;
+    }
+  };
+
+  const resolveFixupBase = (nameLower: string, visiting = new Set<string>()): number | undefined => {
+    const sym = addrByNameLower.get(nameLower);
+    if (sym !== undefined) return sym;
+    const literal = parseNumberLiteral(nameLower);
+    if (literal !== undefined) return literal;
+    if (/^-?[0-9]+$/.test(nameLower)) return Number.parseInt(nameLower, 10);
+    const equ = env.classicEquExprs?.get(nameLower);
+    if (equ) {
+      if (visiting.has(nameLower)) return undefined;
+      visiting.add(nameLower);
+      const value = evalClassicAliasExpr(equ.expr, visiting, equ.currentLocation);
+      if (value !== undefined) {
+        addrByNameLower.set(nameLower, value);
+        env.consts.set(nameLower, value);
+        return value;
+      }
+    }
+    return undefined;
+  };
 
   for (const placed of placedContributions) {
     const sink = placed.sink;
 
     for (const fx of sink.fixups) {
-      const base = addrByNameLower.get(fx.baseLower);
+      const base = resolveFixupBase(fx.baseLower);
       const addr = base === undefined ? undefined : base + fx.addend;
       if (addr === undefined) {
         const where = startOf(sink);
@@ -318,7 +406,7 @@ export function resolvePlacedNamedSectionFixups(
     }
 
     for (const fx of sink.rel8Fixups) {
-      const base = addrByNameLower.get(fx.baseLower);
+      const base = resolveFixupBase(fx.baseLower);
       const target = base === undefined ? undefined : base + fx.addend;
       if (target === undefined) {
         const where = startOf(sink);

--- a/src/semantics/env.ts
+++ b/src/semantics/env.ts
@@ -67,6 +67,7 @@ export interface CompileEnv {
   visibleConsts?: Map<string, number>;
   visibleEnums?: Map<string, number>;
   visibleTypes?: Map<string, TypeDeclNode | UnionDeclNode>;
+  classicEquExprs?: Map<string, { expr: ImmExprNode; currentLocation?: number }>;
 }
 
 const diag = diagSemanticsError;
@@ -330,15 +331,17 @@ function classicInstructionSize(item: AsmInstructionNode): number {
   if (['sub', 'and', 'or', 'xor', 'cp'].includes(head)) return indexed ? 3 : ops[0]?.kind === 'Imm' ? 2 : 1;
   if (head === 'ld') {
     if (indexed) return ops[0]?.kind === 'Imm' || ops[1]?.kind === 'Imm' ? 4 : 3;
-    if (ixiyReg(r0) || ixiyReg(r1)) return ops[1]?.kind === 'Imm' ? 4 : 2;
     if (ops[0]?.kind === 'Mem' || ops[1]?.kind === 'Mem') {
+      const memOp = ops[0]?.kind === 'Mem' ? ops[0] : ops[1];
       const memReg = ops[0]?.kind === 'Mem' ? r1 : r0;
-      return memReg === 'A' && (regFromMem(ops[0]) === 'BC' || regFromMem(ops[0]) === 'DE' || regFromMem(ops[1]) === 'BC' || regFromMem(ops[1]) === 'DE')
-        ? 1
-        : memReg === 'HL'
-          ? 3
-          : 3;
+      const indirectReg = regFromMem(memOp);
+      if (indirectReg) {
+        if (memReg === 'A' && (indirectReg === 'BC' || indirectReg === 'DE')) return 1;
+        if (indirectReg === 'HL') return 1;
+      }
+      return memReg && ['BC', 'DE', 'SP', 'IX', 'IY'].includes(memReg) ? 4 : 3;
     }
+    if (ixiyReg(r0) || ixiyReg(r1)) return ops[1]?.kind === 'Imm' ? 4 : 2;
     if (ops[1]?.kind === 'Imm') return r0 && ['BC', 'DE', 'HL', 'SP'].includes(r0) ? 3 : 2;
     return 1;
   }
@@ -407,6 +410,8 @@ function seedClassicCurrentLocationEquates(program: ProgramNode, env: CompileEnv
           const equ = item as ClassicEquDecl;
           const expr = equ.value ?? equ.expr;
           if (expr) {
+            env.classicEquExprs?.set(equ.name, { expr, currentLocation: current });
+            env.classicEquExprs?.set(equ.name.toLowerCase(), { expr, currentLocation: current });
             const value = containsCurrentLocation(expr)
               ? evalImmExpr(expr, scratchEnv, undefined, { currentLocation: current })
               : evalImmExpr(expr, scratchEnv);
@@ -475,6 +480,7 @@ export function buildEnv(
   options?: BuildEnvOptions,
 ): CompileEnv {
   const consts = new Map<string, number>();
+  const classicEquExprs = new Map<string, { expr: ImmExprNode; currentLocation?: number }>();
   const enums = new Map<string, number>();
   const types = new Map<string, TypeDeclNode | UnionDeclNode>();
   const moduleIds = new Map<string, string>();
@@ -616,6 +622,7 @@ export function buildEnv(
     visibleConsts,
     visibleEnums,
     visibleTypes,
+    classicEquExprs,
   };
 
   seedClassicCurrentLocationEquates(program, env);
@@ -631,8 +638,20 @@ export function buildEnv(
       if (!claim('const', item.name, item.span.file)) continue;
       if (isClassicCaseInsensitiveConst(item) && consts.has(item.name.toLowerCase())) continue;
 
-      const v = evalImmExpr(constValueExpr(item), env, diagnostics);
+      const expr = constValueExpr(item);
+      if (isClassicCaseInsensitiveConst(item)) {
+        if (!classicEquExprs.has(item.name)) classicEquExprs.set(item.name, { expr });
+        if (!classicEquExprs.has(item.name.toLowerCase())) {
+          classicEquExprs.set(item.name.toLowerCase(), { expr });
+        }
+      }
+      const beforeDiagnostics = diagnostics.length;
+      const v = evalImmExpr(expr, env, diagnostics);
       if (v === undefined) {
+        if (isClassicCaseInsensitiveConst(item)) {
+          diagnostics.splice(beforeDiagnostics);
+          continue;
+        }
         diag(diagnostics, item.span.file, `Failed to evaluate const "${item.name}".`);
         continue;
       }

--- a/test/asm80/asm80_directives_integration.test.ts
+++ b/test/asm80/asm80_directives_integration.test.ts
@@ -13,6 +13,7 @@ import { buildEnv } from '../../src/semantics/env.js';
 import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
 import type { BinArtifact } from '../../src/formats/types.js';
+import type { Asm80Artifact } from '../../src/formats/types.js';
 
 const file = '/fixtures/asm80/directives.z80';
 
@@ -408,6 +409,246 @@ describe('asm80 directive lowering integration', () => {
       0x22, 0x00, 0x09, 0xed, 0x43, 0x00, 0x09, 0xed, 0x53, 0x00, 0x09, 0xed, 0x73, 0x00, 0x09,
       0xdd, 0x22, 0x00, 0x09, 0xfd, 0x22, 0x00, 0x09,
     ]);
+  });
+
+  it('resolves classic equ aliases to exact labels after DS reservations', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-ds-equ-alias-'));
+    const entry = join(dir, 'ds-equ-alias.asm');
+    writeFileSync(
+      entry,
+      [
+        'org 4000H',
+        'ld (GAME_OVER_KEY_GATE_LO),hl',
+        'GAME_OVER_KEY_GATE:',
+        'ds 2',
+        'GAME_OVER_KEY_GATE_LO equ GAME_OVER_KEY_GATE',
+        'CODE:',
+        'ld hl,(GAME_OVER_KEY_GATE_LO)',
+        'TARGET:',
+        'db 0',
+        'binfrom 4000H',
+        'end',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin) throw new Error('missing bin artifact');
+    expect([...bin.bytes]).toEqual([
+      0x22,
+      0x03,
+      0x40,
+      0x00,
+      0x00,
+      0x2a,
+      0x03,
+      0x40,
+      0x00,
+    ]);
+  });
+
+  it('resolves classic equ aliases declared before their target label', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-forward-equ-target-'));
+    const entry = join(dir, 'forward-equ-target.asm');
+    writeFileSync(
+      entry,
+      [
+        'org 4000H',
+        'ALIAS equ TARGET',
+        'ld hl,(ALIAS)',
+        'TARGET:',
+        'db 0',
+        'binfrom 4000H',
+        'end',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin) throw new Error('missing bin artifact');
+    expect([...bin.bytes]).toEqual([0x2a, 0x03, 0x40, 0x00]);
+  });
+
+  it('resolves compound classic equ aliases through forward aliases', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-compound-forward-equ-'));
+    const entry = join(dir, 'compound-forward-equ.asm');
+    writeFileSync(
+      entry,
+      [
+        'org 4000H',
+        'ALIAS equ TARGET',
+        'ALIAS_PLUS equ ALIAS+1',
+        'ld hl,(ALIAS_PLUS)',
+        'TARGET:',
+        'db 0,0',
+        'binfrom 4000H',
+        'end',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin) throw new Error('missing bin artifact');
+    expect([...bin.bytes]).toEqual([0x2a, 0x04, 0x40, 0x00, 0x00]);
+  });
+
+  it('preserves current-location context for deferred classic equ aliases', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-forward-equ-current-'));
+    const entry = join(dir, 'forward-equ-current.asm');
+    writeFileSync(
+      entry,
+      [
+        'org 4000H',
+        'ALIAS equ TARGET+($-$)',
+        'ld hl,(ALIAS)',
+        'TARGET:',
+        'db 0',
+        'binfrom 4000H',
+        'end',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin) throw new Error('missing bin artifact');
+    expect([...bin.bytes]).toEqual([0x2a, 0x03, 0x40, 0x00]);
+  });
+
+  it('rejects labels that shadow unresolved classic equ aliases', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-equ-shadow-'));
+    const entry = join(dir, 'equ-shadow.asm');
+    writeFileSync(
+      entry,
+      [
+        'org 4000H',
+        'ALIAS equ TARGET',
+        'ld hl,(ALIAS)',
+        'ALIAS:',
+        'db 0',
+        'TARGET:',
+        'db 0',
+        'binfrom 4000H',
+        'end',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.some((d) => d.severity === 'error' && d.message.includes('Duplicate symbol name "ALIAS"'))).toBe(true);
+  });
+
+  it('resolves forward classic equ aliases in word data', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-forward-equ-dw-'));
+    const entry = join(dir, 'forward-equ-dw.asm');
+    writeFileSync(
+      entry,
+      [
+        'org 4000H',
+        'ALIAS equ TARGET',
+        'dw ALIAS',
+        'TARGET:',
+        'db 0AAH',
+        'binfrom 4000H',
+        'end',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin) throw new Error('missing bin artifact');
+    expect([...bin.bytes]).toEqual([0x02, 0x40, 0xaa]);
+  });
+
+  it('keeps forward classic equ aliases self-contained in emitted asm80', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-forward-equ-asm80-'));
+    const entry = join(dir, 'forward-equ-asm80.asm');
+    writeFileSync(
+      entry,
+      [
+        'org 4000H',
+        'ALIAS equ TARGET',
+        'dw ALIAS',
+        'TARGET:',
+        'db 0AAH',
+        'binfrom 4000H',
+        'end',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const res = await compile(entry, { emitAsm80: true }, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const asm80 = res.artifacts.find((a): a is Asm80Artifact => a.kind === 'asm80');
+    expect(asm80).toBeDefined();
+    if (!asm80) throw new Error('missing asm80 artifact');
+    expect(asm80.text).toContain('ALIAS EQU $4002');
+    expect(asm80.text).toContain('DW ALIAS');
+  });
+
+  it('resolves forward classic equ aliases in byte data', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-forward-equ-db-'));
+    const entry = join(dir, 'forward-equ-db.asm');
+    writeFileSync(
+      entry,
+      [
+        'org 4000H',
+        'ALIAS equ TARGET',
+        'db ALIAS',
+        'TARGET:',
+        'db 0AAH',
+        'binfrom 4000H',
+        'end',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin) throw new Error('missing bin artifact');
+    expect([...bin.bytes]).toEqual([0x01, 0xaa]);
+  });
+
+  it('does not include trailing reserve-only classic DS in the loadable binary', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-trailing-ds-'));
+    const entry = join(dir, 'trailing-ds.asm');
+    writeFileSync(
+      entry,
+      ['org 4000H', 'db 0AAH', 'RAM_START:', 'ds 4', 'RAM_END:', 'end'].join('\n'),
+      'utf8',
+    );
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin) throw new Error('missing bin artifact');
+    expect([...bin.bytes]).toEqual([0xaa]);
   });
 
   it('compiles classic SRA A', async () => {


### PR DESCRIPTION
## Summary
- Treat classic ASM80 `DS` without a fill as reserve-only space so trailing RAM reservations do not extend the loadable binary.
- Resolve classic absolute-memory `LD (symbol),r` / `LD r,(symbol)` through symbolic fixups before falling back to immediate address evaluation, matching ASM80 forward `EQU` behavior for Tetro.
- Publish exact classic label/equate addresses during lowering and make named-section fixups constants-aware.
- Avoid double-defining inline raw-data labels and add focused regression coverage for forward `EQU` aliases across `DS`.

## Reviewer Notes
This PR is aimed at matching ASM80 behavior closely enough for Tetro/debug80 replacement work. The motivating case was Tetro emitting `$4A70` for `GAME_OVER_KEY_GATE_LO` where ASM80 emits `$4A71`. The final symbol table was already correct, but early instructions baked a stale prepass value. Classic absolute-memory LD operands now remain symbolic until final fixup resolution.

The `DS` change intentionally applies to classic ASM80 raw data only: `DS n` reserves address space, while `DS n,fill` still emits initialized bytes. This keeps loadable binaries trimmed like ASM80 while preserving explicit fill behavior.

## Verification
- `npm test -- --run test/asm80/asm80_directives_integration.test.ts test/frontend/asm80_classic_module.test.ts test/backend/pr135_isa_jr_djnz.test.ts`
- `npm run typecheck -- --pretty false`
- `npm run check:source-file-sizes:enforce`
- `npm run check:fixture-coverage`
- `npm run test:asm80:baseline`
- Fresh Tetro comparison against ASM80: `asm80_range=0x4000..0x4a5c asm80_trim_len=2653 zax_len=2653 mismatch=-1`

## Follow-up / Consolidation
- Replace the fragile classic instruction-size prepass with a shared layout/dry-run service.
- Centralize classic symbol publication and duplicate checking.
- Make reserve-only versus filled `DS` explicit in the lowered model.
- Consolidate classic branch/LD fixup helpers after compatibility stabilizes.