### PR TITLE
[codex] Consolidate ASM80 equate resolution

### DIFF
--- a/docs/design/asm80-compatibility-baseline.md
+++ b/docs/design/asm80-compatibility-baseline.md
@@ -60,9 +60,9 @@ data, includes, expressions, placement, and a broad set of Z80 opcodes.
 | Area                     | Covered                                                                                                                                                    | Source of coverage                                 | Explicitly excluded or deferred                                      |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------------------- |
 | Source mode              | `.z80` and `.asm` classic ASM80 mode; `.zax` unchanged                                                                                                     | MON3, TEC-1G, `test/asm80/mon3_acceptance.test.ts` | Full ASM80 clone mode                                                |
-| Labels and equates       | Colon labels, label plus statement, `NAME: .equ`, `NAME .equ`, undotted `EQU`                                                                              | MON3, TEC-1G                                       | Macro-local and text-substitution label semantics                    |
+| Labels and equates       | Colon labels, label plus statement, `NAME: .equ`, `NAME .equ`, undotted `EQU`, forward and compound `EQU` aliases                                         | MON3, TEC-1G, Tetro                                | Macro-local and text-substitution label semantics                    |
 | Literals and expressions | Trailing `H`/`B`, `0xNN`, `$`, `+ - * /`, parentheses, one-character strings                                                                               | MON3, TEC-1G, directive tests                      | Broad ASM80 expression extensions unless corpus-driven               |
-| Data and directives      | `.org`, `.include`, `.db`, `.dw`, `.ds`, `.align`, `.cstr`, `.pstr`, `.istr`, `.binfrom`, `.binto`, `.end`; dotted, undotted, and mixed case where covered | MON3, TEC-1G, ASM80 directive/string/align tests   | dialect aliases such as `DEFB`/`DEFW`/`RMB`, `DUP`, `.incbin`, `.set`, segments, `.pragma`, `.ent` |
+| Data and directives      | `.org`, `.include`, `.db`, `.dw`, `.ds`, `.align`, `.cstr`, `.pstr`, `.istr`, `.binfrom`, `.binto`, `.end`; dotted, undotted, and mixed case where covered; trailing reserve-only `DS` does not extend the loadable binary | MON3, TEC-1G, Tetro, ASM80 directive/string/align tests | dialect aliases such as `DEFB`/`DEFW`/`RMB`, `DUP`, `.incbin`, `.set`, segments, `.pragma`, `.ent` |
 | Z80 syntax               | Ordinary MON3 instruction heads and operand/addressing forms; TEC-1G additions such as `SRA A` and `LD (addr),HL`                                          | MON3 audit, TEC-1G audit, opcode gap tests         | Instruction forms absent from real corpora do not block the baseline |
 | Includes and output      | Relative quoted includes, included-file diagnostics, post-`.end` `.binfrom`/`.binto`, no-`.org` sources starting at zero                                   | MON3, TEC-1G, directive and CLI diagnostics tests  | `.include file:block`                                                |
 | Baseline corpora         | MON3 recursive tree as the primary corpus; TEC-1G non-macro corpus as the secondary corpus                                                                 | `npm run test:asm80:baseline`                      | Macro-bearing TEC-1G `Education/tbasic.z80`                          |
@@ -78,6 +78,7 @@ The first compatibility level requires:
 - `.include "file"` with paths relative to the including file
 - `.db` with expressions and double-quoted string fragments
 - `.dw` with expressions and symbol fixups
+- `.ds count` and `.ds count, fill`
 - `.end`
 - `.binfrom`
 - ASM80 trailing-base literals such as `0FFH`, `0101b`, and `10101010B`
@@ -86,6 +87,10 @@ The first compatibility level requires:
 - current-location expressions using `$`
 - one-character string values in expressions
 - ordinary Z80 instruction syntax used by MON3
+
+`DS` reserves address space. A `DS` range between emitted bytes can affect the
+loadable binary by creating a gap, but a trailing reserve-only `DS` advances the
+assembly location without extending the cropped binary output.
 
 Early compatibility additions that are already useful even when not required by
 MON3:
@@ -172,7 +177,14 @@ slice of this baseline:
 - `.cstr`, `.pstr`, and `.istr`
 - `.binfrom`
 - `.end`
+- forward `EQU` aliases
+- compound `EQU` aliases that reference other forward aliases
+- `EQU` aliases in `DB` and `DW` operands
+- declaration-time `$` handling inside classic `EQU` expressions
+- reserve-only trailing `DS` binary trimming
 - lowered ASM80 artifact emission for recorded classic items
+- lowered ASM80 artifact preservation for resolved aliases and generated
+  padding/data directives
 - focused MON3 opcode-gap audit showing no unsupported encoder forms in the
   current recursive MON3 corpus
 
@@ -189,6 +201,11 @@ The secondary TEC-1G software corpus is tracked in
 `docs/design/asm80-tec1g-compatibility-audit.md`. It deliberately excludes
 sources containing `.macro`/`.endm`, and currently verifies 12 non-macro TEC-1G
 programs byte-for-byte against ASM80.
+
+The Tetro source tree is a useful follow-up corpus for loadable application
+semantics, especially reserve-only `DS` behavior. It is tracked as an opt-in
+acceptance check rather than a standing baseline gate until the project decides
+to promote it.
 
 ## Baseline corpora and gates
 

--- a/docs/design/asm80-tetro-compatibility-audit.md
+++ b/docs/design/asm80-tetro-compatibility-audit.md
@@ -1,0 +1,60 @@
+# ASM80 Tetro compatibility audit
+
+Status: exploratory corpus, not yet part of the standing ASM80 baseline gate
+Date: 2026-05-11
+
+## Purpose
+
+Tetro is a practical ASM80-style application corpus outside MON3. It is useful
+for checking that ZAX can replace ASM80 for loadable Tech-1 programs without
+expanding into full ASM80 compatibility.
+
+This corpus does not change the baseline policy: ZAX remains macro-free for the
+ASM80 compatibility track, and source files should be normalized rather than
+adding low-value dialect aliases.
+
+## Corpus
+
+Default source:
+
+- `/Users/johnhardy/Documents/projects/tetro/src/tetro.asm`
+
+The source includes nested files under the Tetro source root, so any reference
+comparison must copy or run against the whole source tree rather than only
+sibling `.asm` files.
+
+## Current result
+
+The current compatibility result is byte-for-byte parity with ASM80 after
+trimming the ASM80 reference binary to the populated listing range:
+
+- populated range: `0x4000..0x4a5c`
+- ZAX bytes: `2653`
+- trimmed ASM80 bytes: `2653`
+- first mismatch: none
+
+Raw ASM80 output may be a full 64K image in this case, while ZAX emits the
+loadable populated range. The comparable reference is therefore the ASM80
+listing range, not the raw file length.
+
+## Compatibility deltas
+
+Tetro is the corpus that made reserve-only `DS` behavior a priority. ASM80 uses
+`DS` to reserve address space; trailing reserved space does not necessarily
+belong in the loadable binary. ZAX should match this behavior so RAM-loaded
+applications do not grow because of uninitialized storage at the end of a
+source file.
+
+The corpus also exercises forward and compound `EQU` aliases in ordinary
+operands and data directives.
+
+## Gate
+
+Tetro should stay opt-in for now:
+
+```sh
+ZAX_RUN_TETRO_ACCEPTANCE=1 npx vitest run test/asm80/tetro_acceptance.test.ts
+```
+
+Promotion into `npm run test:asm80:baseline` should be a deliberate decision,
+not a side effect of exploratory compatibility work.

--- a/src/lowering/classicEquResolution.ts
+++ b/src/lowering/classicEquResolution.ts
@@ -1,0 +1,110 @@
+import type { ImmExprNode } from '../frontend/ast.js';
+import { evalImmExpr, type CompileEnv } from '../semantics/env.js';
+
+export type ClassicEquResolutionContext = {
+  env: CompileEnv;
+  lookupSymbol?: (nameLower: string) => number | undefined;
+  cacheResolved?: (nameLower: string, value: number) => void;
+};
+
+function scopedEnv(ctx: ClassicEquResolutionContext): CompileEnv {
+  if (!ctx.lookupSymbol) return ctx.env;
+  const consts = new Map(ctx.env.consts);
+  for (const name of ctx.env.classicEquExprs?.keys() ?? []) {
+    const lower = name.toLowerCase();
+    const value = ctx.lookupSymbol(lower);
+    if (value !== undefined) consts.set(lower, value);
+  }
+  return { ...ctx.env, consts };
+}
+
+export function resolveClassicEquSymbol(
+  name: string,
+  ctx: ClassicEquResolutionContext,
+  visiting = new Set<string>(),
+): number | undefined {
+  const lower = name.toLowerCase();
+  const symbol = ctx.lookupSymbol?.(lower);
+  if (symbol !== undefined) return symbol;
+  const direct = ctx.env.consts.get(name) ?? ctx.env.enums.get(name);
+  if (direct !== undefined) return direct;
+  const alt = ctx.env.consts.get(lower) ?? ctx.env.enums.get(lower);
+  if (alt !== undefined) return alt;
+
+  const equ = ctx.env.classicEquExprs?.get(name) ?? ctx.env.classicEquExprs?.get(lower);
+  if (!equ || visiting.has(lower)) return undefined;
+  visiting.add(lower);
+  try {
+    const value = evalClassicEquExpr(equ.expr, ctx, visiting, equ.currentLocation);
+    if (value !== undefined) {
+      ctx.cacheResolved?.(lower, value);
+    }
+    return value;
+  } finally {
+    visiting.delete(lower);
+  }
+}
+
+export function evalClassicEquExpr(
+  expr: ImmExprNode,
+  ctx: ClassicEquResolutionContext,
+  visiting = new Set<string>(),
+  currentLocation?: number,
+): number | undefined {
+  const env = scopedEnv(ctx);
+  const value =
+    currentLocation === undefined
+      ? evalImmExpr(expr, env)
+      : evalImmExpr(expr, env, undefined, { currentLocation });
+  if (value !== undefined) return value;
+
+  switch (expr.kind) {
+    case 'ImmCurrentLocation':
+      return currentLocation;
+    case 'ImmName':
+      return resolveClassicEquSymbol(expr.name, ctx, visiting);
+    case 'ImmUnary': {
+      const v = evalClassicEquExpr(expr.expr, ctx, visiting, currentLocation);
+      if (v === undefined) return undefined;
+      switch (expr.op) {
+        case '+':
+          return +v;
+        case '-':
+          return -v;
+        case '~':
+          return ~v;
+      }
+      return undefined;
+    }
+    case 'ImmBinary': {
+      const left = evalClassicEquExpr(expr.left, ctx, visiting, currentLocation);
+      const right = evalClassicEquExpr(expr.right, ctx, visiting, currentLocation);
+      if (left === undefined || right === undefined) return undefined;
+      switch (expr.op) {
+        case '*':
+          return left * right;
+        case '/':
+          return right === 0 ? undefined : Math.trunc(left / right);
+        case '%':
+          return right === 0 ? undefined : left % right;
+        case '+':
+          return left + right;
+        case '-':
+          return left - right;
+        case '&':
+          return left & right;
+        case '^':
+          return left ^ right;
+        case '|':
+          return left | right;
+        case '<<':
+          return left << right;
+        case '>>':
+          return left >> right;
+      }
+      return undefined;
+    }
+    default:
+      return undefined;
+  }
+}

--- a/src/lowering/loweredAsmByteEmission.ts
+++ b/src/lowering/loweredAsmByteEmission.ts
@@ -1,8 +1,8 @@
 import type { Diagnostic } from '../diagnosticTypes.js';
-import type { ImmExprNode } from '../frontend/ast.js';
-import { evalImmExpr as evalImmExprWithEnv, type CompileEnv } from '../semantics/env.js';
+import type { CompileEnv } from '../semantics/env.js';
 import type { LoweredAsmBlock, LoweredAsmProgram, LoweredAsmItem, LoweredImmExpr } from './loweredAsmTypes.js';
 import type { SectionKind } from './loweringTypes.js';
+import { resolveClassicEquSymbol } from './classicEquResolution.js';
 
 export type LoweredAsmByteEmissionContext = {
   diagnostics: Diagnostic[];
@@ -23,82 +23,6 @@ const toByte = (value: number): number => value & 0xff;
 const toWord = (value: number): number => value & 0xffff;
 
 function evalLoweredImmExpr(expr: LoweredImmExpr, env: CompileEnv): number | undefined {
-  const evalClassicAliasExpr = (
-    classicExpr: ImmExprNode,
-    visiting: Set<string>,
-    currentLocation?: number,
-  ): number | undefined => {
-    const value =
-      currentLocation === undefined
-        ? evalImmExprWithEnv(classicExpr, env)
-        : evalImmExprWithEnv(classicExpr, env, undefined, { currentLocation });
-    if (value !== undefined) return value;
-
-    switch (classicExpr.kind) {
-      case 'ImmCurrentLocation':
-        return currentLocation;
-      case 'ImmName':
-        return evalClassicAliasSymbol(classicExpr.name, visiting);
-      case 'ImmUnary': {
-        const v = evalClassicAliasExpr(classicExpr.expr, visiting, currentLocation);
-        if (v === undefined) return undefined;
-        switch (classicExpr.op) {
-          case '+':
-            return +v;
-          case '-':
-            return -v;
-          case '~':
-            return ~v;
-        }
-        return undefined;
-      }
-      case 'ImmBinary': {
-        const left = evalClassicAliasExpr(classicExpr.left, visiting, currentLocation);
-        const right = evalClassicAliasExpr(classicExpr.right, visiting, currentLocation);
-        if (left === undefined || right === undefined) return undefined;
-        switch (classicExpr.op) {
-          case '*':
-            return left * right;
-          case '/':
-            return right === 0 ? undefined : Math.trunc(left / right);
-          case '%':
-            return right === 0 ? undefined : left % right;
-          case '+':
-            return left + right;
-          case '-':
-            return left - right;
-          case '&':
-            return left & right;
-          case '^':
-            return left ^ right;
-          case '|':
-            return left | right;
-          case '<<':
-            return left << right;
-          case '>>':
-            return left >> right;
-        }
-        return undefined;
-      }
-      default:
-        return undefined;
-    }
-  };
-
-  const evalClassicAliasSymbol = (name: string, visiting = new Set<string>()): number | undefined => {
-    const direct = env.consts.get(name) ?? env.enums.get(name);
-    if (direct !== undefined) return direct;
-    const lower = name.toLowerCase();
-    const alt = env.consts.get(lower) ?? env.enums.get(lower);
-    if (alt !== undefined) return alt;
-    const equ = env.classicEquExprs?.get(name) ?? env.classicEquExprs?.get(lower);
-    if (!equ || visiting.has(lower)) return undefined;
-    visiting.add(lower);
-    const value = evalClassicAliasExpr(equ.expr, visiting, equ.currentLocation);
-    if (value !== undefined) env.consts.set(lower, value);
-    return value;
-  };
-
   switch (expr.kind) {
     case 'literal':
       return expr.value;
@@ -108,7 +32,7 @@ function evalLoweredImmExpr(expr: LoweredImmExpr, env: CompileEnv): number | und
       const lower = expr.name.toLowerCase();
       const alt = env.consts.get(lower) ?? env.enums.get(lower);
       if (alt !== undefined) return alt + expr.addend;
-      const classicAlias = evalClassicAliasSymbol(expr.name);
+      const classicAlias = resolveClassicEquSymbol(expr.name, { env });
       if (classicAlias !== undefined) return classicAlias + expr.addend;
       return undefined;
     }

--- a/src/lowering/programLoweringFinalize.ts
+++ b/src/lowering/programLoweringFinalize.ts
@@ -5,8 +5,7 @@ import type {
 import type { SectionKind } from './loweringTypes.js';
 import type { ProgramEmissionFinalizeContext } from './programLowering.js';
 import { parseNumberLiteral } from '../frontend/parseImm.js';
-import type { ImmExprNode } from '../frontend/ast.js';
-import { evalImmExpr as evalImmExprWithEnv } from '../semantics/env.js';
+import { resolveClassicEquSymbol } from './classicEquResolution.js';
 
 export function computeSectionBases(
   ctx: Pick<ProgramEmissionFinalizeContext, 'baseExprs' | 'evalImmExpr' | 'env' | 'diagnostics' | 'diag' | 'primaryFile' | 'alignTo' | 'codeOffset' | 'dataOffset'>,
@@ -131,86 +130,22 @@ export function finalizeProgramEmission(ctx: ProgramEmissionFinalizeContext): {
     });
   }
 
-  const evalClassicAliasExpr = (
-    expr: ImmExprNode,
-    visiting: Set<string>,
-    currentLocation?: number,
-  ): number | undefined => {
-    const aliasEnv = { ...ctx.env, consts: new Map(ctx.env.consts) };
-    for (const [name, value] of addrByNameLower) aliasEnv.consts.set(name, value);
-    const value =
-      currentLocation === undefined
-        ? ctx.evalImmExpr(expr, aliasEnv, [])
-        : evalImmExprWithEnv(expr, aliasEnv, [], { currentLocation });
-    if (value !== undefined) return value;
-
-    switch (expr.kind) {
-      case 'ImmCurrentLocation':
-        return currentLocation;
-      case 'ImmName':
-        return resolveFixupBase(expr.name.toLowerCase(), visiting);
-      case 'ImmUnary': {
-        const v = evalClassicAliasExpr(expr.expr, visiting, currentLocation);
-        if (v === undefined) return undefined;
-        switch (expr.op) {
-          case '+':
-            return +v;
-          case '-':
-            return -v;
-          case '~':
-            return ~v;
-        }
-        return undefined;
-      }
-      case 'ImmBinary': {
-        const l = evalClassicAliasExpr(expr.left, visiting, currentLocation);
-        const r = evalClassicAliasExpr(expr.right, visiting, currentLocation);
-        if (l === undefined || r === undefined) return undefined;
-        switch (expr.op) {
-          case '*':
-            return l * r;
-          case '/':
-            return r === 0 ? undefined : (l / r) | 0;
-          case '%':
-            return r === 0 ? undefined : l % r;
-          case '+':
-            return l + r;
-          case '-':
-            return l - r;
-          case '&':
-            return l & r;
-          case '^':
-            return l ^ r;
-          case '|':
-            return l | r;
-          case '<<':
-            return l << r;
-          case '>>':
-            return l >> r;
-        }
-        return undefined;
-      }
-      default:
-        return undefined;
-    }
-  };
-
   const resolveFixupBase = (nameLower: string, visiting = new Set<string>()): number | undefined => {
     const sym = addrByNameLower.get(nameLower);
     if (sym !== undefined) return sym;
     const literal = parseNumberLiteral(nameLower);
     if (literal !== undefined) return literal;
     if (/^-?[0-9]+$/.test(nameLower)) return Number.parseInt(nameLower, 10);
-    const equ = ctx.env.classicEquExprs?.get(nameLower);
-    if (equ) {
-      if (visiting.has(nameLower)) return undefined;
-      visiting.add(nameLower);
-      const value = evalClassicAliasExpr(equ.expr, visiting, equ.currentLocation);
-      if (value !== undefined) {
-        addrByNameLower.set(nameLower, value);
-        ctx.env.consts.set(nameLower, value);
-        return value;
-      }
+    const value = resolveClassicEquSymbol(nameLower, {
+      env: ctx.env,
+      lookupSymbol: (name) => addrByNameLower.get(name),
+      cacheResolved: (name, resolved) => {
+        addrByNameLower.set(name, resolved);
+        ctx.env.consts.set(name, resolved);
+      },
+    }, visiting);
+    if (value !== undefined) {
+      return value;
     }
     return undefined;
   };

--- a/src/lowering/sectionPlacement.ts
+++ b/src/lowering/sectionPlacement.ts
@@ -1,12 +1,13 @@
 import type { Diagnostic } from '../diagnosticTypes.js';
 import type { SymbolEntry } from '../formats/types.js';
-import { evalImmExpr, type CompileEnv } from '../semantics/env.js';
+import type { CompileEnv } from '../semantics/env.js';
 import type { ImmExprNode, SourceSpan } from '../frontend/ast.js';
 import { diagAt } from './loweringDiagnostics.js';
 import type { NamedSectionContributionSink } from './sectionContributions.js';
 import type { NonBankedSectionKeyId } from '../sectionKeys.js';
 import { formatNonBankedSectionKey } from '../sectionKeys.js';
 import { parseNumberLiteral } from '../frontend/parseImm.js';
+import { resolveClassicEquSymbol } from './classicEquResolution.js';
 
 export type PlacedNamedSectionContribution = {
   /** Sink carrying bytes/fixups for one contribution. */
@@ -292,88 +293,24 @@ export function resolvePlacedNamedSectionFixups(
     if (sym.kind === 'constant' || sym.address === undefined) continue;
     addrByNameLower.set(sym.name.toLowerCase(), sym.address);
   }
-  const evalClassicAliasExpr = (
-    expr: ImmExprNode,
-    visiting: Set<string>,
-    currentLocation?: number,
-  ): number | undefined => {
-    const aliasEnv = { ...env, consts: new Map(env.consts) };
-    for (const [name, value] of addrByNameLower) aliasEnv.consts.set(name, value);
-    const value =
-      currentLocation === undefined
-        ? evalImmExpr(expr, aliasEnv)
-        : evalImmExpr(expr, aliasEnv, undefined, { currentLocation });
-    if (value !== undefined) return value;
-
-    switch (expr.kind) {
-      case 'ImmCurrentLocation':
-        return currentLocation;
-      case 'ImmName':
-        return resolveFixupBase(expr.name.toLowerCase(), visiting);
-      case 'ImmUnary': {
-        const v = evalClassicAliasExpr(expr.expr, visiting, currentLocation);
-        if (v === undefined) return undefined;
-        switch (expr.op) {
-          case '+':
-            return +v;
-          case '-':
-            return -v;
-          case '~':
-            return ~v;
-        }
-        return undefined;
-      }
-      case 'ImmBinary': {
-        const l = evalClassicAliasExpr(expr.left, visiting, currentLocation);
-        const r = evalClassicAliasExpr(expr.right, visiting, currentLocation);
-        if (l === undefined || r === undefined) return undefined;
-        switch (expr.op) {
-          case '*':
-            return l * r;
-          case '/':
-            return r === 0 ? undefined : (l / r) | 0;
-          case '%':
-            return r === 0 ? undefined : l % r;
-          case '+':
-            return l + r;
-          case '-':
-            return l - r;
-          case '&':
-            return l & r;
-          case '^':
-            return l ^ r;
-          case '|':
-            return l | r;
-          case '<<':
-            return l << r;
-          case '>>':
-            return l >> r;
-        }
-        return undefined;
-      }
-      default:
-        return undefined;
-    }
-  };
-
   const resolveFixupBase = (nameLower: string, visiting = new Set<string>()): number | undefined => {
     const sym = addrByNameLower.get(nameLower);
     if (sym !== undefined) return sym;
     const literal = parseNumberLiteral(nameLower);
     if (literal !== undefined) return literal;
     if (/^-?[0-9]+$/.test(nameLower)) return Number.parseInt(nameLower, 10);
-    const equ = env.classicEquExprs?.get(nameLower);
-    if (equ) {
-      if (visiting.has(nameLower)) return undefined;
-      visiting.add(nameLower);
-      const value = evalClassicAliasExpr(equ.expr, visiting, equ.currentLocation);
-      if (value !== undefined) {
-        addrByNameLower.set(nameLower, value);
-        env.consts.set(nameLower, value);
-        return value;
-      }
-    }
-    return undefined;
+    return resolveClassicEquSymbol(
+      nameLower,
+      {
+        env,
+        lookupSymbol: (name) => addrByNameLower.get(name),
+        cacheResolved: (name, value) => {
+          addrByNameLower.set(name, value);
+          env.consts.set(name, value);
+        },
+      },
+      visiting,
+    );
   };
 
   for (const placed of placedContributions) {

--- a/test/asm80/asm80_directives_integration.test.ts
+++ b/test/asm80/asm80_directives_integration.test.ts
@@ -504,6 +504,33 @@ describe('asm80 directive lowering integration', () => {
     expect([...bin.bytes]).toEqual([0x2a, 0x04, 0x40, 0x00, 0x00]);
   });
 
+  it('resolves repeated aliases inside a classic equ expression', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-repeated-forward-equ-'));
+    const entry = join(dir, 'repeated-forward-equ.asm');
+    writeFileSync(
+      entry,
+      [
+        'org 4000H',
+        'ALIAS equ TARGET',
+        'SUM equ ALIAS+ALIAS',
+        'dw SUM',
+        'TARGET:',
+        'db 0AAH',
+        'binfrom 4000H',
+        'end',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const res = await compile(entry, {}, { formats: defaultFormatWriters });
+
+    expect(res.diagnostics.filter((d) => d.severity === 'error')).toEqual([]);
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin) throw new Error('missing bin artifact');
+    expect([...bin.bytes]).toEqual([0x04, 0x80, 0xaa]);
+  });
+
   it('preserves current-location context for deferred classic equ aliases', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'zax-asm80-forward-equ-current-'));
     const entry = join(dir, 'forward-equ-current.asm');

--- a/test/asm80/tetro_acceptance.test.ts
+++ b/test/asm80/tetro_acceptance.test.ts
@@ -1,0 +1,207 @@
+import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { compile } from '../../src/compile.js';
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
+import { defaultFormatWriters } from '../../src/formats/index.js';
+import type { BinArtifact } from '../../src/formats/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const manifest = {
+  source: process.env.TETRO_SOURCE ?? '/Users/johnhardy/Documents/projects/tetro/src/tetro.asm',
+};
+
+type ListingRange = {
+  start: number;
+  end: number;
+};
+
+function normalizeExecutableCandidate(candidate: string): string {
+  return candidate.includes('/') || candidate.includes('\\') ? resolve(candidate) : candidate;
+}
+
+const asm80Candidates = [
+  process.env.ASM80,
+  process.env.ASM80_PATH,
+  '/Users/johnhardy/Documents/projects/debug80/node_modules/.bin/asm80',
+  'asm80',
+]
+  .filter(
+    (candidate): candidate is string => candidate !== undefined && candidate.trim().length > 0,
+  )
+  .map(normalizeExecutableCandidate);
+const asm80 = asm80Candidates.find((candidate) => {
+  const probe = spawnSync(candidate, ['-h'], { encoding: 'utf8' });
+  return !probe.error;
+});
+const tetroFilesAvailable = existsSync(manifest.source);
+const runTetroAcceptance = process.env.ZAX_RUN_TETRO_ACCEPTANCE === '1';
+const describeTetro = tetroFilesAvailable && asm80 && runTetroAcceptance ? describe : describe.skip;
+
+function byteHex(value: number | undefined): string {
+  return value === undefined ? 'EOF' : `0x${value.toString(16).padStart(2, '0')}`;
+}
+
+function offsetHex(offset: number): string {
+  return `0x${offset.toString(16).padStart(4, '0')}`;
+}
+
+function diagnosticLocation(diagnostic: Diagnostic): string {
+  if (diagnostic.line === undefined || diagnostic.column === undefined) return diagnostic.file;
+  return `${diagnostic.file}:${diagnostic.line}:${diagnostic.column}`;
+}
+
+function summarizeDiagnostics(diagnostics: Diagnostic[], limit = 3): string {
+  const preview = diagnostics
+    .slice(0, limit)
+    .map(
+      (diagnostic) =>
+        `${diagnosticLocation(diagnostic)}: ${diagnostic.severity} [${diagnostic.id}] ${
+          diagnostic.message
+        }`,
+    );
+  return [
+    `Diagnostics preview (showing ${preview.length} of ${diagnostics.length}):`,
+    ...preview,
+  ].join('\n');
+}
+
+function findFirstMismatch(actual: Buffer, reference: Buffer): number {
+  const maxLength = Math.max(actual.length, reference.length);
+  for (let i = 0; i < maxLength; i++) {
+    if (actual[i] !== reference[i]) return i;
+  }
+  return -1;
+}
+
+function summarizeBinaryMismatch(actual: Buffer, reference: Buffer): string {
+  const firstMismatch = findFirstMismatch(actual, reference);
+  const lines = [`Binary length: actual=${actual.length} reference=${reference.length}`];
+  if (firstMismatch >= 0) {
+    lines.push(
+      `First mismatch @${offsetHex(firstMismatch)}: actual=${byteHex(
+        actual[firstMismatch],
+      )} reference=${byteHex(reference[firstMismatch])}`,
+    );
+  } else {
+    lines.push('First mismatch: none');
+  }
+  return lines.join('\n');
+}
+
+function parseListingWrittenRange(listingPath: string): ListingRange {
+  const text = readFileSync(listingPath, 'utf8');
+  let start: number | undefined;
+  let end = 0;
+  for (const line of text.split(/\r?\n/)) {
+    const match = /^([0-9A-Fa-f]{4})\s+/.exec(line);
+    if (!match) continue;
+    const address = Number.parseInt(match[1]!, 16);
+    const bytes = line
+      .slice(7, 31)
+      .trim()
+      .split(/\s+/)
+      .filter((token) => /^[0-9A-Fa-f]{2}$/.test(token)).length;
+    if (bytes === 0) continue;
+    start = start === undefined ? address : Math.min(start, address);
+    end = Math.max(end, address + bytes);
+  }
+  return { start: start ?? 0, end };
+}
+
+function binaryFromListingRange(bytes: Buffer, range: ListingRange): Buffer {
+  if (bytes.length !== 0x10000) return bytes;
+  let end = range.end;
+  for (let index = bytes.length - 1; index >= range.start; index--) {
+    if (bytes[index] !== 0) {
+      end = Math.max(end, index + 1);
+      break;
+    }
+  }
+  return bytes.subarray(range.start, end);
+}
+
+function buildAsm80Reference(source: string): Buffer {
+  if (!asm80) throw new Error('asm80 executable not found');
+  const outDir = mkdtempSync(join(tmpdir(), 'zax-tetro-asm80-reference-'));
+  const sourceRoot = dirname(source);
+  const outName = 'tetro-reference.bin';
+  const outBin = join(outDir, outName);
+  const listing = join(outDir, 'tetro-reference.lst');
+  try {
+    cpSync(sourceRoot, outDir, { recursive: true });
+    const result = spawnSync(asm80, ['-m', 'Z80', '-t', 'bin', '-o', outName, basename(source)], {
+      cwd: outDir,
+      encoding: 'utf8',
+    });
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(
+        [`asm80 failed with status ${result.status}`, result.stdout.trim(), result.stderr.trim()]
+          .filter((part) => part.length > 0)
+          .join('\n'),
+      );
+    }
+    const bytes = readFileSync(outBin);
+    const range = parseListingWrittenRange(listing);
+    return binaryFromListingRange(bytes, range);
+  } finally {
+    rmSync(outDir, { recursive: true, force: true });
+  }
+}
+
+describeTetro('ASM80 Tetro acceptance', () => {
+  it('compiles Tetro and matches a fresh ASM80-built reference binary', async () => {
+    const res = await compile(
+      manifest.source,
+      { emitBin: true, emitHex: false, emitD8m: false, emitListing: false },
+      { formats: defaultFormatWriters },
+    );
+    const errors = res.diagnostics.filter((d) => d.severity === 'error');
+    if (errors.length > 0) throw new Error(summarizeDiagnostics(res.diagnostics));
+
+    const bin = res.artifacts.find((a): a is BinArtifact => a.kind === 'bin');
+    expect(bin).toBeDefined();
+    if (!bin) throw new Error('missing bin artifact');
+
+    const actual = Buffer.from(bin.bytes);
+    const expected = buildAsm80Reference(manifest.source);
+    const binarySummary = summarizeBinaryMismatch(actual, expected);
+
+    if (actual.length !== expected.length || findFirstMismatch(actual, expected) !== -1) {
+      throw new Error(binarySummary);
+    }
+  });
+});
+
+if (runTetroAcceptance && !tetroFilesAvailable) {
+  describe('ASM80 Tetro acceptance', () => {
+    it('requires the local Tetro source when opt-in acceptance is enabled', () => {
+      throw new Error(`Tetro source is unavailable: ${manifest.source}`);
+    });
+  });
+} else if (runTetroAcceptance && !asm80) {
+  describe('ASM80 Tetro acceptance', () => {
+    it('requires asm80 when opt-in acceptance is enabled', () => {
+      throw new Error('asm80 executable is unavailable. Set ASM80 or ASM80_PATH.');
+    });
+  });
+} else if (!tetroFilesAvailable) {
+  describe('ASM80 Tetro acceptance', () => {
+    it.todo('skipped: local Tetro source is unavailable');
+  });
+} else if (!asm80) {
+  describe('ASM80 Tetro acceptance', () => {
+    it.todo('skipped: asm80 executable is unavailable');
+  });
+} else if (!runTetroAcceptance) {
+  describe('ASM80 Tetro acceptance', () => {
+    it.todo('set ZAX_RUN_TETRO_ACCEPTANCE=1 to run the local Tetro acceptance check');
+  });
+}


### PR DESCRIPTION
## Summary

Consolidates ASM80 classic `EQU` alias resolution into one lowering helper and records the current Tetro compatibility evidence without expanding the standing baseline gate.

## What changed

- Added `src/lowering/classicEquResolution.ts` as the shared resolver for classic `EQU` expressions.
- Replaced duplicated resolver logic in:
  - `src/lowering/loweredAsmByteEmission.ts`
  - `src/lowering/programLoweringFinalize.ts`
  - `src/lowering/sectionPlacement.ts`
- Preserved stage-specific behavior:
  - byte emission can resolve classic aliases without caching into the global env
  - fixup stages can resolve against placed symbols and cache successful aliases into their address maps/env
- Updated the ASM80 compatibility baseline doc with:
  - forward and compound `EQU` aliases
  - `EQU` use in `DB`/`DW`
  - trailing reserve-only `DS` semantics
  - Tetro as opt-in evidence rather than a standing baseline expansion
- Added `docs/design/asm80-tetro-compatibility-audit.md`.
- Added opt-in `test/asm80/tetro_acceptance.test.ts`, enabled with `ZAX_RUN_TETRO_ACCEPTANCE=1`.

## Reviewer notes

The main correctness risk is alias resolution visibility. The helper deliberately accepts an optional `lookupSymbol`/`cacheResolved` pair so late fixup stages can see placed symbols, while lowered ASM byte emission does not accidentally cache values while symbol visibility is still narrower.

Tetro remains outside `npm run test:asm80:baseline`; this PR documents and tests it as an opt-in acceptance check only.

## Verification

- `npm run lint`
- `npm run typecheck -- --pretty false`
- `npm test -- --run test/asm80/asm80_directives_integration.test.ts test/pr584_named_section_fixups_integration.test.ts test/backend/issue1356_named_section_ld_hl.test.ts test/asm80/tetro_acceptance.test.ts`
- `ZAX_RUN_TETRO_ACCEPTANCE=1 npm test -- --run test/asm80/tetro_acceptance.test.ts`
- `npm run check:source-file-sizes:enforce`
- `npm run check:fixture-coverage`
- `npm run test:asm80:baseline`
