### PR TITLE
[codex] Tighten ASM80 baseline diagnostics

### DIFF
--- a/docs/design/asm80-tetro-compatibility-audit.md
+++ b/docs/design/asm80-tetro-compatibility-audit.md
@@ -53,7 +53,7 @@ operands and data directives.
 Tetro should stay opt-in for now:
 
 ```sh
-ZAX_RUN_TETRO_ACCEPTANCE=1 npx vitest run test/asm80/tetro_acceptance.test.ts
+npm run test:asm80:tetro
 ```
 
 Promotion into `npm run test:asm80:baseline` should be a deliberate decision,

--- a/docs/reference/testing-verification-guide.md
+++ b/docs/reference/testing-verification-guide.md
@@ -59,6 +59,23 @@ ASM80=/path/to/asm80 \
 npm run test:asm80:baseline
 ```
 
+Run the opt-in Tetro application check when touching loadable binary range
+semantics, `DS` behavior, or classic `EQU` resolution:
+
+```sh
+npm run test:asm80:tetro
+```
+
+This builds a fresh ASM80 reference from the local Tetro source tree and trims
+the ASM80 64K output to the populated listing range before comparing it with
+ZAX output. Override the default source path and ASM80 executable when needed:
+
+```sh
+TETRO_SOURCE=/path/to/tetro.asm \
+ASM80=/path/to/asm80 \
+npm run test:asm80:tetro
+```
+
 For docs-only changes, check changed docs paths with Prettier:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "test:ci:coverage-core": "vitest run --coverage --exclude 'test/cli_*.test.ts' --exclude 'test/cli/**/*.test.ts'",
     "test:ci:slow-reliability": "vitest run --no-file-parallelism --maxWorkers=1 --minWorkers=1 --testTimeout=20000 --hookTimeout=300000 --passWithNoTests 'test/cli_*.test.ts' 'test/cli/**/*.test.ts'",
     "test:asm80:baseline": "node scripts/dev/run-asm80-baseline.mjs",
+    "test:asm80:tetro": "ZAX_RUN_TETRO_ACCEPTANCE=1 vitest run test/asm80/tetro_acceptance.test.ts",
     "test:watch": "vitest",
     "format": "prettier -w .",
     "format:check": "prettier -c .",

--- a/src/frontend/asm80/classicLine.ts
+++ b/src/frontend/asm80/classicLine.ts
@@ -6,6 +6,7 @@ export type ClassicLine =
   | { kind: 'binfrom'; exprText: string }
   | { kind: 'binto'; exprText: string }
   | { kind: 'end' }
+  | { kind: 'unsupportedDirective'; label?: string; directive: string }
   | {
       kind: 'rawData';
       label?: string;
@@ -86,6 +87,18 @@ function parseStatement(text: string, label?: string): ClassicLine | undefined {
       name === 'istr'
     ) {
       return { kind: 'rawData', ...(label ? { label } : {}), directive: name, valuesText: payload };
+    }
+    if (text.trimStart().startsWith('.')) {
+      return { kind: 'unsupportedDirective', ...(label ? { label } : {}), directive: name };
+    }
+    if (
+      name === 'macro' ||
+      name === 'rept' ||
+      name === 'endm' ||
+      name === 'block' ||
+      name === 'endblock'
+    ) {
+      return { kind: 'unsupportedDirective', ...(label ? { label } : {}), directive: name };
     }
   }
 

--- a/src/frontend/asm80/parseClassicModule.ts
+++ b/src/frontend/asm80/parseClassicModule.ts
@@ -150,6 +150,12 @@ function canonicalDirectiveForRejectedAlias(head: string): string | undefined {
   }
 }
 
+function headColumn(raw: string, head: string, label?: string): number {
+  const searchStart = label ? raw.indexOf(':') + 1 : 0;
+  const index = raw.toLowerCase().indexOf(head.toLowerCase(), searchStart);
+  return index < 0 ? 1 : index + 1;
+}
+
 export function parseClassicModule(
   path: string,
   sourceText: string,
@@ -199,7 +205,7 @@ export function parseClassicModule(
             _diagnostics,
             linePath,
             `${parsed.head.toUpperCase()} is not part of the supported ASM80 baseline; use ${canonicalDirective}.`,
-            { line: index + 1, column: raw.indexOf(parsed.head) + 1 },
+            { line: lineSpan.start.line, column: headColumn(raw, parsed.head, parsed.label) },
           );
           pendingRawLabel = undefined;
           break;
@@ -214,6 +220,18 @@ export function parseClassicModule(
         pendingRawLabel = undefined;
         break;
       }
+      case 'unsupportedDirective':
+        if (parsed.label) {
+          items.push({ kind: 'AsmLabel', span: lineSpan, name: parsed.label });
+        }
+        parseDiag(
+          _diagnostics,
+          linePath,
+          `Unsupported ASM80 directive ".${parsed.directive}". The supported baseline intentionally excludes macros and non-corpus directives.`,
+          { line: lineSpan.start.line, column: headColumn(raw, parsed.directive, parsed.label) },
+        );
+        pendingRawLabel = undefined;
+        break;
       case 'equ':
         items.push({
           kind: 'ClassicEqu',

--- a/src/lowering/README.md
+++ b/src/lowering/README.md
@@ -41,8 +41,12 @@ Lowering turns the typed AST + semantic environment into:
 ### Program-level lowering
 
 - `programLowering.ts`
-- `programLoweringDeclarations.ts` (bin/hex/raw decls)
+- `programLoweringTraversal.ts` (module item dispatch, including classic ASM80 directive dispatch)
+- `programLoweringDeclarations.ts` (bin/raw decls, including classic ASM80 raw data)
 - `programLoweringData.ts` (data blocks / initializers)
+- `classicInstructionLowering.ts` (ASM80 instruction compatibility overlay)
+- `classicEquResolution.ts` (classic ASM80 `EQU` alias resolution)
+- `classicTraversalHelpers.ts` (classic ASM80 traversal/address helpers)
 - `emitVisibility.ts` (callable/op visibility)
 
 ### Function-level lowering

--- a/test/asm80/asm80_baseline_workflow.test.ts
+++ b/test/asm80/asm80_baseline_workflow.test.ts
@@ -14,6 +14,17 @@ describe('ASM80 baseline acceptance workflow', () => {
     expect(pkg.scripts?.['test:asm80:baseline']).toBe('node scripts/dev/run-asm80-baseline.mjs');
   });
 
+  it('keeps the Tetro acceptance check opt-in and separate from the standing baseline', () => {
+    const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(pkg.scripts?.['test:asm80:tetro']).toBe(
+      'ZAX_RUN_TETRO_ACCEPTANCE=1 vitest run test/asm80/tetro_acceptance.test.ts',
+    );
+    expect(pkg.scripts?.['test:asm80:baseline']).not.toContain('tetro');
+  });
+
   it('documents the opt-in baseline command with both external corpora', () => {
     const doc = readFileSync(
       join(repoRoot, 'docs', 'reference', 'testing-verification-guide.md'),
@@ -34,6 +45,16 @@ describe('ASM80 baseline acceptance workflow', () => {
     expect(doc).toContain('MON3_SOURCE');
     expect(doc).toContain('TEC1G_SOFTWARE_ROOT');
     expect(doc).toContain('ASM80');
+  });
+
+  it('documents the opt-in Tetro acceptance command and source override', () => {
+    const doc = readFileSync(
+      join(repoRoot, 'docs', 'reference', 'testing-verification-guide.md'),
+      'utf8',
+    );
+
+    expect(doc).toContain('npm run test:asm80:tetro');
+    expect(doc).toContain('TETRO_SOURCE');
   });
 
   it('wires the baseline wrapper to the documented override variables', () => {

--- a/test/frontend/asm80_classic_line.test.ts
+++ b/test/frontend/asm80_classic_line.test.ts
@@ -16,6 +16,7 @@ describe('classic ASM80 logical line parser', () => {
       '        .binfrom 0C000H',
       '        .binto 0C010H',
       '        END',
+      '        set 4,(hl)',
     ].map((text, index) => parseClassicLine('/classic.z80', text, index + 1, 0));
 
     expect(lines).toEqual([
@@ -30,6 +31,7 @@ describe('classic ASM80 logical line parser', () => {
       { kind: 'binfrom', exprText: '0C000H' },
       { kind: 'binto', exprText: '0C010H' },
       { kind: 'end' },
+      { kind: 'instruction', head: 'set', operandText: '4,(hl)' },
     ]);
   });
 

--- a/test/frontend/asm80_classic_module.test.ts
+++ b/test/frontend/asm80_classic_module.test.ts
@@ -126,22 +126,51 @@ describe('classic ASM80 module parser', () => {
   });
 
   it('rejects non-baseline dialect aliases with canonical directive guidance', () => {
-    const diagnostics: { message: string }[] = [];
+    const diagnostics: { message: string; line?: number; column?: number }[] = [];
     const module = parseClassicModule(
       '/classic.z80',
-      ['bytes: DEFB 1,2', 'words: defw 1234H', 'buf: RMB 8'].join('\n'),
+      ['DEFB_LABEL: DEFB 1,2', 'DEFW_LABEL: defw 1234H', 'RMB_LABEL: RMB 8'].join('\n'),
       diagnostics as never[],
     );
 
     expect(module.items).toMatchObject([
-      { kind: 'AsmLabel', name: 'bytes' },
-      { kind: 'AsmLabel', name: 'words' },
-      { kind: 'AsmLabel', name: 'buf' },
+      { kind: 'AsmLabel', name: 'DEFB_LABEL' },
+      { kind: 'AsmLabel', name: 'DEFW_LABEL' },
+      { kind: 'AsmLabel', name: 'RMB_LABEL' },
     ]);
     expect(diagnostics.map((diagnostic) => diagnostic.message)).toEqual([
       'DEFB is not part of the supported ASM80 baseline; use DB.',
       'DEFW is not part of the supported ASM80 baseline; use DW.',
       'RMB is not part of the supported ASM80 baseline; use DS.',
+    ]);
+    expect(diagnostics.map((diagnostic) => [diagnostic.line, diagnostic.column])).toEqual([
+      [1, 13],
+      [2, 13],
+      [3, 12],
+    ]);
+  });
+
+  it('rejects unsupported ASM80 directives before they reach instruction encoding', () => {
+    const diagnostics: { message: string; line?: number; column?: number }[] = [];
+    const module = parseClassicModule(
+      '/classic.z80',
+      ['.macro FOO', 'incbin_label: .incbin "data.bin"', 'pragma_label: .pragma anything'].join('\n'),
+      diagnostics as never[],
+    );
+
+    expect(module.items).toMatchObject([
+      { kind: 'AsmLabel', name: 'incbin_label' },
+      { kind: 'AsmLabel', name: 'pragma_label' },
+    ]);
+    expect(diagnostics.map((diagnostic) => diagnostic.message)).toEqual([
+      'Unsupported ASM80 directive ".macro". The supported baseline intentionally excludes macros and non-corpus directives.',
+      'Unsupported ASM80 directive ".incbin". The supported baseline intentionally excludes macros and non-corpus directives.',
+      'Unsupported ASM80 directive ".pragma". The supported baseline intentionally excludes macros and non-corpus directives.',
+    ]);
+    expect(diagnostics.map((diagnostic) => [diagnostic.line, diagnostic.column])).toEqual([
+      [1, 2],
+      [2, 16],
+      [3, 16],
     ]);
   });
 


### PR DESCRIPTION
## Summary

Tightens the ASM80 compatibility boundary now that MON3/TEC-1G/Tetro are being used as replacement-assembler proof sets.

## What changed

- Adds explicit classic-parser diagnostics for unsupported dotted ASM80 directives instead of silently ignoring them.
- Keeps undotted unknown mnemonics flowing to instruction encoding, including real Z80 instructions such as `set 4,(hl)`.
- Fixes rejected dialect-alias diagnostic locations so uppercase `DEFB`/`DEFW`/`RMB` report non-zero columns.
- Adds `npm run test:asm80:tetro` as a named opt-in Tetro acceptance check.
- Updates the testing guide, Tetro audit doc, baseline workflow tests, and lowering README ownership notes.

## Reviewer notes

The important behavior boundary is that unsupported dotted directives such as `.macro`, `.incbin`, and `.pragma` should now fail clearly, while ordinary instruction heads should not be reclassified as unsupported directives. The standing ASM80 baseline initially caught an over-broad `set` classification during development; this PR includes a parser regression test for that.

Tetro remains separate from `npm run test:asm80:baseline`; this PR adds a named command but does not promote it into the standing gate.

## Verification

- `npm run lint`
- `npm run typecheck -- --pretty false`
- `npm test -- --run test/frontend/asm80_classic_module.test.ts test/frontend/asm80_classic_line.test.ts test/asm80/asm80_baseline_workflow.test.ts test/asm80/asm80_directives_integration.test.ts test/asm80/tetro_acceptance.test.ts`
- `npm run test:asm80:baseline`
- `npm run test:asm80:tetro`
- `npm run check:source-file-sizes:enforce`
- `npm run check:fixture-coverage`
