### PR TITLE
[codex] Consolidate ASM80 lowering helpers

### DIFF
--- a/src/lowering/classicInstructionLowering.ts
+++ b/src/lowering/classicInstructionLowering.ts
@@ -1,6 +1,10 @@
 import type { AsmOperandNode, ImmExprNode, SourceSpan } from '../frontend/ast.js';
-import { evalImmExpr as evalImmExprWithEnv } from '../semantics/env.js';
 import type { LoweringContext } from './programLowering.js';
+import {
+  activeClassicAddress,
+  containsCurrentLocation,
+  evalClassicImmAtCurrent,
+} from './classicTraversalHelpers.js';
 
 export type ClassicInstructionNode = {
   kind: string;
@@ -8,41 +12,6 @@ export type ClassicInstructionNode = {
   head?: string;
   operands?: AsmOperandNode[];
 };
-
-function containsCurrentLocation(expr: ImmExprNode): boolean {
-  switch (expr.kind) {
-    case 'ImmCurrentLocation':
-      return true;
-    case 'ImmUnary':
-      return containsCurrentLocation(expr.expr);
-    case 'ImmBinary':
-      return containsCurrentLocation(expr.left) || containsCurrentLocation(expr.right);
-    default:
-      return false;
-  }
-}
-
-function currentActiveAddress(ctx: LoweringContext): number | undefined {
-  const section = ctx.activeSectionRef.current;
-  const offset =
-    section === 'data'
-      ? ctx.dataOffsetRef.current
-      : section === 'var'
-        ? ctx.varOffsetRef.current
-        : ctx.codeOffsetRef.current;
-  const baseExpr = section === 'data' ? ctx.baseExprs.data : section === 'var' ? undefined : ctx.baseExprs.code;
-  if (!baseExpr) return offset;
-  const base = ctx.evalImmExpr(baseExpr, ctx.env, ctx.diagnostics);
-  return base === undefined ? undefined : base + offset;
-}
-
-function evalClassicImmAtCurrent(
-  ctx: LoweringContext,
-  expr: ImmExprNode,
-  currentLocation: number,
-): number | undefined {
-  return evalImmExprWithEnv(expr, ctx.env, ctx.diagnostics, { currentLocation });
-}
 
 function jpConditionOpcodeFromName(nameRaw: string): number | undefined {
   switch (nameRaw.toUpperCase()) {
@@ -195,7 +164,7 @@ export function lowerClassicInstruction(ctx: LoweringContext, item: ClassicInstr
     targetExpr: ImmExprNode,
   ): boolean => {
     if (!containsCurrentLocation(targetExpr)) return false;
-    const current = currentActiveAddress(ctx);
+    const current = activeClassicAddress(ctx);
     if (current === undefined) {
       ctx.diag(ctx.diagnostics, item.span.file, `Failed to evaluate current location.`);
       return true;
@@ -221,7 +190,7 @@ export function lowerClassicInstruction(ctx: LoweringContext, item: ClassicInstr
     opcode: number,
     targetExpr: ImmExprNode,
   ): boolean => {
-    const current = currentActiveAddress(ctx);
+    const current = activeClassicAddress(ctx);
     if (current === undefined) {
       ctx.diag(ctx.diagnostics, item.span.file, `Failed to evaluate current location.`);
       return true;
@@ -284,7 +253,7 @@ export function lowerClassicInstruction(ctx: LoweringContext, item: ClassicInstr
   if (head === 'call') {
     if (item.operands.length === 1 && first?.kind === 'Imm') {
       if (containsCurrentLocation(first.expr)) {
-        const current = currentActiveAddress(ctx);
+        const current = activeClassicAddress(ctx);
         const target = current === undefined ? undefined : evalClassicImmAtCurrent(ctx, first.expr, current);
         if (target !== undefined) {
           ctx.emitRawCodeBytes(
@@ -339,7 +308,7 @@ export function lowerClassicInstruction(ctx: LoweringContext, item: ClassicInstr
   }
   if (head === 'jp' && item.operands.length === 1 && first?.kind === 'Imm') {
     if (containsCurrentLocation(first.expr)) {
-      const current = currentActiveAddress(ctx);
+      const current = activeClassicAddress(ctx);
       const target = current === undefined ? undefined : evalClassicImmAtCurrent(ctx, first.expr, current);
       if (target !== undefined) {
         ctx.emitRawCodeBytes(
@@ -385,7 +354,7 @@ export function lowerClassicInstruction(ctx: LoweringContext, item: ClassicInstr
         return;
       }
       if (containsCurrentLocation(target.expr)) {
-        const current = currentActiveAddress(ctx);
+        const current = activeClassicAddress(ctx);
         const value = current === undefined ? undefined : evalClassicImmAtCurrent(ctx, target.expr, current);
         if (value !== undefined) {
           ctx.emitRawCodeBytes(

--- a/src/lowering/classicTraversalHelpers.ts
+++ b/src/lowering/classicTraversalHelpers.ts
@@ -1,4 +1,6 @@
 import type { AsmOperandNode, ImmExprNode, SourceSpan } from '../frontend/ast.js';
+import { evalImmExpr as evalImmExprWithEnv } from '../semantics/env.js';
+import type { SectionKind } from './loweringTypes.js';
 import type { LoweringContext } from './programLowering.js';
 
 export type ClassicNode = {
@@ -14,6 +16,20 @@ export type ClassicNode = {
   head?: string;
   operands?: AsmOperandNode[];
 };
+
+type ClassicAddressContext = Pick<
+  LoweringContext,
+  | 'activeSectionRef'
+  | 'baseExprs'
+  | 'codeOffsetRef'
+  | 'dataOffsetRef'
+  | 'varOffsetRef'
+  | 'evalImmExpr'
+  | 'env'
+  | 'diagnostics'
+>;
+
+type ClassicEvalContext = Pick<LoweringContext, 'env' | 'diagnostics'>;
 
 function isKind(item: { kind: string }, ...kinds: string[]): boolean {
   return kinds.includes(item.kind);
@@ -51,17 +67,55 @@ export function classicExpr(item: ClassicNode): ImmExprNode | undefined {
   return item.value ?? item.expr;
 }
 
-export function activeSectionOffset(ctx: LoweringContext): number {
+export function activeSectionOffset(ctx: ClassicAddressContext): number {
   return ctx.activeSectionRef.current === 'data' ? ctx.dataOffsetRef.current : ctx.codeOffsetRef.current;
 }
 
-export function activeSectionAddress(ctx: LoweringContext): number | undefined {
-  const offset = activeSectionOffset(ctx);
-  const baseExpr =
-    ctx.activeSectionRef.current === 'data' ? ctx.baseExprs.data : ctx.baseExprs.code;
+export function activeSectionAddress(ctx: ClassicAddressContext): number | undefined {
+  return sectionAddressAtOffset(ctx, ctx.activeSectionRef.current, activeSectionOffset(ctx));
+}
+
+export function activeClassicAddress(ctx: ClassicAddressContext): number | undefined {
+  const section = ctx.activeSectionRef.current;
+  const offset =
+    section === 'data'
+      ? ctx.dataOffsetRef.current
+      : section === 'var'
+        ? ctx.varOffsetRef.current
+        : ctx.codeOffsetRef.current;
+  return sectionAddressAtOffset(ctx, section, offset);
+}
+
+export function sectionAddressAtOffset(
+  ctx: Pick<ClassicAddressContext, 'baseExprs' | 'evalImmExpr' | 'env' | 'diagnostics'>,
+  section: SectionKind,
+  offset: number,
+): number | undefined {
+  const baseExpr = section === 'data' ? ctx.baseExprs.data : section === 'var' ? undefined : ctx.baseExprs.code;
   if (!baseExpr) return offset;
   const base = ctx.evalImmExpr(baseExpr, ctx.env, ctx.diagnostics);
   return base === undefined ? undefined : base + offset;
+}
+
+export function containsCurrentLocation(expr: ImmExprNode): boolean {
+  switch (expr.kind) {
+    case 'ImmCurrentLocation':
+      return true;
+    case 'ImmUnary':
+      return containsCurrentLocation(expr.expr);
+    case 'ImmBinary':
+      return containsCurrentLocation(expr.left) || containsCurrentLocation(expr.right);
+    default:
+      return false;
+  }
+}
+
+export function evalClassicImmAtCurrent(
+  ctx: ClassicEvalContext,
+  expr: ImmExprNode,
+  currentLocation: number,
+): number | undefined {
+  return evalImmExprWithEnv(expr, ctx.env, ctx.diagnostics, { currentLocation });
 }
 
 export function publishClassicAddressConst(ctx: LoweringContext, name: string, address: number): void {

--- a/src/lowering/fixupBaseResolution.ts
+++ b/src/lowering/fixupBaseResolution.ts
@@ -1,0 +1,35 @@
+import { parseNumberLiteral } from '../frontend/parseImm.js';
+import type { CompileEnv } from '../semantics/env.js';
+import { resolveClassicEquSymbol } from './classicEquResolution.js';
+
+export type FixupBaseResolver = (
+  nameLower: string,
+  visiting?: Set<string>,
+) => number | undefined;
+
+export function createFixupBaseResolver(args: {
+  env: CompileEnv;
+  addrByNameLower: Map<string, number>;
+}): FixupBaseResolver {
+  const { env, addrByNameLower } = args;
+
+  return (nameLower: string, visiting = new Set<string>()): number | undefined => {
+    const sym = addrByNameLower.get(nameLower);
+    if (sym !== undefined) return sym;
+    const literal = parseNumberLiteral(nameLower);
+    if (literal !== undefined) return literal;
+    if (/^-?[0-9]+$/.test(nameLower)) return Number.parseInt(nameLower, 10);
+    return resolveClassicEquSymbol(
+      nameLower,
+      {
+        env,
+        lookupSymbol: (name) => addrByNameLower.get(name),
+        cacheResolved: (name, value) => {
+          addrByNameLower.set(name, value);
+          env.consts.set(name, value);
+        },
+      },
+      visiting,
+    );
+  };
+}

--- a/src/lowering/programLoweringDeclarations.ts
+++ b/src/lowering/programLoweringDeclarations.ts
@@ -9,7 +9,11 @@ import type { NamedSectionContributionSink } from './sectionContributions.js';
 
 import type { Context } from './programLowering.js';
 import type { SectionKind } from './loweringTypes.js';
-import { evalImmExpr as evalImmExprWithEnv } from '../semantics/env.js';
+import {
+  containsCurrentLocation,
+  evalClassicImmAtCurrent,
+  sectionAddressAtOffset,
+} from './classicTraversalHelpers.js';
 
 type NamedSectionTarget = { node: NamedSectionNode; sink: NamedSectionContributionSink };
 type RawValueLike =
@@ -51,19 +55,6 @@ function rawImmValue(value: RawValueLike): ImmExprNode | undefined {
   if (typeof value === 'string') return undefined;
   if (!('kind' in value)) return undefined;
   return value.kind.startsWith('Imm') ? (value as ImmExprNode) : undefined;
-}
-
-function containsCurrentLocation(expr: ImmExprNode): boolean {
-  switch (expr.kind) {
-    case 'ImmCurrentLocation':
-      return true;
-    case 'ImmUnary':
-      return containsCurrentLocation(expr.expr);
-    case 'ImmBinary':
-      return containsCurrentLocation(expr.left) || containsCurrentLocation(expr.right);
-    default:
-      return false;
-  }
 }
 
 export function createProgramLoweringDeclarationHelpers(ctx: Context): {
@@ -389,10 +380,7 @@ export function createProgramLoweringDeclarationHelpers(ctx: Context): {
         namedSection?.sink.offset ??
         (activeSection === 'code' ? ctx.codeOffsetRef.current : ctx.dataOffsetRef.current);
       if (namedSection) return namedSection.sink.anchor.node.anchor ? undefined : offset;
-      const baseExpr = activeSection === 'code' ? ctx.baseExprs.code : ctx.baseExprs.data;
-      if (!baseExpr) return offset;
-      const base = ctx.evalImmExpr(baseExpr, ctx.env, ctx.diagnostics);
-      return base === undefined ? undefined : base + offset;
+      return sectionAddressAtOffset(ctx, activeSection, offset);
     };
 
     if (decl.directive === 'ds') {
@@ -505,8 +493,9 @@ export function createProgramLoweringDeclarationHelpers(ctx: Context): {
         continue;
       }
 
-      const current = containsCurrentLocation(imm) ? currentAddress() : undefined;
-      if (containsCurrentLocation(imm) && current === undefined) {
+      const usesCurrentLocation = containsCurrentLocation(imm);
+      const current = usesCurrentLocation ? currentAddress() : undefined;
+      if (usesCurrentLocation && current === undefined) {
         ctx.diag(ctx.diagnostics, decl.span.file, `Failed to evaluate current location.`);
         if (decl.directive === 'db') writeByte(0);
         else writeWord(0);
@@ -515,7 +504,7 @@ export function createProgramLoweringDeclarationHelpers(ctx: Context): {
       const evaluated =
         current === undefined
           ? ctx.evalImmExpr(imm, ctx.env, ctx.diagnostics)
-          : evalImmExprWithEnv(imm, ctx.env, ctx.diagnostics, { currentLocation: current });
+          : evalClassicImmAtCurrent(ctx, imm, current);
       loweredValues.push(
         evaluated === undefined ? ctx.lowerImmExprForLoweredAsm(imm) : { kind: 'literal', value: evaluated },
       );

--- a/src/lowering/programLoweringFinalize.ts
+++ b/src/lowering/programLoweringFinalize.ts
@@ -4,8 +4,7 @@ import type {
 } from '../formats/types.js';
 import type { SectionKind } from './loweringTypes.js';
 import type { ProgramEmissionFinalizeContext } from './programLowering.js';
-import { parseNumberLiteral } from '../frontend/parseImm.js';
-import { resolveClassicEquSymbol } from './classicEquResolution.js';
+import { createFixupBaseResolver } from './fixupBaseResolution.js';
 
 export function computeSectionBases(
   ctx: Pick<ProgramEmissionFinalizeContext, 'baseExprs' | 'evalImmExpr' | 'env' | 'diagnostics' | 'diag' | 'primaryFile' | 'alignTo' | 'codeOffset' | 'dataOffset'>,
@@ -130,25 +129,7 @@ export function finalizeProgramEmission(ctx: ProgramEmissionFinalizeContext): {
     });
   }
 
-  const resolveFixupBase = (nameLower: string, visiting = new Set<string>()): number | undefined => {
-    const sym = addrByNameLower.get(nameLower);
-    if (sym !== undefined) return sym;
-    const literal = parseNumberLiteral(nameLower);
-    if (literal !== undefined) return literal;
-    if (/^-?[0-9]+$/.test(nameLower)) return Number.parseInt(nameLower, 10);
-    const value = resolveClassicEquSymbol(nameLower, {
-      env: ctx.env,
-      lookupSymbol: (name) => addrByNameLower.get(name),
-      cacheResolved: (name, resolved) => {
-        addrByNameLower.set(name, resolved);
-        ctx.env.consts.set(name, resolved);
-      },
-    }, visiting);
-    if (value !== undefined) {
-      return value;
-    }
-    return undefined;
-  };
+  const resolveFixupBase = createFixupBaseResolver({ env: ctx.env, addrByNameLower });
 
   for (const fx of ctx.fixups) {
     const base = resolveFixupBase(fx.baseLower);

--- a/src/lowering/sectionPlacement.ts
+++ b/src/lowering/sectionPlacement.ts
@@ -6,8 +6,7 @@ import { diagAt } from './loweringDiagnostics.js';
 import type { NamedSectionContributionSink } from './sectionContributions.js';
 import type { NonBankedSectionKeyId } from '../sectionKeys.js';
 import { formatNonBankedSectionKey } from '../sectionKeys.js';
-import { parseNumberLiteral } from '../frontend/parseImm.js';
-import { resolveClassicEquSymbol } from './classicEquResolution.js';
+import { createFixupBaseResolver } from './fixupBaseResolution.js';
 
 export type PlacedNamedSectionContribution = {
   /** Sink carrying bytes/fixups for one contribution. */
@@ -293,25 +292,7 @@ export function resolvePlacedNamedSectionFixups(
     if (sym.kind === 'constant' || sym.address === undefined) continue;
     addrByNameLower.set(sym.name.toLowerCase(), sym.address);
   }
-  const resolveFixupBase = (nameLower: string, visiting = new Set<string>()): number | undefined => {
-    const sym = addrByNameLower.get(nameLower);
-    if (sym !== undefined) return sym;
-    const literal = parseNumberLiteral(nameLower);
-    if (literal !== undefined) return literal;
-    if (/^-?[0-9]+$/.test(nameLower)) return Number.parseInt(nameLower, 10);
-    return resolveClassicEquSymbol(
-      nameLower,
-      {
-        env,
-        lookupSymbol: (name) => addrByNameLower.get(name),
-        cacheResolved: (name, value) => {
-          addrByNameLower.set(name, value);
-          env.consts.set(name, value);
-        },
-      },
-      visiting,
-    );
-  };
+  const resolveFixupBase = createFixupBaseResolver({ env, addrByNameLower });
 
   for (const placed of placedContributions) {
     const sink = placed.sink;


### PR DESCRIPTION
## Summary

Consolidates duplicated ASM80 lowering helper logic without changing the parser, accepted syntax, or emitted binary behavior.

## What changed

- Moved shared classic current-location helpers into `classicTraversalHelpers.ts`:
  - `containsCurrentLocation`
  - `evalClassicImmAtCurrent`
  - `activeClassicAddress`
  - `sectionAddressAtOffset`
- Removed duplicated current-location logic from:
  - `classicInstructionLowering.ts`
  - `programLoweringDeclarations.ts`
- Added `fixupBaseResolution.ts` as the shared resolver for final fixup base symbols.
- Removed duplicated fixup-base resolution from:
  - `programLoweringFinalize.ts`
  - `sectionPlacement.ts`

## Reviewer notes

This PR deliberately avoids the larger `classicDirectiveLowering` split. The changes are intended to be mechanical helper extraction only.

Important behavior to check:

- Classic current-location expressions still use the same effective address in instruction and raw-data lowering.
- Named-section raw data still preserves its special local sink semantics.
- Final program fixups and placed named-section fixups still resolve constants, literals, decimal names, symbols, and classic `EQU` aliases the same way.

## Verification

- `npm run lint`
- `npm run typecheck -- --pretty false`
- `npm test -- --run test/asm80/asm80_directives_integration.test.ts test/asm80/asm80_align_directive.test.ts test/asm80/asm80_string_directives.test.ts test/pr582_named_section_routing_integration.test.ts test/pr582_section_contribution_sinks.test.ts test/pr585_named_section_layout_integration.test.ts test/pr584_named_section_fixups_integration.test.ts test/backend/issue1356_named_section_ld_hl.test.ts test/asm80/tetro_acceptance.test.ts`
- `npm run test:asm80:baseline`
- `npm run test:asm80:tetro`
- `npm run check:source-file-sizes:enforce`
- `npm run check:fixture-coverage`
