### PR TITLE
Extract ASM80 acceptance test helpers

### DIFF
--- a/test/asm80/mon3_acceptance.test.ts
+++ b/test/asm80/mon3_acceptance.test.ts
@@ -1,15 +1,20 @@
-import { copyFileSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
-import { basename, dirname, join, resolve } from 'node:path';
-import { spawnSync } from 'node:child_process';
-import { tmpdir } from 'node:os';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
 import { compile } from '../../src/compile.js';
-import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
 import type { BinArtifact } from '../../src/formats/types.js';
+import {
+  copyZ80Siblings,
+  findAsm80Executable,
+  findFirstMismatch,
+  runAsm80Reference,
+  summarizeBinaryMismatch,
+  summarizeDiagnostics,
+} from '../helpers/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -21,24 +26,7 @@ const manifest = {
   source: process.env.MON3_SOURCE ?? '/Users/johnhardy/Documents/projects/MON3/src/mon3.z80',
 };
 
-function normalizeExecutableCandidate(candidate: string): string {
-  return candidate.includes('/') || candidate.includes('\\') ? resolve(candidate) : candidate;
-}
-
-const asm80Candidates = [
-  process.env.ASM80,
-  process.env.ASM80_PATH,
-  '/Users/johnhardy/Documents/projects/debug80/node_modules/.bin/asm80',
-  'asm80',
-]
-  .filter(
-    (candidate): candidate is string => candidate !== undefined && candidate.trim().length > 0,
-  )
-  .map(normalizeExecutableCandidate);
-const asm80 = asm80Candidates.find((candidate) => {
-  const probe = spawnSync(candidate, ['-h'], { encoding: 'utf8' });
-  return !probe.error;
-});
+const asm80 = findAsm80Executable();
 const mon3FilesAvailable = existsSync(manifest.source);
 const runMon3Acceptance = process.env.ZAX_RUN_MON3_ACCEPTANCE === '1';
 const describeMon3 =
@@ -50,88 +38,14 @@ const describeMon3 =
     ? describe
     : describe.skip;
 
-function byteHex(value: number | undefined): string {
-  return value === undefined ? 'EOF' : `0x${value.toString(16).padStart(2, '0')}`;
-}
-
-function offsetHex(offset: number): string {
-  return `0x${offset.toString(16).padStart(4, '0')}`;
-}
-
-function diagnosticLocation(diagnostic: Diagnostic): string {
-  if (diagnostic.line === undefined || diagnostic.column === undefined) return diagnostic.file;
-  return `${diagnostic.file}:${diagnostic.line}:${diagnostic.column}`;
-}
-
-function summarizeDiagnostics(diagnostics: Diagnostic[], limit = 3): string {
-  const preview = diagnostics
-    .slice(0, limit)
-    .map(
-      (diagnostic) =>
-        `${diagnosticLocation(diagnostic)}: ${diagnostic.severity} [${diagnostic.id}] ${
-          diagnostic.message
-        }`,
-    );
-  return [
-    `Diagnostics preview (showing ${preview.length} of ${diagnostics.length}):`,
-    ...preview,
-  ].join('\n');
-}
-
-function findFirstMismatch(actual: Buffer, reference: Buffer): number {
-  const maxLength = Math.max(actual.length, reference.length);
-  for (let i = 0; i < maxLength; i++) {
-    if (actual[i] !== reference[i]) return i;
-  }
-  return -1;
-}
-
-function summarizeBinaryMismatch(actual: Buffer, reference: Buffer): string {
-  const firstMismatch = findFirstMismatch(actual, reference);
-  const lines = [`Binary length: actual=${actual.length} reference=${reference.length}`];
-  if (firstMismatch >= 0) {
-    lines.push(
-      `First mismatch @${offsetHex(firstMismatch)}: actual=${byteHex(
-        actual[firstMismatch],
-      )} reference=${byteHex(reference[firstMismatch])}`,
-    );
-  } else {
-    lines.push('First mismatch: none');
-  }
-  return lines.join('\n');
-}
-
-function copyAsm80SourceTree(source: string, outDir: string): void {
-  for (const entry of readdirSync(dirname(source))) {
-    if (entry.toLowerCase().endsWith('.z80')) {
-      copyFileSync(join(dirname(source), entry), join(outDir, entry));
-    }
-  }
-}
-
 function buildAsm80Reference(source: string): Buffer {
-  if (!asm80) throw new Error('asm80 executable not found');
-  const outDir = mkdtempSync(join(tmpdir(), 'zax-mon3-asm80-reference-'));
-  const outName = 'mon3-reference.bin';
-  const outBin = join(outDir, outName);
-  try {
-    copyAsm80SourceTree(source, outDir);
-    const result = spawnSync(asm80, ['-m', 'Z80', '-t', 'bin', '-o', outName, basename(source)], {
-      cwd: outDir,
-      encoding: 'utf8',
-    });
-    if (result.error) throw result.error;
-    if (result.status !== 0) {
-      throw new Error(
-        [`asm80 failed with status ${result.status}`, result.stdout.trim(), result.stderr.trim()]
-          .filter((part) => part.length > 0)
-          .join('\n'),
-      );
-    }
-    return readFileSync(outBin);
-  } finally {
-    rmSync(outDir, { recursive: true, force: true });
-  }
+  return runAsm80Reference({
+    asm80,
+    source,
+    tempPrefix: 'zax-mon3-asm80-reference-',
+    outputName: 'mon3-reference.bin',
+    prepareSourceTree: copyZ80Siblings,
+  });
 }
 
 describe('MON3 acceptance failure summaries', () => {

--- a/test/asm80/tetro_acceptance.test.ts
+++ b/test/asm80/tetro_acceptance.test.ts
@@ -1,159 +1,41 @@
-import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
-import { basename, dirname, join, resolve } from 'node:path';
-import { spawnSync } from 'node:child_process';
-import { tmpdir } from 'node:os';
-import { fileURLToPath } from 'node:url';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
 import { compile } from '../../src/compile.js';
-import type { Diagnostic } from '../../src/diagnosticTypes.js';
 import { defaultFormatWriters } from '../../src/formats/index.js';
 import type { BinArtifact } from '../../src/formats/types.js';
+import {
+  binaryFromListingRange,
+  copySourceRoot,
+  findAsm80Executable,
+  findFirstMismatch,
+  parseListingWrittenRange,
+  runAsm80Reference,
+  summarizeBinaryMismatch,
+  summarizeDiagnostics,
+} from '../helpers/index.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
 const manifest = {
   source: process.env.TETRO_SOURCE ?? '/Users/johnhardy/Documents/projects/tetro/src/tetro.asm',
 };
 
-type ListingRange = {
-  start: number;
-  end: number;
-};
-
-function normalizeExecutableCandidate(candidate: string): string {
-  return candidate.includes('/') || candidate.includes('\\') ? resolve(candidate) : candidate;
-}
-
-const asm80Candidates = [
-  process.env.ASM80,
-  process.env.ASM80_PATH,
-  '/Users/johnhardy/Documents/projects/debug80/node_modules/.bin/asm80',
-  'asm80',
-]
-  .filter(
-    (candidate): candidate is string => candidate !== undefined && candidate.trim().length > 0,
-  )
-  .map(normalizeExecutableCandidate);
-const asm80 = asm80Candidates.find((candidate) => {
-  const probe = spawnSync(candidate, ['-h'], { encoding: 'utf8' });
-  return !probe.error;
-});
+const asm80 = findAsm80Executable();
 const tetroFilesAvailable = existsSync(manifest.source);
 const runTetroAcceptance = process.env.ZAX_RUN_TETRO_ACCEPTANCE === '1';
 const describeTetro = tetroFilesAvailable && asm80 && runTetroAcceptance ? describe : describe.skip;
 
-function byteHex(value: number | undefined): string {
-  return value === undefined ? 'EOF' : `0x${value.toString(16).padStart(2, '0')}`;
-}
-
-function offsetHex(offset: number): string {
-  return `0x${offset.toString(16).padStart(4, '0')}`;
-}
-
-function diagnosticLocation(diagnostic: Diagnostic): string {
-  if (diagnostic.line === undefined || diagnostic.column === undefined) return diagnostic.file;
-  return `${diagnostic.file}:${diagnostic.line}:${diagnostic.column}`;
-}
-
-function summarizeDiagnostics(diagnostics: Diagnostic[], limit = 3): string {
-  const preview = diagnostics
-    .slice(0, limit)
-    .map(
-      (diagnostic) =>
-        `${diagnosticLocation(diagnostic)}: ${diagnostic.severity} [${diagnostic.id}] ${
-          diagnostic.message
-        }`,
-    );
-  return [
-    `Diagnostics preview (showing ${preview.length} of ${diagnostics.length}):`,
-    ...preview,
-  ].join('\n');
-}
-
-function findFirstMismatch(actual: Buffer, reference: Buffer): number {
-  const maxLength = Math.max(actual.length, reference.length);
-  for (let i = 0; i < maxLength; i++) {
-    if (actual[i] !== reference[i]) return i;
-  }
-  return -1;
-}
-
-function summarizeBinaryMismatch(actual: Buffer, reference: Buffer): string {
-  const firstMismatch = findFirstMismatch(actual, reference);
-  const lines = [`Binary length: actual=${actual.length} reference=${reference.length}`];
-  if (firstMismatch >= 0) {
-    lines.push(
-      `First mismatch @${offsetHex(firstMismatch)}: actual=${byteHex(
-        actual[firstMismatch],
-      )} reference=${byteHex(reference[firstMismatch])}`,
-    );
-  } else {
-    lines.push('First mismatch: none');
-  }
-  return lines.join('\n');
-}
-
-function parseListingWrittenRange(listingPath: string): ListingRange {
-  const text = readFileSync(listingPath, 'utf8');
-  let start: number | undefined;
-  let end = 0;
-  for (const line of text.split(/\r?\n/)) {
-    const match = /^([0-9A-Fa-f]{4})\s+/.exec(line);
-    if (!match) continue;
-    const address = Number.parseInt(match[1]!, 16);
-    const bytes = line
-      .slice(7, 31)
-      .trim()
-      .split(/\s+/)
-      .filter((token) => /^[0-9A-Fa-f]{2}$/.test(token)).length;
-    if (bytes === 0) continue;
-    start = start === undefined ? address : Math.min(start, address);
-    end = Math.max(end, address + bytes);
-  }
-  return { start: start ?? 0, end };
-}
-
-function binaryFromListingRange(bytes: Buffer, range: ListingRange): Buffer {
-  if (bytes.length !== 0x10000) return bytes;
-  let end = range.end;
-  for (let index = bytes.length - 1; index >= range.start; index--) {
-    if (bytes[index] !== 0) {
-      end = Math.max(end, index + 1);
-      break;
-    }
-  }
-  return bytes.subarray(range.start, end);
-}
-
 function buildAsm80Reference(source: string): Buffer {
-  if (!asm80) throw new Error('asm80 executable not found');
-  const outDir = mkdtempSync(join(tmpdir(), 'zax-tetro-asm80-reference-'));
-  const sourceRoot = dirname(source);
-  const outName = 'tetro-reference.bin';
-  const outBin = join(outDir, outName);
-  const listing = join(outDir, 'tetro-reference.lst');
-  try {
-    cpSync(sourceRoot, outDir, { recursive: true });
-    const result = spawnSync(asm80, ['-m', 'Z80', '-t', 'bin', '-o', outName, basename(source)], {
-      cwd: outDir,
-      encoding: 'utf8',
-    });
-    if (result.error) throw result.error;
-    if (result.status !== 0) {
-      throw new Error(
-        [`asm80 failed with status ${result.status}`, result.stdout.trim(), result.stderr.trim()]
-          .filter((part) => part.length > 0)
-          .join('\n'),
-      );
-    }
-    const bytes = readFileSync(outBin);
-    const range = parseListingWrittenRange(listing);
-    return binaryFromListingRange(bytes, range);
-  } finally {
-    rmSync(outDir, { recursive: true, force: true });
-  }
+  return runAsm80Reference({
+    asm80,
+    source,
+    tempPrefix: 'zax-tetro-asm80-reference-',
+    outputName: 'tetro-reference.bin',
+    prepareSourceTree: copySourceRoot,
+    transformOutput: (bytes, outDir) =>
+      binaryFromListingRange(bytes, parseListingWrittenRange(join(outDir, 'tetro-reference.lst'))),
+  });
 }
 
 describeTetro('ASM80 Tetro acceptance', () => {

--- a/test/helpers/asm80_acceptance.ts
+++ b/test/helpers/asm80_acceptance.ts
@@ -1,0 +1,166 @@
+import { cpSync, copyFileSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+
+import type { Diagnostic } from '../../src/diagnosticTypes.js';
+
+export type ListingRange = {
+  start: number;
+  end: number;
+};
+
+export type Asm80ReferenceOptions = {
+  asm80: string | undefined;
+  source: string;
+  tempPrefix: string;
+  outputName: string;
+  prepareSourceTree: (source: string, outDir: string) => void;
+  transformOutput?: (bytes: Buffer, outDir: string) => Buffer;
+};
+
+export function normalizeExecutableCandidate(candidate: string): string {
+  return candidate.includes('/') || candidate.includes('\\') ? resolve(candidate) : candidate;
+}
+
+export function findAsm80Executable(): string | undefined {
+  const candidates = [
+    process.env.ASM80,
+    process.env.ASM80_PATH,
+    '/Users/johnhardy/Documents/projects/debug80/node_modules/.bin/asm80',
+    'asm80',
+  ]
+    .filter(
+      (candidate): candidate is string => candidate !== undefined && candidate.trim().length > 0,
+    )
+    .map(normalizeExecutableCandidate);
+
+  return candidates.find((candidate) => {
+    const probe = spawnSync(candidate, ['-h'], { encoding: 'utf8' });
+    return !probe.error;
+  });
+}
+
+function byteHex(value: number | undefined): string {
+  return value === undefined ? 'EOF' : `0x${value.toString(16).padStart(2, '0')}`;
+}
+
+function offsetHex(offset: number): string {
+  return `0x${offset.toString(16).padStart(4, '0')}`;
+}
+
+function diagnosticLocation(diagnostic: Diagnostic): string {
+  if (diagnostic.line === undefined || diagnostic.column === undefined) return diagnostic.file;
+  return `${diagnostic.file}:${diagnostic.line}:${diagnostic.column}`;
+}
+
+export function summarizeDiagnostics(diagnostics: Diagnostic[], limit = 3): string {
+  const preview = diagnostics
+    .slice(0, limit)
+    .map(
+      (diagnostic) =>
+        `${diagnosticLocation(diagnostic)}: ${diagnostic.severity} [${diagnostic.id}] ${
+          diagnostic.message
+        }`,
+    );
+  return [
+    `Diagnostics preview (showing ${preview.length} of ${diagnostics.length}):`,
+    ...preview,
+  ].join('\n');
+}
+
+export function findFirstMismatch(actual: Buffer, reference: Buffer): number {
+  const maxLength = Math.max(actual.length, reference.length);
+  for (let i = 0; i < maxLength; i++) {
+    if (actual[i] !== reference[i]) return i;
+  }
+  return -1;
+}
+
+export function summarizeBinaryMismatch(actual: Buffer, reference: Buffer): string {
+  const firstMismatch = findFirstMismatch(actual, reference);
+  const lines = [`Binary length: actual=${actual.length} reference=${reference.length}`];
+  if (firstMismatch >= 0) {
+    lines.push(
+      `First mismatch @${offsetHex(firstMismatch)}: actual=${byteHex(
+        actual[firstMismatch],
+      )} reference=${byteHex(reference[firstMismatch])}`,
+    );
+  } else {
+    lines.push('First mismatch: none');
+  }
+  return lines.join('\n');
+}
+
+export function copyZ80Siblings(source: string, outDir: string): void {
+  for (const entry of readdirSync(dirname(source))) {
+    if (entry.toLowerCase().endsWith('.z80')) {
+      copyFileSync(join(dirname(source), entry), join(outDir, entry));
+    }
+  }
+}
+
+export function copySourceRoot(source: string, outDir: string): void {
+  cpSync(dirname(source), outDir, { recursive: true });
+}
+
+export function parseListingWrittenRange(listingPath: string): ListingRange {
+  const text = readFileSync(listingPath, 'utf8');
+  let start: number | undefined;
+  let end = 0;
+  for (const line of text.split(/\r?\n/)) {
+    const match = /^([0-9A-Fa-f]{4})\s+/.exec(line);
+    if (!match) continue;
+    const address = Number.parseInt(match[1]!, 16);
+    const bytes = line
+      .slice(7, 31)
+      .trim()
+      .split(/\s+/)
+      .filter((token) => /^[0-9A-Fa-f]{2}$/.test(token)).length;
+    if (bytes === 0) continue;
+    start = start === undefined ? address : Math.min(start, address);
+    end = Math.max(end, address + bytes);
+  }
+  return { start: start ?? 0, end };
+}
+
+export function binaryFromListingRange(bytes: Buffer, range: ListingRange): Buffer {
+  if (bytes.length !== 0x10000) return bytes;
+  let end = range.end;
+  for (let index = bytes.length - 1; index >= range.start; index--) {
+    if (bytes[index] !== 0) {
+      end = Math.max(end, index + 1);
+      break;
+    }
+  }
+  return bytes.subarray(range.start, end);
+}
+
+export function runAsm80Reference(options: Asm80ReferenceOptions): Buffer {
+  if (!options.asm80) throw new Error('asm80 executable not found');
+  const outDir = mkdtempSync(join(tmpdir(), options.tempPrefix));
+  const outBin = join(outDir, options.outputName);
+  try {
+    options.prepareSourceTree(options.source, outDir);
+    const result = spawnSync(
+      options.asm80,
+      ['-m', 'Z80', '-t', 'bin', '-o', options.outputName, basename(options.source)],
+      {
+        cwd: outDir,
+        encoding: 'utf8',
+      },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(
+        [`asm80 failed with status ${result.status}`, result.stdout.trim(), result.stderr.trim()]
+          .filter((part) => part.length > 0)
+          .join('\n'),
+      );
+    }
+    const bytes = readFileSync(outBin);
+    return options.transformOutput ? options.transformOutput(bytes, outDir) : bytes;
+  } finally {
+    rmSync(outDir, { recursive: true, force: true });
+  }
+}

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -1,5 +1,6 @@
 export * from './diagnostics.js';
 export * from './cli.js';
 export * from './cliBuild.js';
+export * from './asm80_acceptance.js';
 export * from './lowered_program.js';
 export * from './setup.js';


### PR DESCRIPTION
## Summary
- Add shared `test/helpers/asm80_acceptance.ts` for ASM80 executable discovery, diagnostics summaries, binary mismatch summaries, source staging helpers, listing-range trimming, and reference assembly execution.
- Re-export the helper from `test/helpers/index.ts` so ASM80 acceptance tests use the existing helper barrel.
- Update MON3 and Tetro acceptance tests to share the harness while keeping corpus-specific source paths, opt-in gates, source staging, and Tetro listing-range trimming local to each test.

## Reviewer Notes
This is test harness consolidation only; no compiler behavior changed.

Risk areas to check:
- MON3 must still copy only sibling `.z80` files before invoking ASM80.
- Tetro must still copy the full source root and trim full-64K ASM80 output using the listing range.
- Skip/todo behavior and opt-in env vars must remain corpus-specific.
- The diagnostic/binary summary self-test remains in the MON3 suite but now exercises the shared helper functions.

## Verification
- `npm test -- --run test/asm80/mon3_acceptance.test.ts test/asm80/tetro_acceptance.test.ts`
- `npm run typecheck -- --pretty false`
- `npm run lint`
- `npm run check:source-file-sizes:enforce`
- `npm run test:asm80:baseline`
- `npm run test:asm80:tetro`
- `npm run check:fixture-coverage`
